### PR TITLE
feat：add --model flag to override LLM model per review

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -297,6 +297,7 @@ ocr review \
 | `--timeout` | — | `10` | 同時実行タスクのタイムアウト（分） |
 | `--audience` | — | `human` | `human`（進捗を表示）または`agent`（サマリーのみ） |
 | `--background` | `-b` | — | レビューのための任意の要件/ビジネスコンテキスト。`--commit`使用時に未指定の場合、コミットメッセージから自動取得 |
+| `--model` | — | — | このレビューでLLMモデルをオーバーライド（例：`claude-opus-4-5`） |
 | `--rule` | — | — | カスタムJSONレビュールールへのパス |
 | `--max-tools` | — | 組み込み値 | ファイルごとのツール呼び出しラウンドの上限。テンプレートのデフォルトより大きい場合のみ有効 |
 | `--max-git-procs` | — | 組み込み値 | gitサブプロセスの最大同時実行数 |
@@ -317,6 +318,10 @@ ocr review --from main --to my-feature --concurrency 4
 
 # 特定のコミットを詳細なJSON出力でレビュー
 ocr review --commit abc123 --format json --audience agent
+
+# モデルを一時的にオーバーライド
+ocr review --model claude-opus-4-5
+ocr review --commit abc123 --model claude-haiku-4-5
 
 # 要件コンテキストを提供してより的確なレビューを実施
 ocr review --background "ログインAPIにレート制限を追加"

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -297,6 +297,7 @@ ocr review \
 | `--timeout` | - | `10` | 동시 task timeout(분) |
 | `--audience` | - | `human` | `human`(progress 표시) 또는 `agent`(summary only) |
 | `--background` | `-b` | - | 리뷰를 위한 선택적 요구사항/비즈니스 컨텍스트. `--commit` 사용 시 미지정이면 commit message에서 자동 추출 |
+| `--model` | - | - | 이번 리뷰에서 LLM model override (예: `claude-opus-4-5`) |
 | `--rule` | - | - | custom JSON review rules 경로 |
 | `--max-tools` | - | built-in | 파일별 최대 tool call round. template default보다 클 때만 적용 |
 | `--max-git-procs` | - | built-in | 최대 동시 git subprocess 수 |
@@ -317,6 +318,10 @@ ocr review --from main --to my-feature --concurrency 4
 
 # 특정 commit을 verbose JSON output으로 리뷰
 ocr review --commit abc123 --format json --audience agent
+
+# 이번 리뷰에서 model 임시 override
+ocr review --model claude-opus-4-5
+ocr review --commit abc123 --model claude-haiku-4-5
 
 # 요구사항 컨텍스트를 제공하여 더 정확한 리뷰 수행
 ocr review --background "로그인 API에 rate limiting 추가"

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ See the [`examples/`](./examples/) directory for integration examples:
 | `--timeout` | — | `10` | Concurrent task timeout in minutes |
 | `--audience` | — | `human` | `human` (show progress) or `agent` (summary only) |
 | `--background` | `-b` | — | Optional requirement/business context for the review; auto-filled from commit message when using `--commit` |
+| `--model` | — | — | Override LLM model for this review (e.g., `claude-opus-4-5`) |
 | `--rule` | — | — | Path to custom JSON review rules |
 | `--max-tools` | — | built-in | Max tool call rounds per file; only takes effect when greater than template default |
 | `--max-git-procs` | — | built-in | Max concurrent git subprocesses |
@@ -319,6 +320,10 @@ ocr review --from main --to my-feature --concurrency 4
 
 # Review a specific commit with verbose JSON output
 ocr review --commit abc123 --format json --audience agent
+
+# Override model for this review
+ocr review --model claude-opus-4-5
+ocr review --commit abc123 --model claude-haiku-4-5
 
 # Provide requirement context for more targeted review
 ocr review --background "Adding rate limiting to the login API"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,6 +297,7 @@ ocr review \
 | `--timeout` | — | `10` | 并发任务超时时间（分钟） |
 | `--audience` | — | `human` | `human`（显示进度）或 `agent`（仅输出摘要） |
 | `--background` | `-b` | — | 可选的需求/业务背景信息；使用 `--commit` 时如未指定则自动从 commit message 中提取 |
+| `--model` | — | — | 覆盖配置文件中的 LLM 模型（如 `claude-opus-4-5`） |
 | `--rule` | — | — | 自定义 JSON 审查规则路径 |
 | `--max-tools` | — | 内置默认 | 每个文件的最大工具调用轮次；仅在大于模板默认值时生效 |
 | `--max-git-procs` | — | 内置默认 | 最大并发 git 子进程数 |
@@ -317,6 +318,10 @@ ocr review --from main --to my-feature --concurrency 4
 
 # 审查特定提交并以 JSON 格式输出详细信息
 ocr review --commit abc123 --format json --audience agent
+
+# 临时覆盖模型进行审查
+ocr review --model claude-opus-4-5
+ocr review --commit abc123 --model claude-haiku-4-5
 
 # 提供需求背景以获得更有针对性的审查
 ocr review --background "为登录 API 添加限流"

--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -104,6 +104,7 @@ type reviewOptions struct {
 	outputFormat   string
 	audience       string // --audience: "human" (default) or "agent"
 	background     string // --background: optional requirement context
+	model          string // --model: override llm.model from config
 	concurrency    int
 	perFileTimeout int
 	maxTools       int
@@ -128,6 +129,7 @@ func parseReviewFlags(args []string) (reviewOptions, error) {
 	a.IntVar(&opts.perFileTimeout, "timeout", 10, "concurrent task timeout in minutes")
 	a.StringVar(&opts.audience, "audience", "human", "output audience: human (show progress) or agent (summary only)")
 	a.StringVarP(&opts.background, "background", "b", "", "optional requirement/business context for the review")
+	a.StringVar(&opts.model, "model", "", "override LLM model for this review (e.g., claude-opus-4-5)")
 	a.IntVar(&opts.maxTools, "max-tools", 0, "max tool call rounds per file (0 = template default; min 10)")
 	a.IntVar(&opts.maxGitProcs, "max-git-procs", 16, "max concurrent git subprocesses")
 	a.BoolVarP(&opts.preview, "preview", "p", false, "preview which files will be reviewed without running the LLM")
@@ -216,6 +218,7 @@ Flags:
   --max-git-procs int     max concurrent git subprocesses (default 16)
   --from string           source ref to start diff from (e.g., 'main')
   --max-tools int         max tool call rounds per file (0 = template default; min 10)
+  --model string          override LLM model for this review (e.g., claude-opus-4-5)
   -p, --preview           preview which files will be reviewed without running the LLM
   --repo string           root directory of the git repository (default: current dir)
   --rule string           path to JSON file with system review rules

--- a/cmd/opencodereview/flags_test.go
+++ b/cmd/opencodereview/flags_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestParseReviewFlagsModelOverride(t *testing.T) {
+	opts, err := parseReviewFlags([]string{"--model", "claude-opus-4-5"})
+	if err != nil {
+		t.Fatalf("parseReviewFlags: %v", err)
+	}
+
+	if opts.model != "claude-opus-4-5" {
+		t.Errorf("model = %q, want %q", opts.model, "claude-opus-4-5")
+	}
+	if opts.outputFormat != "text" {
+		t.Errorf("outputFormat = %q, want %q", opts.outputFormat, "text")
+	}
+	if opts.audience != "human" {
+		t.Errorf("audience = %q, want %q", opts.audience, "human")
+	}
+}

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -91,6 +91,9 @@ func runReview(args []string) error {
 
 	llmClient := llm.NewLLMClient(ep)
 	model := ep.Model
+	if opts.model != "" {
+		model = opts.model
+	}
 
 	gitRunner := gitcmd.New(opts.maxGitProcs)
 


### PR DESCRIPTION
## Description

  Adds a `--model` flag to `ocr review`, allowing users to override the configured LLM model for a single review run without changing `~/.opencodereview/config.json`.

  This is useful when users want to temporarily switch models for a specific review, for example:

  ocr review --model claude-opus-4-5
  ocr review --commit abc123 --model claude-haiku-4-5

  The flag is documented in all README language variants, and a unit test was added for flag parsing.

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactoring (no functional changes)
  - [x] Documentation update
  - [ ] CI / Build / Tooling

  ## How Has This Been Tested?

  - [ ] make test passes locally
  - [x] Manual testing (describe below)

  Tested locally with:

  go test ./cmd/opencodereview
  go test ./...

  Also verified that ocr review --help includes the new --model flag.

  ## Checklist

  - [x] My code follows the project's coding style (go fmt, go vet)
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove my fix is effective or my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have updated the documentation accordingly (if applicable)
  - [x] I have signed the CLA

  ## Related Issues

[ alibaba/open-code-review#83](https://github.com/alibaba/open-code-review/issues/83)

  ## Verify

<img width="1536" height="458" alt="image" src="https://github.com/user-attachments/assets/ac3861fc-64fe-4e6f-b72d-feefa44a4834" />

<img width="1534" height="662" alt="image" src="https://github.com/user-attachments/assets/bd9fffe4-5798-4218-89ac-fea84f6b915b" />
