### PR TITLE
feat: 支持 --commit 多哈希合并审查

### DIFF
--- a/.claude/commands/open-code-review.md
+++ b/.claude/commands/open-code-review.md
@@ -12,7 +12,7 @@ Run the OCR command:
 ocr review --audience agent [user-args]
 ```
 - Default (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode).
-- If the user provides `--commit` or `--c`: pass through as-is.
+- If the user provides `--commit` or `--c`: pass through as-is. Supports comma-separated hashes for multi-commit review (e.g., `--commit abc123,def456`).
 - If the user provides `--from` and `--to`: pass through as-is.
 - (Optional) Provide `--background "requirement context"` to review whether the requirements are correctly implemented.
 - Capture full stdout. Set a 5-minute timeout.

--- a/NPM-README.md
+++ b/NPM-README.md
@@ -58,6 +58,9 @@ ocr review --from main --to feature-branch
 
 # Review a single commit
 ocr review --commit abc123
+
+# Review multiple commits combined
+ocr review --commit abc123,def456
 ```
 
 ## Commands
@@ -77,14 +80,14 @@ ocr review --commit abc123
 | `--repo` | | current dir | Git repository root |
 | `--from` | | | Source ref (e.g., `main`) |
 | `--to` | | | Target ref (e.g., `feature-branch`) |
-| `--commit` | `-c` | | Review a single commit |
+| `--commit` | `-c` | | Review commit(s) — single hash or comma-separated for multiple |
 | `--format` | `-f` | `text` | Output format: `text` or `json` |
 | `--concurrency` | | `4` | Max concurrent file reviews |
 | `--timeout` | | `10` | Per-file timeout (minutes) |
 
 ## Features
 
-- **Three review modes**: workspace changes, branch range, single commit
+- **Three review modes**: workspace changes, branch range, single or multiple commits
 - **Context-aware**: Agent reads arbitrary files, searches code via `git grep`, inspects diffs
 - **Plan phase**: Large changes (>50 lines) get risk analysis first
 - **Any LLM**: Works with OpenAI, Claude-compatible endpoints, local models

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ ocr review --from main --to feature-branch
 
 # Single commit
 ocr review --commit abc123
+
+# Multiple commits combined (e.g., your own commits interleaved with others')
+ocr review --commit abc123,def456
 ```
 
 ## Commands
@@ -125,7 +128,7 @@ ocr review --commit abc123
 | `--repo` | — | current dir | Git repository root |
 | `--from` | — | — | Source ref (e.g., `main`) |
 | `--to` | — | — | Target ref (e.g., `feature-branch`) |
-| `--commit` | `-c` | — | Single commit to review |
+| `--commit` | `-c` | — | Commit hash(es) to review — single or comma-separated for multiple |
 | `--preview` | `-p` | `false` | Preview which files will be reviewed without running the LLM |
 | `--format` | `-f` | `text` | Output format: `text` or `json` |
 | `--concurrency` | — | `8` | Max concurrent file reviews |
@@ -149,6 +152,9 @@ ocr review --from main --to my-feature --concurrency 4
 
 # Review a specific commit with verbose JSON output
 ocr review --commit abc123 --format json --audience agent
+
+# Review multiple commits combined (e.g., bug fix across several commits)
+ocr review --commit abc123,def456 --format json --audience agent
 
 # Use custom review rules
 ocr review --rule /path/to/my-rules.json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,6 +105,9 @@ ocr review --from main --to feature-branch
 
 # 单个提交
 ocr review --commit abc123
+
+# 多个提交合并审查（例如你的提交之间夹杂了其他人的提交）
+ocr review --commit abc123,def456
 ```
 
 ## 命令
@@ -125,7 +128,7 @@ ocr review --commit abc123
 | `--repo` | — | 当前目录 | Git 仓库根目录 |
 | `--from` | — | — | 源引用（如 `main`） |
 | `--to` | — | — | 目标引用（如 `feature-branch`） |
-| `--commit` | `-c` | — | 审查单个提交 |
+| `--commit` | `-c` | — | 审查提交，支持单个或逗号分隔的多个提交 |
 | `--preview` | `-p` | `false` | 预览将被审查的文件列表，不调用 LLM |
 | `--format` | `-f` | `text` | 输出格式：`text` 或 `json` |
 | `--concurrency` | — | `8` | 最大并发文件审查数 |
@@ -149,6 +152,9 @@ ocr review --from main --to my-feature --concurrency 4
 
 # 审查特定提交并以 JSON 格式输出详细信息
 ocr review --commit abc123 --format json --audience agent
+
+# 审查多个提交合并（例如一个 bug 修复跨了多个提交）
+ocr review --commit abc123,def456 --format json --audience agent
 
 # 使用自定义审查规则
 ocr review --rule /path/to/my-rules.json

--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -119,7 +119,7 @@ func parseReviewFlags(args []string) (reviewOptions, error) {
 	a.StringVar(&opts.repoDir, "repo", "", "root directory of the git repository (default: current dir)")
 	a.StringVar(&opts.from, "from", "", "source ref to start diff from (e.g., 'main')")
 	a.StringVar(&opts.to, "to", "", "target ref to end diff at (e.g., 'feature-branch')")
-	a.StringVarP(&opts.commit, "commit", "c", "", "single commit hash or tag to review (vs its parent)")
+	a.StringVarP(&opts.commit, "commit", "c", "", "commit hash(es) to review -- single hash or comma-separated for multiple (vs their parent(s))")
 	a.StringVarP(&opts.outputFormat, "format", "f", "text", "output format: text or json")
 	a.IntVar(&opts.concurrency, "concurrency", 8, "max concurrent file reviews")
 	a.IntVar(&opts.perFileTimeout, "timeout", 10, "concurrent task timeout in minutes")
@@ -178,6 +178,10 @@ Examples:
   ocr review --commit abc123
   ocr review -c abc123
 
+  # Review multiple commits combined
+  ocr review --commit abc123,def456
+  ocr review -c abc123,def456
+
   # Output JSON format
   ocr review --format json
   ocr review -f json
@@ -192,7 +196,7 @@ Examples:
 Flags:
   --audience string       output audience: human (show progress) or agent (summary only) (default "human")
   -b, --background string optional requirement/business context for the review
-  -c, --commit string     single commit hash or tag to review (vs its parent)
+  -c, --commit string     commit hash(es) to review -- single hash or comma-separated for multiple
   -f, --format string     output format: text or json (default "text")
   --concurrency int       max concurrent file reviews (default 8)
   --from string           source ref to start diff from (e.g., 'main')

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/open-code-review/open-code-review/internal/agent"
@@ -84,7 +85,13 @@ func runReview(args []string) error {
 
 	collector := tool.NewCommentCollector()
 	mode := tool.ParseReviewMode(opts.from, opts.to, opts.commit)
-	ref, _ := mode.RefValue(opts.to, opts.commit)
+	// For multi-commit mode, use the last commit hash as the FileReader ref.
+	refCommit := opts.commit
+	if strings.Contains(opts.commit, ",") {
+		parts := strings.Split(opts.commit, ",")
+		refCommit = strings.TrimSpace(parts[len(parts)-1])
+	}
+	ref, _ := mode.RefValue(opts.to, refCommit)
 	diffMap := make(map[string]string)
 	fileReader := &tool.FileReader{
 		RepoDir: repoDir,

--- a/cmd/testdiff/main.go
+++ b/cmd/testdiff/main.go
@@ -106,6 +106,9 @@ Examples:
   # Single commit vs its parent
   go run ./cmd/testdiff -commit abc1234
 
+  # Multiple commits combined
+  go run ./cmd/testdiff -commit abc1234,def5678
+
   # Summary only (file paths and line counts)
   go run ./cmd/testdiff -from master -to dev-ref -summary
 
@@ -113,7 +116,7 @@ Flags:
   -repo DIR       git repository root (default: auto-detect via git rev-parse)
   -from REF       source ref (e.g. 'main')
   -to REF         target ref (e.g. 'feature-branch')
-  -commit SHA     single commit to review (vs its parent)
+  -commit SHA     commit hash(es) to review -- single or comma-separated for multiple
   -format FMT     output format: text or json (default: text)
   -summary        show file list and insertions/deletions only`)
 }
@@ -136,12 +139,28 @@ func resolveRepo(input string) (string, error) {
 func buildProvider(repoDir string, args cliArgs) *diff.Provider {
 	switch {
 	case args.commit != "":
+		if strings.Contains(args.commit, ",") {
+			commits := parseCommitList(args.commit)
+			return diff.NewMultiCommitProvider(repoDir, commits)
+		}
 		return diff.NewCommitProvider(repoDir, args.commit)
 	case args.from != "" && args.to != "":
 		return diff.NewProvider(repoDir, args.from, args.to)
 	default:
 		return diff.NewWorkspaceProvider(repoDir)
 	}
+}
+
+func parseCommitList(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // ---- output helpers ----

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -316,7 +316,12 @@ func (a *Agent) loadDiffs() error {
 
 	switch {
 	case a.args.Commit != "":
-		provider = diff.NewCommitProvider(a.args.RepoDir, a.args.Commit)
+		if strings.Contains(a.args.Commit, ",") {
+			commits := parseCommitList(a.args.Commit)
+			provider = diff.NewMultiCommitProvider(a.args.RepoDir, commits)
+		} else {
+			provider = diff.NewCommitProvider(a.args.RepoDir, a.args.Commit)
+		}
 	case a.args.From != "" && a.args.To != "":
 		provider = diff.NewProvider(a.args.RepoDir, a.args.From, a.args.To)
 	default:
@@ -340,6 +345,20 @@ func (a *Agent) loadDiffs() error {
 	}
 
 	return nil
+}
+
+// parseCommitList splits a comma-separated commit string into individual hashes,
+// trimming whitespace and skipping empty parts.
+func parseCommitList(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // lookupTool returns the provider for a given tool from the registry,

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -34,9 +34,10 @@ var providerDirIgnoreDirs = []string{
 type Mode int
 
 const (
-	ModeWorkspace Mode = iota // current workspace (staged + unstaged + untracked)
-	ModeCommit                // single commit vs its parent
-	ModeRange                 // merge-base(from,to)..to
+	ModeWorkspace   Mode = iota // current workspace (staged + unstaged + untracked)
+	ModeCommit                  // single commit vs its parent
+	ModeRange                   // merge-base(from,to)..to
+	ModeMultiCommit             // multiple commits combined
 )
 
 // Provider retrieves and parse git diffs from a repository.
@@ -49,6 +50,9 @@ type Provider struct {
 
 	// Commit mode parameter
 	commit string // single commit hash/ref
+
+	// Multi-commit mode parameters
+	commits []string // multiple commit hashes for combined review
 
 	mergeBase string // cached common ancestor for range mode
 }
@@ -69,6 +73,15 @@ func NewCommitProvider(repoDir, commit string) *Provider {
 		repoDir: repoDir,
 		mode:    ModeCommit,
 		commit:  commit,
+	}
+}
+
+// NewMultiCommitProvider creates a Provider for multi-commit mode: combined changes from multiple commits.
+func NewMultiCommitProvider(repoDir string, commits []string) *Provider {
+	return &Provider{
+		repoDir: repoDir,
+		mode:    ModeMultiCommit,
+		commits: commits,
 	}
 }
 
@@ -121,6 +134,9 @@ func (p *Provider) GetDiff() ([]model.Diff, error) {
 			return nil, fmt.Errorf("git show failed: %w", err)
 		}
 		combined.WriteString(out)
+
+	case ModeMultiCommit:
+		return p.getMultiCommitDiff()
 
 	case ModeWorkspace:
 		tracked, err := p.workspaceTrackedDiff()
@@ -241,6 +257,27 @@ func (p *Provider) filterDiffs(diffs []model.Diff) []model.Diff {
 }
 
 // ---- Internal helpers ----
+
+// getMultiCommitDiff generates a combined diff from multiple commits by running
+// git show for each commit individually, parsing the results, and merging them.
+func (p *Provider) getMultiCommitDiff() ([]model.Diff, error) {
+	diffSets := make([][]model.Diff, 0, len(p.commits))
+
+	for _, c := range p.commits {
+		out, err := p.runGit("show", "--no-color", "-U"+fmt.Sprint(DiffContextLines), c)
+		if err != nil {
+			return nil, fmt.Errorf("git show %s failed: %w", c, err)
+		}
+		diffs, err := ParseDiffText(out, p.repoDir)
+		if err != nil {
+			return nil, fmt.Errorf("parse diff for commit %s: %w", c, err)
+		}
+		diffSets = append(diffSets, diffs)
+	}
+
+	merged := MergeDiffs(diffSets...)
+	return p.filterDiffs(merged), nil
+}
 
 func (p *Provider) computeMergeBase(from, to string) string {
 	out, err := p.runGit("merge-base", from, to)

--- a/internal/diff/merge.go
+++ b/internal/diff/merge.go
@@ -1,0 +1,72 @@
+package diff
+
+import (
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+// MergeDiffs merges multiple slices of model.Diff (one per commit) into a single
+// combined diff set. Files that appear in multiple commits have their diff text
+// concatenated and their insertions/deletions summed.
+func MergeDiffs(diffSets ...[]model.Diff) []model.Diff {
+	if len(diffSets) == 0 {
+		return nil
+	}
+	if len(diffSets) == 1 {
+		return diffSets[0]
+	}
+
+	// Collect diffs by NewPath, preserving order of first appearance.
+	type entry struct {
+		diff       model.Diff
+		diffTexts  []string
+		seenCount  int
+	}
+	fileOrder := make([]string, 0)
+	fileMap := make(map[string]*entry)
+
+	for _, diffs := range diffSets {
+		for _, d := range diffs {
+			key := d.NewPath
+			if key == "/dev/null" {
+				key = d.OldPath
+			}
+			if e, ok := fileMap[key]; ok {
+				e.diffTexts = append(e.diffTexts, d.Diff)
+				e.diff.Insertions += d.Insertions
+				e.diff.Deletions += d.Deletions
+				e.seenCount++
+				// Merge flags: if any commit marks file as new/deleted, propagate.
+				if d.IsNew {
+					e.diff.IsNew = true
+				}
+				if d.IsDeleted {
+					e.diff.IsDeleted = true
+				}
+				if d.IsBinary {
+					e.diff.IsBinary = true
+				}
+			} else {
+				fileOrder = append(fileOrder, key)
+				e := &entry{
+					diff:      d,
+					diffTexts: []string{d.Diff},
+					seenCount: 1,
+				}
+				fileMap[key] = e
+			}
+		}
+	}
+
+	result := make([]model.Diff, 0, len(fileOrder))
+	for _, key := range fileOrder {
+		e := fileMap[key]
+		if e.seenCount > 1 {
+			e.diff.Diff = strings.Join(e.diffTexts, "\n\n")
+		}
+		result = append(result, e.diff)
+	}
+
+	return result
+}

--- a/internal/diff/merge_test.go
+++ b/internal/diff/merge_test.go
@@ -1,0 +1,150 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+func TestMergeDiffs_Empty(t *testing.T) {
+	result := MergeDiffs()
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestMergeDiffs_SingleSet(t *testing.T) {
+	input := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "hunk1", Insertions: 3, Deletions: 1},
+	}
+	result := MergeDiffs(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(result))
+	}
+	if result[0].Diff != "hunk1" {
+		t.Errorf("expected Diff 'hunk1', got %q", result[0].Diff)
+	}
+}
+
+func TestMergeDiffs_DisjointFiles(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "foo-change", Insertions: 2, Deletions: 1},
+	}
+	set2 := []model.Diff{
+		{OldPath: "a/bar.go", NewPath: "b/bar.go", Diff: "bar-change", Insertions: 5, Deletions: 3},
+	}
+	result := MergeDiffs(set1, set2)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(result))
+	}
+	paths := map[string]bool{result[0].NewPath: true, result[1].NewPath: true}
+	if !paths["b/foo.go"] || !paths["b/bar.go"] {
+		t.Errorf("expected foo.go and bar.go, got %v", result)
+	}
+}
+
+func TestMergeDiffs_SameFileAcrossCommits(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "hunk-from-commit1", Insertions: 3, Deletions: 1},
+	}
+	set2 := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "hunk-from-commit2", Insertions: 5, Deletions: 2},
+	}
+	result := MergeDiffs(set1, set2)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 merged diff, got %d", len(result))
+	}
+	d := result[0]
+	if d.Insertions != 8 {
+		t.Errorf("expected 8 insertions, got %d", d.Insertions)
+	}
+	if d.Deletions != 3 {
+		t.Errorf("expected 3 deletions, got %d", d.Deletions)
+	}
+	expected := "hunk-from-commit1\n\nhunk-from-commit2"
+	if d.Diff != expected {
+		t.Errorf("expected merged diff %q, got %q", expected, d.Diff)
+	}
+}
+
+func TestMergeDiffs_NewThenModify(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "/dev/null", NewPath: "b/new.go", Diff: "add-file", Insertions: 10, Deletions: 0, IsNew: true},
+	}
+	set2 := []model.Diff{
+		{OldPath: "a/new.go", NewPath: "b/new.go", Diff: "modify-file", Insertions: 2, Deletions: 1},
+	}
+	result := MergeDiffs(set1, set2)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 merged diff, got %d", len(result))
+	}
+	d := result[0]
+	if !d.IsNew {
+		t.Error("expected IsNew=true from first commit")
+	}
+	if d.Insertions != 12 {
+		t.Errorf("expected 12 insertions, got %d", d.Insertions)
+	}
+	if d.Deletions != 1 {
+		t.Errorf("expected 1 deletion, got %d", d.Deletions)
+	}
+}
+
+func TestMergeDiffs_DeletedFile(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "a/old.go", NewPath: "/dev/null", Diff: "delete-file", Insertions: 0, Deletions: 5, IsDeleted: true},
+	}
+	result := MergeDiffs(set1)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(result))
+	}
+	if !result[0].IsDeleted {
+		t.Error("expected IsDeleted=true")
+	}
+}
+
+func TestMergeDiffs_BinaryFile(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "a/image.png", NewPath: "b/image.png", Diff: "", IsBinary: true},
+	}
+	result := MergeDiffs(set1)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(result))
+	}
+	if !result[0].IsBinary {
+		t.Error("expected IsBinary=true")
+	}
+}
+
+func TestMergeDiffs_Mixed(t *testing.T) {
+	set1 := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "foo-c1", Insertions: 1, Deletions: 0},
+		{OldPath: "/dev/null", NewPath: "b/new.go", Diff: "new-c1", Insertions: 10, Deletions: 0, IsNew: true},
+	}
+	set2 := []model.Diff{
+		{OldPath: "a/foo.go", NewPath: "b/foo.go", Diff: "foo-c2", Insertions: 2, Deletions: 1},
+		{OldPath: "a/bar.go", NewPath: "b/bar.go", Diff: "bar-c2", Insertions: 3, Deletions: 0},
+	}
+	result := MergeDiffs(set1, set2)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 diffs, got %d", len(result))
+	}
+
+	// Find foo.go (merged across commits)
+	var fooDiff *model.Diff
+	for i := range result {
+		if result[i].NewPath == "b/foo.go" {
+			fooDiff = &result[i]
+			break
+		}
+	}
+	if fooDiff == nil {
+		t.Fatal("foo.go not found in result")
+	}
+	if fooDiff.Insertions != 3 {
+		t.Errorf("expected 3 insertions for foo.go, got %d", fooDiff.Insertions)
+	}
+	if fooDiff.Deletions != 1 {
+		t.Errorf("expected 1 deletion for foo.go, got %d", fooDiff.Deletions)
+	}
+}

--- a/plugins/open-code-review/commands/review.md
+++ b/plugins/open-code-review/commands/review.md
@@ -14,7 +14,7 @@ Run the OCR command:
 ocr review --audience agent [user-args]
 ```
 - Default (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode).
-- If the user provides `--commit` or `--c`: pass through as-is.
+- If the user provides `--commit` or `--c`: pass through as-is. Supports comma-separated hashes for multi-commit review (e.g., `--commit abc123,def456`).
 - If the user provides `--from` and `--to`: pass through as-is.
 - (Optional) Provide `--background "requirement context"` to review whether the requirements are correctly implemented.
 - Capture full stdout. Set a 5-minute timeout.

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -82,6 +82,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Background context** (RECOMMENDED): use `--background "context"` or `-b "context"` to provide business context for better review quality
 - **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
 - **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
+- **Multiple commits**: use `--commit hash1,hash2` to review multiple commits combined (e.g., your own commits interleaved with others')
 - **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
 - **Timeout**: default timeout is 10 minutes per file; adjust with `--timeout <minutes>`
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
@@ -95,6 +96,7 @@ ocr review --audience agent --background "business context here" [user-args]
 | "review my changes" / "review the working copy" | `ocr review --audience agent -b "context"` |
 | "review this PR" / "review feature branch" | `ocr review --audience agent -b "context" --from main --to <branch>` |
 | "review commit abc123" | `ocr review --audience agent -b "context" --commit abc123` |
+| "review my commits abc123 and def456" | `ocr review --audience agent -b "context" --commit abc123,def456` |
 | "what would be reviewed?" (dry-run) | `ocr review --preview` |
 
 **Output mode:**


### PR DESCRIPTION
## 关联 Issue

Closes #7

## 使用场景

当修复某个问题时，可能一次没有 commit 完全，期间又有其他人 commit 了，因此需要对个人的多次 commit 进行合并审查。

```bash
# 之前：只能审查单个 commit
ocr review --commit abc123

# 现在：支持合并审查多个 commit
ocr review --commit abc123,def456
```

## 实现方案

采用**纯 diff 合并**方式，保持项目只做只读 git 操作的设计原则：

1. 对每个 commit 分别执行 `git show`，解析为 `[]model.Diff`
2. 按文件路径合并：同一文件在多个 commit 中的变更进行 diff 文本拼接和增删行数累加
3. 不同文件保持独立，直接透传

### 向后兼容

`--commit abc123`（单个哈希）行为完全不变，只有传入逗号分隔的多个哈希时才走新的合并路径。

## 主要改动

| 文件 | 类型 | 说明 |
|------|------|------|
| `internal/diff/merge.go` | 新增 | `MergeDiffs` 多 commit diff 合并逻辑 |
| `internal/diff/merge_test.go` | 新增 | 8 个单元测试覆盖各种合并场景 |
| `internal/diff/git.go` | 修改 | 新增 `ModeMultiCommit`、`NewMultiCommitProvider`、`getMultiCommitDiff` |
| `internal/agent/agent.go` | 修改 | `loadDiffs` 支持逗号分隔 commit 路由到 `MultiCommitProvider` |
| `cmd/opencodereview/review_cmd.go` | 修改 | `FileReader.Ref` 使用最后一个 commit 哈希 |
| `cmd/opencodereview/flags.go` | 修改 | 更新 `--commit` 用法说明 |
| `cmd/testdiff/main.go` | 修改 | 测试工具支持多 commit |
| `README.md` / `README.zh-CN.md` | 修改 | 更新使用说明和示例 |
| `NPM-README.md` | 修改 | 更新使用说明 |
| `SKILL.md` | 修改 | 更新参数说明和调用模式 |
| `.claude/commands/` / `plugins/` | 修改 | 更新命令说明 |

## 测试

### 单元测试

```
=== RUN   TestMergeDiffs_Empty
--- PASS
=== RUN   TestMergeDiffs_SingleSet
--- PASS
=== RUN   TestMergeDiffs_DisjointFiles
--- PASS
=== RUN   TestMergeDiffs_SameFileAcrossCommits
--- PASS
=== RUN   TestMergeDiffs_NewThenModify
--- PASS
=== RUN   TestMergeDiffs_DeletedFile
--- PASS
=== RUN   TestMergeDiffs_BinaryFile
--- PASS
=== RUN   TestMergeDiffs_Mixed
--- PASS
```

### 端到端测试

使用 testdiff 工具在本仓库验证：

```bash
# 单个 commit（向后兼容）
go run ./cmd/testdiff -commit e6bac87 -summary
# 输出：1 file(s), +1/-1 lines

# 多个 commit 合并审查（同文件）
go run ./cmd/testdiff -commit e6bac87,8b87a45 -summary
# 输出：1 file(s), +2/-2 lines（insertions/deletions 正确累加）

# 多个 commit 合并审查（不同文件）
go run ./cmd/testdiff -commit 5f4e5a2,9a6a87b -summary
# 输出：7 file(s), +230/-0 lines
```