### PR TITLE
Remove deprecated MiMo v2 models

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -154,9 +154,6 @@ var registry = []Provider{
 		Models: []string{
 			"mimo-v2.5-pro",
 			"mimo-v2.5",
-			"mimo-v2-pro",
-			"mimo-v2-omni",
-			"mimo-v2-flash",
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

[V2 系列模型最终于 2026.6.30 00:00 正式下线](https://s.mi.cn/8ATpzTCC78)

Remove deprecated MiMo V2 model names from the built-in MiMo provider registry.

Removed models:
- `mimo-v2-pro`
- `mimo-v2-omni`
- `mimo-v2-flash`
