### PR TITLE
fix: update mimo provider endpoint and add mimo flash model

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -81,13 +81,14 @@ var registry = []Provider{
 		Name:        "mimo",
 		DisplayName: "Xiaomi MiMo API",
 		Protocol:    "openai",
-		BaseURL:     "https://token-plan-cn.xiaomimimo.com/v1",
+		BaseURL:     "https://api.xiaomimimo.com/v1",
 		EnvVar:      "MIMO_API_KEY",
 		Models: []string{
 			"mimo-v2.5-pro",
 			"mimo-v2.5",
 			"mimo-v2-pro",
 			"mimo-v2-omni",
+			"mimo-v2-flash",
 		},
 	},
 }


### PR DESCRIPTION
## Summary

  - Update the built-in MiMo provider base URL from the token-plan endpoint to the API endpoint
  - Keep MiMo configured as an OpenAI-compatible provider
  - Add `mimo-v2-flash` to the built-in MiMo model list

  ## Why

  The previous MiMo base URL pointed at `https://token-plan-cn.xiaomimimo.com/v1`, which is not the normal API endpoint used for OpenAI-compatible requests. This change updates the provider preset to
  `https://api.xiaomimimo.com/v1` so `ocr config provider` and `ocr llm test` resolve MiMo requests to the correct API host.

ocr config provider:
<img width="1200" height="304" alt="image" src="https://github.com/user-attachments/assets/45bdb3dd-051a-476d-b4a0-da8562a629b1" />

ocr llm test:
<img width="1194" height="136" alt="image" src="https://github.com/user-attachments/assets/eb6cc8cb-943d-43df-bdd4-33a0f40f186d" />
