### PR TITLE
fix: handle Windows paths in session encodeRepoPath

### DIFF
--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -55,8 +55,30 @@ func generateUUID() string {
 }
 
 func encodeRepoPath(p string) string {
-	p = strings.TrimPrefix(p, "/")
-	return strings.ReplaceAll(p, "/", "-")
+	// Handle empty or invalid input
+	if p == "" {
+		return "empty"
+	}
+
+	vol := filepath.VolumeName(p)
+	p = p[len(vol):]
+
+	// Trim leading path separators
+	p = strings.TrimLeft(p, "/\\")
+
+	// Replace separators with -
+	p = strings.ReplaceAll(p, "/", "-")
+	p = strings.ReplaceAll(p, "\\", "-")
+
+	// Replace colons (from Windows drive letters)
+	vol = strings.ReplaceAll(vol, ":", "_")
+
+	// Handle edge case where path was only separators or volume name
+	result := vol + p
+	if result == "" {
+		return "empty"
+	}
+	return result
 }
 
 func (jw *jsonlWriter) open() error {

--- a/internal/session/persist_test.go
+++ b/internal/session/persist_test.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestEncodeRepoPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "empty",
+		},
+		{
+			name:     "relative path",
+			input:    "relative/path/to/repo",
+			expected: "relative-path-to-repo",
+		},
+		{
+			name:     "path with mixed separators",
+			input:    "path/to\\mixed",
+			expected: "path-to-mixed",
+		},
+	}
+
+	// Add platform-specific test cases
+	if runtime.GOOS == "windows" {
+		tests = append(tests, []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{
+				name:     "windows drive path",
+				input:    "D:\\Users\\admin\\project",
+				expected: "D_Users-admin-project",
+			},
+			{
+				name:     "windows C drive",
+				input:    "C:\\code\\myapp",
+				expected: "C_code-myapp",
+			},
+			{
+				name:     "windows relative path",
+				input:    "relative\\path\\to\\repo",
+				expected: "relative-path-to-repo",
+			},
+			{
+				name:     "windows drive only",
+				input:    "C:",
+				expected: "C_",
+			},
+			{
+				name:     "windows drive with separator only",
+				input:    "D:\\",
+				expected: "D_",
+			},
+		}...)
+	} else {
+		tests = append(tests, []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{
+				name:     "unix absolute path",
+				input:    "/home/user/project",
+				expected: "home-user-project",
+			},
+			{
+				name:     "unix nested path",
+				input:    "/Users/john/dev/myapp",
+				expected: "Users-john-dev-myapp",
+			},
+			{
+				name:     "unix root only",
+				input:    "/",
+				expected: "empty",
+			},
+		}...)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := encodeRepoPath(tt.input)
+			if result != tt.expected {
+				t.Errorf("encodeRepoPath(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
Make encodeRepoPath cross-platform by properly handling volume names, backslash separators, and drive letter colons. Add unit tests covering Unix, Windows, and edge-case inputs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
Issue #34 