### PR TITLE
feat: add built-in Mimo provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -77,6 +77,19 @@ var registry = []Provider{
 			"glm-4.7",
 		},
 	},
+	{
+		Name:        "mimo",
+		DisplayName: "Xiaomi MiMo API",
+		Protocol:    "openai",
+		BaseURL:     "https://token-plan-cn.xiaomimimo.com/v1",
+		EnvVar:      "MIMO_API_KEY",
+		Models: []string{
+			"mimo-v2.5-pro",
+			"mimo-v2.5",
+			"mimo-v2-pro",
+			"mimo-v2-omni",
+		},
+	},
 }
 
 var registryMap map[string]Provider


### PR DESCRIPTION
## Summary

  Adds Mimo as a built-in LLM provider so users can configure it through the interactive provider setup flow and provider-based config.

  ## Changes

  - Added `mimo` to the built-in provider registry.
  - Configured Mimo provider metadata, including display name, protocol, base URL, API key environment variable, and default model list.
  - Enables Mimo to appear in:
    - `ocr config provider`
    - `ocr llm providers`
  - Allows users to select and persist Mimo configuration through the existing provider config flow.

ocr config provider:
<img width="1309" height="324" alt="image" src="https://github.com/user-attachments/assets/b4c7c71e-58fe-44a1-b8db-ed0b812c9262" />

ocr llm test: 
<img width="749" height="126" alt="image" src="https://github.com/user-attachments/assets/97c906d2-c4e9-42a7-932b-99f3c01bc176" />
