### PR TITLE
ci: use self-hosted runners with container images for build and deplo…

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,13 +18,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container:
+      image: node:20
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
 
       - name: Install dependencies
         working-directory: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container:
+      image: golang:1.26.4
     strategy:
       matrix:
         include:
@@ -27,10 +29,6 @@ jobs:
             goarch: arm64
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
 
       - name: Build
         env:
@@ -56,7 +54,9 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container:
+      image: ubuntu:24.04
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -76,17 +76,17 @@ jobs:
 
   npm-publish:
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container:
+      image: node:20
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
+      - name: Install jq
+        run: apt-get update && apt-get install -y jq
 
       - name: Inject version from tag
         run: jq --arg v "${GITHUB_REF_NAME#v}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
- deploy-pages: switch to self-hosted runner with node:20 container, remove redundant setup-node

- release: use self-hosted runner with golang:1.26.4 container for build job, remove redundant setup-go

- release: use self-hosted runner with ubuntu:24.04 container for release job

- release: use self-hosted runner with node:20 container for npm-publish job, remove redundant setup-node

- release: add jq installation step for version injection in npm-publish


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
