### PR TITLE
feat(codex): add local Codex plugin support

### DIFF
--- a/CONTRIBUTING.ko-KR.md
+++ b/CONTRIBUTING.ko-KR.md
@@ -1,0 +1,223 @@
+# OpenCodeReview 기여 가이드
+
+OpenCodeReview에 기여해 주셔서 감사합니다. 오타 수정, bug report, 새 기능 구현 등 모든 기여는 프로젝트에 도움이 됩니다.
+
+[English](CONTRIBUTING.md) | [简体中文版](CONTRIBUTING.zh-CN.md) | [日本語版](CONTRIBUTING.ja-JP.md) | 한국어
+
+## Code of Conduct
+
+이 프로젝트에 참여하는 모든 사람은 서로를 존중하고 포용적인 환경을 유지해야 합니다. 모든 interaction에서 친절하고 건설적인 태도를 유지해 주세요.
+
+## 기여 방법
+
+코드 작성 외에도 여러 방식으로 기여할 수 있습니다.
+
+- **Bug report**: 문제가 있으면 재현 단계와 함께 issue를 열어 주세요.
+- **Feature 제안**: 개선 아이디어가 있다면 [GitHub Discussions](https://github.com/alibaba/open-code-review/discussions/categories/ideas)에서 논의를 시작하거나 [Feature Request](https://github.com/alibaba/open-code-review/issues/new?template=feature_request.yml) issue를 열 수 있습니다.
+- **문서 개선**: 오타 수정, 설명 보완, 예시 추가를 환영합니다. 문서 문제를 보고하려면 [Documentation Issue](https://github.com/alibaba/open-code-review/issues/new?template=docs_report.yml)를 열어 주세요.
+- **Pull request 리뷰**: 다른 contributor의 코드를 리뷰하는 것도 큰 도움이 됩니다.
+- **코드 작성**: bug fix, feature 추가, performance 개선 등을 기여할 수 있습니다.
+
+## 시작하기
+
+### 전제 조건
+
+- [Go 1.25+](https://go.dev/dl/)
+- [Git](https://git-scm.com/)
+- [Make](https://www.gnu.org/software/make/)
+
+### Setup
+
+```bash
+# 1. GitHub에서 repository를 fork합니다
+
+# 2. fork를 clone합니다
+git clone https://github.com/<your-username>/open-code-review.git
+cd open-code-review
+
+# 3. main repo에서 update를 가져오기 위해 upstream remote를 추가합니다
+git remote add upstream https://github.com/alibaba/open-code-review.git
+
+# 4. project를 build합니다
+make build
+
+# 5. test를 실행합니다
+make test
+```
+
+모든 과정이 통과하면 기여를 시작할 준비가 된 것입니다.
+
+> **참고:** `upstream` remote는 contributor에게 read-only입니다. main repository의 최신 변경을 가져오는 데 사용하며 직접 push할 수 없습니다. 모든 기여는 fork(`origin`)에 push한 뒤 Pull Request로 제출해야 합니다.
+
+## 개발 workflow
+
+### Branching
+
+`main`에서 feature branch를 만듭니다.
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b feat/your-feature-name
+```
+
+변경 유형을 나타내기 위해 prefix를 사용합니다.
+
+| Prefix | Purpose |
+|--------|---------|
+| `feat/` | 새 기능 |
+| `fix/` | bug fix |
+| `docs/` | 문서 변경만 포함 |
+| `refactor/` | 동작 변화 없는 code refactoring |
+| `test/` | test 추가 또는 수정 |
+| `chore/` | build, CI, tooling 변경 |
+
+### Commit Messages
+
+[Conventional Commits](https://www.conventionalcommits.org/) 형식을 따릅니다.
+
+```text
+<type>(<scope>): <short summary>
+
+[optional body]
+```
+
+예시:
+
+```text
+feat(agent): add support for custom tool definitions
+fix(llm): handle timeout errors in Anthropic API calls
+docs(README): update configuration examples
+```
+
+### Code Quality
+
+변경을 제출하기 전에 모든 check가 통과하는지 확인하세요.
+
+```bash
+# Format and lint (Go standard tooling)
+go fmt ./...
+go vet ./...
+
+# race detection과 함께 test 실행
+make test
+
+# build 성공 확인
+make build
+```
+
+### Project Structure
+
+```text
+.
+├── cmd/opencodereview/   # CLI entry point
+├── internal/
+│   ├── agent/            # Review agent logic
+│   ├── config/           # Configuration management
+│   ├── diff/             # Git diff parsing
+│   ├── llm/              # LLM API client (Anthropic & OpenAI)
+│   ├── model/            # Data models
+│   ├── session/          # Review session management
+│   ├── tool/             # Built-in tools (file_read, code_search, etc.)
+│   ├── telemetry/        # OpenTelemetry integration
+│   └── viewer/           # WebUI session viewer
+├── pages/                # WebUI frontend
+├── scripts/              # Build & install scripts
+└── bin/                  # NPM wrapper
+```
+
+## 문서 기여
+
+문서는 OpenCodeReview의 중요한 일부입니다. README, inline code comment, configuration example, 사용자에게 노출되는 모든 text의 개선을 환영합니다.
+
+### 문서 기여에 해당하는 작업
+
+- 오타, 문법 오류, 깨진 link 수정
+- 혼란스러운 설명을 명확히 하거나 빠진 맥락 추가
+- command나 configuration option의 사용 예시 추가
+- feature 변경 이후 오래된 내용 update
+- 지역화 문서 번역 또는 개선(`README.zh-CN.md`, `README.ja-JP.md`, `README.ko-KR.md`, `CONTRIBUTING.zh-CN.md`, `CONTRIBUTING.ja-JP.md`, `CONTRIBUTING.ko-KR.md`)
+
+### 문서 workflow
+
+1. 문제를 발견했지만 직접 수정할 계획이 없다면 [Documentation Issue](https://github.com/alibaba/open-code-review/issues/new?template=docs_report.yml)를 열어 주세요.
+2. 직접 수정하려면 repo를 fork하고 변경한 뒤 `docs/` branch prefix로 PR을 제출하세요. 예: `docs/fix-config-example`.
+3. 문서만 변경하는 PR은 test 변경이 필요하지 않지만, 포함한 command와 code snippet이 정확한지 확인해 주세요.
+
+### 문서 파일
+
+| File | Purpose |
+|------|---------|
+| `README.md` | main project documentation (English) |
+| `README.zh-CN.md` | Chinese translation |
+| `README.ja-JP.md` | Japanese translation |
+| `README.ko-KR.md` | Korean translation |
+| `CONTRIBUTING.md` | contribution guide (English) |
+| `CONTRIBUTING.zh-CN.md` | contribution guide (Chinese) |
+| `CONTRIBUTING.ja-JP.md` | contribution guide (Japanese) |
+| `CONTRIBUTING.ko-KR.md` | contribution guide (Korean) |
+
+## 변경 제출
+
+### Issue 열기
+
+큰 변경을 시작하기 전에는 먼저 issue를 열어 접근 방식을 논의해 주세요. 이렇게 하면 중복 작업을 줄이고 기여 방향이 프로젝트와 맞는지 확인할 수 있습니다.
+
+Bug를 보고할 때는 다음 정보를 포함해 주세요.
+
+1. OpenCodeReview version(`ocr version`)
+2. OS와 architecture
+3. 재현 단계
+4. 기대 동작과 실제 동작
+5. 관련 log 또는 error message
+
+### Pull Request 절차
+
+1. **PR을 focused하게 유지**: 하나의 PR에는 하나의 논리적 변경만 포함하세요. 서로 독립적인 변경이 여러 개라면 별도 PR로 제출하세요.
+2. **Test 작성**: 동작 변경에는 test를 추가하거나 update하세요.
+3. **문서 update**: 사용자에게 보이는 동작이 바뀌면 관련 문서를 update하세요.
+4. **CLA 서명**: 모든 contributor는 PR이 merge되기 전에 Contributor License Agreement에 서명해야 합니다.
+5. **PR template 작성**: 변경 내용과 이유를 설명하세요.
+
+### PR title format
+
+commit message와 같은 Conventional Commits 형식을 사용합니다.
+
+```text
+feat(agent): add support for custom tool definitions
+```
+
+### Review process
+
+- maintainer가 보통 며칠 내에 PR을 리뷰합니다.
+- 변경 요청이 있을 수 있습니다. 이는 일반적이고 협업적인 과정입니다.
+- 승인되면 maintainer가 PR을 merge합니다.
+
+## Contributor License Agreement (CLA)
+
+모든 contributor는 Alibaba Open Source Contributor License Agreement에 서명해야 합니다. 이는 프로젝트가 license terms에 따라 배포될 수 있도록 하기 위한 절차입니다.
+
+첫 PR을 열면 CLA bot이 안내 comment를 남깁니다. link를 따라 전자 서명하면 되며 보통 1분 정도면 끝납니다.
+
+## 처음 기여하는 분들
+
+처음이라면 다음 label이 붙은 issue를 찾아보세요.
+
+- [`good first issue`](https://github.com/alibaba/open-code-review/labels/good%20first%20issue): 시작하기 좋은 작고 범위가 명확한 task
+- [`help wanted`](https://github.com/alibaba/open-code-review/labels/help%20wanted): community help를 환영하는 issue
+
+시작하기 좋은 영역:
+
+- error message와 CLI output 개선
+- test가 부족한 code path의 test 작성
+- 문서 개선
+
+## Community
+
+- **Bug Reports**: [GitHub Issues](https://github.com/alibaba/open-code-review/issues)
+- **Feature Suggestions**: [GitHub Discussions (Ideas)](https://github.com/alibaba/open-code-review/discussions/categories/ideas) 또는 [Feature Request Issue](https://github.com/alibaba/open-code-review/issues/new?template=feature_request.yml)
+- **Questions & Help**: OpenCodeReview 사용과 관련한 질문은 [GitHub Discussions](https://github.com/alibaba/open-code-review/discussions)에 올릴 수 있습니다.
+
+## License
+
+OpenCodeReview에 기여하면 해당 기여가 [Apache License 2.0](LICENSE)에 따라 license되는 것에 동의하는 것입니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,11 @@ Documentation is a crucial part of OpenCodeReview. We welcome improvements to RE
 | ----------------------- | ------------------------------------ |
 | `README.md`             | Main project documentation (English) |
 | `README.zh-CN.md`       | Chinese translation                  |
+| `README.ja-JP.md`       | Japanese translation                 |
 | `README.ko-KR.md`       | Korean translation                   |
 | `CONTRIBUTING.md`       | Contribution guide (English)         |
 | `CONTRIBUTING.zh-CN.md` | Contribution guide (Chinese)         |
+| `CONTRIBUTING.ja-JP.md` | Contribution guide (Japanese)        |
 | `CONTRIBUTING.ko-KR.md` | Contribution guide (Korean)          |
 
 ## Submitting Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to OpenCodeReview! Every contribution matters — whether it's fixing a typo, reporting a bug, or implementing a new feature.
 
-[简体中文版](CONTRIBUTING.zh-CN.md) | [日本語版](CONTRIBUTING.ja-JP.md)
+[简体中文版](CONTRIBUTING.zh-CN.md) | [日本語版](CONTRIBUTING.ja-JP.md) | [한국어](CONTRIBUTING.ko-KR.md)
 
 ## Code of Conduct
 
@@ -135,7 +135,7 @@ Documentation is a crucial part of OpenCodeReview. We welcome improvements to RE
 - Clarifying confusing explanations or adding missing context
 - Adding usage examples for commands or configuration options
 - Updating outdated content (e.g., after a feature change)
-- Translating or improving the Chinese documentation (`README.zh-CN.md`, `CONTRIBUTING.zh-CN.md`)
+- Translating or improving localized documentation (`README.zh-CN.md`, `README.ja-JP.md`, `README.ko-KR.md`, `CONTRIBUTING.zh-CN.md`, `CONTRIBUTING.ja-JP.md`, `CONTRIBUTING.ko-KR.md`)
 
 ### Documentation Workflow
 
@@ -149,8 +149,10 @@ Documentation is a crucial part of OpenCodeReview. We welcome improvements to RE
 | ----------------------- | ------------------------------------ |
 | `README.md`             | Main project documentation (English) |
 | `README.zh-CN.md`       | Chinese translation                  |
+| `README.ko-KR.md`       | Korean translation                   |
 | `CONTRIBUTING.md`       | Contribution guide (English)         |
 | `CONTRIBUTING.zh-CN.md` | Contribution guide (Chinese)         |
+| `CONTRIBUTING.ko-KR.md` | Contribution guide (Korean)          |
 
 ## Submitting Changes
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
 </p>
 <p align="center">
-  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語 | <a href="README.ko-KR.md">한국어</a>
 </p>
 
 ---
@@ -184,7 +184,43 @@ npx skills add alibaba/open-code-review --skill open-code-review
 
 これにより`/open-code-review:review`スラッシュコマンドが登録され、OCRを実行して問題を自動的にフィルタリング・修正します。
 
-#### オプション3: コマンドファイルを直接コピー
+#### オプション3: Codexプラグインとしてインストール
+
+ローカルCodexでは、このリポジトリからOpen Code Reviewプラグインをインストールできます：
+
+```bash
+codex plugin marketplace add alibaba/open-code-review
+codex
+/plugins
+```
+
+ローカルcheckoutまたはforkでは、次を使用できます：
+
+```bash
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+`Open Code Review`をインストールして有効化した後、新しいCodex threadを開始して明示的に呼び出します：
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+これにより、ローカルOCR CLIを実行するCodex skillが登録されます：
+
+```bash
+ocr review --audience agent
+```
+
+この統合はOCRの内部LLM backendを変更せず、Codex用のOpenAI Responses API endpoint設定も必要ありません。OCR自体には、CLI setupセクションで説明されている`ocr` CLIのインストールと設定が引き続き必要です。
+
+韓国語ガイド：[`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
+
+#### オプション4: コマンドファイルを直接コピー
 
 パッケージマネージャーを使わずに素早くセットアップしたい場合は、コマンドファイルをコピーするだけでClaude Codeで`/open-code-review`スラッシュコマンドを使えるようになります。
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,0 +1,415 @@
+<p align="center">
+  <a href="https://alibaba.github.io/open-code-review/">
+    <img src="imgs/logo.svg" alt="OpenCodeReview logo" width="240" height="240">
+  </a>
+</p>
+<p align="center">오픈 소스 AI 코드 리뷰 에이전트.</p>
+<p align="center">
+  <a href="https://www.npmjs.com/package/@alibaba-group/open-code-review"><img alt="npm" src="https://img.shields.io/npm/v/@alibaba-group/open-code-review?style=flat-square" /></a>
+  <a href="https://github.com/alibaba/open-code-review/actions/workflows/release.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/alibaba/open-code-review/release.yml?style=flat-square" /></a>
+  <a href="https://goreportcard.com/report/github.com/alibaba/open-code-review"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/alibaba/open-code-review?style=flat-square" /></a>
+  <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
+</p>
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a> | 한국어
+</p>
+
+---
+
+## Open Code Review란?
+
+Open Code Review는 AI 기반 코드 리뷰 CLI 도구입니다. Alibaba Group의 내부 공식 AI 코드 리뷰 어시스턴트에서 시작했으며, 지난 2년 동안 수만 명의 개발자에게 제공되어 수백만 건의 코드 결함을 찾아냈습니다. 대규모 환경에서 충분히 검증한 뒤 커뮤니티를 위해 오픈 소스 프로젝트로 공개했습니다. 모델 endpoint만 설정하면 바로 사용할 수 있습니다.
+
+이 도구는 Git diff를 읽고, 변경 파일을 tool-use 기능을 가진 agent를 통해 설정 가능한 LLM으로 전달한 뒤, 라인 단위 위치 정보가 포함된 구조화된 리뷰 코멘트를 생성합니다. agent는 전체 파일 내용 읽기, 코드베이스 검색, 다른 변경 파일 확인 등을 통해 맥락을 확보하고 표면적인 diff 피드백이 아닌 깊이 있는 리뷰를 수행할 수 있습니다.
+
+![Highlights](imgs/highlights-en.png)
+
+## 왜 Open Code Review인가?
+
+### 범용 Agent의 문제
+
+Claude Code Skills 같은 범용 agent로 코드 리뷰를 해봤다면 다음 문제를 경험했을 수 있습니다.
+
+- **불완전한 커버리지**: 큰 changeset에서는 일부 파일만 선택적으로 리뷰하고 중요한 파일을 놓치기 쉽습니다.
+- **위치 드리프트**: 지적된 문제가 실제 코드 위치와 맞지 않거나 라인 번호와 파일 참조가 어긋나는 일이 자주 발생합니다.
+- **불안정한 품질**: 자연어 기반 Skill은 디버깅이 어렵고, 작은 prompt 변화에도 리뷰 품질이 크게 흔들릴 수 있습니다.
+
+근본 원인은 순수 언어 중심 아키텍처가 리뷰 프로세스에 강한 제약을 제공하지 못한다는 점입니다.
+
+### 핵심 설계: 결정적 엔지니어링과 Agent의 하이브리드
+
+Open Code Review의 핵심 철학은 결정적 엔지니어링과 agent를 결합해 각자가 가장 잘하는 일을 맡기는 것입니다.
+
+**결정적 엔지니어링: 강한 제약**
+
+반드시 정확해야 하는 리뷰 단계는 언어 모델이 아니라 엔지니어링 로직이 보장합니다.
+
+- **정확한 파일 선택**: 어떤 파일을 리뷰하고 어떤 파일을 필터링할지 결정해 중요한 변경이 누락되지 않도록 합니다.
+- **스마트 파일 번들링**: 관련 파일을 하나의 리뷰 단위로 묶습니다. 예를 들어 `message_en.properties`와 `message_zh.properties`를 함께 묶습니다. 각 번들은 독립된 context를 가진 sub-agent로 실행되며, 대규모 changeset에서도 안정적인 divide-and-conquer 전략과 동시 리뷰를 지원합니다.
+- **세밀한 rule 매칭**: 각 파일의 특성에 맞는 리뷰 rule을 매칭해 모델의 주의를 집중시키고 정보 노이즈를 줄입니다. 순수 자연어 기반 rule 안내보다 template engine 기반 rule 매칭이 더 안정적이고 예측 가능합니다.
+- **외부 위치 지정 및 reflection 모듈**: 독립적인 comment positioning과 comment reflection 모듈이 AI 피드백의 위치 정확도와 내용 정확도를 체계적으로 개선합니다.
+
+**Agent: 동적 의사결정**
+
+agent의 강점은 동적 판단과 동적 context 검색이 중요한 지점에 집중됩니다.
+
+- **시나리오 최적화 prompt**: 코드 리뷰에 깊이 최적화된 prompt template으로 효과를 높이고 token 사용량을 줄입니다.
+- **시나리오 최적화 toolset**: 대규모 production 데이터의 tool-call trace를 분석해 도출했습니다. 호출 빈도 분포, tool별 반복률, 신규 tool이 전체 call chain에 미치는 영향 등을 반영해 범용 agent toolkit보다 코드 리뷰에 더 안정적이고 예측 가능한 전용 toolset을 제공합니다.
+
+## 사용 방법
+
+### CLI
+
+#### 설치
+
+**NPM 사용(권장)**
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+설치 후 `ocr` 명령을 전역에서 사용할 수 있습니다.
+
+**GitHub Release 사용**
+
+[GitHub Releases](https://github.com/alibaba/open-code-review/releases)에서 최신 binary를 다운로드합니다.
+
+```bash
+# macOS (Apple Silicon)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# macOS (Intel)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux (x86_64)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux (ARM64)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Windows (x86_64): ocr.exe를 PATH에 포함된 디렉터리로 이동하세요
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-amd64.exe
+
+# Windows (ARM64): ocr.exe를 PATH에 포함된 디렉터리로 이동하세요
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
+```
+
+**소스에서 빌드**
+
+```bash
+git clone https://github.com/alibaba/open-code-review.git
+cd open-code-review
+make build
+sudo cp dist/opencodereview /usr/local/bin/ocr
+```
+
+#### Quick Start
+
+**1. LLM 설정**
+
+**코드 리뷰를 실행하기 전에 반드시 LLM을 설정해야 합니다.**
+
+```bash
+# Option A: 대화형 config
+ocr config set llm.url https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token your-api-key-here
+ocr config set llm.model claude-opus-4-6
+ocr config set llm.use_anthropic true
+
+# Option B: 환경 변수(가장 높은 우선순위)
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=your-api-key-here
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true
+```
+
+config는 `~/.opencodereview/config.json`에 저장됩니다.
+
+Claude Code 환경 변수(`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`)와도 호환되며, `~/.zshrc` / `~/.bashrc`의 export도 파싱합니다.
+
+> **CC-Switch 사용자 참고**: [CC-Switch](https://github.com/farion1231/cc-switch)를 [routing service](https://www.ccswitch.io/en/docs?section=proxy&item=service)와 함께 사용한다면, 추가 설정 없이 `llm.url`을 CC-Switch proxy 주소로 지정할 수 있습니다.
+> - **Claude** provider: `llm.url`을 `http://127.0.0.1:15721`로 설정
+> - **CodeX** provider: `llm.url`을 `http://127.0.0.1:15721/v1`로 설정
+> - provider 설정에 맞게 `llm.model` 설정
+> - `llm.auth_token`은 아무 값이나 사용할 수 있음
+> - `extra_body` 설정은 그대로 적용됨
+
+**2. 연결 테스트**
+
+```bash
+ocr llm test
+```
+
+**3. 리뷰 실행**
+
+```bash
+cd your-project
+
+# Workspace mode: staged, unstaged, untracked 변경을 모두 리뷰
+ocr review
+
+# Branch range: 두 ref 비교
+ocr review --from main --to feature-branch
+
+# 단일 commit
+ocr review --commit abc123
+```
+
+### Coding Agent와 통합
+
+OCR은 AI coding agent에 slash command로 자연스럽게 통합할 수 있으며, agent workflow 안에서 바로 코드 리뷰를 실행할 수 있습니다.
+
+#### Option 1: Skill로 설치
+
+`npx`로 OCR skill을 프로젝트에 설치합니다.
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review
+```
+
+이 명령은 [skills registry](skills/open-code-review/SKILL.md)의 `open-code-review` skill을 설치합니다. 이 skill은 coding agent가 `ocr`을 호출해 코드 리뷰를 수행하고, issue를 우선순위별로 분류하며, 필요한 경우 fix를 적용하는 방법을 알려줍니다.
+
+#### Option 2: Claude Code Plugin으로 설치
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code)에서는 Claude Code 안에서 다음 명령으로 command plugin을 설치합니다.
+
+```bash
+/plugin marketplace add alibaba/open-code-review
+/plugin install open-code-review@open-code-review
+```
+
+이렇게 하면 OCR을 실행하고 issue를 자동으로 필터링 및 수정하는 `/open-code-review:review` slash command가 등록됩니다.
+
+#### Option 3: Codex Plugin으로 설치
+
+local Codex에서는 이 repository에서 Open Code Review plugin을 설치합니다.
+
+```bash
+codex plugin marketplace add alibaba/open-code-review
+codex
+/plugins
+```
+
+local checkout이나 fork에서는 다음을 사용할 수 있습니다.
+
+```bash
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+`Open Code Review`를 설치하고 활성화한 뒤, 새 Codex thread를 시작해 명시적으로 호출합니다.
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+이 plugin은 local OCR CLI를 실행하는 Codex skill을 등록합니다.
+
+```bash
+ocr review --audience agent
+```
+
+이 통합은 OCR의 내부 LLM backend를 변경하지 않으며 Codex용 OpenAI Responses API endpoint 설정을 요구하지 않습니다. OCR 자체는 CLI 설정 섹션에 설명된 대로 `ocr` CLI 설치와 설정이 필요합니다.
+
+한국어 가이드: [`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
+
+#### Option 4: Command 파일 직접 복사
+
+package manager 없이 빠르게 설정하려면 command 파일을 복사해 Claude Code에서 `/open-code-review` slash command를 사용할 수 있습니다.
+
+**Project-level**(git으로 팀과 공유):
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/commands/review.md
+```
+
+**User-level**(여러 프로젝트에서 개인 전역 사용):
+
+```bash
+mkdir -p ~/.claude/commands
+curl -o ~/.claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/commands/review.md
+```
+
+> **전제 조건**: 모든 통합 방식은 `ocr` CLI가 설치되어 있고 LLM이 설정되어 있어야 합니다. 위의 [설치](#설치)와 [LLM 설정](#1-llm-설정)을 참고하세요.
+
+### CI/CD 통합
+
+OCR은 CI/CD pipeline에 통합해 Merge Request / Pull Request 코드 리뷰를 자동화할 수 있습니다.
+
+CI 통합의 핵심 명령:
+
+```bash
+ocr review \
+  --from "origin/main" \
+  --to "origin/feature-branch" \
+  --format json
+```
+
+`--format json` flag는 CI script에서 파싱하기 좋은 machine-readable 결과를 출력합니다.
+
+통합 예시는 [`examples/`](./examples/) 디렉터리를 참고하세요.
+
+- [`github_actions/`](./examples/github_actions/): GitHub Actions 통합 예시
+- [`gitlab_ci/`](./examples/gitlab_ci/): GitLab CI 통합 예시
+
+## Commands
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `ocr review` | `ocr r` | 코드 리뷰 시작 |
+| `ocr rules check <file>` | - | 파일 경로에 적용될 리뷰 rule 미리보기 |
+| `ocr config set <key> <value>` | - | config 값 설정 |
+| `ocr llm test` | - | LLM 연결 테스트 |
+| `ocr viewer` | `ocr v` | `localhost:5483`에서 WebUI session viewer 실행 |
+| `ocr version` | - | version 정보 표시 |
+
+### `ocr review` Flags
+
+| Flag | Shorthand | Default | Description |
+|------|-----------|---------|-------------|
+| `--repo` | - | current dir | Git repository root |
+| `--from` | - | - | Source ref 예: `main` |
+| `--to` | - | - | Target ref 예: `feature-branch` |
+| `--commit` | `-c` | - | 리뷰할 단일 commit |
+| `--preview` | `-p` | `false` | LLM 실행 없이 리뷰 대상 파일 미리보기 |
+| `--format` | `-f` | `text` | Output format: `text` 또는 `json` |
+| `--concurrency` | - | `8` | 최대 동시 파일 리뷰 수 |
+| `--timeout` | - | `10` | 동시 task timeout(분) |
+| `--audience` | - | `human` | `human`(progress 표시) 또는 `agent`(summary only) |
+| `--rule` | - | - | custom JSON review rules 경로 |
+| `--max-tools` | - | built-in | 파일별 최대 tool call round. template default보다 클 때만 적용 |
+| `--max-git-procs` | - | built-in | 최대 동시 git subprocess 수 |
+| `--tools` | - | - | custom JSON tools config 경로 |
+
+## Examples
+
+```bash
+# 리뷰 대상 파일 미리보기(LLM call 없음)
+ocr review --preview
+ocr review -c abc123 -p
+
+# default 설정으로 workspace 변경 리뷰
+ocr review
+
+# 더 높은 concurrency로 branch diff 리뷰
+ocr review --from main --to my-feature --concurrency 4
+
+# 특정 commit을 verbose JSON output으로 리뷰
+ocr review --commit abc123 --format json --audience agent
+
+# custom review rules 사용
+ocr review --rule /path/to/my-rules.json
+
+# 파일에 적용될 rule 미리보기
+ocr rules check src/main/java/com/example/Foo.java
+ocr rules check --rule custom.json src/main/resources/mapper/UserMapper.xml
+
+# browser에서 review session history 보기
+ocr viewer
+ocr viewer --addr :3000
+```
+
+### Viewer 보안
+
+viewer는 session JSONL 내용(LLM request messages와 responses)을 HTTP로 제공합니다. 모든 request에 대해 Host header allowlist를 적용합니다. loopback 이름(`localhost`, `127.0.0.0/8`, `::1`)과 실제 bind host는 항상 허용됩니다. wildcard bind(`--addr :3000`, `--addr 0.0.0.0:3000`)와 다른 non-loopback hostname은 `OCR_VIEWER_ALLOWED_HOSTS` 환경 변수에 comma-separated 값으로 추가해야 합니다.
+
+```bash
+OCR_VIEWER_ALLOWED_HOSTS=review.internal,ocr.lan ocr viewer --addr :3000
+```
+
+이 설정은 local viewer를 대상으로 하는 DNS rebinding 공격을 차단합니다.
+
+## Review Rules
+
+OCR은 네 계층의 priority chain으로 review rule을 해석합니다. 각 계층은 first-match-wins 방식입니다. 파일 경로가 pattern에 match되면 해당 rule을 사용하고, 아니면 다음 계층으로 넘어갑니다.
+
+| Priority | Source | Path | Description |
+|----------|--------|------|-------------|
+| 1 (highest) | `--rule` flag | User-specified path | CLI explicit override |
+| 2 | Project config | `<repoDir>/.opencodereview/rule.json` | project별 rule, git commit 가능 |
+| 3 | Global config | `~/.opencodereview/rule.json` | user-wide 개인 선호 |
+| 4 (lowest) | System default | Embedded `system_rules.json` | 일반 language와 file type을 다루는 built-in rule |
+
+### Rule File Format
+
+모든 계층은 같은 JSON format을 공유합니다.
+
+```json
+{
+  "rules": [
+    {
+      "path": "force-api/**/*.java",
+      "rule": "All new methods must validate required parameters for null values"
+    },
+    {
+      "path": "**/*mapper*.xml",
+      "rule": "Check SQL for injection risks, parameter errors, and missing closing tags"
+    }
+  ]
+}
+```
+
+- `path`는 `**` recursive matching과 `{java,kt}` brace expansion을 지원합니다.
+- 각 계층 안에서는 rule이 선언 순서대로 평가되며 첫 번째 match가 선택됩니다.
+- rule file이 없으면 조용히 건너뜁니다.
+
+## Configuration Reference
+
+Config file: `~/.opencodereview/config.json`
+
+| Key | Type | Example |
+|-----|------|---------|
+| `llm.url` | string | `https://api.openai.com/v1/chat/completions` |
+| `llm.auth_token` | string | `sk-xxxxxxx` |
+| `llm.model` | string | `claude-opus-4-6` |
+| `llm.use_anthropic` | boolean | `true` \| `false` |
+| `language` | string | `English` \| `Chinese` (default: Chinese) |
+| `telemetry.enabled` | boolean | `true` \| `false` |
+| `telemetry.exporter` | string | `console` \| `otlp` |
+| `telemetry.otlp_endpoint` | string | OTLP collector address |
+| `telemetry.content_logging` | boolean | telemetry에 prompt 포함 여부 |
+
+환경 변수는 config file보다 우선합니다.
+
+### Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `OCR_LLM_URL` | LLM API endpoint URL |
+| `OCR_LLM_TOKEN` | API key / auth token |
+| `OCR_LLM_MODEL` | Model name |
+| `OCR_USE_ANTHROPIC` | `true` = Anthropic, `false` = OpenAI |
+
+## Telemetry
+
+관측성을 위한 OpenTelemetry 통합(spans, metrics)입니다. 기본값은 disabled입니다.
+
+```bash
+ocr config set telemetry.enabled true
+ocr config set telemetry.exporter otlp
+ocr config set telemetry.otlp_endpoint localhost:4317
+```
+
+exported data에 LLM prompt와 response를 포함하려면 `telemetry.content_logging`을 설정합니다.
+
+## Contributing
+
+개발 환경 설정, coding guideline, pull request 제출 방법은 [CONTRIBUTING.ko-KR.md](CONTRIBUTING.ko-KR.md)를 참고하세요.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
+
+## License
+
+[Apache-2.0](LICENSE) Copyright 2026 Alibaba

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
 </p>
 <p align="center">
-  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a>
+  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a> | <a href="README.ko-KR.md">한국어</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -184,7 +184,43 @@ For [Claude Code](https://docs.anthropic.com/en/docs/claude-code), install the c
 
 This registers the `/open-code-review:review` slash command, which runs OCR and automatically filters and fixes issues.
 
-#### Option 3: Copy the Command File Directly
+#### Option 3: Install as a Codex Plugin
+
+For local Codex, install the Open Code Review plugin from this repository:
+
+```bash
+codex plugin marketplace add alibaba/open-code-review
+codex
+/plugins
+```
+
+For a local checkout or fork:
+
+```bash
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+Install and enable `Open Code Review`, then start a new Codex thread and invoke it explicitly:
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+This registers a Codex skill that runs the local OCR CLI:
+
+```bash
+ocr review --audience agent
+```
+
+This integration does not change OCR's internal LLM backend and does not require configuring an OpenAI Responses API endpoint for Codex. OCR itself still requires the `ocr` CLI to be installed and configured as described in the CLI setup section.
+
+Korean guide: [`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
+
+#### Option 4: Copy the Command File Directly
 
 For a quick setup without any package manager, simply copy the command file to use the `/open-code-review` slash command in Claude Code.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/alibaba/open-code-review/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/alibaba/open-code-review?style=flat-square" /></a>
 </p>
 <p align="center">
-  <a href="README.md">English</a> | 简体中文 | <a href="README.ja-JP.md">日本語</a>
+  <a href="README.md">English</a> | 简体中文 | <a href="README.ja-JP.md">日本語</a> | <a href="README.ko-KR.md">한국어</a>
 </p>
 
 ---
@@ -184,7 +184,43 @@ npx skills add alibaba/open-code-review --skill open-code-review
 
 此命令注册 `/open-code-review:review` 斜杠命令，运行 OCR 并自动过滤和修复问题。
 
-#### 方式三：直接复制命令文件
+#### 方式三：作为 Codex Plugin 安装
+
+对于本地 Codex，可以从此仓库安装 Open Code Review plugin：
+
+```bash
+codex plugin marketplace add alibaba/open-code-review
+codex
+/plugins
+```
+
+对于本地 checkout 或 fork：
+
+```bash
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+安装并启用 `Open Code Review` 后，启动新的 Codex thread 并显式调用：
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+这会注册一个 Codex skill，用于运行本地 OCR CLI：
+
+```bash
+ocr review --audience agent
+```
+
+此集成不会改变 OCR 的内部 LLM backend，也不需要为 Codex 配置 OpenAI Responses API endpoint。OCR 本身仍需要按照 CLI setup 部分安装并配置 `ocr` CLI。
+
+韩文指南：[`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
+
+#### 方式四：直接复制命令文件
 
 如果不想使用任何包管理器，可以直接复制命令文件，在 Claude Code 中使用 `/open-code-review` 斜杠命令。
 

--- a/plugins/open-code-review/.codex-plugin/plugin.json
+++ b/plugins/open-code-review/.codex-plugin/plugin.json
@@ -22,8 +22,7 @@
     "developerName": "Alibaba",
     "category": "Developer Tools",
     "capabilities": [
-      "Read",
-      "Write"
+      "Read"
     ],
     "websiteURL": "https://github.com/alibaba/open-code-review",
     "defaultPrompt": [

--- a/plugins/open-code-review/.codex-plugin/plugin.json
+++ b/plugins/open-code-review/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "open-code-review",
+  "version": "1.0.0",
+  "description": "Use Alibaba Open Code Review from local Codex.",
+  "author": {
+    "name": "Alibaba"
+  },
+  "homepage": "https://github.com/alibaba/open-code-review",
+  "repository": "https://github.com/alibaba/open-code-review",
+  "license": "Apache-2.0",
+  "keywords": [
+    "code-review",
+    "codex",
+    "ocr",
+    "open-code-review"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Open Code Review",
+    "shortDescription": "Run structured code reviews from local Codex.",
+    "longDescription": "Adds a Codex skill that invokes the local Open Code Review CLI to review Git workspace changes, commits, and branch comparisons.",
+    "developerName": "Alibaba",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/alibaba/open-code-review",
+    "defaultPrompt": [
+      "Use Open Code Review to review my current changes.",
+      "Use Open Code Review to review this branch against main.",
+      "Use Open Code Review to review and fix high-confidence issues."
+    ]
+  }
+}

--- a/plugins/open-code-review/CODEX.ko-KR.md
+++ b/plugins/open-code-review/CODEX.ko-KR.md
@@ -1,0 +1,108 @@
+# Open Code Review Codex 플러그인 사용법
+
+이 문서는 로컬 Codex에서 Alibaba Open Code Review를 사용하는 방법을 설명합니다.
+
+## 개요
+
+이 플러그인은 Open Code Review를 Codex 내부 LLM backend로 바꾸지 않습니다. Codex에서 로컬 `ocr` CLI를 호출할 수 있도록 skill을 제공하는 통합입니다.
+
+```text
+Codex
+  └─ Open Code Review plugin
+      └─ ocr review --audience agent
+```
+
+## 사전 준비
+
+`ocr` CLI가 설치되어 있어야 합니다.
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+설치 확인:
+
+```bash
+command -v ocr
+ocr version
+```
+
+OCR 자체의 LLM 설정도 필요합니다.
+
+```bash
+ocr llm test
+```
+
+이 명령이 실패하면 Codex 플러그인 설치와 별개로 OCR의 LLM 설정을 먼저 완료해야 합니다.
+
+## Codex에서 설치
+
+Codex에서 이 repo를 marketplace로 추가합니다.
+
+```bash
+codex plugin marketplace add alibaba/open-code-review
+codex
+```
+
+Codex 안에서 `/plugins`를 열고 `Open Code Review`를 설치 및 활성화합니다.
+
+로컬 checkout 또는 fork에서 테스트할 때는 다음을 사용할 수 있습니다.
+
+```bash
+codex plugin marketplace add .
+codex
+```
+
+## 사용 예시
+
+새 Codex thread에서 다음처럼 요청합니다.
+
+```text
+@Open Code Review review my current changes
+```
+
+브랜치 비교:
+
+```text
+@Open Code Review review this branch against main
+```
+
+검토 후 안전한 항목만 수정:
+
+```text
+@Open Code Review review and fix high-confidence issues
+```
+
+## 내부적으로 실행되는 명령
+
+현재 workspace 변경사항 검토:
+
+```bash
+ocr review --audience agent
+```
+
+특정 commit 검토:
+
+```bash
+ocr review --audience agent --commit <sha>
+```
+
+브랜치 비교:
+
+```bash
+ocr review --audience agent --from <base-ref> --to <head-ref>
+```
+
+미리보기:
+
+```bash
+ocr review --preview
+```
+
+## 주의사항
+
+- 이 플러그인은 OpenAI Responses API endpoint를 설정하지 않습니다.
+- 이 플러그인은 `OPENAI_API_KEY`나 `gpt-5.1-codex-max` 설정을 요구하지 않습니다.
+- OCR 자체는 별도의 LLM 설정이 필요합니다.
+- 파일 수정은 사용자가 명시적으로 요청한 경우에만 수행합니다.
+- commit 생성은 사용자가 명시적으로 요청한 경우에만 수행합니다.

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: open-code-review
+description: Use Alibaba Open Code Review (`ocr`) from local Codex to review Git workspace changes, staged or unstaged changes, untracked files, commits, pull requests, or branch comparisons. Use when the user asks to review code, review a PR, compare branches, or review and optionally fix code review findings.
+license: Apache-2.0
+metadata:
+  author: alibaba
+  homepage: https://github.com/alibaba/open-code-review
+  version: "1.0.0"
+---
+
+# Open Code Review for Codex
+
+Use the local `ocr` CLI from the active Git workspace.
+
+This skill integrates Open Code Review with local Codex by invoking the `ocr` command. It does not configure OpenAI Responses API, does not require a Codex API endpoint, and does not make Codex the internal LLM backend for OCR.
+
+## Preconditions
+
+Before running a review, check the environment:
+
+```bash
+command -v ocr
+git rev-parse --is-inside-work-tree
+```
+
+If `ocr` is not installed, tell the user to install it:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+Do not install global packages unless the user explicitly asked to set up the tool.
+
+Check OCR's LLM connectivity before the first real review:
+
+```bash
+ocr llm test
+```
+
+If this fails, report that OCR itself is not configured yet. Do not invent credentials, API keys, endpoint URLs, or model names.
+
+## Review workflow
+
+Run from the Git repository root unless the user provided a different repository path.
+
+For current workspace changes:
+
+```bash
+ocr review --audience agent
+```
+
+For a single commit:
+
+```bash
+ocr review --audience agent --commit <sha>
+```
+
+For a branch comparison:
+
+```bash
+ocr review --audience agent --from <base-ref> --to <head-ref>
+```
+
+For preview mode without invoking the LLM:
+
+```bash
+ocr review --preview
+```
+
+When useful business or requirement context is available, pass it through `--background`:
+
+```bash
+ocr review --audience agent --background "<concise context>"
+```
+
+## Argument handling
+
+- If the user provides `--commit` or `-c`, pass it through.
+- If the user provides `--from` and `--to`, pass them through.
+- If the user asks what would be reviewed, use `--preview`.
+- Always use `--audience agent` for actual reviews so OCR emits agent-friendly output.
+- Do not use `--audience human` because progress UI can pollute Codex output.
+
+## Reporting
+
+Classify OCR findings by priority:
+
+- High: obvious bugs, security issues, clear correctness problems, or well-founded fixes.
+- Medium: plausible issues that are context-dependent or require manual validation.
+- Low: likely false positives, nitpicks, or weak suggestions.
+
+Report High and Medium findings grouped by priority. Omit Low findings unless the user explicitly asks for all findings.
+
+Use this format:
+
+```markdown
+## Code Review Results
+
+**Files reviewed**: N
+**Issues found**: X high priority / Y medium priority
+
+### High Priority
+
+- **`path/to/file.ext:42`** — Brief issue summary
+  - Recommendation: Concrete fix
+
+### Medium Priority
+
+- **`path/to/file.ext:88`** — Brief issue summary
+  - Recommendation: Concrete fix or manual validation step
+```
+
+If no actionable issues remain after filtering, say:
+
+```text
+Review complete — no actionable issues found.
+```
+
+## Fix policy
+
+Do not modify files unless the user explicitly asks to fix issues.
+
+If the user asks to review and fix:
+
+1. Focus on High and Medium findings.
+2. Apply only safe, localized fixes.
+3. Re-run relevant tests or checks when available.
+4. Summarize changed files and remaining risks.
+
+Do not commit changes unless the user explicitly asks for a commit.

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -1,97 +1,147 @@
 ---
 name: open-code-review
-description: Use Alibaba Open Code Review (`ocr`) from local Codex to review Git workspace changes, staged or unstaged changes, untracked files, commits, pull requests, or branch comparisons. Use when the user asks to review code, review a PR, compare branches, or review and optionally fix code review findings.
+description: >
+  Performs AI-powered code review on Git changes using the `ocr` CLI from
+  alibaba/open-code-review. Use when the user asks to review code, review
+  a pull request, review staged/unstaged changes, review a commit, or
+  compare branches for code quality issues. Produces line-level review
+  comments and can automatically apply fixes when requested. With appropriate
+  review rules, can detect various types of issues including bugs, security
+  vulnerabilities, performance problems, and code quality concerns.
 license: Apache-2.0
+compatibility: >
+  Requires the `ocr` CLI installed (via `npm install -g
+  @alibaba-group/open-code-review` or GitHub release binary). Requires a
+  configured LLM (Anthropic or OpenAI-compatible) before first run.
 metadata:
   author: alibaba
   homepage: https://github.com/alibaba/open-code-review
   version: "1.0.0"
 ---
 
-# Open Code Review for Codex
+# Open Code Review
 
-Use the local `ocr` CLI from the active Git workspace.
+This Codex plugin skill intentionally mirrors the canonical skill at
+`skills/open-code-review/SKILL.md`. Keep both files synchronized when updating
+OCR agent instructions; a symlink is avoided because plugin installs may only
+materialize the plugin subtree.
 
-This skill integrates Open Code Review with local Codex by invoking the `ocr` command. It does not configure OpenAI Responses API, does not require a Codex API endpoint, and does not make Codex the internal LLM backend for OCR.
+A skill for invoking [open-code-review](https://github.com/alibaba/open-code-review) (`ocr`) — an open-source AI code review CLI that reads Git diffs and generates structured, line-level review comments.
 
-## Preconditions
+## Prerequisites check
 
-Before running a review, check the environment:
+Before starting a review, verify the environment:
 
 ```bash
-command -v ocr
-git rev-parse --is-inside-work-tree
+# 1. Check the CLI is installed
+which ocr || echo "NOT INSTALLED"
+
+# 2. Verify LLM connectivity
+ocr llm test
 ```
 
-If `ocr` is not installed, tell the user to install it:
+If `ocr` is not installed, install it first:
 
 ```bash
 npm install -g @alibaba-group/open-code-review
 ```
 
-Do not install global packages unless the user explicitly asked to set up the tool.
+If `ocr llm test` fails, the user must configure an LLM. Guide them with one of these options:
 
-Check OCR's LLM connectivity before the first real review:
-
-```bash
-ocr llm test
-```
-
-If this fails, report that OCR itself is not configured yet. Do not invent credentials, API keys, endpoint URLs, or model names.
-
-## Review workflow
-
-Run from the Git repository root unless the user provided a different repository path.
-
-For current workspace changes:
+**Option A — Environment variables (highest priority, recommended for CI):**
 
 ```bash
-ocr review --audience agent
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=<api-key>
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true
 ```
 
-For a single commit:
+**Option B — Persistent config:**
 
 ```bash
-ocr review --audience agent --commit <sha>
+ocr config set llm.url https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token <api-key>
+ocr config set llm.model claude-opus-4-6
+ocr config set llm.use_anthropic true
 ```
 
-For a branch comparison:
+Stop here and ask the user to provide credentials — never invent or hardcode API keys.
+
+## Workflow
+
+### Step 1: Gather Business Context
+
+Analyze the review target (commits, branch, or changes) to extract concise business context. Pass this context via `--background` to improve review quality.
+
+### Step 2: Run Code Review
+
+Run the OCR command with appropriate flags. **Always pass business context via `--background`** when available:
 
 ```bash
-ocr review --audience agent --from <base-ref> --to <head-ref>
+ocr review --audience agent --background "business context here" [user-args]
 ```
 
-For preview mode without invoking the LLM:
+**Argument handling:**
 
-```bash
-ocr review --preview
-```
+- **Background context** (RECOMMENDED): use `--background "context"` or `-b "context"` to provide business context for better review quality
+- **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
+- **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
+- **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
+- **Timeout**: default timeout is 10 minutes per file; adjust with `--timeout <minutes>`
+- **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
+- **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
+- **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
 
-When useful business or requirement context is available, pass it through `--background`:
+**Common invocation patterns:**
 
-```bash
-ocr review --audience agent --background "<concise context>"
-```
+| User says | Command to run |
+|-----------|---------------|
+| "review my changes" / "review the working copy" | `ocr review --audience agent -b "context"` |
+| "review this PR" / "review feature branch" | `ocr review --audience agent -b "context" --from main --to <branch>` |
+| "review commit abc123" | `ocr review --audience agent -b "context" --commit abc123` |
+| "what would be reviewed?" (dry-run) | `ocr review --preview` |
 
-## Argument handling
+**Output mode:**
 
-- If the user provides `--commit` or `-c`, pass it through.
-- If the user provides `--from` and `--to`, pass them through.
-- If the user asks what would be reviewed, use `--preview`.
-- Always use `--audience agent` for actual reviews so OCR emits agent-friendly output.
-- Do not use `--audience human` because progress UI can pollute Codex output.
+- Always use `--audience agent` to suppress progress UI and emit only the final summary
 
-## Reporting
+### Step 3: Classify and Report
 
-Classify OCR findings by priority:
+For each comment from the review output, classify by priority and report all issues to the user:
 
-- High: obvious bugs, security issues, clear correctness problems, or well-founded fixes.
-- Medium: plausible issues that are context-dependent or require manual validation.
-- Low: likely false positives, nitpicks, or weak suggestions.
+- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
+- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
+- **Low**: Likely false positives, lacking sufficient context, nitpicks, or meaningless suggestions
 
-Report High and Medium findings grouped by priority. Omit Low findings unless the user explicitly asks for all findings.
+Report all comments grouped by priority level.
 
-Use this format:
+### Step 4: Fix
+
+Before applying fixes, check whether the user requested automatic fixes:
+
+- If the user explicitly requested "review and fix" or similar, proceed with automatic fixes
+- If the user only requested "review" without fix intent, ask for permission before applying any changes
+
+When fixing issues and suggestions:
+
+- Focus on High and Medium priority items
+- Apply fixes directly to the code when safe and well-defined
+- For complex fixes requiring manual intervention, clearly describe what needs to be done
+- Always verify fixes with the user before committing
+
+## Output Format
+
+Each comment contains:
+
+- `path`: File path
+- `content`: Review comment text
+- `start_line` / `end_line`: Line range (both 0 means positioning failed)
+- `suggestion_code`: Optional fix suggestion
+- `existing_code`: Optional original code snippet
+- `thinking`: Optional LLM reasoning process
+
+After filtering comments by priority, present results using this template:
 
 ```markdown
 ## Code Review Results
@@ -101,30 +151,86 @@ Use this format:
 
 ### High Priority
 
-- **`path/to/file.ext:42`** — Brief issue summary
-  - Recommendation: Concrete fix
+- **`path/to/file.java:42`** — Brief description
+  > Recommendation: How to fix
 
 ### Medium Priority
 
-- **`path/to/file.ext:88`** — Brief issue summary
-  - Recommendation: Concrete fix or manual validation step
+- **`path/to/file.ts:88`** — Brief description
+  > Recommendation: How to fix (if applicable)
 ```
 
-If no actionable issues remain after filtering, say:
+If the review found no issues after filtering, simply state: "Review complete — no issues found in N files."
 
-```text
-Review complete — no actionable issues found.
+**Priority classification:**
+
+- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
+- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
+- **Low**: Discarded silently (likely false positives, lacking context, nitpicks, or meaningless suggestions)
+
+**Handling mispositioned comments:**
+
+When `start_line` and `end_line` are both `0`, the comment failed to locate the exact position in the file. In such cases:
+
+1. Read the comment content to understand the issue
+2. Examine the target file mentioned in the comment
+3. Identify the relevant code section based on the comment's context
+4. Apply the fix or suggestion to the correct location
+
+## Custom Review Rules
+
+If the user wants project-specific rules, OCR resolves them in this priority order:
+
+1. `--rule <path>` flag (highest)
+2. `<repo>/.opencodereview/rule.json`
+3. `~/.opencodereview/rule.json`
+4. Built-in system defaults (lowest)
+
+Rule file format:
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": "All new methods must validate required parameters for null"
+    },
+    {
+      "path": "**/*mapper*.xml",
+      "rule": "Check SQL for injection risks and missing closing tags"
+    }
+  ]
+}
 ```
 
-## Fix policy
+To preview which rule applies to a file before reviewing:
 
-Do not modify files unless the user explicitly asks to fix issues.
+```bash
+ocr rules check src/main/java/com/example/Foo.java
+```
 
-If the user asks to review and fix:
+## Gotchas
 
-1. Focus on High and Medium findings.
-2. Apply only safe, localized fixes.
-3. Re-run relevant tests or checks when available.
-4. Summarize changed files and remaining risks.
+- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. Always run `ocr llm test` before the first review.
+- **Working directory matters** — `ocr review` operates on the Git repo at the current directory. Use `--repo /path/to/repo` to run from elsewhere.
+- **Untracked files are reviewed in workspace mode** — running bare `ocr review` includes staged, unstaged, *and* untracked changes. Stage selectively if you want narrower scope.
+- **Large diffs may hit token limits** — files with very large diffs may be truncated. The default `MAX_TOKENS` is 58888 per request.
+- **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
+- **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
+- **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
 
-Do not commit changes unless the user explicitly asks for a commit.
+## Validation
+
+After the review completes, verify success by checking:
+
+1. The command exited with code 0
+2. Comments were generated (or "No comments generated" message appears)
+3. Warnings (if any) are displayed in stderr
+
+If errors occurred, check the stderr warnings for details about which files failed and why.
+
+## References
+
+- Full docs: https://github.com/alibaba/open-code-review
+- NPM package: https://www.npmjs.com/package/@alibaba-group/open-code-review
+- Issue tracker: https://github.com/alibaba/open-code-review/issues


### PR DESCRIPTION
## Summary

This PR adds local Codex plugin support for Open Code Review.

The integration mirrors the existing Claude Code plugin pattern: Codex loads a bundled skill and invokes the local `ocr` CLI with `ocr review --audience agent`.

## Changes

- Add `plugins/open-code-review/.codex-plugin/plugin.json`
- Add `plugins/open-code-review/skills/open-code-review/SKILL.md`
- Add Korean Codex usage guide: `plugins/open-code-review/CODEX.ko-KR.md`
- Document Codex plugin installation and usage in `README.md`
- Add Korean documentation: `README.ko-KR.md` and `CONTRIBUTING.ko-KR.md`
- Link Korean documentation from `README.md` and `CONTRIBUTING.md`
- Add Codex plugin instructions to Chinese and Japanese READMEs
- Synchronize the Codex plugin skill with the canonical OCR skill to reduce drift
- Use read-only Codex plugin capability by default

## Non-goals

- This does not add or change an OpenAI Responses API backend.
- This does not make Codex the internal LLM runner for OCR.
- This does not change existing Claude Code plugin behavior.

## Validation

- Validated plugin manifest JSON with PowerShell `ConvertFrom-Json` (`jq` was not available on the local Windows PATH)
- Verified bundled skill path exists
- Verified Korean usage guide path exists
- Ran `git diff --check`
- Tested local marketplace installation with `codex plugin marketplace add .` when Codex CLI is available
