### PR TITLE
fix(session): restrict session dir and file permissions to owner-only

### DIFF
--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -96,12 +96,12 @@ func (jw *jsonlWriter) open() error {
 	}
 
 	sessionDir := filepath.Join(home, ".opencodereview", "sessions", encodeRepoPath(jw.repoDir))
-	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+	if err := os.MkdirAll(sessionDir, 0700); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
 	}
 
 	filename := filepath.Join(sessionDir, jw.sessionID+".jsonl")
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("open session file: %w", err)
 	}

--- a/internal/session/persist_test.go
+++ b/internal/session/persist_test.go
@@ -191,6 +191,44 @@ func TestSetErrorWritesJSONL(t *testing.T) {
 	}
 }
 
+func TestSessionFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permissions not enforced on Windows")
+	}
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	repoDir := t.TempDir()
+	sessionID := generateUUID()
+
+	jw, err := newJSONLWriter(sessionID, repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	if err != nil {
+		t.Fatalf("newJSONLWriter: %v", err)
+	}
+	jw.WriteSessionStart(time.Now())
+	defer jw.flushAndClose()
+
+	sessionDir := filepath.Join(tmpHome, ".opencodereview", "sessions", encodeRepoPath(repoDir))
+	sessionFile := filepath.Join(sessionDir, sessionID+".jsonl")
+
+	dirInfo, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != os.FileMode(0700) {
+		t.Errorf("session dir mode = %04o, want 0700", got)
+	}
+
+	fileInfo, err := os.Stat(sessionFile)
+	if err != nil {
+		t.Fatalf("stat session file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != os.FileMode(0600) {
+		t.Errorf("session file mode = %04o, want 0600", got)
+	}
+}
+
 func TestSessionEndIncludesFailures(t *testing.T) {
 	repoDir := t.TempDir()
 	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})


### PR DESCRIPTION
## Description

Session directories were created with `0755` (`rwxr-xr-x`) and session
files with `0644` (`rw-r--r--`), making them readable by any local user
on shared systems such as multi-user servers and CI runners.

Session JSONL files contain full LLM request and response data, including
the complete source code diff, file contents read by the `file_read` tool,
and the model's analysis. On a shared machine any co-tenant can read all
of it with no special privileges.

Change `MkdirAll` mode from `0755` to `0700` and `OpenFile` mode from
`0644` to `0600`, restricting access to the file owner only. This matches
the `0600` permission already used for the config file (which holds the
API key) in `cmd/opencodereview/provider_cmd.go`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

`go test -count=1 ./...` passes across all 12 packages. A new regression
test `TestSessionFilePermissions` was added to
`internal/session/persist_test.go`. It skips on Windows (where NTFS does
not enforce Unix permission bits) and runs on Linux/macOS, asserting that
the session directory is created with mode `0700` and the JSONL file with
mode `0600`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #144