### PR TITLE
fix(tool): correct git grep ref argument order in code_search

### DIFF
--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -67,7 +67,6 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 	cmdArgs = append(cmdArgs, "-e", searchText)
 
 	if ref := p.FileReader.Ref; ref != "" {
-		cmdArgs = append(cmdArgs, "--end-of-options")
 		cmdArgs = append(cmdArgs, ref)
 	}
 
@@ -104,6 +103,10 @@ func (p *CodeSearchProvider) runGitGrep(parentCtx context.Context, cmdArgs []str
 }
 
 func (p *CodeSearchProvider) gitGrep(ctx context.Context, searchText string, caseSensitive bool, usePerlRegexp bool, pathspec []string) (string, error) {
+	if ref := p.FileReader.Ref; ref != "" && strings.HasPrefix(ref, "-") {
+		return "Error: invalid ref: refs must not start with '-'", nil
+	}
+
 	cmdArgs := p.buildGrepArgs(searchText, caseSensitive, usePerlRegexp, pathspec)
 
 	outStr, errStr, err := p.runGitGrep(ctx, cmdArgs)

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -29,14 +29,14 @@ func TestBuildGrepArgs_CommitMode(t *testing.T) {
 	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: "abc1234"})
 	args := p.buildGrepArgs("myFunc", false, false, []string{"pkg/"})
 
-	assertContainsInOrder(t, args, "-e", "myFunc", "--end-of-options", "abc1234", "--", "pkg/")
+	assertContainsInOrder(t, args, "-e", "myFunc", "abc1234", "--", "pkg/")
 }
 
 func TestBuildGrepArgs_RefUsesEndOfOptions(t *testing.T) {
 	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: "-O./pwn.sh"})
 	args := p.buildGrepArgs("myFunc", false, false, nil)
 
-	assertContainsInOrder(t, args, "-e", "myFunc", "--end-of-options", "-O./pwn.sh", "--")
+	assertContainsInOrder(t, args, "-e", "myFunc", "-O./pwn.sh", "--")
 }
 
 func TestBuildGrepArgs_PatternStartingWithDash(t *testing.T) {
@@ -207,8 +207,8 @@ func TestGitGrep_OptionLikeRefDoesNotLaunchPager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(result, "unable to resolve revision") && !strings.Contains(result, "Not a valid object name") {
-		t.Fatalf("expected invalid revision error, got: %s", result)
+	if !strings.Contains(result, "invalid ref") {
+		t.Fatalf("expected invalid ref error, got: %s", result)
 	}
 	if _, err := os.Stat(proofPath); err == nil {
 		t.Fatal("option-like ref launched pager and created proof file")


### PR DESCRIPTION
## Summary

Fix `code_search` failures in commit/range review modes by correcting `git grep` argument ordering and preserving option-like ref safety checks.

## Problem

In commit/range mode, `code_search` constructed `git grep` args with an invalid revision placement, which caused errors like:

- `fatal: unable to resolve revision: --end-of-options`

As a result, `code_search` became unreliable for `--commit` and `--from/--to` workflows.

## Root Cause

`buildGrepArgs` assembled arguments in a way that made Git parse an invalid token as a revision.

## Changes

- Corrected `git grep` arg order in:
  - `internal/tool/code_search.go`
- Added/kept defensive guard for option-like refs (`-...`) to avoid ambiguous/unsafe execution.
- Updated tests to match the corrected command structure and behavior:
  - `internal/tool/code_search_test.go`

## Validation

Executed per contribution guide:

- `go fmt ./...`
- `go vet ./...`
- `make test` (race enabled)
- `make build`

All passed.

## Impact

- Restores `code_search` correctness in commit/range mode.
- Improves stability of AI review tool-calls for non-workspace reviews.
- Keeps security behavior for option-like refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)