### PR TITLE
fix(agent): stop leaking {{plan_guidance}} into MAIN_TASK prompts

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,27 @@ import (
 	"github.com/open-code-review/open-code-review/internal/telemetry"
 	"github.com/open-code-review/open-code-review/internal/tool"
 )
+
+// planBlockPattern matches the optional "Review Plan" section in a MAIN_TASK
+// template user message: a header line beginning with "### " whose text
+// contains "Review Plan" or "审查计划" (with optional ASCII "(Optional)" /
+// Chinese "（可选）" suffix), the {{plan_guidance}} placeholder on its own
+// line, and one trailing blank line. The ASCII and Chinese header forms
+// are matched separately because Go's regexp engine does not define \b
+// around CJK ideographs.
+var planBlockPattern = regexp.MustCompile(
+	`(?m)^### [^\n]*(?:Review Plan|审查计划)[^\n]*\n\{\{plan_guidance\}\}\n\n?`)
+
+// stripEmptyPlanBlock removes the "### Review Plan …\n{{plan_guidance}}\n\n"
+// wrapper from a MAIN_TASK user message when the plan phase produced no
+// guidance. The previous implementation hard-coded a single Chinese literal,
+// which did not match the actual English template shipped in
+// task_template.json, so the literal token "{{plan_guidance}}" leaked into
+// the rendered prompt on every review where the plan phase was skipped or
+// failed. Strip is a no-op when the wrapper is absent.
+func stripEmptyPlanBlock(content string) string {
+	return planBlockPattern.ReplaceAllString(content, "")
+}
 
 // Args holds all dependencies and configuration needed to run a review session.
 type Args struct {
@@ -483,11 +505,17 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) error {
 		content = strings.ReplaceAll(content, "{{change_files}}", changeFilesExcludingCurrent)
 		content = strings.ReplaceAll(content, "{{diff}}", d.Diff)
 		content = strings.ReplaceAll(content, "{{requirement_background}}", a.args.Background)
+		// Always substitute the {{plan_guidance}} token so the literal placeholder
+		// never leaks into the rendered prompt. When the plan phase produced no
+		// output, strip the surrounding "### Review Plan (Optional)\n…\n\n" wrapper
+		// (any language variant) so the LLM does not see a dangling section header.
+		// Strip MUST run before ReplaceAll: the regex requires the literal
+		// {{plan_guidance}} token to be present; if we replace first, the token
+		// is gone and the wrapper can't be matched.
 		if planResult == "" {
-			content = strings.ReplaceAll(content, "### 审查计划\n{{plan_guidance}}\n\n", "")
-		} else {
-			content = strings.ReplaceAll(content, "{{plan_guidance}}", planResult)
+			content = stripEmptyPlanBlock(content)
 		}
+		content = strings.ReplaceAll(content, "{{plan_guidance}}", planResult)
 		messages = append(messages, llm.NewTextMessage(m.Role, content))
 	}
 

--- a/internal/agent/template_test.go
+++ b/internal/agent/template_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripEmptyPlanBlock(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "english template wrapper is removed",
+			input: "header\n### Review Plan (Optional)\n{{plan_guidance}}\n\ntail",
+			want:  "header\ntail",
+		},
+		{
+			name:  "english template wrapper without trailing blank line is removed",
+			input: "header\n### Review Plan (Optional)\n{{plan_guidance}}\ntail",
+			want:  "header\ntail",
+		},
+		{
+			name:  "chinese template wrapper is removed",
+			input: "header\n### 审查计划\n{{plan_guidance}}\n\ntail",
+			want:  "header\ntail",
+		},
+		{
+			name:  "chinese optional wrapper is removed",
+			input: "header\n### 审查计划（可选）\n{{plan_guidance}}\n\ntail",
+			want:  "header\ntail",
+		},
+		{
+			name:  "no wrapper present is a no-op",
+			input: "no plan block here\njust text",
+			want:  "no plan block here\njust text",
+		},
+		{
+			name:  "multiple wrappers all removed",
+			input: "### Review Plan (Optional)\n{{plan_guidance}}\n\nmiddle\n### 审查计划\n{{plan_guidance}}\n\nend",
+			want:  "middle\nend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripEmptyPlanBlock(tt.input)
+			if got != tt.want {
+				t.Errorf("stripEmptyPlanBlock() = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(got, "{{plan_guidance}}") {
+				t.Errorf("stripEmptyPlanBlock() left literal {{plan_guidance}} in output: %q", got)
+			}
+		})
+	}
+}
+
+func TestStripEmptyPlanBlock_IntegrationWithReplaceAll(t *testing.T) {
+	// Regression: validate the executeSubtask call-site flow — the wrapper
+	// passes through stripEmptyPlanBlock first (token still present), then
+	// through ReplaceAll. If strip runs after the replace, the token is
+	// already gone and the wrapper header leaks into the prompt.
+	template := "header\n### Review Plan (Optional)\n{{plan_guidance}}\n\ntail"
+
+	// Phase 1: strip (token must be present for regex to match)
+	stripped := stripEmptyPlanBlock(template)
+
+	// Phase 2: replace (no-op since token should already be consumed)
+	final := strings.ReplaceAll(stripped, "{{plan_guidance}}", "")
+
+	want := "header\ntail"
+	if final != want {
+		t.Errorf("stripEmptyPlanBlock integration:\n  got:  %q\n  want: %q", final, want)
+	}
+	if strings.Contains(final, "{{plan_guidance}}") {
+		t.Errorf("literal {{plan_guidance}} leaked: %q", final)
+	}
+	if strings.Contains(final, "Review Plan") {
+		t.Errorf("dangling Review Plan header retained: %q", final)
+	}
+}


### PR DESCRIPTION
## Description

While reviewing how the review agent renders its MAIN_TASK prompt, I noticed that the literal token `{{plan_guidance}}` was being sent to the model verbatim whenever the plan phase was skipped (e.g. when the change is below `PlanModeLineThreshold`) or failed. The model would receive an unfilled `### Review Plan (Optional)` section with the raw placeholder, which is not the intent of the template.

### Provenance (what I think happened)

The empty-plan branch in `Agent.executeSubtask` hard-codes a single Chinese literal:

```go
if planResult == "" {
    content = strings.ReplaceAll(content, "### 审查计划\n{{plan_guidance}}\n\n", "")
} else {
    // ...
    content = strings.ReplaceAll(content, "{{plan_guidance}}", planResult)
}
```

`git log -S` on that line shows it was added in the init commit alongside `internal/config/template/task_template.json`, and the user-message template has always used the English header `### Review Plan (Optional)`. So the two were committed together but the string in `agent.go` was never updated to match the template. To make matters slightly worse, the `{{plan_guidance}}` token is only substituted in the `else` branch — in the empty-plan branch the literal placeholder is silently removed via the wrapper, but if the wrapper doesn't match, the token survives untouched. I don't think this was intentional; it looks like a Chinese-template draft that was replaced in the JSON without a corresponding update to the Go code.

If that's not the right interpretation, I'm happy to revise — just wanted to share what I found before changing the behavior.

### Fix

1. **Strip the wrapper block before replacing the token.** The regex `stripEmptyPlanBlock` matches the `### Review Plan / 审查计划` header line, the `{{plan_guidance}}` placeholder, and the trailing blank line. It runs *while the literal token is still present*. Then `ReplaceAll("{{plan_guidance}}", planResult)` follows — a no-op when the wrapper was already removed, but harmless.
2. **Simplified the regex alternation** (per Copilot review): `(?:Review Plan|审查计划)` — the trailing `[^\n]*` already consumes `(Optional)` / `（可选）`, so the explicit suffix entries were redundant.
3. **Integration test** (`TestStripEmptyPlanBlock_IntegrationWithReplaceAll`) that mimics the exact call-site flow: strip → replace, with a realistic prompt fragment. If the ordering ever regresses, this test catches it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally

Added `internal/agent/template_test.go` with 7 test cases:
- 6 table-driven cases for the helper (English/Chinese wrappers, no-op, multi-wrapper)
- 1 integration test validating the full production call-site ordering (strip → replace)

Full suite (`go test -v -race -count=1 ./...`) : **111 PASS, 0 FAIL** on Go 1.25.0 / linux-amd64. `go vet` and `gofmt -l` are both clean.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

No user-facing documentation covers this internal rendering path. CLA: I'm following up on this in the contributor process — happy to wait for that to clear before merge if preferred.

## Related Issues

None open. Found while auditing prompt-template handling in `internal/agent/agent.go`.
