### PR TITLE
feat: add Kimi provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -90,6 +90,25 @@ var registry = []Provider{
 			"mimo-v2-omni",
 		},
 	},
+	{
+		Name:        "kimi",
+		DisplayName: "Kimi API",
+		Protocol:    "openai",
+		BaseURL:     "https://api.moonshot.cn/v1",
+		EnvVar:      "KIMI_API_KEY",
+		Models: []string{
+			"kimi-k2.5",
+			"kimi-k2.6",
+			"kimi-k2.7-code",
+			"moonshot-v1-8k",
+			"moonshot-v1-32k",
+			"moonshot-v1-128k",
+			"moonshot-v1-auto",
+			"moonshot-v1-8k-vision-preview",
+			"moonshot-v1-32k-vision-preview",
+			"moonshot-v1-128k-vision-preview",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -100,13 +100,6 @@ var registry = []Provider{
 			"kimi-k2.5",
 			"kimi-k2.6",
 			"kimi-k2.7-code",
-			"moonshot-v1-8k",
-			"moonshot-v1-32k",
-			"moonshot-v1-128k",
-			"moonshot-v1-auto",
-			"moonshot-v1-8k-vision-preview",
-			"moonshot-v1-32k-vision-preview",
-			"moonshot-v1-128k-vision-preview",
 		},
 	},
 }


### PR DESCRIPTION
 ## Summary

  - Add built-in Kimi provider configuration
  - Use Moonshot OpenAI-compatible endpoint: `https://api.moonshot.cn/v1`
  - Support `KIMI_API_KEY` as the provider API key environment variable
  - Add default Kimi/Moonshot model options, including K2, text, auto, and vision preview models

OCR review:
<img width="1226" height="532" alt="image" src="https://github.com/user-attachments/assets/d54a0ff2-cb2b-47aa-84ce-aeb34e8e404a" />

OCR config provider:
<img width="624" height="300" alt="image" src="https://github.com/user-attachments/assets/57418c82-8b2d-48e7-bafd-565ce48fca83" />
