### PR TITLE
ci: fix dubious ownership error on self-hosted runners

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -45,6 +45,9 @@ jobs:
           fetch-depth: 0  # Full history needed for merge-base diff
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Mark repository as safe directory
+        run: git config --global --add safe.directory '*'
+
       - name: Fetch PR head ref (ensures fork commits are available)
         run: git fetch origin pull/${{ github.event.pull_request.number }}/head
 


### PR DESCRIPTION
Add safe.directory '*' to git config before running git operations. Self-hosted runners may run jobs under a different OS user than the one that owns the workspace, causing git to refuse operations with a 'dubious ownership' error.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
