### PR TITLE
chore: update ci pipeline examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,10 @@ The core command for CI integration:
 ocr review \
   --from "origin/main" \
   --to "origin/feature-branch" \
-  --format json \
-  --audience agent
+  --format json
 ```
 
-The `--format json` and `--audience agent` flags output machine-readable results suitable for parsing in CI scripts.
+The `--format json` flag outputs machine-readable results suitable for parsing in CI scripts.
 
 See the [`examples/`](./examples/) directory for integration examples:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,11 +208,10 @@ CI 集成的核心命令：
 ocr review \
   --from "origin/main" \
   --to "origin/feature-branch" \
-  --format json \
-  --audience agent
+  --format json
 ```
 
-`--format json` 和 `--audience agent` 参数输出适合 CI 脚本解析的机器可读结果。
+`--format json` 参数输出适合 CI 脚本解析的机器可读结果。
 
 集成示例请参见 [`examples/`](./examples/) 目录：
 

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -95,7 +95,6 @@ jobs:
             --from "origin/${BASE_REF}" \
             --to "origin/${HEAD_REF}" \
             --format json \
-            --audience agent \
             > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
 
           echo "OCR review completed. Output:"
@@ -111,12 +110,11 @@ jobs:
             const fs = require('fs');
             const path = '/tmp/ocr-result.json';
 
-            // Read OCR output (skip first line which is not valid JSON)
+            // Read OCR output
             let result;
             try {
               const raw = fs.readFileSync(path, 'utf8');
-              const jsonContent = raw.substring(raw.indexOf('\n') + 1);
-              result = JSON.parse(jsonContent);
+              result = JSON.parse(raw);
             } catch (e) {
               console.log('Failed to parse OCR output:', e.message);
               // Post a simple comment if parsing fails

--- a/examples/gitlab_ci/.gitlab-ci.yml
+++ b/examples/gitlab_ci/.gitlab-ci.yml
@@ -42,7 +42,6 @@ code-review:
         --from "origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" \
         --to "origin/${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}" \
         --format json \
-        --audience agent \
         > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
       echo "OCR review completed."
       cat /tmp/ocr-result.json
@@ -139,10 +138,9 @@ code-review:
 
       # --- Main ---
 
-      # Read OCR result (skip first line which is summary, not JSON)
+      # Read OCR result
       try:
           with open("/tmp/ocr-result.json", "r") as f:
-              next(f)  # Skip first line
               result = json.load(f)
       except (FileNotFoundError, json.JSONDecodeError) as e:
           print(f"Failed to parse OCR output: {e}", file=sys.stderr)

--- a/examples/gitlab_ci/.gitlab-ci.yml
+++ b/examples/gitlab_ci/.gitlab-ci.yml
@@ -27,7 +27,7 @@ code-review:
 
     # Configure OCR
     - mkdir -p ~/.open-code-review
-    # Gitlab CI/CD does not support confuring variables with value length less than 8, so you can't set use_anthropic as a CI variable
+    # Gitlab CI/CD does not support setting variables with value length less than 8, so you can't set use_anthropic as a CI variable
     - |
       ocr config set llm.url $OCR_LLM_URL
       ocr config set llm.auth_token $OCR_LLM_AUTH_TOKEN

--- a/examples/gitlab_ci/README.md
+++ b/examples/gitlab_ci/README.md
@@ -172,8 +172,7 @@ script:
         "ocr", "review",
         "--from", f"origin/{TARGET_BRANCH}",
         "--to", f"origin/{SOURCE_BRANCH}",
-        "--format", "json",
-        "--audience", "agent"
+        "--format", "json"
     ], capture_output=True, text=True)
 
     # Save output for the posting script


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
This pull request updates documentation and CI example scripts to remove the obsolete `--audience agent` flag from the `ocr review` command, reflecting recent changes to the command-line interface. It also simplifies the parsing logic for the OCR output in both GitHub Actions and GitLab CI examples, as the output is now valid JSON without a summary line.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)
Tested in github actions and gitlab ci, no issues found

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
