### PR TITLE
fix(llm): increase test MaxTokens to 512 and handle empty response

### DIFF
--- a/cmd/opencodereview/llm_cmd.go
+++ b/cmd/opencodereview/llm_cmd.go
@@ -70,7 +70,7 @@ func runLLMTest() error {
 		return llmClient.CompletionsWithCtx(ctx, llm.ChatRequest{
 			Model:     ep.Model,
 			Messages:  messages,
-			MaxTokens: 256,
+			MaxTokens: 512,
 		})
 	}()
 	if err != nil {
@@ -84,7 +84,11 @@ func runLLMTest() error {
 	fmt.Printf("Source: %s\n", ep.Source)
 	fmt.Printf("URL:    %s\n", ep.URL)
 	fmt.Printf("Model:  %s\n", model)
-	fmt.Printf("%s\n", resp.Content())
+	if content := resp.Content(); content != "" {
+		fmt.Printf("LLM test succeeded with response: %s\n", content)
+	} else {
+		fmt.Println("LLM test succeeded.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
When running ocr llm test, the MaxTokens value was set to 256, which may cause models with built-in reasoning capabilities (e.g., OpenAI o-series) or extended thinking (e.g., Anthropic Claude with thinking enabled) to consume the entire output budget on reasoning/thinking tokens, leaving no visible content in the response. This resulted in an empty line being printed after the connection metadata, which could mislead users into thinking the test failed.

Two changes are made:

1. Increase MaxTokens from 256 to 512 — providing more headroom for reasoning models, reducing the likelihood that visible output is entirely consumed by reasoning tokens.
2. Handle empty response content explicitly — when resp.Content() returns an empty string, print a concise success message ("LLM test succeeded.") instead of an empty line; when content is non-empty, print it with a success prefix ("LLM test succeeded with response: ...") to make the output more informative and unambiguous.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)
The llm test output now appears like this:
<img width="1886" height="332" alt="image" src="https://github.com/user-attachments/assets/a1815d8f-d331-4273-981c-656550a8becd" />


## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
#156 
