### PR TITLE
fix: use text/tabwriter for dynamic column alignment in ocr llm provi…

### DIFF
--- a/cmd/opencodereview/llm_cmd.go
+++ b/cmd/opencodereview/llm_cmd.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"text/tabwriter"
 	"time"
 
 	"github.com/open-code-review/open-code-review/internal/config/testconnection"
@@ -89,10 +91,14 @@ func runLLMTest() error {
 func runLLMProviders() {
 	providers := llm.ListProviders()
 	fmt.Println("\nBuilt-in providers:")
-	fmt.Printf("  %-14s %-10s %s\n", "NAME", "PROTOCOL", "BASE URL")
-	fmt.Printf("  %-14s %-10s %s\n", "----", "--------", "--------")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "  NAME\tPROTOCOL\tBASE URL\n")
+	fmt.Fprintf(w, "  ----\t--------\t--------\n")
 	for _, p := range providers {
-		fmt.Printf("  %-14s %-10s %s\n", p.Name, p.Protocol, p.BaseURL)
+		fmt.Fprintf(w, "  %s\t%s\t%s\n", p.Name, p.Protocol, p.BaseURL)
+	}
+	if err := w.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to flush output: %v\n", err)
 	}
 	fmt.Println("\nUse 'ocr config provider' to configure a provider interactively.")
 	fmt.Println("Use 'ocr config set provider <name>' to switch providers non-interactively.")


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
Fix `ocr llm providers` output columns misalign.

- Replace hardcoded fmt.Printf width specifiers with text/tabwriter
- Column widths now adapt to actual content, preventing overflow
- Eliminates risk of misaligned columns when provider names exceed preset width

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)
Before the fix:

<img width="1192" height="572" alt="image" src="https://github.com/user-attachments/assets/ef13d3d1-9f47-4c7a-9565-1a173ef1262b" />

After the fix:

<img width="1372" height="492" alt="image" src="https://github.com/user-attachments/assets/f00da839-7309-4385-b463-0f7e20c854a3" />

Current behavior will not change in this pr.

Before:

<img width="1324" height="550" alt="image" src="https://github.com/user-attachments/assets/c66e042d-5cb7-4db9-bdfc-8b36de73f4bd" />

After:

<img width="1410" height="544" alt="image" src="https://github.com/user-attachments/assets/d919b3f9-40d6-46ee-890d-56a5a853ec62" />




## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
#145 