### PR TITLE
feat: add minimax provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -90,6 +90,23 @@ var registry = []Provider{
 			"mimo-v2-omni",
 		},
 	},
+	{
+		Name:        "minimax",
+		DisplayName: "MiniMax API",
+		Protocol:    "openai",
+		BaseURL:     "https://api.minimaxi.com/v1",
+		EnvVar:      "MINIMAX_API_KEY",
+		Models: []string{
+			"MiniMax-M3",
+			"MiniMax-M2.7",
+			"MiniMax-M2.7-highspeed",
+			"MiniMax-M2.5",
+			"MiniMax-M2.5-highspeed",
+			"MiniMax-M2.1",
+			"MiniMax-M2.1-highspeed",
+			"MiniMax-M2",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -102,10 +102,6 @@ var registry = []Provider{
 			"MiniMax-M2.7-highspeed",
 			"MiniMax-M2.5",
 			"MiniMax-M2.5-highspeed",
-			"MiniMax-M2.1",
-			"MiniMax-M2.1-highspeed",
-			"MiniMax-M2",
-			"M2-her",
 		},
 	},
 }

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -105,6 +105,7 @@ var registry = []Provider{
 			"MiniMax-M2.1",
 			"MiniMax-M2.1-highspeed",
 			"MiniMax-M2",
+			"M2-her",
 		},
 	},
 }


### PR DESCRIPTION
## Summary

  - Add MiniMax as a built-in LLM provider
  - Configure MiniMax through the OpenAI-compatible API endpoint: `https://api.minimaxi.com/v1`
  - Use `MINIMAX_API_KEY` as the API key environment variable
  - Add MiniMax model options, including `MiniMax-M3`, `MiniMax-M2.x`, and `M2-her`


OCR llm test:
<img width="798" height="197" alt="image" src="https://github.com/user-attachments/assets/6f256276-83d6-47f6-9b11-bb2d218e333b" />

OCR config provider:
<img width="1176" height="313" alt="image" src="https://github.com/user-attachments/assets/230956f3-8f15-4df8-b4d1-f07faab1786b" />

