### PR TITLE
docs: add Japanese document

### DIFF
--- a/CONTRIBUTING.ja-JP.md
+++ b/CONTRIBUTING.ja-JP.md
@@ -1,0 +1,218 @@
+# OpenCodeReviewへのコントリビューション
+
+OpenCodeReviewへのコントリビューションに興味を持っていただきありがとうございます！タイポの修正、バグ報告、新機能の実装など、あらゆる貢献が重要です。
+
+[English Version](CONTRIBUTING.md) | [简体中文版](CONTRIBUTING.zh-CN.md)
+
+## 行動規範
+
+このプロジェクトに参加することで、敬意と包摂性のある環境を維持することに同意したことになります。すべてのやり取りにおいて、親切かつ建設的であるよう心がけてください。
+
+## コントリビューションの方法
+
+コードを書く以外にも、さまざまな貢献の方法があります：
+
+- **バグ報告** — 何か壊れているものを見つけましたか？再現手順を添えてissueを開いてください。
+- **機能提案** — 改善のアイデアがありますか？[GitHub Discussions](https://github.com/alibaba/open-code-review/discussions/categories/ideas)で会話を始めるか、[Feature Request](https://github.com/alibaba/open-code-review/issues/new?template=feature_request.yml) issueを開くことができます。
+- **ドキュメントの改善** — タイポの修正、説明の明確化、例の追加など。問題の報告には[Documentation Issue](https://github.com/alibaba/open-code-review/issues/new?template=docs_report.yml)を開くこともできます。
+- **プルリクエストのレビュー** — 他のコントリビューターのコードレビューを手伝ってください。
+- **コードを書く** — バグ修正、機能追加、パフォーマンス改善など。
+
+## はじめに
+
+### 前提条件
+
+- [Go 1.25+](https://go.dev/dl/)
+- [Git](https://git-scm.com/)
+- [Make](https://www.gnu.org/software/make/)
+
+### セットアップ
+
+```bash
+# 1. GitHubでリポジトリをフォーク
+
+# 2. フォークをクローン
+git clone https://github.com/<your-username>/open-code-review.git
+cd open-code-review
+
+# 3. upstreamリモートを追加（メインリポジトリから更新を同期するため）
+git remote add upstream https://github.com/alibaba/open-code-review.git
+
+# 4. プロジェクトをビルド
+make build
+
+# 5. テストを実行
+make test
+```
+
+すべてパスすれば、コントリビューションの準備完了です。
+
+> **注意:** `upstream`リモートはコントリビューターにとって読み取り専用です — メインリポジトリから最新の変更を取得するために使います。upstreamに直接プッシュすることはできません。すべてのコントリビューションは自分のフォーク（`origin`）にプッシュし、Pull Request経由で提出する必要があります。
+
+## 開発ワークフロー
+
+### ブランチ運用
+
+`main`からフィーチャーブランチを作成します：
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b feat/your-feature-name
+```
+
+変更の種類を示すプレフィックスを使用してください：
+
+| プレフィックス | 用途                                  |
+| ----------- | ------------------------------------- |
+| `feat/`     | 新機能                                |
+| `fix/`      | バグ修正                              |
+| `docs/`     | ドキュメントのみ                      |
+| `refactor/` | コードのリファクタリング（動作変更なし） |
+| `test/`     | テストの追加・更新                    |
+| `chore/`    | ビルド、CI、ツーリングの変更          |
+
+### コミットメッセージ
+
+[Conventional Commits](https://www.conventionalcommits.org/)形式に従ってください：
+
+```
+<type>(<scope>): <short summary>
+
+[optional body]
+```
+
+例：
+
+```
+feat(agent): add support for custom tool definitions
+fix(llm): handle timeout errors in Anthropic API calls
+docs(README): update configuration examples
+```
+
+### コード品質
+
+変更を提出する前に、すべてのチェックをパスすることを確認してください：
+
+```bash
+# フォーマットとリント（Go標準ツーリング）
+go fmt ./...
+go vet ./...
+
+# レース検出付きでテストを実行
+make test
+
+# ビルドが成功すること
+make build
+```
+
+### プロジェクト構成
+
+```
+├── cmd/opencodereview/   # CLIエントリーポイント
+├── internal/
+│   ├── agent/            # レビューエージェントのロジック
+│   ├── config/           # 設定管理
+│   ├── diff/             # Git diffのパース
+│   ├── llm/              # LLM APIクライアント（Anthropic & OpenAI）
+│   ├── model/            # データモデル
+│   ├── session/          # レビューセッション管理
+│   ├── tool/             # 組み込みツール（file_read、code_searchなど）
+│   ├── telemetry/        # OpenTelemetry統合
+│   └── viewer/           # WebUIセッションビューアー
+├── pages/                # WebUIフロントエンド
+├── scripts/              # ビルド & インストールスクリプト
+└── bin/                  # NPMラッパー
+```
+
+## ドキュメントへのコントリビューション
+
+ドキュメントはOpenCodeReviewの重要な一部です。READMEファイル、インラインコードコメント、設定例、その他ユーザー向けテキストの改善を歓迎します。
+
+### ドキュメントコントリビューションに該当するもの
+
+- タイポ、文法エラー、リンク切れの修正
+- 分かりにくい説明の明確化や不足しているコンテキストの追加
+- コマンドや設定オプションの使用例の追加
+- 古くなった内容の更新（機能変更後など）
+- 中国語ドキュメント（`README.zh-CN.md`、`CONTRIBUTING.zh-CN.md`）の翻訳や改善
+
+### ドキュメントのワークフロー
+
+1. 問題を見つけたが自分で修正する予定がない場合は、[Documentation Issue](https://github.com/alibaba/open-code-review/issues/new?template=docs_report.yml)を開いてください。
+2. 自分で修正したい場合は、リポジトリをフォークし、変更を加え、`docs/`ブランチプレフィックス（例：`docs/fix-config-example`）でPRを提出してください。
+3. ドキュメントのみのPRにテストの変更は不要ですが、含めるコマンドやコードスニペットが正確であることを確認してください。
+
+### ドキュメントファイル
+
+| ファイル                | 用途                                 |
+| ----------------------- | ------------------------------------ |
+| `README.md`             | メインのプロジェクトドキュメント（英語） |
+| `README.zh-CN.md`       | 中国語訳                             |
+| `CONTRIBUTING.md`       | コントリビューションガイド（英語）   |
+| `CONTRIBUTING.zh-CN.md` | コントリビューションガイド（中国語） |
+
+## 変更の提出
+
+### Issueを開く
+
+大きな変更に取り組む前に、まずissueを開いてアプローチについて議論してください。これにより、作業の重複を防ぎ、コントリビューションがプロジェクトの方向性と一致することを確認できます。
+
+バグを報告する際は、以下を含めてください：
+
+1. OpenCodeReviewのバージョン（`ocr version`）
+2. OSとアーキテクチャ
+3. 再現手順
+4. 期待される動作と実際の動作
+5. 関連するログやエラーメッセージ
+
+### Pull Requestのプロセス
+
+1. **PRはフォーカスを絞る** — 1つのPRには1つの論理的な変更のみ。複数の独立した変更がある場合は、別々のPRとして提出してください。
+2. **テストを書く** — 動作の変更にはテストを追加・更新してください。
+3. **ドキュメントを更新する** — 変更がユーザー向けの動作に影響する場合は、関連ドキュメントを更新してください。
+4. **CLAに署名する** — すべてのコントリビューターは、PRがマージされる前にContributor License Agreementに署名する必要があります（下記参照）。
+5. **PRテンプレートに記入する** — 変更の内容と理由を記述してください。
+
+### PRタイトルの形式
+
+コミットメッセージと同じConventional Commits形式を使用してください：
+
+```
+feat(agent): add support for custom tool definitions
+```
+
+### レビュープロセス
+
+- メンテナーがPRをレビューします。通常は数営業日以内です。
+- 変更をお願いすることがあります — これは通常の協力的なプロセスであり、敵対的なものではありません。
+- 承認されると、メンテナーがPRをマージします。
+
+## Contributor License Agreement（CLA）
+
+コントリビューションをマージする前に、すべてのコントリビューターにAlibaba Open Source Contributor License Agreementへの署名をお願いしています。これにより、プロジェクトがライセンス条項の下で配布できることが保証されます。
+
+最初のPRを開くと、CLAボットが手順を記載したコメントを投稿します。リンクをたどって電子署名するだけです — 1分もかかりません。
+
+## 初めてのコントリビューター
+
+プロジェクトは初めてですか？以下のラベルが付いたissueを探してみてください：
+
+- [`good first issue`](https://github.com/alibaba/open-code-review/labels/good%20first%20issue) — 始めるのに最適な、小さくスコープが明確なタスク。
+- [`help wanted`](https://github.com/alibaba/open-code-review/labels/help%20wanted) — コミュニティの協力を歓迎するissue。
+
+始めるのに適した領域：
+
+- エラーメッセージやCLI出力の改善
+- テストされていないコードパスへのテストの作成
+- ドキュメントの改善
+
+## コミュニティ
+
+- **バグ報告** — [GitHub Issues](https://github.com/alibaba/open-code-review/issues)
+- **機能提案** — [GitHub Discussions (Ideas)](https://github.com/alibaba/open-code-review/discussions/categories/ideas)または[Feature Request Issue](https://github.com/alibaba/open-code-review/issues/new?template=feature_request.yml)
+- **質問 & ヘルプ** — OpenCodeReviewの使い方について質問があれば、お気軽に[GitHub Discussions](https://github.com/alibaba/open-code-review/discussions)で質問してください
+
+## ライセンス
+
+OpenCodeReviewにコントリビューションすることで、あなたのコントリビューションが[Apache License 2.0](LICENSE)の下でライセンスされることに同意したことになります。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to OpenCodeReview! Every contribution matters — whether it's fixing a typo, reporting a bug, or implementing a new feature.
 
-[简体中文版](CONTRIBUTING.zh-CN.md)
+[简体中文版](CONTRIBUTING.zh-CN.md) | [日本語版](CONTRIBUTING.ja-JP.md)
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -2,7 +2,7 @@
 
 感谢你对 OpenCodeReview 的关注！无论是修复拼写错误、报告 Bug，还是实现新功能，每一份贡献都很有价值。
 
-[English version](CONTRIBUTING.md)
+[English version](CONTRIBUTING.md) | [日本語版](CONTRIBUTING.ja-JP.md)
 
 ## 行为准则
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,0 +1,379 @@
+<p align="center">
+  <a href="https://alibaba.github.io/open-code-review/">
+    <img src="imgs/logo.svg" alt="OpenCodeReview logo" width="240" height="240">
+  </a>
+</p>
+<p align="center">オープンソースのAIコードレビューエージェント。</p>
+<p align="center">
+  <a href="https://www.npmjs.com/package/@alibaba-group/open-code-review"><img alt="npm" src="https://img.shields.io/npm/v/@alibaba-group/open-code-review?style=flat-square" /></a>
+  <a href="https://github.com/alibaba/open-code-review/actions/workflows/release.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/alibaba/open-code-review/release.yml?style=flat-square" /></a>
+  <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
+</p>
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語
+</p>
+
+---
+
+## Open Code Reviewとは？
+
+Open Code ReviewはAIを活用したコードレビューCLIツールです。もともとはAlibaba Group社内の公式AIコードレビューアシスタントとして誕生し、過去2年間で数万人の開発者にサービスを提供し、数百万件のコード欠陥を発見してきました。大規模な環境で徹底的に検証された後、コミュニティ向けのオープンソースプロジェクトとして公開されました。モデルのエンドポイントを設定するだけで使い始められます。
+
+Gitのdiffを読み取り、変更されたファイルをツール利用機能を持つエージェント経由で設定可能なLLMに送信し、行レベルの精度で構造化されたレビューコメントを生成します。エージェントはファイル全体の内容を読み取り、コードベースを検索し、コンテキストのために他の変更ファイルを参照し、深いレビューを生成できます — 単なる表面的なdiffへのフィードバックではありません。
+
+![Highlights](imgs/highlights-en.png)
+
+## なぜOpen Code Reviewなのか？
+
+### 汎用エージェントの問題点
+
+Claude CodeのSkillsのような汎用エージェントをコードレビューに使ったことがあれば、次のような課題に直面したことがあるはずです：
+
+- **不完全なカバレッジ** — 大きな変更セットでは、エージェントが「手を抜き」、一部のファイルだけを選択的にレビューして他を見落としがちです。
+- **位置のずれ** — 報告された問題が実際のコード位置と一致せず、行番号やファイル参照がターゲットからずれることが頻繁にあります。
+- **不安定な品質** — 自然言語駆動のSkillsはデバッグが難しく、わずかなプロンプトの違いでレビュー品質が大きく変動します。
+
+根本原因は、純粋に言語駆動のアーキテクチャにはレビュープロセスに対するハードな制約が欠けていることです。
+
+### コア設計: 決定論的エンジニアリング × エージェントのハイブリッド
+
+Open Code Reviewのコア哲学は、決定論的エンジニアリングとエージェントを組み合わせ、それぞれが得意とする領域を担当させることです。
+
+**決定論的エンジニアリング — ハードな制約**
+
+*絶対に間違えてはならない*レビューステップについては、言語モデルではなくエンジニアリングロジックが正しさを保証します：
+
+- **正確なファイル選択** — どのファイルをレビューし、どのファイルをフィルタリングすべきかを正確に決定し、重要な変更が見落とされないようにします。
+- **スマートなファイルバンドル** — 関連するファイルを単一のレビューユニットにグループ化します（例：`message_en.properties`と`message_zh.properties`はまとめてバンドルされます）。各バンドルは分離されたコンテキストを持つサブエージェントとして実行されます — 非常に大きな変更セットでも安定する分割統治戦略で、自然に並行レビューもサポートします。
+- **きめ細かなルールマッチング** — 各ファイルの特性に応じてレビュールールをマッチングし、モデルの注意を鋭く集中させ、情報ノイズを発生源から排除します。純粋に言語駆動のルール誘導と比べて、テンプレートエンジンベースのルールマッチングはより安定的で予測可能です。
+- **外部の位置特定・リフレクションモジュール** — 独立したコメント位置特定モジュールとコメントリフレクションモジュールにより、AIフィードバックの位置精度と内容精度の両方を体系的に向上させます。
+
+**エージェント — 動的な意思決定**
+
+エージェントの強みは、最も重要な領域 — 動的な意思決定と動的なコンテキスト取得 — に集中させています：
+
+- **シナリオに最適化されたプロンプト** — コードレビュー向けに深く最適化されたプロンプトテンプレートにより、効果を高めつつトークン消費を削減します。
+- **シナリオに最適化されたツールセット** — 大規模な本番データにおけるツール呼び出しトレースの詳細な分析 — 呼び出し頻度の分布、ツールごとの繰り返し率、新しいツールが呼び出しチェーン全体に与える影響など — から抽出された、汎用エージェントツールキットよりもコードレビューにおいて安定的で予測可能な専用ツールセットです。
+
+## 使い方
+
+### CLI
+
+#### インストール
+
+**NPM経由（推奨）**
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+インストール後、`ocr`コマンドがグローバルに利用可能になります。
+
+**GitHub Releaseから**
+
+[GitHub Releases](https://github.com/alibaba/open-code-review/releases)から最新のバイナリをダウンロードします：
+
+```bash
+# macOS (Apple Silicon)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# macOS (Intel)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux (x86_64)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux (ARM64)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Windows (x86_64) — ocr.exe を PATH の通ったディレクトリに移動してください
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-amd64.exe
+
+# Windows (ARM64) — ocr.exe を PATH の通ったディレクトリに移動してください
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
+```
+
+**ソースから**
+
+```bash
+git clone https://github.com/alibaba/open-code-review.git
+cd open-code-review
+make build
+sudo cp dist/opencodereview /usr/local/bin/ocr
+```
+
+#### クイックスタート
+
+**1. LLMの設定**
+
+**コードレビューの前に必ずLLMを設定する必要があります。**
+
+```bash
+# オプションA: 対話的な設定
+ocr config set llm.url https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token your-api-key-here
+ocr config set llm.model claude-opus-4-6
+ocr config set llm.use_anthropic true
+
+# オプションB: 環境変数（最優先）
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=your-api-key-here
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true
+```
+
+設定は`~/.opencodereview/config.json`に保存されます。
+
+また、Claude Codeの環境変数（`ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL`）とも互換性があり、`~/.zshrc` / `~/.bashrc`からこれらのexportをパースします。
+
+> **CC-Switchユーザー向けの注意**: [CC-Switch](https://github.com/farion1231/cc-switch)を[ルーティングサービス](https://www.ccswitch.io/en/docs?section=proxy&item=service)有効で使用している場合、追加設定なしで`llm.url`をCC-Switchのプロキシアドレスに向けることができます：
+> - **Claude**プロバイダーの場合: `llm.url`を`http://127.0.0.1:15721`に設定
+> - **CodeX**プロバイダーの場合: `llm.url`を`http://127.0.0.1:15721/v1`に設定
+> - `llm.model`はプロバイダー設定に応じて設定
+> - `llm.auth_token`は任意の値で構いません
+> - `extra_body`設定は引き続き有効です
+
+**2. 疎通テスト**
+
+```bash
+ocr llm test
+```
+
+**3. レビュー**
+
+```bash
+cd your-project
+
+# ワークスペースモード — ステージ済み・未ステージ・未追跡のすべての変更をレビュー
+ocr review
+
+# ブランチ範囲 — 2つのrefを比較
+ocr review --from main --to feature-branch
+
+# 単一コミット
+ocr review --commit abc123
+```
+
+### コーディングエージェントとの統合
+
+OCRはスラッシュコマンドとしてAIコーディングエージェントにシームレスに統合でき、エージェントのワークフロー内で直接コードレビューが可能になります。
+
+#### オプション1: Skillとしてインストール
+
+`npx`を使ってOCRスキルをプロジェクトにインストールします：
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review
+```
+
+これにより、[skillsレジストリ](skills/open-code-review/SKILL.md)から`open-code-review`スキルがインストールされ、コーディングエージェントにコードレビューのための`ocr`の呼び出し方、優先度による問題の分類、必要に応じた修正の適用を教えます。
+
+#### オプション2: Claude Codeプラグインとしてインストール
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code)の場合、Claude Code内で以下のコマンドを実行してコマンドプラグインをインストールします：
+
+```bash
+/plugin marketplace add alibaba/open-code-review
+/plugin install open-code-review@open-code-review
+```
+
+これにより`/open-code-review:review`スラッシュコマンドが登録され、OCRを実行して問題を自動的にフィルタリング・修正します。
+
+#### オプション3: コマンドファイルを直接コピー
+
+パッケージマネージャーを使わずに素早くセットアップしたい場合は、コマンドファイルをコピーするだけでClaude Codeで`/open-code-review`スラッシュコマンドを使えるようになります。
+
+**プロジェクトレベル**（gitでチームと共有）：
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/commands/review.md
+```
+
+**ユーザーレベル**（全プロジェクトで個人用にグローバル利用）：
+
+```bash
+mkdir -p ~/.claude/commands
+curl -o ~/.claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/commands/review.md
+```
+
+> **前提条件**: すべての統合方法において、`ocr` CLIのインストールとLLMの設定が必要です。上記の[インストール](#インストール)と[LLMの設定](#1-llmの設定)を参照してください。
+
+### CI/CD統合
+
+OCRをCI/CDパイプラインに統合して、Merge Request / Pull Requestのコードレビューを自動化できます。
+
+CI統合のコアコマンド：
+
+```bash
+ocr review \
+  --from "origin/main" \
+  --to "origin/feature-branch" \
+  --format json
+```
+
+`--format json`フラグは、CIスクリプトでのパースに適した機械可読な結果を出力します。
+
+統合例は[`examples/`](./examples/)ディレクトリを参照してください：
+
+- [`github_actions/`](./examples/github_actions/) — GitHub Actions統合の例
+- [`gitlab_ci/`](./examples/gitlab_ci/) — GitLab CI統合の例
+
+## コマンド
+
+| コマンド | エイリアス | 説明 |
+|---------|-------|-------------|
+| `ocr review` | `ocr r` | コードレビューを開始 |
+| `ocr rules check <file>` | — | ファイルパスに適用されるレビュールールをプレビュー |
+| `ocr config set <key> <value>` | — | 設定値をセット |
+| `ocr llm test` | — | LLMの疎通テスト |
+| `ocr viewer` | `ocr v` | `localhost:5483`でWebUIセッションビューアーを起動 |
+| `ocr version` | — | バージョン情報を表示 |
+
+### `ocr review`のフラグ
+
+| フラグ | 短縮形 | デフォルト | 説明 |
+|------|-----------|---------|-------------|
+| `--repo` | — | カレントディレクトリ | Gitリポジトリのルート |
+| `--from` | — | — | ソースref（例：`main`） |
+| `--to` | — | — | ターゲットref（例：`feature-branch`） |
+| `--commit` | `-c` | — | レビュー対象の単一コミット |
+| `--preview` | `-p` | `false` | LLMを実行せずにレビュー対象ファイルをプレビュー |
+| `--format` | `-f` | `text` | 出力形式：`text`または`json` |
+| `--concurrency` | — | `8` | ファイルレビューの最大同時実行数 |
+| `--timeout` | — | `10` | 同時実行タスクのタイムアウト（分） |
+| `--audience` | — | `human` | `human`（進捗を表示）または`agent`（サマリーのみ） |
+| `--rule` | — | — | カスタムJSONレビュールールへのパス |
+| `--max-tools` | — | 組み込み値 | ファイルごとのツール呼び出しラウンドの上限。テンプレートのデフォルトより大きい場合のみ有効 |
+| `--max-git-procs` | — | 組み込み値 | gitサブプロセスの最大同時実行数 |
+| `--tools` | — | — | カスタムJSONツール設定へのパス |
+
+## 例
+
+```bash
+# レビュー対象ファイルをプレビュー（LLM呼び出しなし）
+ocr review --preview
+ocr review -c abc123 -p
+
+# デフォルト設定でワークスペースの変更をレビュー
+ocr review
+
+# 高めの同時実行数でブランチのdiffをレビュー
+ocr review --from main --to my-feature --concurrency 4
+
+# 特定のコミットを詳細なJSON出力でレビュー
+ocr review --commit abc123 --format json --audience agent
+
+# カスタムレビュールールを使用
+ocr review --rule /path/to/my-rules.json
+
+# ファイルに適用されるルールをプレビュー
+ocr rules check src/main/java/com/example/Foo.java
+ocr rules check --rule custom.json src/main/resources/mapper/UserMapper.xml
+
+# ブラウザでレビューセッション履歴を表示
+ocr viewer
+ocr viewer --addr :3000
+```
+
+### ビューアーのセキュリティ
+
+ビューアーはセッションのJSONLコンテンツ（LLMリクエストメッセージとレスポンス）をHTTPで配信します。すべてのリクエストに対してHostヘッダーの許可リストを強制します：ループバック名（`localhost`、`127.0.0.0/8`、`::1`）と実際のバインドホストは常に許可されます。ワイルドカードバインド（`--addr :3000`、`--addr 0.0.0.0:3000`）やその他の非ループバックのホスト名は、環境変数`OCR_VIEWER_ALLOWED_HOSTS`（カンマ区切り）で追加する必要があります：
+
+```bash
+OCR_VIEWER_ALLOWED_HOSTS=review.internal,ocr.lan ocr viewer --addr :3000
+```
+
+これにより、ローカルビューアーに対するDNSリバインディング攻撃をブロックします。
+
+## レビュールール
+
+OCRは4層の優先度チェーンを使ってレビュールールを解決します。各層はファーストマッチ優先です：ファイルパスがパターンにマッチすればそのルールが使われ、マッチしなければ次の層にフォールスルーします。
+
+| 優先度 | ソース | パス | 説明 |
+|----------|--------|------|-------------|
+| 1（最高） | `--rule`フラグ | ユーザー指定パス | CLIによる明示的なオーバーライド |
+| 2 | プロジェクト設定 | `<repoDir>/.opencodereview/rule.json` | プロジェクトごとのルール。gitにコミット可能 |
+| 3 | グローバル設定 | `~/.opencodereview/rule.json` | ユーザー全体の個人設定 |
+| 4（最低） | システムデフォルト | 組み込みの`system_rules.json` | 一般的な言語とファイルタイプをカバーする組み込みルール |
+
+### ルールファイルの形式
+
+第1〜3層は同じJSON形式を共有します：
+
+```json
+{
+  "rules": [
+    {
+      "path": "force-api/**/*.java",
+      "rule": "All new methods must validate required parameters for null values"
+    },
+    {
+      "path": "**/*mapper*.xml",
+      "rule": "Check SQL for injection risks, parameter errors, and missing closing tags"
+    }
+  ]
+}
+```
+
+- `path`は`**`による再帰マッチと`{java,kt}`のブレース展開をサポートします。
+- 各層の中では、ルールは宣言順に評価されます — 最初にマッチしたものが採用されます。
+- ルールファイルが存在しない場合は、何も出力せずスキップされます。
+
+## 設定リファレンス
+
+設定ファイル：`~/.opencodereview/config.json`
+
+| キー | 型 | 例 |
+|-----|------|---------|
+| `llm.url` | string | `https://api.openai.com/v1/chat/completions` |
+| `llm.auth_token` | string | `sk-xxxxxxx` |
+| `llm.model` | string | `claude-opus-4-6` |
+| `llm.use_anthropic` | boolean | `true` \| `false` |
+| `language` | string | `English` \| `Chinese`（デフォルト：Chinese） |
+| `telemetry.enabled` | boolean | `true` \| `false` |
+| `telemetry.exporter` | string | `console` \| `otlp` |
+| `telemetry.otlp_endpoint` | string | OTLPコレクターのアドレス |
+| `telemetry.content_logging` | boolean | テレメトリーにプロンプトを含める |
+
+環境変数は設定ファイルより優先されます。
+
+### 環境変数
+
+| 変数 | 用途 |
+|----------|---------|
+| `OCR_LLM_URL` | LLM APIエンドポイントURL |
+| `OCR_LLM_TOKEN` | APIキー / 認証トークン |
+| `OCR_LLM_MODEL` | モデル名 |
+| `OCR_USE_ANTHROPIC` | `true` = Anthropic、`false` = OpenAI |
+
+
+## テレメトリー
+
+可観測性（スパン、メトリクス）のためのOpenTelemetry統合。デフォルトでは無効です。
+
+```bash
+ocr config set telemetry.enabled true
+ocr config set telemetry.exporter otlp
+ocr config set telemetry.otlp_endpoint localhost:4317
+```
+
+エクスポートデータにLLMのプロンプトとレスポンスを含めるには、`telemetry.content_logging`を設定してください。
+
+## コントリビューション
+
+開発環境のセットアップ、コーディングガイドライン、プルリクエストの提出方法については[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
+
+## ライセンス
+
+[Apache-2.0](LICENSE) — Copyright 2026 Alibaba

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
 </p>
 <p align="center">
-  English | <a href="README.zh-CN.md">简体中文</a>
+  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a>
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
 </p>
 <p align="center">
-  <a href="README.md">English</a> | 简体中文
+  <a href="README.md">English</a> | 简体中文 | <a href="README.ja-JP.md">日本語</a>
 </p>
 
 ---


### PR DESCRIPTION
## Description

I created Japanese translated documents.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
