### PR TITLE
fix: use Xiaomi MiMo API endpoint and add mimo flash model

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -81,13 +81,14 @@ var registry = []Provider{
 		Name:        "mimo",
 		DisplayName: "Xiaomi MiMo API",
 		Protocol:    "openai",
-		BaseURL:     "https://token-plan-cn.xiaomimimo.com/v1",
+		BaseURL:     "https://api.xiaomimimo.com/v1",
 		EnvVar:      "MIMO_API_KEY",
 		Models: []string{
 			"mimo-v2.5-pro",
 			"mimo-v2.5",
 			"mimo-v2-pro",
 			"mimo-v2-omni",
+			"mimo-v2-flash",
 		},
 	},
 }

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -77,6 +77,19 @@ var registry = []Provider{
 			"glm-4.7",
 		},
 	},
+	{
+		Name:        "mimo",
+		DisplayName: "Xiaomi MiMo API",
+		Protocol:    "openai",
+		BaseURL:     "https://token-plan-cn.xiaomimimo.com/v1",
+		EnvVar:      "MIMO_API_KEY",
+		Models: []string{
+			"mimo-v2.5-pro",
+			"mimo-v2.5",
+			"mimo-v2-pro",
+			"mimo-v2-omni",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -81,7 +81,7 @@ var registry = []Provider{
 		Name:        "mimo",
 		DisplayName: "Xiaomi MiMo API",
 		Protocol:    "openai",
-		BaseURL:     "https://token-plan-cn.xiaomimimo.com/v1",
+		BaseURL:     "https://api.xiaomimimo.com/v1",
 		EnvVar:      "MIMO_API_KEY",
 		Models: []string{
 			"mimo-v2.5-pro",


### PR DESCRIPTION
## Summary

  Updates the built-in Xiaomi MiMo provider configuration to use the standard API endpoint instead of the Token Plan China endpoint, and adds the MiMo flash model to the default model list.

  ## Changes

  - Changed Xiaomi MiMo `BaseURL` from the Token Plan China endpoint:
    - `https://token-plan-cn.xiaomimimo.com/v1`
  - To the standard OpenAI-compatible API endpoint:
    - `https://api.xiaomimimo.com/v1`
  - Added `mimo-v2-flash` to the built-in Xiaomi MiMo model list.

  ## Rationale

  The previous Base URL pointed to the Xiaomi MiMo Token Plan China endpoint, which is specific to Token Plan users and regional subscription configuration. The built-in provider should use the general
  OpenAI-compatible API endpoint by default.

<img width="1258" height="313" alt="image" src="https://github.com/user-attachments/assets/50fc9972-7568-4ecb-bfed-5e877ff5eab5" />
