### PR TITLE
fix(agent): user includes should have higher priority than system sup…

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -53,13 +53,13 @@ func (a *Agent) whyExcluded(d model.Diff) ExcludeReason {
 		return ExcludeUserRule
 	}
 
+	if f != nil && f.HasInclude() && f.IsUserIncluded(path) {
+		return ExcludeNone
+	}
+
 	ext := a.extFromPath(path)
 	if ext != "" && !allowedext.IsAllowedExt(ext) {
 		return ExcludeExtension
-	}
-
-	if f != nil && f.HasInclude() && f.IsUserIncluded(path) {
-		return ExcludeNone
 	}
 
 	if allowedext.IsExcludedPath(path) {

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -207,7 +207,7 @@ func TestWhyExcluded_DefaultPathFilter(t *testing.T) {
 func TestWhyExcluded_UserIncludePattern(t *testing.T) {
 	agent := New(Args{
 		FileFilter: &rules.FileFilter{
-			Include: []string{"src/**/*.go", "pkg/**/*.go"},
+			Include: []string{"src/**/*.go", "pkg/**/*.go", "**/*.supportedext"},
 		},
 	})
 
@@ -260,13 +260,12 @@ func TestWhyExcluded_UserIncludePattern(t *testing.T) {
 			},
 			expected: ExcludeNone,
 		},
-		// --- Extension filter still takes precedence over include logic ---
 		{
-			name: "unsupported extension excluded before include check",
+			name: "include check overrides extension exclusion",
 			diff: model.Diff{
-				NewPath: "docs/readme.md",
+				NewPath: "internal/test.supportedext",
 			},
-			expected: ExcludeExtension,
+			expected: ExcludeNone,
 		},
 		{
 			name: "unsupported extension even if path looks like include dir",


### PR DESCRIPTION
## Description

This PR simply allows the user to override the exclude list of allows extensions by explicitly including files in the rules set.

Before this change it was not possible to have e.g.:

```json
{
    "include": ["*.po", "*.xlf"]
}
```
in your rules.json file and have it work because the files would be excluded before the `include` rules are tested.

This feature was documented and tested for, but I do not think this is expected an beheviour, however I am open to be convinced otherwise :)


<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Tested 

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
