### PR TITLE
Fix workspace symlink diff containment

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -283,12 +283,7 @@ func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {
 
 	var results []string
 	for _, f := range files {
-		fullPath := filepath.Join(p.repoDir, f)
-		stat, serr := os.Stat(fullPath)
-		if serr != nil || stat.IsDir() {
-			continue
-		}
-		content, rerr := os.ReadFile(fullPath)
+		content, rerr := readWorkspaceFileForDiff(p.repoDir, f)
 		if rerr != nil {
 			continue
 		}

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -148,6 +148,100 @@ func TestCommitDiffTreatsOptionLikeRefAsRevision(t *testing.T) {
 	}
 }
 
+func TestWorkspaceUntrackedSymlinkDoesNotReadExternalTarget(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+	runGitTest(t, repo, "config", "commit.gpgsign", "false")
+
+	if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write base.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "base.txt")
+	runGitTest(t, repo, "commit", "-q", "-m", "initial commit")
+
+	secret := "TOP_SECRET_ISSUE123_SHOULD_NOT_LEAK\n"
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte(secret), 0o644); err != nil {
+		t.Fatalf("write external secret: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "leaked_link")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	provider := NewWorkspaceProvider(repo, gitcmd.New(0))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff returned error: %v", err)
+	}
+
+	var found bool
+	for _, d := range diffs {
+		if strings.Contains(d.Diff, secret) || strings.Contains(d.NewFileContent, secret) {
+			t.Fatalf("workspace diff leaked external symlink target content: %+v", d)
+		}
+		if d.NewPath == "leaked_link" {
+			found = true
+			if d.NewFileContent != outside {
+				t.Fatalf("NewFileContent = %q, want symlink target %q", d.NewFileContent, outside)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected diff for untracked symlink")
+	}
+}
+
+func TestWorkspaceTrackedFileChangedToSymlinkDoesNotReadExternalTarget(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+	runGitTest(t, repo, "config", "commit.gpgsign", "false")
+
+	victim := filepath.Join(repo, "victim.txt")
+	if err := os.WriteFile(victim, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("write victim.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "victim.txt")
+	runGitTest(t, repo, "commit", "-q", "-m", "initial commit")
+
+	secret := "TRACKED_SYMLINK_SECRET_SHOULD_NOT_LEAK\n"
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte(secret), 0o644); err != nil {
+		t.Fatalf("write external secret: %v", err)
+	}
+	if err := os.Remove(victim); err != nil {
+		t.Fatalf("remove victim.txt: %v", err)
+	}
+	if err := os.Symlink(outside, victim); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	provider := NewWorkspaceProvider(repo, gitcmd.New(0))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff returned error: %v", err)
+	}
+
+	var foundSymlinkAdd bool
+	for _, d := range diffs {
+		if strings.Contains(d.Diff, secret) || strings.Contains(d.NewFileContent, secret) {
+			t.Fatalf("workspace diff leaked external symlink target content: %+v", d)
+		}
+		if d.NewPath == "victim.txt" && d.IsNew {
+			foundSymlinkAdd = true
+			if d.NewFileContent != outside {
+				t.Fatalf("NewFileContent = %q, want symlink target %q", d.NewFileContent, outside)
+			}
+		}
+	}
+	if !foundSymlinkAdd {
+		t.Fatal("expected new-file diff for tracked file changed to symlink")
+	}
+}
+
 // TestRangeDiffDetectsRename guards against issue #99: when a file is renamed
 // on the target branch, `ocr review --from master --to BRANCH` must recognize
 // the rename and read content at the NEW path. Before the fix the rename could

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -119,8 +118,7 @@ func finalizeDiff(ctx context.Context, d *model.Diff, repoDir string, ref string
 		d.NewFileContent = string(output)
 		return
 	}
-	fullPath := filepath.Join(repoDir, d.NewPath)
-	content, err := os.ReadFile(fullPath)
+	content, err := readWorkspaceFileForDiff(repoDir, d.NewPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read file %s for review: %v\n", d.NewPath, err)
 		return

--- a/internal/diff/workspace_file.go
+++ b/internal/diff/workspace_file.go
@@ -4,24 +4,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/pathutil"
 )
 
 func readWorkspaceFileForDiff(repoDir, relPath string) ([]byte, error) {
-	repoRoot, err := filepath.Abs(repoDir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve repository path %q: %w", repoDir, err)
-	}
-	repoRoot, err = filepath.EvalSymlinks(repoRoot)
+	repoRoot, err := pathutil.CanonicalPath(repoDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve repository path %q: %w", repoDir, err)
 	}
 	if filepath.IsAbs(relPath) {
-		return nil, fmt.Errorf("file path %q is outside repository", relPath)
+		return nil, fmt.Errorf("file path %q must be relative, not absolute", relPath)
 	}
 
 	fullPath := filepath.Join(repoRoot, relPath)
-	if !pathWithinBase(repoRoot, fullPath) {
+	if !pathutil.WithinBase(repoRoot, fullPath) {
 		return nil, fmt.Errorf("file path %q is outside repository", relPath)
 	}
 
@@ -29,7 +26,7 @@ func readWorkspaceFileForDiff(repoDir, relPath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve parent path for %q: %w", relPath, err)
 	}
-	if !pathWithinBase(repoRoot, parent) {
+	if !pathutil.WithinBase(repoRoot, parent) {
 		return nil, fmt.Errorf("file path %q is outside repository", relPath)
 	}
 
@@ -52,7 +49,7 @@ func readWorkspaceFileForDiff(repoDir, relPath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve file %q: %w", relPath, err)
 	}
-	if !pathWithinBase(repoRoot, resolvedPath) {
+	if !pathutil.WithinBase(repoRoot, resolvedPath) {
 		return nil, fmt.Errorf("file path %q is outside repository", relPath)
 	}
 	content, err := os.ReadFile(resolvedPath)
@@ -60,12 +57,4 @@ func readWorkspaceFileForDiff(repoDir, relPath string) ([]byte, error) {
 		return nil, fmt.Errorf("read file %q: %w", relPath, err)
 	}
 	return content, nil
-}
-
-func pathWithinBase(base, target string) bool {
-	rel, err := filepath.Rel(base, target)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }

--- a/internal/diff/workspace_file.go
+++ b/internal/diff/workspace_file.go
@@ -1,0 +1,71 @@
+package diff
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func readWorkspaceFileForDiff(repoDir, relPath string) ([]byte, error) {
+	repoRoot, err := filepath.Abs(repoDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository path %q: %w", repoDir, err)
+	}
+	repoRoot, err = filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository path %q: %w", repoDir, err)
+	}
+	if filepath.IsAbs(relPath) {
+		return nil, fmt.Errorf("file path %q is outside repository", relPath)
+	}
+
+	fullPath := filepath.Join(repoRoot, relPath)
+	if !pathWithinBase(repoRoot, fullPath) {
+		return nil, fmt.Errorf("file path %q is outside repository", relPath)
+	}
+
+	parent, err := filepath.EvalSymlinks(filepath.Dir(fullPath))
+	if err != nil {
+		return nil, fmt.Errorf("resolve parent path for %q: %w", relPath, err)
+	}
+	if !pathWithinBase(repoRoot, parent) {
+		return nil, fmt.Errorf("file path %q is outside repository", relPath)
+	}
+
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat file %q: %w", relPath, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("file path %q is a directory", relPath)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("read symlink %q: %w", relPath, err)
+		}
+		return []byte(target), nil
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve file %q: %w", relPath, err)
+	}
+	if !pathWithinBase(repoRoot, resolvedPath) {
+		return nil, fmt.Errorf("file path %q is outside repository", relPath)
+	}
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", relPath, err)
+	}
+	return content, nil
+}
+
+func pathWithinBase(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}

--- a/internal/diff/workspace_file_test.go
+++ b/internal/diff/workspace_file_test.go
@@ -1,0 +1,20 @@
+package diff
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadWorkspaceFileForDiffRejectsAbsolutePath(t *testing.T) {
+	repo := t.TempDir()
+	absPath := filepath.Join(repo, "file.txt")
+
+	_, err := readWorkspaceFileForDiff(repo, absPath)
+	if err == nil {
+		t.Fatal("expected absolute path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be relative") {
+		t.Fatalf("error = %q, want relative-path message", err)
+	}
+}

--- a/internal/pathutil/path.go
+++ b/internal/pathutil/path.go
@@ -1,0 +1,25 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CanonicalPath returns an absolute path with symlinks resolved.
+func CanonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+// WithinBase reports whether target is base itself or contained under base.
+func WithinBase(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}

--- a/internal/pathutil/path_test.go
+++ b/internal/pathutil/path_test.go
@@ -1,0 +1,55 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWithinBase(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "repo")
+	if err := os.Mkdir(base, 0o755); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{name: "base", target: base, want: true},
+		{name: "child", target: filepath.Join(base, "dir", "file.txt"), want: true},
+		{name: "parent", target: filepath.Dir(base), want: false},
+		{name: "sibling with prefix", target: base + "-other", want: false},
+		{name: "cleaned traversal", target: filepath.Join(base, "..", filepath.Base(base)+"-other"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WithinBase(base, tc.target); got != tc.want {
+				t.Fatalf("WithinBase(%q, %q) = %v, want %v", base, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalPathResolvesSymlink(t *testing.T) {
+	realDir := t.TempDir()
+	linkParent := t.TempDir()
+	linkPath := filepath.Join(linkParent, "repo-link")
+	if err := os.Symlink(realDir, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	got, err := CanonicalPath(linkPath)
+	if err != nil {
+		t.Fatalf("CanonicalPath: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks realDir: %v", err)
+	}
+	if got != want {
+		t.Fatalf("CanonicalPath(%q) = %q, want %q", linkPath, got, want)
+	}
+}

--- a/internal/tool/filereader.go
+++ b/internal/tool/filereader.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/pathutil"
 )
 
 // ReviewMode represents the active review mode.
@@ -88,17 +89,13 @@ func (fr *FileReader) readFromDisk(path string) (string, error) {
 }
 
 func (fr *FileReader) resolveWorkspacePath(path string) (string, error) {
-	repoRoot, err := filepath.Abs(fr.RepoDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve repository path %q: %w", fr.RepoDir, err)
-	}
-	repoRoot, err = filepath.EvalSymlinks(repoRoot)
+	repoRoot, err := pathutil.CanonicalPath(fr.RepoDir)
 	if err != nil {
 		return "", fmt.Errorf("resolve repository path %q: %w", fr.RepoDir, err)
 	}
 
 	fullPath := filepath.Join(repoRoot, path)
-	if !pathWithinBase(repoRoot, fullPath) {
+	if !pathutil.WithinBase(repoRoot, fullPath) {
 		return "", fmt.Errorf("file path %q is outside repository", path)
 	}
 
@@ -109,18 +106,10 @@ func (fr *FileReader) resolveWorkspacePath(path string) (string, error) {
 		}
 		return "", fmt.Errorf("resolve file %q: %w", path, err)
 	}
-	if !pathWithinBase(repoRoot, resolvedPath) {
+	if !pathutil.WithinBase(repoRoot, resolvedPath) {
 		return "", fmt.Errorf("file path %q is outside repository", path)
 	}
 	return resolvedPath, nil
-}
-
-func pathWithinBase(base, target string) bool {
-	rel, err := filepath.Rel(base, target)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func (fr *FileReader) readFromGitShow(parentCtx context.Context, path string) (string, error) {


### PR DESCRIPTION
## Description

Fixes workspace diff loading so symlinks are not followed outside the repository.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Fixes #123 
