### PR TITLE
feat(rules): add built-in Rust and Cargo.toml review rules

### DIFF
--- a/internal/config/rules/rule_docs/cargo_toml.md
+++ b/internal/config/rules/rule_docs/cargo_toml.md
@@ -1,0 +1,19 @@
+#### Cargo Manifest Hygiene
+- Avoid introducing wildcard dependency versions such as `*`; use an explicit compatible version requirement
+- Avoid unpinned `git` dependencies in production crates unless a `rev`, `tag`, or documented policy makes the source reproducible
+- Keep dependencies in the narrowest appropriate section: `dependencies`, `dev-dependencies`, `build-dependencies`, or target-specific dependencies
+- Prefer workspace-managed versions and features in multi-crate repositories when the surrounding manifest already uses workspace inheritance
+
+#### Edition, MSRV, and Resolver
+- New packages should declare an explicit `edition`
+- Library crates should declare `rust-version` when the repository has a minimum supported Rust version policy
+- Workspaces using feature resolver v2 or newer should avoid accidentally falling back to legacy feature unification
+
+#### Feature Flags
+- Features should be additive and should not disable behavior in dependent crates
+- Optional dependencies should be exposed through intentional feature names rather than leaking internal dependency names when that would become public API
+- Default features should stay small for libraries; avoid enabling heavy optional integrations by default without a clear reason
+
+#### Release and Metadata
+- Published crates should include accurate `license` or `license-file`, `repository`, `description`, and relevant include/exclude settings
+- Avoid accidentally packaging generated artifacts, credentials, local paths, test fixtures with secrets, or large binary assets

--- a/internal/config/rules/rule_docs/rust.md
+++ b/internal/config/rules/rule_docs/rust.md
@@ -1,0 +1,53 @@
+#### Obvious Typos or Spelling Errors
+- Spelling errors in type names, function names, variable names, enum variants, trait names, or module names at their declaration sites; do not report spelling errors at call sites
+- Strings in log messages, panic messages, error messages, or public diagnostics containing spelling errors that affect readability
+
+#### Ownership and Lifetime Correctness
+- Incorrectly returned references, borrowed values escaping their valid scope, or lifetime relationships that make an API unsound or unusable
+- Excessive or unnecessary `clone()` calls introduced to satisfy borrowing when a borrow, iterator, `Cow`, or ownership transfer would be clearer and cheaper
+- Interior mutability (`RefCell`, `Cell`, `Mutex`) used to work around ownership without a real shared-mutability requirement
+- Reference cycles with `Rc<RefCell<T>>` or `Arc<Mutex<T>>` where `Weak` should be used to break ownership cycles
+
+#### Error Handling and Panics
+- `unwrap()`, `expect()`, `panic!`, `todo!`, or `unimplemented!` in production/library paths where the failure is recoverable or can be propagated with `Result`
+- Errors converted to strings too early or discarded without context; prefer preserving the original error and adding actionable context at boundaries
+- `Result` or `Option` values ignored, swallowed, or mapped to misleading defaults
+- Public APIs that panic on ordinary invalid input instead of returning a typed error, unless the panic documents a clear programming invariant
+
+#### Unsafe Code Boundaries
+- `unsafe` blocks that are broader than necessary or hide multiple unrelated invariants
+- Missing or stale safety rationale for `unsafe` blocks, `unsafe fn`, `unsafe impl Send`, or `unsafe impl Sync`
+- Raw pointer dereferences without clear validity, alignment, initialization, aliasing, and lifetime guarantees
+- FFI boundaries that do not validate null pointers, buffer lengths, ownership transfer, string encoding, or allocator compatibility
+- `static mut`, unchecked `transmute`, `MaybeUninit`, `mem::zeroed`, or manual drop logic used without a documented invariant that makes the operation sound
+
+#### Concurrency and Shared State
+- Holding `Mutex`, `RwLock`, or `RefCell` guards longer than necessary, especially across calls into user code or potentially blocking operations
+- Holding synchronous locks across `.await`, or using blocking I/O, sleeps, or CPU-heavy work directly inside async tasks
+- Check-then-act races around shared state, cache initialization, file creation, or atomics
+- Atomic operations with ordering that is too weak for the data being protected, or overly strong orderings that hide the intended synchronization contract
+- Unsafe `Send` or `Sync` implementations that do not prove all contained state is thread-safe under the documented invariants
+
+#### Async and Cancellation Safety
+- Spawned tasks whose `JoinHandle` is dropped when failures, cancellation, or shutdown still need to be observed
+- Futures that are not cancellation-safe around partial writes, lock acquisition, transactions, or resource cleanup
+- Async functions that use synchronous filesystem, network, or process APIs in request/worker paths where the runtime can be blocked
+- Retry loops without backoff, timeout, cancellation propagation, or bounded attempts
+
+#### Collections, Iterators, and Performance
+- Avoid unnecessary allocations in hot paths, such as repeated `String` construction, `format!`, `collect()`, or `to_vec()` where borrowing or streaming is sufficient
+- Prefer iterator adapters and standard library collection APIs when they make ownership and complexity clearer; avoid dense iterator chains that obscure error handling or side effects
+- Ensure hash maps, vectors, and strings are preallocated when the expected size is known and growth cost is material
+- Avoid O(n^2) lookups from nested loops when a `HashMap`, `HashSet`, sorting, or indexing strategy would clearly reduce complexity
+
+#### Type and API Design
+- Model domain states with enums, newtypes, and typed IDs instead of booleans, strings, or primitive integers when invalid states would otherwise be representable
+- Prefer standard conversion and borrowing traits (`From`, `TryFrom`, `AsRef`, `Borrow`, `IntoIterator`) when designing reusable APIs
+- Public structs, enums, traits, and errors should have useful names, visibility, trait derives, and documentation appropriate to the crate boundary
+- Avoid exposing concrete collection or synchronization types in public APIs when a slice, iterator, trait, or narrower abstraction would preserve flexibility
+
+#### Security-Sensitive Code
+- Validate path, URL, command, SQL, and serialized input before use; do not build shell commands or SQL with unchecked string concatenation
+- Do not log secrets, tokens, credentials, private keys, or personally identifiable information
+- Check integer conversions, byte slicing, and length arithmetic for overflow, truncation, and UTF-8 boundary errors
+- Cryptographic, random, authentication, and authorization code must use well-reviewed crates and explicit error handling; flag ad hoc implementations

--- a/internal/config/rules/system_rules.go
+++ b/internal/config/rules/system_rules.go
@@ -125,10 +125,11 @@ type DetailResolver interface {
 // The first match wins; if none match, it falls back to DefaultRule.
 // Supports full glob syntax including ** for recursive directory matching.
 func (r *SystemRule) Resolve(path string) string {
+	lowerPath := strings.ToLower(path)
 	for _, pr := range r.PathRules {
 		expanded := expandBraces(pr.Pattern)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, path); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return pr.Rule
 			}
 		}
@@ -137,10 +138,11 @@ func (r *SystemRule) Resolve(path string) string {
 }
 
 func (r *SystemRule) resolveDetail(path string) RuleDetail {
+	lowerPath := strings.ToLower(path)
 	for _, pr := range r.PathRules {
 		expanded := expandBraces(pr.Pattern)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, path); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return RuleDetail{Rule: pr.Rule, Source: "system", Pattern: pr.Pattern}
 			}
 		}
@@ -382,10 +384,11 @@ func matchProjectRule(pr *ProjectRule, path string) string {
 	if pr == nil {
 		return ""
 	}
+	lowerPath := strings.ToLower(path)
 	for _, entry := range pr.Rules {
 		expanded := expandBraces(entry.Path)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, path); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return entry.Rule
 			}
 		}
@@ -397,13 +400,14 @@ func matchProjectRuleDetail(pr *ProjectRule, path, source string) *RuleDetail {
 	if pr == nil {
 		return nil
 	}
+	lowerPath := strings.ToLower(path)
 	for _, entry := range pr.Rules {
 		if entry.Rule == "" {
 			continue
 		}
 		expanded := expandBraces(entry.Path)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, path); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return &RuleDetail{Rule: entry.Rule, Source: source, Pattern: entry.Path}
 			}
 		}

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -6,7 +6,7 @@
     "**/pom.xml": "pom_xml.md",
     "**/build.gradle": "build_gradle.md",
     "**/package.json": "package_json.md",
-    "**/cargo.toml": "cargo_toml.md",
+    "**/Cargo.toml": "cargo_toml.md",
     "**/*.{json,json5}": "json.md",
     "**/*.{yaml,yml}": "yaml.md",
     "**/*.java": "java.md",

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -6,12 +6,14 @@
     "**/pom.xml": "pom_xml.md",
     "**/build.gradle": "build_gradle.md",
     "**/package.json": "package_json.md",
+    "**/cargo.toml": "cargo_toml.md",
     "**/*.{json,json5}": "json.md",
     "**/*.{yaml,yml}": "yaml.md",
     "**/*.java": "java.md",
     "**/*.ets": "arkts.md",
     "**/*.{ts,js,tsx,jsx}": "ts_js_tsx_jsx.md",
     "**/*.{kt}": "kotlin.md",
+    "**/*.rs": "rust.md",
     "**/*.{cpp,cc,hpp}": "cpp.md",
     "**/*.c": "c.md"
   }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -76,6 +76,9 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"components/Button.ets", "State Decorator"},
 		{"entry/src/main/module.json5", "json-key"},
 		{"entry/oh-package.json5", "json-key"},
+		{"src/lib.rs", "Ownership and Lifetime Correctness"},
+		{"crates/service/src/main.rs", "Unsafe Code Boundaries"},
+		{"crates/service/cargo.toml", "Cargo Manifest Hygiene"},
 	}
 
 	for _, tt := range tests {
@@ -99,7 +102,6 @@ func TestResolve_FallbackToDefault(t *testing.T) {
 		"readme.md",
 		"docs/architecture.txt",
 		"Makefile",
-		"src/unknown.rs",
 		"internal/agent/agent.go",
 		"scripts/deploy.py",
 		"ios/ViewController.m",

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -78,7 +78,7 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"entry/oh-package.json5", "json-key"},
 		{"src/lib.rs", "Ownership and Lifetime Correctness"},
 		{"crates/service/src/main.rs", "Unsafe Code Boundaries"},
-		{"crates/service/cargo.toml", "Cargo Manifest Hygiene"},
+		{"crates/service/Cargo.toml", "Cargo Manifest Hygiene"},
 	}
 
 	for _, tt := range tests {
@@ -153,24 +153,33 @@ func TestResolve_CustomRule_DefaultFallback(t *testing.T) {
 	}
 }
 
-func TestResolve_CaseSensitivity(t *testing.T) {
+func TestResolve_CaseInsensitive(t *testing.T) {
 	rule := &SystemRule{
 		DefaultRule: "default",
 		PathRules: []PathRule{
 			{Pattern: "**/*.java", Rule: "java-rule"},
+			{Pattern: "**/Cargo.toml", Rule: "cargo-rule"},
 		},
 	}
 
-	// agent.go calls strings.ToLower(newPath) before Resolve,
-	// so uppercase extensions should NOT match if not lowercased.
 	got := rule.Resolve("Foo.Java")
-	if got != "default" {
-		t.Errorf("expected default for uppercase extension, got %q", got)
+	if got != "java-rule" {
+		t.Errorf("expected java-rule for uppercase extension, got %q", got)
 	}
 
 	got = rule.Resolve("foo.java")
 	if got != "java-rule" {
 		t.Errorf("expected java-rule for lowercase, got %q", got)
+	}
+
+	got = rule.Resolve("crates/service/Cargo.toml")
+	if got != "cargo-rule" {
+		t.Errorf("expected cargo-rule for canonical Cargo.toml, got %q", got)
+	}
+
+	got = rule.Resolve("crates/service/cargo.toml")
+	if got != "cargo-rule" {
+		t.Errorf("expected cargo-rule for lowercased cargo.toml, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds built-in review rules for Rust source files and Cargo manifests.

This change adds:

- `**/*.rs` mapping to a Rust-specific review rule document
- `**/Cargo.toml` mapping to a Cargo manifest review rule document
- default rule resolution tests for Rust source files and Cargo manifests

The Rust rules cover ownership/lifetime correctness, error handling and panics, `unsafe` boundaries, concurrency, async cancellation safety, performance, API design, and security-sensitive code. The Cargo rules cover dependency hygiene, edition/MSRV/resolver settings, feature flags, and package metadata.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

Ran the relevant config package tests and full Go test suite locally:

- `go test ./internal/config/...`
- `go test ./...`
- `make test`

Also manually verified rule resolution:

- `go run ./cmd/opencodereview rules check src/lib.rs`
- `go run ./cmd/opencodereview rules check crates/service/Cargo.toml`
- `go run ./cmd/opencodereview rules check crates/service/cargo.toml`

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #73
Fixes #75
