### PR TITLE
feat: add install.sh for one-line release install

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -88,7 +88,23 @@ npm install -g @alibaba-group/open-code-review
 
 **GitHub Releaseから**
 
-[GitHub Releases](https://github.com/alibaba/open-code-review/releases)から最新のバイナリをダウンロードします：
+1 つのコマンドで、お使いの OS / アーキテクチャ向けの最新バイナリをインストールできます（macOS / Linux）：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+このスクリプトは適切なリリースバイナリを選択し、SHA-256 チェックサムを検証して、`ocr` として `/usr/local/bin` にインストールします。インストール先は `OCR_INSTALL_DIR` で、リリースバージョンは `OCR_VERSION` で上書きできます：
+
+```bash
+OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
+```
+
+<details>
+<summary>手動ダウンロード（Windows を含む全プラットフォーム）</summary>
+
+[GitHub Releases](https://github.com/alibaba/open-code-review/releases)からお使いのプラットフォーム向けのバイナリをダウンロードします：
 
 ```bash
 # macOS (Apple Silicon)
@@ -113,6 +129,8 @@ curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/dow
 # Windows (ARM64) — ocr.exe を PATH の通ったディレクトリに移動してください
 curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
+
+</details>
 
 **ソースから**
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -88,7 +88,23 @@ npm install -g @alibaba-group/open-code-review
 
 **GitHub Release 사용**
 
-[GitHub Releases](https://github.com/alibaba/open-code-review/releases)에서 최신 binary를 다운로드합니다.
+명령 한 번으로 사용 중인 OS/아키텍처에 맞는 최신 binary를 설치합니다 (macOS / Linux):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+이 스크립트는 알맞은 릴리스 binary를 선택하고 SHA-256 체크섬을 검증한 뒤 `ocr`로 `/usr/local/bin`에 설치합니다. 설치 위치는 `OCR_INSTALL_DIR`로, 릴리스 버전은 `OCR_VERSION`으로 재정의할 수 있습니다:
+
+```bash
+OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
+```
+
+<details>
+<summary>수동 다운로드 (Windows 포함 모든 플랫폼)</summary>
+
+[GitHub Releases](https://github.com/alibaba/open-code-review/releases)에서 사용 중인 플랫폼의 binary를 다운로드합니다.
 
 ```bash
 # macOS (Apple Silicon)
@@ -113,6 +129,8 @@ curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/dow
 # Windows (ARM64): ocr.exe를 PATH에 포함된 디렉터리로 이동하세요
 curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
+
+</details>
 
 **소스에서 빌드**
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,23 @@ After installation, the `ocr` command is available globally.
 
 **From GitHub Release**
 
-Download the latest binary from [GitHub Releases](https://github.com/alibaba/open-code-review/releases):
+Install the latest binary for your OS/architecture with one command (macOS / Linux):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+The script picks the right release binary, verifies its SHA-256 checksum, and installs it as `ocr` in `/usr/local/bin`. Override the target with `OCR_INSTALL_DIR` or pin a release with `OCR_VERSION`:
+
+```bash
+OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
+```
+
+<details>
+<summary>Manual download (all platforms, including Windows)</summary>
+
+Download the binary for your platform from [GitHub Releases](https://github.com/alibaba/open-code-review/releases):
 
 ```bash
 # macOS (Apple Silicon)
@@ -113,6 +129,8 @@ curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/dow
 # Windows (ARM64) — move ocr.exe to a directory in your PATH
 curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
+
+</details>
 
 **From Source**
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -88,7 +88,23 @@ npm install -g @alibaba-group/open-code-review
 
 **Из GitHub Release**
 
-Скачайте свежий бинарный файл со страницы [GitHub Releases](https://github.com/alibaba/open-code-review/releases):
+Установите свежий бинарный файл для вашей ОС/архитектуры одной командой (macOS / Linux):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+Скрипт сам выбирает подходящий бинарный файл релиза, проверяет его контрольную сумму SHA-256 и устанавливает его как `ocr` в `/usr/local/bin`. Каталог установки можно переопределить через `OCR_INSTALL_DIR`, а версию релиза зафиксировать через `OCR_VERSION`:
+
+```bash
+OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
+```
+
+<details>
+<summary>Ручная загрузка (все платформы, включая Windows)</summary>
+
+Скачайте бинарный файл для вашей платформы со страницы [GitHub Releases](https://github.com/alibaba/open-code-review/releases):
 
 ```bash
 # macOS (Apple Silicon)
@@ -113,6 +129,8 @@ curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/dow
 # Windows (ARM64) — переместите ocr.exe в каталог из вашего PATH
 curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
+
+</details>
 
 **Из исходников**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,23 @@ npm install -g @alibaba-group/open-code-review
 
 **从 GitHub Release 下载**
 
-从 [GitHub Releases](https://github.com/alibaba/open-code-review/releases) 下载最新二进制文件：
+使用一条命令为你的操作系统/架构安装最新二进制文件（macOS / Linux）：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+该脚本会自动选择匹配的发布二进制文件，校验其 SHA-256 校验和，并将其作为 `ocr` 安装到 `/usr/local/bin`。可通过 `OCR_INSTALL_DIR` 覆盖安装目录，或通过 `OCR_VERSION` 指定发布版本：
+
+```bash
+OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
+```
+
+<details>
+<summary>手动下载（所有平台，包括 Windows）</summary>
+
+从 [GitHub Releases](https://github.com/alibaba/open-code-review/releases) 下载适用于你平台的二进制文件：
 
 ```bash
 # macOS (Apple Silicon)
@@ -113,6 +129,8 @@ curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/dow
 # Windows (ARM64) — 将 ocr.exe 移动到 PATH 目录中
 curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
+
+</details>
 
 **从源码构建**
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Install the ocr (Open Code Review) CLI from GitHub releases.
+#   curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+# Env: OCR_INSTALL_DIR (default /usr/local/bin), OCR_VERSION (default latest).
+set -eu
+
+main() {
+  REPO="alibaba/open-code-review"
+  BIN="ocr"
+  ASSET_PREFIX="opencodereview"
+  INSTALL_DIR="${OCR_INSTALL_DIR:-/usr/local/bin}"
+  VERSION="${OCR_VERSION:-}"
+
+  command -v curl >/dev/null 2>&1 || err "curl is required"
+  if command -v shasum >/dev/null 2>&1; then
+    SHA_CMD="shasum -a 256"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    SHA_CMD="sha256sum"
+  else
+    err "shasum or sha256sum is required for checksum verification"
+  fi
+
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$os" in
+    darwin|linux) ;;
+    *) err "unsupported OS: $os (download the Windows binary from GitHub releases)" ;;
+  esac
+
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) err "unsupported architecture: $arch" ;;
+  esac
+
+  if [ -z "$VERSION" ]; then
+    VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+      sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+    [ -n "$VERSION" ] || err "could not resolve latest release tag"
+  fi
+
+  asset="${ASSET_PREFIX}-${os}-${arch}"
+  base="https://github.com/$REPO/releases/download/$VERSION"
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  printf 'downloading %s %s (%s/%s)...\n' "$BIN" "$VERSION" "$os" "$arch"
+  curl -fsSL -o "$tmp/$asset" "$base/$asset" || err "download failed: $base/$asset"
+  curl -fsSL -o "$tmp/sha256sum.txt" "$base/sha256sum.txt" || err "sha256sum.txt download failed"
+
+  want="$(awk -v a="$asset" '$2 == a {print tolower($1)}' "$tmp/sha256sum.txt")"
+  [ -n "$want" ] || err "no checksum entry for $asset in sha256sum.txt"
+  got="$($SHA_CMD "$tmp/$asset" | awk '{print tolower($1)}')"
+  [ "$got" = "$want" ] || err "checksum mismatch for $asset (got $got, want $want)"
+
+  chmod 0755 "$tmp/$asset"
+  install_binary "$tmp/$asset" "$INSTALL_DIR" "$BIN"
+
+  printf 'installed %s %s -> %s\n' "$BIN" "$VERSION" "$INSTALL_DIR/$BIN"
+  post_install_path_notice "$BIN" "$INSTALL_DIR"
+}
+
+# Move the staged binary into place, escalating with sudo only when needed.
+install_binary() {
+  src="$1"
+  dir="$2"
+  bin="$3"
+  if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then
+    mv "$src" "$dir/$bin"
+  elif command -v sudo >/dev/null 2>&1; then
+    printf 'note: %s is not writable; escalating with sudo\n' "$dir"
+    sudo mkdir -p "$dir"
+    sudo mv "$src" "$dir/$bin"
+  else
+    err "$dir is not writable and sudo is unavailable; set OCR_INSTALL_DIR to a writable path"
+  fi
+}
+
+post_install_path_notice() {
+  bin="$1"
+  install_dir="$2"
+  case ":$PATH:" in
+    *":$install_dir:"*) ;;
+    *) printf 'note: %s is not on your PATH; add it or run %s/%s directly\n' "$install_dir" "$install_dir" "$bin"; return ;;
+  esac
+  command -v "$bin" >/dev/null 2>&1 || printf 'note: open a new shell so %s resolves on PATH\n' "$bin"
+}
+
+err() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,6 @@ main() {
   VERSION="${OCR_VERSION:-}"
 
   command -v curl >/dev/null 2>&1 || err "curl is required"
-  command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 ||
-    err "shasum or sha256sum is required for checksum verification"
 
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   case "$os" in
@@ -39,7 +37,7 @@ main() {
   asset="${ASSET_PREFIX}-${os}-${arch}"
   base="https://github.com/$REPO/releases/download/$VERSION"
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  trap 'rm -rf "$tmp"' INT TERM EXIT
 
   printf 'downloading %s %s (%s/%s)...\n' "$BIN" "$VERSION" "$os" "$arch"
   curl -fsSL -o "$tmp/$asset" "$base/$asset" || err "download failed: $base/$asset"
@@ -50,24 +48,24 @@ main() {
   got="$(sha256 "$tmp/$asset" | awk '{print tolower($1)}')"
   [ "$got" = "$want" ] || err "checksum mismatch for $asset (got $got, want $want)"
 
-  chmod 0755 "$tmp/$asset"
   install_binary "$tmp/$asset" "$INSTALL_DIR" "$BIN"
 
   printf 'installed %s %s -> %s\n' "$BIN" "$VERSION" "$INSTALL_DIR/$BIN"
   post_install_path_notice "$BIN" "$INSTALL_DIR"
 }
 
-# Move the staged binary into place, escalating with sudo only when needed.
+# Install the staged binary (mode 0755), escalating with sudo only when needed.
+# Using install(1) under sudo gives the binary root ownership in system dirs.
 install_binary() {
   src="$1"
   dir="$2"
   bin="$3"
   if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then
-    mv "$src" "$dir/$bin"
+    install -m 0755 "$src" "$dir/$bin"
   elif command -v sudo >/dev/null 2>&1; then
     printf 'note: %s is not writable; escalating with sudo\n' "$dir"
     sudo mkdir -p "$dir"
-    sudo mv "$src" "$dir/$bin"
+    sudo install -m 0755 "$src" "$dir/$bin"
   else
     err "$dir is not writable and sudo is unavailable; set OCR_INSTALL_DIR to a writable path"
   fi
@@ -87,8 +85,10 @@ post_install_path_notice() {
 sha256() {
   if command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "$1"
-  else
+  elif command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1"
+  else
+    err "shasum or sha256sum is required for checksum verification"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -12,13 +12,8 @@ main() {
   VERSION="${OCR_VERSION:-}"
 
   command -v curl >/dev/null 2>&1 || err "curl is required"
-  if command -v shasum >/dev/null 2>&1; then
-    SHA_CMD="shasum -a 256"
-  elif command -v sha256sum >/dev/null 2>&1; then
-    SHA_CMD="sha256sum"
-  else
+  command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 ||
     err "shasum or sha256sum is required for checksum verification"
-  fi
 
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   case "$os" in
@@ -34,7 +29,9 @@ main() {
   esac
 
   if [ -z "$VERSION" ]; then
-    VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+    release_json="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest")" ||
+      err "failed to fetch latest release info from github api"
+    VERSION="$(printf '%s' "$release_json" |
       sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
     [ -n "$VERSION" ] || err "could not resolve latest release tag"
   fi
@@ -50,7 +47,7 @@ main() {
 
   want="$(awk -v a="$asset" '$2 == a {print tolower($1)}' "$tmp/sha256sum.txt")"
   [ -n "$want" ] || err "no checksum entry for $asset in sha256sum.txt"
-  got="$($SHA_CMD "$tmp/$asset" | awk '{print tolower($1)}')"
+  got="$(sha256 "$tmp/$asset" | awk '{print tolower($1)}')"
   [ "$got" = "$want" ] || err "checksum mismatch for $asset (got $got, want $want)"
 
   chmod 0755 "$tmp/$asset"
@@ -84,6 +81,15 @@ post_install_path_notice() {
     *) printf 'note: %s is not on your PATH; add it or run %s/%s directly\n' "$install_dir" "$install_dir" "$bin"; return ;;
   esac
   command -v "$bin" >/dev/null 2>&1 || printf 'note: open a new shell so %s resolves on PATH\n' "$bin"
+}
+
+# Print the SHA-256 of a file, preferring shasum (macOS) over sha256sum (Linux).
+sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1"
+  else
+    sha256sum "$1"
+  fi
 }
 
 err() { printf 'error: %s\n' "$1" >&2; exit 1; }


### PR DESCRIPTION
## Description

Installing the CLI from a GitHub release currently means copy-pasting one of six platform-specific `curl … && chmod && sudo mv` blocks and picking the right `os-arch` by hand. This adds a POSIX `install.sh` so the whole flow becomes one command:

```bash
curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
```

The script:
- detects OS (`darwin`/`linux`) and arch (`amd64`/`arm64`)
- resolves the latest release tag (override with `OCR_VERSION`)
- downloads the matching `opencodereview-<os>-<arch>` binary and `sha256sum.txt`
- **verifies the SHA-256 checksum fail-closed** — aborts on mismatch, on a missing checksum entry, or when the checksum file can't be fetched
- installs as `ocr` to `/usr/local/bin` (override with `OCR_INSTALL_DIR`; falls back to `sudo` only when the target isn't writable)
- warns if the install dir isn't on `PATH`

The README now leads with the one-liner and keeps the existing per-platform manual downloads in a collapsible `<details>` block for Windows and offline/air-gapped use. No Go/runtime code changes.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- `sh -n install.sh` and `shellcheck install.sh` — clean
- Ran end-to-end against the live `v1.3.13` release into a temp dir: correct binary downloaded, checksum verified, `ocr --version` reports `open-code-review v1.3.13 … darwin/arm64`
- Verified `OCR_INSTALL_DIR` override and the not-on-PATH notice

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

None. This is a standalone addition — it does not modify the existing `scripts/install.js` / `scripts/update.js` npm install/update paths.

