### PR TITLE
fix: ensure current file path is always injected for code_comment and…

### DIFF
--- a/internal/diff/resolver.go
+++ b/internal/diff/resolver.go
@@ -165,7 +165,7 @@ func matchConsecutive(sideLines []indexedLine, targetLines []string) (startLine,
 }
 
 // resolveFromFileContent scans the new file content line-by-line for consecutive
-// matches of the normalized existing_code. Ported from Java's findConsecutiveLines.
+// matches of the normalized existing_code.
 func resolveFromFileContent(d *model.Diff, cm *model.LlmComment) bool {
 	if d.NewFileContent == "" {
 		return false
@@ -173,21 +173,37 @@ func resolveFromFileContent(d *model.Diff, cm *model.LlmComment) bool {
 
 	fileLines := strings.Split(d.NewFileContent, "\n")
 	targetLines := splitAndNormalize(cm.ExistingCode)
-	if len(targetLines) == 0 || len(fileLines) < len(targetLines) {
+	if len(targetLines) == 0 {
 		return false
 	}
 
-	for i := 0; i <= len(fileLines)-len(targetLines); i++ {
+	// Normalize file lines the same way as target (skip blanks) and track actual line numbers.
+	normalizedFileLines := make([]string, 0, len(fileLines))
+	fileLineNums := make([]int, 0, len(fileLines))
+	for i, line := range fileLines {
+		n := normalizeLine(strings.TrimRight(line, "\r"))
+		if n == "" {
+			continue
+		}
+		normalizedFileLines = append(normalizedFileLines, n)
+		fileLineNums = append(fileLineNums, i+1)
+	}
+
+	if len(normalizedFileLines) < len(targetLines) {
+		return false
+	}
+
+	for i := 0; i <= len(normalizedFileLines)-len(targetLines); i++ {
 		matched := true
 		for j, target := range targetLines {
-			if normalizeLine(strings.TrimRight(fileLines[i+j], "\r")) != target {
+			if normalizedFileLines[i+j] != target {
 				matched = false
 				break
 			}
 		}
 		if matched {
-			cm.StartLine = i + 1
-			cm.EndLine = i + len(targetLines)
+			cm.StartLine = fileLineNums[i]
+			cm.EndLine = fileLineNums[i+len(targetLines)-1]
 			return true
 		}
 	}

--- a/internal/diff/resolver.go
+++ b/internal/diff/resolver.go
@@ -177,7 +177,9 @@ func resolveFromFileContent(d *model.Diff, cm *model.LlmComment) bool {
 		return false
 	}
 
-	// Normalize file lines the same way as target (skip blanks) and track actual line numbers.
+	// Normalize file lines the same way as target: skip blanks so that
+	// blank lines in the source don't break the sliding-window match.
+	// "Consecutive" here means adjacent non-blank lines.
 	normalizedFileLines := make([]string, 0, len(fileLines))
 	fileLineNums := make([]int, 0, len(fileLines))
 	for i, line := range fileLines {

--- a/internal/diff/resolver_test.go
+++ b/internal/diff/resolver_test.go
@@ -117,6 +117,25 @@ import "fmt"`},
 	}
 }
 
+func TestResolveLineNumbers_FallbackToFileContent_BlankLines(t *testing.T) {
+	// Hunk match fails; fallback must match across blank lines in NewFileContent.
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "package main\n\nfunc foo() {\n\n\treturn 1\n}",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "func foo() {\n\treturn 1\n}",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 3 || cm.EndLine != 6 {
+		t.Errorf("fallback with blank lines: expected 3..6, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
 func TestResolveLineNumbers_NoMatchKeepsZero(t *testing.T) {
 	diffs := []model.Diff{
 		{NewPath: "test.go", Diff: testDiff},

--- a/internal/diff/resolver_test.go
+++ b/internal/diff/resolver_test.go
@@ -136,6 +136,96 @@ func TestResolveLineNumbers_FallbackToFileContent_BlankLines(t *testing.T) {
 	}
 }
 
+func TestResolveLineNumbers_FallbackToFileContent_MultipleBlankLines(t *testing.T) {
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "a\n\n\nb\n\nc\n",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "a\nb\nc",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 1 || cm.EndLine != 6 {
+		t.Errorf("multiple blank lines: expected 1..6, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveLineNumbers_FallbackToFileContent_LeadingBlanks(t *testing.T) {
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "\n\nfoo\nbar\n",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "foo\nbar",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 3 || cm.EndLine != 4 {
+		t.Errorf("leading blanks: expected 3..4, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveLineNumbers_FallbackToFileContent_CRLF(t *testing.T) {
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "alpha\r\nbeta\r\ngamma\r\n",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "beta\ngamma",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 2 || cm.EndLine != 3 {
+		t.Errorf("CRLF: expected 2..3, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveLineNumbers_FallbackToFileContent_FirstMatchWins(t *testing.T) {
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "x\ny\nx\ny\n",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "x\ny",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 1 || cm.EndLine != 2 {
+		t.Errorf("first match wins: expected 1..2, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveLineNumbers_FallbackToFileContent_AllBlankExistingCode(t *testing.T) {
+	diffs := []model.Diff{{
+		NewPath:        "main.go",
+		NewFileContent: "a\nb\nc\n",
+		Diff:           "@@ -1,2 +1,2 @@\n-old\n+new",
+	}}
+	comments := []model.LlmComment{{
+		Path:         "main.go",
+		ExistingCode: "\n\n\n",
+	}}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 0 || cm.EndLine != 0 {
+		t.Errorf("all-blank existing code: expected 0..0, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
 func TestResolveLineNumbers_NoMatchKeepsZero(t *testing.T) {
 	diffs := []model.Diff{
 		{NewPath: "test.go", Diff: testDiff},

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -280,11 +280,10 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		return tool.Of(fmt.Sprintf("Error parsing tool arguments for %s: %v", t.Name(), err))
 	}
 
-	// Inject current file path as default for code_comment when not provided.
+	// Always inject the current file path for code_comment.
+	// The model sometimes hallucinates a path, so we override it.
 	if t == tool.CodeComment && newPath != "" {
-		if _, ok := args["path"]; !ok {
-			args["path"] = newPath
-		}
+		args["path"] = newPath
 	}
 
 	startTime := time.Now()

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -1,0 +1,54 @@
+package llmloop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/llm"
+	"github.com/open-code-review/open-code-review/internal/tool"
+)
+
+func TestExecuteToolCall_CodeCommentOverridesHallucinatedPath(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+
+	r := NewRunner(Deps{
+		Tools:            reg,
+		CommentCollector: collector,
+	})
+
+	args := map[string]any{
+		"path": "wrong.go",
+		"comments": []any{
+			map[string]any{
+				"content":       "issue",
+				"existing_code": "foo",
+			},
+		},
+	}
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := r.executeToolCall(context.Background(), "correct.go", llm.ToolCall{
+		Function: llm.FunctionCall{
+			Name:      "code_comment",
+			Arguments: string(argsJSON),
+		},
+	}, nil)
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("unexpected result: %+v", cp)
+	}
+
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].Path != "correct.go" {
+		t.Errorf("path override: got %q, want %q", comments[0].Path, "correct.go")
+	}
+}


### PR DESCRIPTION
# Improve line number tracking in resolver

## Description

Two fixes for the `:0-0` line numbers issue in review comments:

1. **Wrong file attribution (`internal/agent/agent.go`):** The `code_comment` tool definition doesn't declare a `path` parameter, but some LLMs spontaneously add one. The agent's fallback (`if _, ok := args["path"]; !ok`) only filled the path if it was entirely absent, meaning the LLM's hallucinated value won. Changed this to always override with the correct current-file path.
2. **Blank lines break `resolveFromFileContent` (`internal/diff/resolver.go`):** `splitAndNormalize` strips blank lines from the target `existing_code`, but the old comparison loop iterated over raw file lines (with blanks intact), causing a misalignment whenever the snippet contained blank lines. The fix normalizes file lines the exact same way (skipping blanks and tracking actual line numbers via `fileLineNums`) so both sides stay aligned.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Validated against a real review run (Range mode, 3 files). 
* **Before:** 5/8 comments had `:0-0`. 
* **After:** Following both fixes, all 8 comments resolve to the correct lines when the path and snippet are accurate. See the discussion in the related issue for before/after logs.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA