### PR TITLE
docs: fix Codex spelling across localized READMEs

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -133,7 +133,7 @@ export OCR_USE_ANTHROPIC=true
 
 > **CC-Switchユーザー向けの注意**: [CC-Switch](https://github.com/farion1231/cc-switch)を[ルーティングサービス](https://www.ccswitch.io/en/docs?section=proxy&item=service)有効で使用している場合、追加設定なしで`llm.url`をCC-Switchのプロキシアドレスに向けることができます：
 > - **Claude**プロバイダーの場合: `llm.url`を`http://127.0.0.1:15721`に設定
-> - **CodeX**プロバイダーの場合: `llm.url`を`http://127.0.0.1:15721/v1`に設定
+> - **Codex**プロバイダーの場合: `llm.url`を`http://127.0.0.1:15721/v1`に設定
 > - `llm.model`はプロバイダー設定に応じて設定
 > - `llm.auth_token`は任意の値で構いません
 > - `extra_body`設定は引き続き有効です

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -133,7 +133,7 @@ Claude Code 환경 변수(`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROP
 
 > **CC-Switch 사용자 참고**: [CC-Switch](https://github.com/farion1231/cc-switch)를 [routing service](https://www.ccswitch.io/en/docs?section=proxy&item=service)와 함께 사용한다면, 추가 설정 없이 `llm.url`을 CC-Switch proxy 주소로 지정할 수 있습니다.
 > - **Claude** provider: `llm.url`을 `http://127.0.0.1:15721`로 설정
-> - **CodeX** provider: `llm.url`을 `http://127.0.0.1:15721/v1`로 설정
+> - **Codex** provider: `llm.url`을 `http://127.0.0.1:15721/v1`로 설정
 > - provider 설정에 맞게 `llm.model` 설정
 > - `llm.auth_token`은 아무 값이나 사용할 수 있음
 > - `extra_body` 설정은 그대로 적용됨

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ It is also compatible with Claude Code environment variables (`ANTHROPIC_BASE_UR
 
 > **Note for CC-Switch Users**: If you are using [CC-Switch](https://github.com/farion1231/cc-switch) with [routing service](https://www.ccswitch.io/en/docs?section=proxy&item=service) enabled, you can point `llm.url` to the CC-Switch proxy address without additional configuration:
 > - For **Claude** provider: set `llm.url` to `http://127.0.0.1:15721`
-> - For **CodeX** provider: set `llm.url` to `http://127.0.0.1:15721/v1`
+> - For **Codex** provider: set `llm.url` to `http://127.0.0.1:15721/v1`
 > - Set `llm.model` according to your provider settings
 > - `llm.auth_token` can be any value
 > - `extra_body` settings still apply

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,7 +133,7 @@ export OCR_USE_ANTHROPIC=true
 
 > **CC-Switch 用户特别提醒**：如果你使用 [CC-Switch](https://github.com/farion1231/cc-switch) 并开启了[路由服务](https://www.ccswitch.io/zh/docs?section=proxy&item=service)，可以将 `llm.url` 配置成 CC-Switch 启动的代理地址，无需额外配置：
 > - 如果路由的是 **Claude** 供应商：设置 `llm.url` 为 `http://127.0.0.1:15721`
-> - 如果路由的是 **CodeX** 供应商：设置 `llm.url` 为 `http://127.0.0.1:15721/v1`
+> - 如果路由的是 **Codex** 供应商：设置 `llm.url` 为 `http://127.0.0.1:15721/v1`
 > - `llm.model` 根据你的供应商设置进行配置
 > - `llm.auth_token` 可以设置成任意值
 > - `extra_body` 设置依然生效


### PR DESCRIPTION
## Description

Corrects the provider name in the README set where `CodeX` was used instead of `Codex`. This aligns the English, Simplified Chinese, Japanese, and Korean documentation with the rest of the docs.

- **Scope**
  - Update `/README.md`
  - Update `/README.zh-CN.md`
  - Update `/README.ja-JP.md`
  - Update `/README.ko-KR.md`

- **Change**
  - Replace the provider spelling `CodeX` with `Codex` in the configuration guidance
  - Keep the existing setup instructions and examples otherwise unchanged

```md
- For **Codex** provider: set `llm.url` to `http://127.0.0.1:15721/v1`
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Verified the affected README entries now use `Codex` consistently.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->