### PR TITLE
ci: add PR auto-review workflow (self-hosted + codex)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,312 @@
+# OpenCodeReview - PR Auto-Review (self-hosted runner + Codex subscription)
+#
+# Runs on a self-hosted macOS runner where:
+#   - `codex` CLI is installed and logged in via ChatGPT subscription
+#   - a prebuilt `ocr` binary (with the codex provider) lives at ~/.local/bin/ocr
+#
+# No LLM secrets required: OCR_LLM_PROTOCOL=codex delegates auth to the
+# local Codex CLI session (~/.codex/auth.json), which self-refreshes.
+#
+# Triggers:
+#   - PR opened
+#   - Comment on PR containing '/open-code-review' or '@open-code-review'
+
+name: OpenCodeReview PR Review
+
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Codex account auth must not be shared across concurrent jobs
+# (single-ownership requirement for ChatGPT-managed auth). Serialize all runs.
+concurrency:
+  group: ocr-review
+  cancel-in-progress: false
+
+jobs:
+  code-review:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    # Run on PR events, or on comments starting with trigger keywords
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/open-code-review')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '@open-code-review'))
+    steps:
+      - name: Get PR context
+        id: pr-context
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // For issue_comment events, get PR info
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_ref', pullRequest.head.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history needed for merge-base diff
+          ref: ${{ github.event_name != 'pull_request' && steps.pr-context.outputs.head_sha || '' }}
+
+      - name: Set up PATH for ocr and codex
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
+      - name: Run OpenCodeReview (codex backend)
+        id: review
+        env:
+          OCR_LLM_PROTOCOL: codex
+        run: |
+          # Get base and head refs from PR context (different for comment triggers)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          else
+            BASE_REF="${{ steps.pr-context.outputs.base_ref }}"
+            HEAD_REF="${{ steps.pr-context.outputs.head_ref }}"
+          fi
+
+          echo "Reviewing PR: ${HEAD_REF} against ${BASE_REF}"
+
+          # Run OCR in range mode with JSON output
+          ocr review \
+            --from "origin/${BASE_REF}" \
+            --to "origin/${HEAD_REF}" \
+            --format json \
+            > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
+
+          echo "OCR review completed. Output:"
+          cat /tmp/ocr-result.json
+          echo "OCR review completed. Error log:"
+          cat /tmp/ocr-stderr.log
+
+      - name: Post review comments to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = '/tmp/ocr-result.json';
+
+            // Read OCR output
+            let result;
+            try {
+              const raw = fs.readFileSync(path, 'utf8');
+              result = JSON.parse(raw);
+            } catch (e) {
+              console.log('Failed to parse OCR output:', e.message);
+              // Post a simple comment if parsing fails
+              const stderr = fs.readFileSync('/tmp/ocr-stderr.log', 'utf8').trim();
+              if (stderr) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `⚠️ **OpenCodeReview** encountered an error:\n\`\`\`\n${stderr}\n\`\`\``
+                });
+              }
+              return;
+            }
+
+            const comments = result.comments || [];
+            const warnings = result.warnings || [];
+
+            // If no comments, post a summary
+            if (comments.length === 0) {
+              const message = result.message || 'No comments generated. Looks good to me.';
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `✅ **OpenCodeReview**: ${message}`
+              });
+              return;
+            }
+
+            // Prepare PR review with inline comments
+            const prNumber = context.issue.number;
+            let commitSha;
+
+            // Get commit SHA from event context
+            if (context.eventName === 'pull_request') {
+              commitSha = context.payload.pull_request.head.sha;
+            } else {
+              // For comment events, we need to fetch the PR
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              commitSha = pullRequest.head.sha;
+            }
+
+            // Build review comments array for the PR review API
+            // Only inline comments with line info can be posted via createReview
+            const reviewComments = [];
+            const commentsWithoutLine = [];
+
+            for (const comment of comments) {
+              const body = formatComment(comment);
+
+              // Check if comment has valid line information for inline comment (line >= 1)
+              const hasValidLine = (comment.start_line >= 1) || (comment.end_line >= 1);
+              if (!hasValidLine) {
+                commentsWithoutLine.push({ comment, body });
+                continue;
+              }
+
+              const reviewComment = {
+                path: comment.path,
+                body: body
+              };
+
+              // Use line range if available
+              if (comment.start_line >= 1 && comment.end_line >= 1 && comment.start_line !== comment.end_line) {
+                reviewComment.start_line = comment.start_line;
+                reviewComment.line = comment.end_line;
+                reviewComment.start_side = 'RIGHT';
+                reviewComment.side = 'RIGHT';
+              } else if (comment.end_line >= 1) {
+                reviewComment.line = comment.end_line;
+                reviewComment.side = 'RIGHT';
+              } else if (comment.start_line >= 1) {
+                reviewComment.line = comment.start_line;
+                reviewComment.side = 'RIGHT';
+              }
+
+              reviewComments.push(reviewComment);
+            }
+
+            // Submit as a single PR review with all comments
+            const totalCount = comments.length;
+            const inlineCount = reviewComments.length;
+            const summaryCount = commentsWithoutLine.length;
+            let summaryBody = `🔍 **OpenCodeReview** found **${totalCount}** issue(s) in this PR.`;
+            if (totalCount > 0) {
+              summaryBody += `\n- ✅ ${inlineCount} posted as inline comment(s)`;
+              summaryBody += `\n- 📝 ${summaryCount} posted as summary (missing line info)`;
+            }
+            if (warnings.length > 0) {
+              summaryBody += `\n\n⚠️ ${warnings.length} warning(s) occurred during review.`;
+            }
+
+            // Add comments without line info to summary body
+            for (const { comment, body } of commentsWithoutLine) {
+              summaryBody += '\n\n---\n\n';
+              summaryBody += formatCommentMarkdown(comment);
+            }
+
+            // Statistics tracking
+            let successCount = 0;
+            let failedCount = 0;
+            const failedComments = [];
+
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                commit_id: commitSha,
+                body: summaryBody,
+                event: 'COMMENT',
+                comments: reviewComments
+              });
+              successCount = reviewComments.length;
+              console.log(`Successfully posted review with ${successCount} inline comments (${commentsWithoutLine.length} in summary)`);
+            } catch (e) {
+              console.log('Failed to post review with inline comments:', e.message);
+              console.log('Falling back to posting comments individually...');
+
+              // Fallback: post comments one by one
+              for (const reviewComment of reviewComments) {
+                try {
+                  await github.rest.pulls.createReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                    commit_id: commitSha,
+                    body: '',
+                    event: 'COMMENT',
+                    comments: [reviewComment]
+                  });
+                  successCount++;
+                  console.log(`Successfully posted comment for ${reviewComment.path}`);
+                } catch (innerE) {
+                  failedCount++;
+                  failedComments.push({ comment: reviewComment, error: innerE.message });
+                  console.log(`Failed to post comment for ${reviewComment.path}: ${innerE.message}`);
+                }
+              }
+
+              // Post summary comment with statistics
+              let finalBody = summaryBody;
+              finalBody += `\n\n---\n\n📊 **Posting Statistics:**`;
+              finalBody += `\n- ✅ Successfully posted: ${successCount} comment(s)`;
+              if (failedCount > 0) {
+                finalBody += `\n- ❌ Failed to post: ${failedCount} comment(s)`;
+              }
+
+              // Add failed comments details
+              if (failedComments.length > 0) {
+                finalBody += '\n\n<details><summary>❌ Failed Comments Details</summary>\n\n';
+                for (const { comment, error } of failedComments) {
+                  finalBody += `- \`${comment.path}\`: ${error}\n`;
+                }
+                finalBody += '\n</details>';
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: finalBody
+              });
+            }
+
+            function formatComment(comment) {
+              let body = comment.content || '';
+
+              // Add code suggestion if available
+              if (comment.suggestion_code && comment.existing_code) {
+                body += '\n\n**Suggestion:**\n';
+                body += '```suggestion\n';
+                body += comment.suggestion_code;
+                if (!comment.suggestion_code.endsWith('\n')) body += '\n';
+                body += '```';
+              }
+
+              return body;
+            }
+
+            function formatCommentMarkdown(comment) {
+              let md = `### 📄 \`${comment.path}\``;
+              if (comment.start_line && comment.end_line) {
+                md += ` (L${comment.start_line}-L${comment.end_line})`;
+              }
+              md += '\n\n';
+              md += comment.content || '';
+
+              if (comment.suggestion_code && comment.existing_code) {
+                md += '\n\n<details><summary>💡 Suggested Change</summary>\n\n';
+                md += '**Before:**\n```\n' + comment.existing_code + '\n```\n\n';
+                md += '**After:**\n```\n' + comment.suggestion_code + '\n```\n\n';
+                md += '</details>';
+              }
+
+              return md;
+            }


### PR DESCRIPTION
Add automatic PR review via OpenCodeReview running on a self-hosted macOS runner, using the Codex CLI (ChatGPT subscription auth) as the LLM backend.

- `runs-on: self-hosted`, serialized via concurrency group (codex auth single-ownership)
- No LLM secrets needed: `OCR_LLM_PROTOCOL=codex` delegates to local codex login
- Uses prebuilt `~/.local/bin/ocr` binary with the codex provider

This PR itself doubles as the end-to-end test of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)