### PR TITLE
fix(cli): reject --to without --from in review flags

### DIFF
--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -155,6 +155,9 @@ func parseReviewFlags(args []string) (reviewOptions, error) {
 	if opts.from != "" && opts.to == "" {
 		return opts, fmt.Errorf("--to is required when --from is specified")
 	}
+	if opts.to != "" && opts.from == "" {
+		return opts, fmt.Errorf("--from is required when --to is specified")
+	}
 
 	switch opts.audience {
 	case "human", "agent":

--- a/cmd/opencodereview/review_cmd_test.go
+++ b/cmd/opencodereview/review_cmd_test.go
@@ -24,3 +24,33 @@ func TestValidateReviewRefsRejectsOptionLikeRangeRef(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestParseReviewFlagsRejectsToWithoutFrom(t *testing.T) {
+	_, err := parseReviewFlags([]string{"--to", "HEAD"})
+	if err == nil {
+		t.Fatal("expected --to without --from to fail")
+	}
+	if !strings.Contains(err.Error(), "--from is required when --to is specified") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseReviewFlagsRejectsFromWithoutTo(t *testing.T) {
+	_, err := parseReviewFlags([]string{"--from", "main"})
+	if err == nil {
+		t.Fatal("expected --from without --to to fail")
+	}
+	if !strings.Contains(err.Error(), "--to is required when --from is specified") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseReviewFlagsAllowsFromAndTo(t *testing.T) {
+	opts, err := parseReviewFlags([]string{"--from", "main", "--to", "HEAD"})
+	if err != nil {
+		t.Fatalf("expected --from/--to to pass, got: %v", err)
+	}
+	if opts.from != "main" || opts.to != "HEAD" {
+		t.Fatalf("unexpected opts: from=%q to=%q", opts.from, opts.to)
+	}
+}


### PR DESCRIPTION
## Summary

Reject `--to` when used without `--from` in `ocr review` to prevent silent fallback to workspace mode.

## Problem

The CLI previously accepted `ocr review --to <ref>`, but internal review mode detection only entered range mode when both `--from` and `--to` were provided. This caused a silent fallback to workspace mode, which did not match user intent.

## Root Cause

Flag validation only enforced one direction (`--from` requires `--to`) and missed the symmetric rule (`--to` requires `--from`).

## Changes

- Added symmetric flag validation in `parseReviewFlags`:
  - keep existing: `--from` requires `--to`
  - add new: `--to` requires `--from`
- Added regression tests for:
  - reject `--to` without `--from`
  - reject `--from` without `--to`
  - allow `--from` + `--to`

Modified files:
- `cmd/opencodereview/flags.go`
- `cmd/opencodereview/review_cmd_test.go`

## Validation

Executed per contribution guide:

- `go fmt ./...`
- `go vet ./...`
- `make test` (race enabled)
- `make build`

Behavior check:

- `go run ./cmd/opencodereview review --to HEAD --preview`
  - now returns: `--from is required when --to is specified`

## Impact

- Prevents ambiguous CLI behavior.
- Aligns flag semantics with internal range-mode logic.
- Improves predictability for CI and local scripted usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)