### PR TITLE
fix: remove non-existent Claude Sonnet 4.7 & 4.8 models

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -23,9 +23,7 @@ var registry = []Provider{
 		EnvVar:      "ANTHROPIC_API_KEY",
 		Models: []string{
 			"claude-opus-4-8",
-			"claude-sonnet-4-8",
 			"claude-opus-4-7",
-			"claude-sonnet-4-7",
 			"claude-opus-4-6",
 			"claude-sonnet-4-6",
 		},


### PR DESCRIPTION
## Summary

Remove the non-existent `claude-sonnet-4-7` and `claude-sonnet-4-8` model IDs from the Anthropic provider registry.

The Sonnet model line does **not** have 4.7 or 4.8 versions — its latest release is **Sonnet 4.6** (`claude-sonnet-4-6`). Only the **Opus** line has 4.7/4.8 (`claude-opus-4-7`, `claude-opus-4-8`), and those remain in the list. The two removed entries pointed to models that do not exist and would fail at request time.

## Changes

`internal/llm/providers.go` — drop `claude-sonnet-4-8` and `claude-sonnet-4-7` from the Anthropic provider's `Models` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
