### PR TITLE
fix: handle previously swallowed json.Unmarshal errors

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -502,7 +502,10 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 		model = c.cfg.Model
 	}
 
-	params := c.buildAnthropicParams(model, req)
+	params, err := c.buildAnthropicParams(model, req)
+	if err != nil {
+		return nil, err
+	}
 
 	var opts []option.RequestOption
 	for k, v := range c.cfg.ExtraBody {
@@ -518,7 +521,7 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 }
 
 // buildAnthropicParams converts the shared ChatRequest into Anthropic SDK parameters.
-func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) anthropic.MessageNewParams {
+func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (anthropic.MessageNewParams, error) {
 	var systemBlocks []anthropic.TextBlockParam
 	var messages []anthropic.MessageParam
 	var pendingToolResults []Message
@@ -557,7 +560,9 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) an
 			for _, tc := range msg.ToolCalls {
 				argsMap := map[string]any{}
 				if tc.Function.Arguments != "" {
-					json.Unmarshal([]byte(tc.Function.Arguments), &argsMap)
+					if err := json.Unmarshal([]byte(tc.Function.Arguments), &argsMap); err != nil {
+						return anthropic.MessageNewParams{}, fmt.Errorf("invalid tool call arguments for %s: %w", tc.Function.Name, err)
+					}
 				}
 				blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, argsMap, tc.Function.Name))
 			}
@@ -623,7 +628,7 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) an
 		params.Temperature = anthropic.Float(*req.Temperature)
 	}
 
-	return params
+	return params, nil
 }
 
 func buildToolInputSchema(params map[string]any) anthropic.ToolInputSchemaParam {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -107,7 +107,10 @@ func TestBuildAnthropicParams_CacheControl(t *testing.T) {
 		},
 	}
 
-	params := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	if err != nil {
+		t.Fatalf("buildAnthropicParams: %v", err)
+	}
 
 	t.Run("last system block has cache control", func(t *testing.T) {
 		if len(params.System) < 2 {
@@ -166,7 +169,10 @@ func TestBuildAnthropicParams_CacheControl_NoTools(t *testing.T) {
 		},
 	}
 
-	params := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	if err != nil {
+		t.Fatalf("buildAnthropicParams: %v", err)
+	}
 
 	if len(params.System) == 0 {
 		t.Fatal("expected system blocks")
@@ -192,7 +198,10 @@ func TestBuildAnthropicParams_CacheControl_NoSystem(t *testing.T) {
 		},
 	}
 
-	params := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+	if err != nil {
+		t.Fatalf("buildAnthropicParams: %v", err)
+	}
 
 	if len(params.System) != 0 {
 		t.Errorf("expected no system blocks, got %d", len(params.System))

--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -38,7 +38,9 @@ func ParseComments(args map[string]any) ([]model.LlmComment, string) {
 	if arr, ok := args["comments"].([]any); ok && len(arr) > 0 {
 		rawComments = arr
 	} else if s, ok := args["comments"].(string); ok && s != "" {
-		_ = json.Unmarshal([]byte(s), &rawComments)
+		if err := json.Unmarshal([]byte(s), &rawComments); err != nil {
+			return nil, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
+		}
 	}
 	if len(rawComments) == 0 {
 		raw, _ := json.Marshal(args)


### PR DESCRIPTION
## Description

Propagate previously swallowed `json.Unmarshal` errors in two locations:

- **`buildAnthropicParams`** (`internal/llm/client.go`): When parsing tool call arguments, a failed unmarshal silently produced an empty map, causing downstream tool execution to fail with no clear root cause. Now the error is propagated to the caller.
- **`ParseComments`** (`internal/tool/code_comment.go`): When the `comments` field is a JSON string that fails to parse, the error was discarded and the function fell through to a generic "comments array is required" message. Now it returns a specific parse error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

All existing tests pass. `buildAnthropicParams` signature changed to return `(anthropic.MessageNewParams, error)`; test call sites updated accordingly.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

None.