### PR TITLE
feat: add Baidu Qianfan provider and update provider list

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -173,6 +173,21 @@ var registry = []Provider{
 			"MiniMax-M2.5-highspeed",
 		},
 	},
+	{
+		Name:        "baidu-qianfan",
+		DisplayName: "Baidu Qianfan API",
+		Protocol:    "openai",
+		BaseURL:     "https://qianfan.baidubce.com/v2",
+		EnvVar:      "QIANFAN_API_KEY",
+		Models: []string{
+			"ernie-5.1",
+			"ernie-5.0",
+			"ernie-x1.1",
+			"ernie-x1-turbo-32k-preview",
+			"deepseek-v4-pro",
+			"deepseek-v4-flash",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -40,7 +40,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "dashscope", "dashscope-tokenplan", "deepseek", "hy-tokenplan", "kimi", "mimo", "minimax", "openai", "tencent-tokenhub", "volcengine", "z-ai"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "hy-tokenplan", "kimi", "mimo", "minimax", "openai", "tencent-tokenhub", "volcengine", "z-ai"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}


### PR DESCRIPTION
## Description

This PR adds support for **Baidu Qianfan API (百度千帆)** to OpenCodeReview, enabling users to leverage Baidu's ERNIE (文心一言) series models for AI-powered code review.

The provider uses the OpenAI-compatible protocol and can be configured via the `QIANFAN_API_KEY` environment variable.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?
<img width="492" height="327" alt="1" src="https://github.com/user-attachments/assets/d6816eb9-989b-4bf4-80ca-e8abf590092b" />
<img width="338" height="202" alt="2" src="https://github.com/user-attachments/assets/c5f68863-aa5f-4db6-b4d6-5ec053884c05" />
<img width="395" height="158" alt="3" src="https://github.com/user-attachments/assets/a2be4848-c9a3-4dad-80e4-4735c5c161a6" />
<img width="835" height="196" alt="4" src="https://github.com/user-attachments/assets/d1e47416-2c7d-4886-ac04-f60f9cd6e2fb" />


### Testing Steps:

1. **Provider Configuration**: Verified the provider appears in the provider list
   ```bash
   ocr llm list-providers | grep baidu
   ```

2. **Model Selection**: Confirmed correct model names are available
   - `ernie-5.1`, `ernie-5.0`, `ernie-x1.1`, `ernie-x1-turbo-32k-preview`
   - `deepseek-v4-pro`, `deepseek-v4-flash`

3. **Connection Testing**: Tested API connectivity with valid credentials
   ```bash
   export QIANFAN_API_KEY="your-api-key"
   ocr config set provider baidu-qianfan
   ocr config set model ernie-5.1
   ocr llm test
   ```

4. **Code Review**: Performed actual code review using the provider to ensure end-to-end functionality

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (see above)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->

---

### Changes Summary:

**Modified Files:**
- `internal/llm/providers.go` - Added Baidu Qianfan provider configuration

**Key Features:**
- ✅ OpenAI-compatible protocol support
- ✅ Environment variable-based authentication (`QIANFAN_API_KEY`)
- ✅ Multiple model options including ERNIE 5.1 and DeepSeek models
- ✅ Proper model name validation

**Usage Example:**

```bash
# Configure Baidu Qianfan
ocr config set provider baidu-qianfan
ocr config set model ernie-5.1
export QIANFAN_API_KEY="your-api-key"

# Start code review
ocr review
```