### PR TITLE
fix(diff): detect renamed and deleted files correctly in diff parsing

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -127,6 +127,8 @@ func diffStatus(d model.Diff) string {
 		return "added"
 	case d.IsDeleted:
 		return "deleted"
+	case d.IsRenamed:
+		return "renamed"
 	case d.OldPath != d.NewPath && d.OldPath != "" && d.OldPath != "/dev/null":
 		return "renamed"
 	default:

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -115,14 +115,14 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		if base == "" {
 			return nil, fmt.Errorf("cannot find merge-base between %s and %s", p.from, p.to)
 		}
-		out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
+		out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
 		if err != nil {
 			return nil, fmt.Errorf("git diff failed: %w", err)
 		}
 		combined.WriteString(out)
 
 	case ModeCommit:
-		out, err := p.runGit(ctx, "show", "--no-ext-diff", "--no-textconv", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
+		out, err := p.runGit(ctx, "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
 		if err != nil {
 			return nil, fmt.Errorf("git show failed: %w", err)
 		}
@@ -265,14 +265,14 @@ func (p *Provider) computeMergeBase(ctx context.Context, from, to string) string
 }
 
 func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, error) {
-	out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
 	if err == nil && out != "" {
 		return out, nil
 	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
-	return p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--src-prefix=a/", "--dst-prefix=b/", "--staged", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	return p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--staged", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
 }
 
 func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -2,9 +2,11 @@ package diff
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-code-review/open-code-review/internal/gitcmd"
@@ -143,6 +145,66 @@ func TestCommitDiffTreatsOptionLikeRefAsRevision(t *testing.T) {
 		t.Fatal("option-like commit ref was interpreted as a git show option")
 	} else if !os.IsNotExist(statErr) {
 		t.Fatal(statErr)
+	}
+}
+
+// TestRangeDiffDetectsRename guards against issue #99: when a file is renamed
+// on the target branch, `ocr review --from master --to BRANCH` must recognize
+// the rename and read content at the NEW path. Before the fix the rename could
+// surface as delete(old)+add(new) (e.g. diff.renames=false) and the parser's
+// broken /dev/null detection sent the deleted half into `git show ref:oldpath`
+// -> "WARNING: cannot read file ... exit status 128".
+func TestRangeDiffDetectsRename(t *testing.T) {
+	repo := initRepoWithChange(t)
+
+	// Reset the working-tree modification left by the helper.
+	runGitTest(t, repo, "checkout", "--", "sample.txt")
+	// Simulate a user config where git does NOT detect renames on its own;
+	// the provider must force --find-renames.
+	runGitTest(t, repo, "config", "diff.renames", "false")
+
+	// Commit a file large enough for git's similarity detection to work
+	// (tiny files fall below the rename threshold even for 1-line edits).
+	var content strings.Builder
+	for i := 1; i <= 50; i++ {
+		fmt.Fprintf(&content, "line%d\n", i)
+	}
+	orig := filepath.Join(repo, "orig.txt")
+	if err := os.WriteFile(orig, []byte(content.String()), 0o644); err != nil {
+		t.Fatalf("write orig.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "orig.txt")
+	runGitTest(t, repo, "commit", "-q", "-m", "add orig.txt")
+
+	// Rename on a feature branch, with a small edit (like the issue repro).
+	runGitTest(t, repo, "checkout", "-q", "-b", "feature")
+	runGitTest(t, repo, "mv", "orig.txt", "renamed.txt")
+	edited := strings.Replace(content.String(), "line25\n", "line25-edited\n", 1)
+	if err := os.WriteFile(filepath.Join(repo, "renamed.txt"), []byte(edited), 0o644); err != nil {
+		t.Fatalf("edit renamed.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "-A")
+	runGitTest(t, repo, "commit", "-q", "-m", "rename orig.txt")
+
+	runner := gitcmd.New(0)
+	provider := NewProvider(repo, "HEAD~1", "feature", runner)
+
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff (range, rename) returned error: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected exactly 1 diff for a rename, got %d: %+v", len(diffs), diffs)
+	}
+	d := diffs[0]
+	if !d.IsRenamed {
+		t.Errorf("IsRenamed = false, want true")
+	}
+	if d.OldPath != "orig.txt" || d.NewPath != "renamed.txt" {
+		t.Errorf("OldPath/NewPath = %q/%q, want orig.txt/renamed.txt", d.OldPath, d.NewPath)
+	}
+	if d.NewFileContent == "" {
+		t.Errorf("NewFileContent is empty: content at new path was not read at ref")
 	}
 }
 

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -17,8 +17,6 @@ import (
 
 var (
 	diffHeaderRe = regexp.MustCompile(`^diff --git a/(.+?) b/(.+)$`)
-	oldFileRe    = regexp.MustCompile(`^--- a/(.+)$`)
-	newFileRe    = regexp.MustCompile(`^\+\+\+ b/(.+)$`)
 	binaryRe     = regexp.MustCompile(`Binary files `)
 )
 
@@ -57,14 +55,25 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 		switch {
 		case binaryRe.MatchString(line):
 			current.IsBinary = true
-		case oldFileRe.MatchString(line):
-			if p := oldFileRe.FindStringSubmatch(line); len(p) > 1 && p[1] == "/dev/null" {
-				current.IsNew = true
-			}
-		case newFileRe.MatchString(line):
-			if p := newFileRe.FindStringSubmatch(line); len(p) > 1 && p[1] == "/dev/null" {
-				current.IsDeleted = true
-			}
+		// Extended header lines (unambiguous: content lines always carry a
+		// leading "+", "-" or " " prefix, so a bare prefix match is safe).
+		case strings.HasPrefix(line, "new file mode "):
+			current.IsNew = true
+		case strings.HasPrefix(line, "deleted file mode "):
+			current.IsDeleted = true
+		case strings.HasPrefix(line, "rename from "):
+			// Authoritative old path for renames; more reliable than the
+			// "diff --git" header when paths contain spaces.
+			current.OldPath = strings.TrimPrefix(line, "rename from ")
+			current.IsRenamed = true
+		case strings.HasPrefix(line, "rename to "):
+			current.NewPath = strings.TrimPrefix(line, "rename to ")
+			current.IsRenamed = true
+		// git emits "--- /dev/null" / "+++ /dev/null" without a/ b/ prefixes.
+		case line == "--- /dev/null":
+			current.IsNew = true
+		case line == "+++ /dev/null":
+			current.IsDeleted = true
 		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
 			current.Insertions++
 		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -1,0 +1,131 @@
+package diff
+
+import (
+	"context"
+	"testing"
+)
+
+// TestParseDiffText_Rename guards against issue #99: a renamed file must be
+// recognized via the "rename from"/"rename to" extended header lines so that
+// the parser reads content at the NEW path instead of warning about the old
+// path ("cannot read file ... exit status 128").
+func TestParseDiffText_Rename(t *testing.T) {
+	diffText := `diff --git a/pkg/old name.go b/pkg/new name.go
+similarity index 95%
+rename from pkg/old name.go
+rename to pkg/new name.go
+index 1234567..89abcde 100644
+--- a/pkg/old name.go
++++ b/pkg/new name.go
+@@ -1,3 +1,3 @@
+ line1
+-line2
++line2 changed
+ line3
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if !d.IsRenamed {
+		t.Errorf("IsRenamed = false, want true")
+	}
+	if d.OldPath != "pkg/old name.go" {
+		t.Errorf("OldPath = %q, want %q", d.OldPath, "pkg/old name.go")
+	}
+	if d.NewPath != "pkg/new name.go" {
+		t.Errorf("NewPath = %q, want %q", d.NewPath, "pkg/new name.go")
+	}
+	if d.IsNew || d.IsDeleted {
+		t.Errorf("IsNew/IsDeleted = %v/%v, want false/false", d.IsNew, d.IsDeleted)
+	}
+}
+
+// TestParseDiffText_PureRename covers a 100% similarity rename, which carries
+// no hunks and no ---/+++ lines at all.
+func TestParseDiffText_PureRename(t *testing.T) {
+	diffText := `diff --git a/old.go b/new.go
+similarity index 100%
+rename from old.go
+rename to new.go
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if !d.IsRenamed || d.OldPath != "old.go" || d.NewPath != "new.go" {
+		t.Errorf("got IsRenamed=%v OldPath=%q NewPath=%q, want true/old.go/new.go",
+			d.IsRenamed, d.OldPath, d.NewPath)
+	}
+}
+
+// TestParseDiffText_DeletedFile guards the /dev/null detection: git emits
+// "+++ /dev/null" WITHOUT the b/ prefix, which the old regexes required, so
+// deletions were misclassified and triggered a doomed `git show ref:path`.
+func TestParseDiffText_DeletedFile(t *testing.T) {
+	diffText := `diff --git a/gone.go b/gone.go
+deleted file mode 100644
+index 1234567..0000000
+--- a/gone.go
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line1
+-line2
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if !d.IsDeleted {
+		t.Errorf("IsDeleted = false, want true")
+	}
+	if d.NewPath != "/dev/null" {
+		t.Errorf("NewPath = %q, want /dev/null", d.NewPath)
+	}
+	if d.OldPath != "gone.go" {
+		t.Errorf("OldPath = %q, want gone.go", d.OldPath)
+	}
+}
+
+// TestParseDiffText_NewFile covers "--- /dev/null" (no a/ prefix).
+func TestParseDiffText_NewFile(t *testing.T) {
+	diffText := `diff --git a/fresh.go b/fresh.go
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/fresh.go
+@@ -0,0 +1,2 @@
++line1
++line2
+`
+	repo := t.TempDir()
+	diffs, err := ParseDiffText(context.Background(), diffText, repo, "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if !d.IsNew {
+		t.Errorf("IsNew = false, want true")
+	}
+	if d.IsDeleted {
+		t.Errorf("IsDeleted = true, want false")
+	}
+	if d.Insertions != 2 {
+		t.Errorf("Insertions = %d, want 2", d.Insertions)
+	}
+}

--- a/internal/model/diff.go
+++ b/internal/model/diff.go
@@ -9,6 +9,7 @@ type Diff struct {
 	IsBinary       bool   `json:"is_binary"`
 	IsDeleted      bool   `json:"is_deleted"`
 	IsNew          bool   `json:"is_new"`
+	IsRenamed      bool   `json:"is_renamed"`
 	Insertions     int64  `json:"insertions"`
 	Deletions      int64  `json:"deletions"`
 }


### PR DESCRIPTION
## Summary

Fixes #99 — `ocr review --from master --to BRANCH --format json` emitted `[ocr] WARNING: cannot read file <old path> at ref BRANCH: exit status 128` when a file was renamed on the target branch.

## Root Cause

Two compounding bugs:

1. **Broken `/dev/null` detection** (`internal/diff/parser.go`): git emits `--- /dev/null` / `+++ /dev/null` **without** `a/`/`b/` prefixes, but the old regexes required them, so `IsNew`/`IsDeleted` were never set. Deleted files fell through to `git show ref:<old path>` → `exit status 128`.
2. **Renames never handled**: the parser ignored `rename from` / `rename to` extended headers, and the git diff/show call sites did not pass `--find-renames`, so with `diff.renames=false` a rename degraded to delete(old)+add(new); the delete half hit bug 1 and warned about the old path.

## Changes

- Parse `rename from`/`rename to` (authoritative paths, robust for paths with spaces), `new file mode`, `deleted file mode`, and unprefixed `/dev/null` markers in `ParseDiffText`
- Pass `--find-renames` to all 4 git diff/show invocations so rename detection no longer depends on user git config
- Add `IsRenamed` to `model.Diff` (json: `is_renamed`) and prefer it in `diffStatus`
- New `parser_test.go`: rename / pure rename (100% similarity, no hunks) / deleted / new file unit tests
- New `TestRangeDiffDetectsRename` integration test: `diff.renames=false` + branch rename + small edit → exactly 1 diff, `IsRenamed=true`, content read at the new path

## Testing

- `go test -race -count=1 ./...` — all packages pass
- `go vet ./...` and `go build ./...` clean