### PR TITLE
fix(viewer): add Host-header allowlist to block DNS rebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ ocr viewer
 ocr viewer --addr :3000
 ```
 
+### Viewer security
+
+The viewer serves session JSONL contents (LLM request messages and responses) over HTTP. It enforces a Host-header allowlist on every request: loopback names (`localhost`, `127.0.0.0/8`, `::1`) and the concrete bind host are always allowed. Wildcard binds (`--addr :3000`, `--addr 0.0.0.0:3000`) and other non-loopback Hostnames must be added via the `OCR_VIEWER_ALLOWED_HOSTS` environment variable (comma-separated):
+
+```bash
+OCR_VIEWER_ALLOWED_HOSTS=review.internal,ocr.lan ocr viewer --addr :3000
+```
+
+This blocks DNS-rebinding attacks against the local viewer.
+
 ## Review Rules
 
 OCR resolves review rules using a four-layer priority chain. Each layer uses first-match-wins: if a file path matches a pattern, that rule is used; otherwise it falls through to the next layer.

--- a/internal/viewer/hostguard.go
+++ b/internal/viewer/hostguard.go
@@ -1,0 +1,120 @@
+package viewer
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// EnvAllowedHosts is the environment variable users can set to extend the
+// default loopback allowlist with additional hostnames (comma-separated).
+const EnvAllowedHosts = "OCR_VIEWER_ALLOWED_HOSTS"
+
+// hostOnly returns the bare host portion of a Host header value, with any
+// port stripped and surrounding brackets removed from IPv6 literals. Empty
+// or malformed input returns "".
+func hostOnly(h string) string {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return ""
+	}
+	// SplitHostPort handles bracketed IPv6 ([::1]:5483) and host:port forms.
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		return strings.ToLower(host)
+	}
+	// No port. Strip brackets from a bare bracketed IPv6 literal like "[::1]".
+	if strings.HasPrefix(h, "[") && strings.HasSuffix(h, "]") {
+		return strings.ToLower(h[1 : len(h)-1])
+	}
+	// Reject a bare unbracketed IPv6 with embedded colons (ambiguous with port).
+	if strings.Count(h, ":") > 1 {
+		return ""
+	}
+	return strings.ToLower(h)
+}
+
+// isLoopbackHost reports whether host is a loopback name or IP literal that
+// is always safe to accept regardless of operator configuration.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1":
+		return true
+	}
+	// Any 127.0.0.0/8 IPv4 literal.
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return true
+	}
+	return false
+}
+
+// buildAllowedHosts returns the default-deny allowlist used by the host guard.
+// The set always includes the standard loopback names. If bindHost is a
+// concrete (non-wildcard) hostname or IP, it is also included so a user who
+// runs `ocr viewer --addr 192.168.1.10:5483` can still reach the UI at that
+// address. Wildcard binds (empty, 0.0.0.0, ::) are NOT auto-added — operators
+// who bind on a public interface must explicitly set OCR_VIEWER_ALLOWED_HOSTS,
+// which forces them to acknowledge the exposure.
+func buildAllowedHosts(bindHost string, envVal string) map[string]struct{} {
+	allowed := map[string]struct{}{
+		"localhost": {},
+		"127.0.0.1": {},
+		"::1":       {},
+	}
+	bh := strings.ToLower(strings.TrimSpace(bindHost))
+	if bh != "" && bh != "0.0.0.0" && bh != "::" && bh != "*" {
+		// Strip brackets from a bracketed IPv6 literal if present.
+		if strings.HasPrefix(bh, "[") && strings.HasSuffix(bh, "]") {
+			bh = bh[1 : len(bh)-1]
+		}
+		allowed[bh] = struct{}{}
+	}
+	for _, h := range strings.Split(envVal, ",") {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h != "" {
+			allowed[h] = struct{}{}
+		}
+	}
+	return allowed
+}
+
+// hostGuard returns a middleware that rejects requests whose Host header is
+// not on the allowlist. This blocks DNS-rebinding attacks against the local
+// viewer: an attacker page that resolves its own domain to 127.0.0.1 still
+// sends the attacker's domain in the Host header, which fails this check.
+func hostGuard(allowed map[string]struct{}, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := hostOnly(r.Host)
+		if host == "" {
+			http.Error(w, "forbidden host", http.StatusForbidden)
+			return
+		}
+		if isLoopbackHost(host) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if _, ok := allowed[host]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "forbidden host", http.StatusForbidden)
+	})
+}
+
+// splitBindHost returns the host portion of a listen address as passed to
+// http.Server.Addr. Empty input returns "".
+func splitBindHost(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
+}
+
+// resolveAllowedHostsFromEnv reads the OCR_VIEWER_ALLOWED_HOSTS environment
+// variable and combines it with the bind host to produce the active allowlist.
+func resolveAllowedHostsFromEnv(bindAddr string) map[string]struct{} {
+	return buildAllowedHosts(splitBindHost(bindAddr), os.Getenv(EnvAllowedHosts))
+}

--- a/internal/viewer/hostguard_test.go
+++ b/internal/viewer/hostguard_test.go
@@ -1,0 +1,161 @@
+package viewer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHostOnly(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"localhost", "localhost"},
+		{"localhost:5483", "localhost"},
+		{"127.0.0.1:5483", "127.0.0.1"},
+		{"[::1]:5483", "::1"},
+		{"[::1]", "::1"},
+		{"LOCALHOST", "localhost"},
+		{"example.com", "example.com"},
+		{"example.com:8080", "example.com"},
+		{"::1", ""}, // bare unbracketed IPv6 is ambiguous; reject
+		{"a:b:c", ""},
+	}
+	for _, c := range cases {
+		got := hostOnly(c.in)
+		if got != c.want {
+			t.Errorf("hostOnly(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	loopback := []string{"localhost", "127.0.0.1", "127.0.0.2", "::1"}
+	for _, h := range loopback {
+		if !isLoopbackHost(h) {
+			t.Errorf("isLoopbackHost(%q) = false, want true", h)
+		}
+	}
+	notLoopback := []string{"example.com", "192.168.1.10", "10.0.0.1", "8.8.8.8", ""}
+	for _, h := range notLoopback {
+		if isLoopbackHost(h) {
+			t.Errorf("isLoopbackHost(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestBuildAllowedHosts(t *testing.T) {
+	// Default: loopback only
+	a := buildAllowedHosts("", "")
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		if _, ok := a[h]; !ok {
+			t.Errorf("default allowlist missing %q", h)
+		}
+	}
+	if len(a) != 3 {
+		t.Errorf("default allowlist size = %d, want 3, got %v", len(a), a)
+	}
+
+	// Concrete bind host is auto-added
+	a = buildAllowedHosts("192.168.1.10", "")
+	if _, ok := a["192.168.1.10"]; !ok {
+		t.Errorf("concrete bind host not added: %v", a)
+	}
+
+	// Wildcard bind host is NOT auto-added (forces operator to set env var)
+	for _, bh := range []string{"0.0.0.0", "::", ""} {
+		a = buildAllowedHosts(bh, "")
+		if len(a) != 3 {
+			t.Errorf("wildcard bind %q: allowlist size = %d, want 3 (loopback only)", bh, len(a))
+		}
+	}
+
+	// Env extension parsed correctly
+	a = buildAllowedHosts("", "foo.example,bar.example , BAZ.example")
+	for _, h := range []string{"foo.example", "bar.example", "baz.example"} {
+		if _, ok := a[h]; !ok {
+			t.Errorf("env-allowlisted host %q missing: %v", h, a)
+		}
+	}
+}
+
+func TestSplitBindHost(t *testing.T) {
+	cases := map[string]string{
+		"":                "",
+		":5483":           "",
+		"localhost:5483":  "localhost",
+		"127.0.0.1:5483":  "127.0.0.1",
+		"[::1]:5483":      "::1",
+		"0.0.0.0:5483":    "0.0.0.0",
+		"192.168.1.10":    "192.168.1.10",
+	}
+	for in, want := range cases {
+		if got := splitBindHost(in); got != want {
+			t.Errorf("splitBindHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHostGuard(t *testing.T) {
+	body := []byte("session data leak")
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	})
+
+	cases := []struct {
+		name      string
+		bindAddr  string
+		envVal    string
+		hostHdr   string
+		wantCode  int
+		wantLeak  bool
+	}{
+		// Loopback always allowed
+		{"loopback-localhost", "localhost:5483", "", "localhost:5483", 200, true},
+		{"loopback-127", "localhost:5483", "", "127.0.0.1:5483", 200, true},
+		{"loopback-127-anyport", "localhost:5483", "", "127.0.0.1:1234", 200, true},
+		{"loopback-ipv6", "localhost:5483", "", "[::1]:5483", 200, true},
+
+		// Default bind => attacker host rejected (DNS rebinding case)
+		{"rebind-attacker", "localhost:5483", "", "attacker.example", 403, false},
+		{"rebind-with-port", "localhost:5483", "", "evil.com:5483", 403, false},
+		{"link-local-metadata", "localhost:5483", "", "169.254.169.254", 403, false},
+		{"public-ip-rebind", "localhost:5483", "", "8.8.8.8:5483", 403, false},
+
+		// Missing / empty Host header rejected
+		{"empty-host", "localhost:5483", "", "", 403, false},
+
+		// Concrete LAN bind: bind host is allowed, other names still rejected
+		{"lan-bind-self", "192.168.1.10:5483", "", "192.168.1.10:5483", 200, true},
+		{"lan-bind-attacker-rejected", "192.168.1.10:5483", "", "attacker.example", 403, false},
+
+		// Wildcard bind: only loopback allowed without env override
+		{"wildcard-bind-loopback-ok", "0.0.0.0:5483", "", "127.0.0.1:5483", 200, true},
+		{"wildcard-bind-attacker-rejected", "0.0.0.0:5483", "", "evil.example", 403, false},
+
+		// Env extension allows additional hosts
+		{"env-allowed", "0.0.0.0:5483", "ocr.lan,review.internal", "review.internal:5483", 200, true},
+		{"env-not-listed-rejected", "0.0.0.0:5483", "ocr.lan", "review.internal:5483", 403, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			allowed := buildAllowedHosts(splitBindHost(c.bindAddr), c.envVal)
+			h := hostGuard(allowed, inner)
+
+			req := httptest.NewRequest("GET", "http://test/", nil)
+			req.Host = c.hostHdr
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			if rr.Code != c.wantCode {
+				t.Errorf("status = %d, want %d", rr.Code, c.wantCode)
+			}
+			leaked := rr.Body.String() == string(body)
+			if leaked != c.wantLeak {
+				t.Errorf("leaked = %v, want %v (body=%q)", leaked, c.wantLeak, rr.Body.String())
+			}
+		})
+	}
+}

--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -46,9 +46,16 @@ func StartServer(addr string) error {
 		handleSession(w, r, root, repo, sid)
 	})
 
+	// Wrap the mux with a Host-header allowlist. Without this, any web page
+	// the user visits can DNS-rebind its origin to 127.0.0.1 and read the
+	// session JSONL exposed by this viewer (which contains LLM request bodies
+	// = source code being reviewed and the LLM's analysis of it).
+	allowed := resolveAllowedHostsFromEnv(addr)
+	guarded := hostGuard(allowed, mux)
+
 	srv := &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: guarded,
 	}
 
 	fmt.Printf("\nOpen browser: http://%s\n", addr)


### PR DESCRIPTION
## Summary

The viewer's HTTP server (`StartServer` in `internal/viewer/server.go`) accepts every request regardless of the `Host` header. A web page the user visits while `ocr viewer` is running can resolve its own domain to `127.0.0.1` (DNS rebinding) and then have the browser make same-origin requests to `http://127.0.0.1:5483/` and `/r/{repo}/{sessionID}` — exfiltrating every session JSONL the viewer exposes.

## Impact

Each session JSONL (`~/.opencodereview/sessions/<repo>/<session>.jsonl`) records:

- `llm_request` messages, which include the source code being reviewed,
- `llm_response` content, which is the LLM's analysis of that code,
- `tool_call` results (file reads, code searches), and
- `session_start` metadata: `cwd`, `gitBranch`, `model`.

A successful DNS-rebinding attack against a developer running `ocr viewer` reads all of that for every repo the developer has reviewed — including private repos and the model's review findings, which may themselves describe sensitive code paths.

## Location

`internal/viewer/server.go:49-55` — `http.Server{Handler: mux}` is wired with no `Host` validation; default `--addr localhost:5483` is not by itself a defense against DNS rebinding.

## Fix

A new `internal/viewer/hostguard.go`:

- `hostOnly` parses a `Host` header value (handles `host:port`, bracketed IPv6, case-insensitive matching, and rejects ambiguous bare unbracketed IPv6).
- `buildAllowedHosts` returns a default-deny set seeded with the standard loopback names (`localhost`, `127.0.0.1`, `::1`). If the bind host is a concrete hostname or IP it is also added; wildcard binds (`0.0.0.0`, `::`, empty) are NOT auto-added.
- `OCR_VIEWER_ALLOWED_HOSTS` (comma-separated) lets an operator extend the allowlist explicitly — required for any non-loopback bind.
- `hostGuard` is an `http.Handler` middleware that returns `403 forbidden host` on any `Host` not in the allowlist (loopback names always pass via `isLoopbackHost`, which also accepts the full `127.0.0.0/8` range).

`StartServer` wraps the existing mux with `hostGuard` before passing it to `http.Server`.

## Verification

```
go vet ./...                    # exit 0
go build ./...                  # exit 0
go test ./internal/viewer/...   # 5 tests / 25 subtests, all pass
go test ./...                   # all packages pass
```

New tests in `internal/viewer/hostguard_test.go` cover:

- `hostOnly` parsing (host:port stripping, bracketed IPv6, case, ambiguous-input rejection)
- `isLoopbackHost` recognition (`localhost`, `127.0.0.0/8`, `::1`)
- `buildAllowedHosts` (loopback baseline, concrete-bind-add, wildcard-bind-skip, env-extension parsing)
- `hostGuard` end-to-end: loopback variants → 200, attacker DNS-rebinding hosts → 403 with no body leak, LAN bind, wildcard bind + env override.

Verified that without the patch the inner handler returns the session payload to an attacker `Host`; with the patch it returns 403 and no body.

## Detected by

Aeon + manual review (semgrep / trufflehog / osv-scanner all surfaced no fix-PR-worthy finding here — `semgrep p/golang` flagged 1 unrelated `math/rand` jitter use, osv reported only stdlib/x/* CVEs already covered by the Go toolchain bump cadence).

- Severity: high
- CWE-346 (Origin Validation Error)
- CWE-200 (Exposure of Sensitive Information)

## Notes

- Default behavior for `ocr viewer` (no flag) is unchanged: `localhost:5483` keeps working, since `localhost` / `127.0.0.1` are in the loopback set.
- An operator who binds the viewer on a LAN interface and needs to reach it from another host now sets `OCR_VIEWER_ALLOWED_HOSTS=review.internal,ocr.lan ocr viewer --addr :3000` — surfacing the exposure as an explicit choice. Documented in the new "Viewer security" subsection of README.md.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
