### PR TITLE
Harden install and local secret handling

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -61,7 +61,7 @@ func runConfigSet(key, value string) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -101,7 +101,7 @@ func (jw *jsonlWriter) open() error {
 	}
 
 	filename := filepath.Join(sessionDir, jw.sessionID+".jsonl")
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("open session file: %w", err)
 	}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -213,13 +213,10 @@ async function main() {
         }
       }
       if (!verified) {
-        warn("No matching checksum entry found; skipping verification.");
+        throw new Error(`No matching checksum entry found for ${os}/${arch}`);
       }
     } catch (e) {
-      if (e.message.includes("mismatch")) {
-        throw e;
-      }
-      warn(`Could not verify checksum: ${e.message}`);
+      throw new Error(`Could not verify checksum: ${e.message}`);
     }
   }
 

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -183,16 +183,23 @@ async function main() {
           const trimmed = line.trim();
           if (trimmed.includes(`-${platform}-${arch}`)) {
             const expectedSha = trimmed.split(/\s+/)[0].toLowerCase();
-            if (expectedSha && actualSha !== expectedSha) {
+            if (!expectedSha) {
+              throw new Error(`Invalid checksum entry for ${platform}/${arch}`);
+            }
+            if (actualSha !== expectedSha) {
               fs.unlinkSync(tempPath);
-              return;
+              throw new Error(`Checksum mismatch for ${platform}/${arch}`);
             }
             verified = true;
             break;
           }
         }
-      } catch (_) {
-        // checksum fetch failed, continue with the download
+        if (!verified) {
+          throw new Error(`No matching checksum entry found for ${platform}/${arch}`);
+        }
+      } catch (e) {
+        try { fs.unlinkSync(tempPath); } catch (_) {}
+        throw e;
       }
     }
 


### PR DESCRIPTION
## Summary
- fail closed when install/update checksum verification cannot prove release binary integrity
- restrict local config and session JSONL files to owner-readable permissions

## Verification
- node --check scripts/install.js
- node --check scripts/update.js
- verified npm package 1.2.4 tarball integrity and GitHub release binary SHA256 before isolated install
- verified local LLM connection with qwen-coder via ocr llm test

Note: go test was not run in this environment because Go is not installed.