### PR TITLE
feat: add HTTP(S) proxy support for install script

### DIFF
--- a/scripts/config-paths.js
+++ b/scripts/config-paths.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const path = require("path");
+const os = require("os");
+
+const CONFIG_DIR = path.join(os.homedir(), ".opencodereview");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+
+module.exports = { CONFIG_DIR, CONFIG_PATH };

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -3,7 +3,9 @@
 
 const fs = require("fs");
 const path = require("path");
+const http = require("http");
 const https = require("https");
+const tls = require("tls");
 const crypto = require("crypto");
 
 const IS_WINDOWS = process.platform === "win32";
@@ -23,6 +25,99 @@ function warn(msg) {
 
 function error(msg) {
   console.error(`[ERROR] ${msg}`);
+}
+
+const stateDirPath = path.join(require("os").homedir(), ".opencodereview");
+
+function getProxyUrl() {
+  // 1. env vars take highest priority
+  const proxy =
+    process.env.HTTPS_PROXY ||
+    process.env.HTTP_PROXY ||
+    process.env.https_proxy ||
+    process.env.http_proxy;
+  if (proxy) {
+    try {
+      return new URL(proxy);
+    } catch (_) {}
+  }
+
+  // 2. fallback: read from ~/.opencodereview/config.json
+  try {
+    const configPath = path.join(stateDirPath, "config.json");
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      if (config.proxy && config.proxy.url) {
+        return new URL(config.proxy.url);
+      }
+    }
+  } catch (_) {}
+
+  return null;
+}
+
+class HttpsProxyAgent extends https.Agent {
+  constructor(proxyUrl) {
+    super({ keepAlive: true });
+    this._proxyUrl = proxyUrl;
+  }
+
+  createConnection(options, callback) {
+    const proxyPort = this._proxyUrl.port || 3128;
+    const targetHost = options.hostname || options.host;
+    const targetPort = options.port || 443;
+
+    let done = false;
+    const doneOnce = (err, socket) => {
+      if (done) return;
+      done = true;
+      callback(err, socket);
+    };
+
+    const req = http.request({
+      hostname: this._proxyUrl.hostname,
+      port: proxyPort,
+      method: "CONNECT",
+      path: `${targetHost}:${targetPort}`,
+      headers: this._proxyUrl.username
+        ? {
+            "Proxy-Authorization":
+              "Basic " +
+              Buffer.from(
+                this._proxyUrl.username + ":" + (this._proxyUrl.password || "")
+              ).toString("base64"),
+          }
+        : {},
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy();
+      doneOnce(new Error(`Proxy CONNECT ${targetHost}:${targetPort} timed out`));
+    });
+
+    req.on("connect", (res, socket) => {
+      req.setTimeout(0); // clear timeout — CONNECT handshake is done
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        doneOnce(
+          new Error(`Proxy CONNECT ${targetHost}:${targetPort} returned ${res.statusCode}`)
+        );
+        return;
+      }
+      const tlsOpts = {
+        ...options,
+        socket,
+        servername: options.servername || targetHost,
+      };
+      const tlsSocket = tls.connect(tlsOpts, () =>
+        doneOnce(null, tlsSocket)
+      );
+      tlsSocket.on("error", (err) => doneOnce(err));
+    });
+
+    req.on("error", (err) => doneOnce(err));
+    req.end();
+  }
 }
 
 function detectPlatform() {
@@ -95,8 +190,14 @@ function download(url, maxRedirects = 10) {
   if (maxRedirects <= 0) {
     return Promise.reject(new Error(`Too many redirects fetching ${url}`));
   }
+
+  const proxyUrl = getProxyUrl();
+  const options = proxyUrl
+    ? { agent: new HttpsProxyAgent(proxyUrl) }
+    : {};
+
   return new Promise((resolve, reject) => {
-    https.get(url, (res) => {
+    https.get(url, options, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
         download(res.headers.location, maxRedirects - 1).then(resolve).catch(reject);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -7,6 +7,7 @@ const http = require("http");
 const https = require("https");
 const tls = require("tls");
 const crypto = require("crypto");
+const { CONFIG_PATH } = require("./config-paths");
 
 const IS_WINDOWS = process.platform === "win32";
 const BINARY_NAME = IS_WINDOWS ? "opencodereview.exe" : "opencodereview";
@@ -27,8 +28,6 @@ function error(msg) {
   console.error(`[ERROR] ${msg}`);
 }
 
-const stateDirPath = path.join(require("os").homedir(), ".opencodereview");
-
 function getProxyUrl() {
   // 1. env vars take highest priority
   const proxy =
@@ -39,19 +38,23 @@ function getProxyUrl() {
   if (proxy) {
     try {
       return new URL(proxy);
-    } catch (_) {}
+    } catch (_) {
+      warn(`Ignoring invalid proxy env var: ${proxy}`);
+    }
   }
 
   // 2. fallback: read from ~/.opencodereview/config.json
   try {
-    const configPath = path.join(stateDirPath, "config.json");
-    if (fs.existsSync(configPath)) {
-      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    if (fs.existsSync(CONFIG_PATH)) {
+      const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
       if (config.proxy && config.proxy.url) {
-        return new URL(config.proxy.url);
+        const url = new URL(config.proxy.url);
+        return url;
       }
     }
-  } catch (_) {}
+  } catch (e) {
+    warn(`Failed to read proxy config from ${CONFIG_PATH}: ${e.message}`);
+  }
 
   return null;
 }
@@ -112,7 +115,10 @@ class HttpsProxyAgent extends https.Agent {
       const tlsSocket = tls.connect(tlsOpts, () =>
         doneOnce(null, tlsSocket)
       );
-      tlsSocket.on("error", (err) => doneOnce(err));
+      tlsSocket.on("error", (err) => {
+        socket.destroy();
+        doneOnce(err);
+      });
     });
 
     req.on("error", (err) => doneOnce(err));
@@ -183,6 +189,25 @@ function buildUrl(pattern, vars) {
     .replace(/\{arch\}/g, vars.arch);
 }
 
+let _cachedAgent = null;
+let _cachedProxyKey = null;
+
+function getProxyAgent() {
+  const proxyUrl = getProxyUrl();
+  if (!proxyUrl) {
+    _cachedAgent = null;
+    _cachedProxyKey = null;
+    return null;
+  }
+  const key = proxyUrl.href;
+  if (_cachedAgent && _cachedProxyKey === key) {
+    return _cachedAgent;
+  }
+  _cachedAgent = new HttpsProxyAgent(proxyUrl);
+  _cachedProxyKey = key;
+  return _cachedAgent;
+}
+
 function download(url, maxRedirects = 10) {
   if (!url.startsWith("https")) {
     return Promise.reject(new Error(`Refusing non-HTTPS download: ${url}`));
@@ -191,10 +216,8 @@ function download(url, maxRedirects = 10) {
     return Promise.reject(new Error(`Too many redirects fetching ${url}`));
   }
 
-  const proxyUrl = getProxyUrl();
-  const options = proxyUrl
-    ? { agent: new HttpsProxyAgent(proxyUrl) }
-    : {};
+  const agent = getProxyAgent();
+  const options = agent ? { agent } : {};
 
   return new Promise((resolve, reject) => {
     https.get(url, options, (res) => {

--- a/scripts/setup-proxy.js
+++ b/scripts/setup-proxy.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const configDir = path.join(os.homedir(), ".opencodereview");
+const configPath = path.join(configDir, "config.json");
+
+function info(msg) {
+  console.log(`[INFO]  ${msg}`);
+}
+
+function error(msg) {
+  console.error(`[ERROR] ${msg}`);
+}
+
+function loadConfig() {
+  fs.mkdirSync(configDir, { recursive: true });
+  if (fs.existsSync(configPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(configPath, "utf8"));
+    } catch (e) {
+      error(`Failed to parse config.json: ${e.message}`);
+      return {};
+    }
+  }
+  return {};
+}
+
+function saveConfig(config) {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 4) + "\n");
+}
+
+function show() {
+  const config = loadConfig();
+  if (config.proxy && config.proxy.url) {
+    info(`Current proxy: ${config.proxy.url}`);
+  } else {
+    info("No proxy configured.");
+    info("Set one with: node scripts/setup-proxy.js http://127.0.0.1:7897");
+  }
+}
+
+function set(proxyUrl) {
+  // Validate URL
+  try {
+    new URL(proxyUrl);
+  } catch (_) {
+    error(`Invalid URL: ${proxyUrl}`);
+    process.exit(1);
+  }
+
+  const config = loadConfig();
+  config.proxy = { url: proxyUrl };
+  saveConfig(config);
+  info(`Proxy set to: ${proxyUrl}`);
+  info("");
+  info("The following will use this proxy:");
+  info("  - npm postinstall (install.js)");
+  info("  - Auto-update checks (update.js)");
+  info("  - Manual downloads via install.js");
+  info("");
+  info("You can also override it with the HTTPS_PROXY env var.");
+}
+
+function unset() {
+  const config = loadConfig();
+  if (config.proxy) {
+    delete config.proxy;
+    saveConfig(config);
+    info("Proxy configuration removed.");
+  } else {
+    info("No proxy was configured.");
+  }
+}
+
+function main() {
+  const cmd = process.argv[2];
+  const value = process.argv[3];
+
+  switch (cmd) {
+    case "set":
+      if (!value) {
+        error("Usage: node scripts/setup-proxy.js set <proxy-url>");
+        error("Example: node scripts/setup-proxy.js set http://127.0.0.1:7897");
+        process.exit(1);
+      }
+      set(value);
+      break;
+    case "unset":
+      unset();
+      break;
+    case "show":
+    case undefined:
+      show();
+      break;
+    default:
+      error(`Unknown command: ${cmd}`);
+      error("Commands: set <url>, unset, show");
+      process.exit(1);
+  }
+}
+
+main();

--- a/scripts/setup-proxy.js
+++ b/scripts/setup-proxy.js
@@ -2,11 +2,7 @@
 "use strict";
 
 const fs = require("fs");
-const path = require("path");
-const os = require("os");
-
-const configDir = path.join(os.homedir(), ".opencodereview");
-const configPath = path.join(configDir, "config.json");
+const { CONFIG_DIR, CONFIG_PATH } = require("./config-paths");
 
 function info(msg) {
   console.log(`[INFO]  ${msg}`);
@@ -17,20 +13,21 @@ function error(msg) {
 }
 
 function loadConfig() {
-  fs.mkdirSync(configDir, { recursive: true });
-  if (fs.existsSync(configPath)) {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  if (fs.existsSync(CONFIG_PATH)) {
     try {
-      return JSON.parse(fs.readFileSync(configPath, "utf8"));
+      return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
     } catch (e) {
       error(`Failed to parse config.json: ${e.message}`);
-      return {};
+      error("Please fix or remove the corrupted file before retrying.");
+      process.exit(1);
     }
   }
   return {};
 }
 
 function saveConfig(config) {
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 4) + "\n");
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 4) + "\n");
 }
 
 function show() {
@@ -39,7 +36,7 @@ function show() {
     info(`Current proxy: ${config.proxy.url}`);
   } else {
     info("No proxy configured.");
-    info("Set one with: node scripts/setup-proxy.js http://127.0.0.1:7897");
+    info("Set one with: node scripts/setup-proxy.js set http://127.0.0.1:7897");
   }
 }
 


### PR DESCRIPTION
## Summary

Add HTTP(S) proxy support for the npm install script so users behind corporate firewalls or in restricted network environments can download the `opencodereview` binary.

## Changes

### `scripts/install.js`
- Add `getProxyUrl()` — reads proxy config from env vars (`HTTPS_PROXY` > `HTTP_PROXY` > `https_proxy` > `http_proxy`) with fallback to `~/.opencodereview/config.json`
- Add `HttpsProxyAgent` class — implements HTTP CONNECT tunnel for HTTPS downloads through an HTTP proxy
- Support `Proxy-Authorization` Basic auth for authenticated proxies
- 30s timeout on proxy CONNECT handshake with proper cleanup
- Wire the agent into the `download()` function

### `scripts/setup-proxy.js` (new)
- CLI helper for managing proxy configuration without manually editing JSON
- Commands: `set <url>`, `unset`, `show`
- Validates proxy URL format on `set`

## How it works

```
HTTPS_PROXY/HTTP_PROXY env vars  (highest priority)
        ↓  falls back to
~/.opencodereview/config.json → proxy.url
        ↓
HttpsProxyAgent (HTTP CONNECT tunnel)
        ↓
HTTPS download through proxy
```

## Testing

```bash
# Configure proxy
node scripts/setup-proxy.js set http://127.0.0.1:7897
node scripts/setup-proxy.js show

# Test via env var override
HTTPS_PROXY=http://127.0.0.1:7897 npm install
```

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)