### PR TITLE
feat: add tool_calls field to JSON output

### DIFF
--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -195,7 +195,7 @@ type jsonOutput struct {
 	Status         string               `json:"status"`
 	Message        string               `json:"message,omitempty"`
 	Summary        *jsonSummary         `json:"summary,omitempty"`
-	ToolCalls      *jsonToolCalls       `json:"tool_calls,omitempty"`
+	ToolCalls      *jsonToolCalls       `json:"tool_calls"`
 	Comments       []model.LlmComment   `json:"comments"`
 	Warnings       []agent.AgentWarning `json:"warnings,omitempty"`
 	ProjectSummary string               `json:"project_summary,omitempty"`
@@ -269,6 +269,9 @@ func outputJSONNoFiles() error {
 		Status:   "skipped",
 		Message:  "No supported files changed.",
 		Comments: []model.LlmComment{},
+		ToolCalls: &jsonToolCalls{
+			ByTool: map[string]int64{},
+		},
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -232,15 +232,17 @@ func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 		},
 		ProjectSummary: projectSummary,
 	}
-	if len(toolCalls) > 0 {
-		var total int64
-		for _, v := range toolCalls {
-			total += v
-		}
-		out.ToolCalls = &jsonToolCalls{
-			Total:  total,
-			ByTool: toolCalls,
-		}
+	var total int64
+	for _, v := range toolCalls {
+		total += v
+	}
+	byTool := toolCalls
+	if byTool == nil {
+		byTool = make(map[string]int64)
+	}
+	out.ToolCalls = &jsonToolCalls{
+		Total:  total,
+		ByTool: byTool,
 	}
 	if len(comments) == 0 {
 		if hasSubtaskErrors(warnings) {

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -186,10 +186,16 @@ type jsonSummary struct {
 	Elapsed          string `json:"elapsed"`
 }
 
+type jsonToolCalls struct {
+	Total  int64            `json:"total"`
+	ByTool map[string]int64 `json:"by_tool"`
+}
+
 type jsonOutput struct {
 	Status         string               `json:"status"`
 	Message        string               `json:"message,omitempty"`
 	Summary        *jsonSummary         `json:"summary,omitempty"`
+	ToolCalls      *jsonToolCalls       `json:"tool_calls,omitempty"`
 	Comments       []model.LlmComment   `json:"comments"`
 	Warnings       []agent.AgentWarning `json:"warnings,omitempty"`
 	ProjectSummary string               `json:"project_summary,omitempty"`
@@ -210,7 +216,7 @@ func outputJSON(comments []model.LlmComment) error {
 
 func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentWarning,
 	filesReviewed, inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens int64,
-	duration time.Duration, projectSummary string) error {
+	duration time.Duration, projectSummary string, toolCalls map[string]int64) error {
 	out := jsonOutput{
 		Status:   "success",
 		Comments: comments,
@@ -225,6 +231,16 @@ func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 			Elapsed:          duration.Round(time.Second).String(),
 		},
 		ProjectSummary: projectSummary,
+	}
+	if len(toolCalls) > 0 {
+		var total int64
+		for _, v := range toolCalls {
+			total += v
+		}
+		out.ToolCalls = &jsonToolCalls{
+			Total:  total,
+			ByTool: toolCalls,
+		}
 	}
 	if len(comments) == 0 {
 		if hasSubtaskErrors(warnings) {

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -19,26 +19,26 @@ import (
 //
 // Bare `ocr scan` (no --path) scans the entire repository; --path narrows.
 type scanOptions struct {
-	toolConfigPath string
-	rulePath       string
-	repoDir        string
-	paths          string // comma-separated relative paths; empty = whole repo
-	excludes       string // comma-separated gitignore-style exclude patterns
-	outputFormat   string
-	audience       string
-	background     string
-	concurrency    int
-	perFileTimeout int
-	maxTools       int
-	maxGitProcs    int
-	preview        bool
-	noPlan         bool   // --no-plan: skip the PLAN_TASK pre-pass per file
-	noDedup        bool   // --no-dedup: skip the per-batch DEDUP_TASK
-	noSummary      bool   // --no-summary: skip the post-run PROJECT_SUMMARY_TASK
-	batch          string // --batch: override scan template's BATCH_STRATEGY
-	maxTokensBudget int   // --max-tokens-budget: cap total token usage; 0 = unlimited
-	model          string // --model: override resolved LLM model for this scan
-	showHelp       bool
+	toolConfigPath  string
+	rulePath        string
+	repoDir         string
+	paths           string // comma-separated relative paths; empty = whole repo
+	excludes        string // comma-separated gitignore-style exclude patterns
+	outputFormat    string
+	audience        string
+	background      string
+	concurrency     int
+	perFileTimeout  int
+	maxTools        int
+	maxGitProcs     int
+	preview         bool
+	noPlan          bool   // --no-plan: skip the PLAN_TASK pre-pass per file
+	noDedup         bool   // --no-dedup: skip the per-batch DEDUP_TASK
+	noSummary       bool   // --no-summary: skip the post-run PROJECT_SUMMARY_TASK
+	batch           string // --batch: override scan template's BATCH_STRATEGY
+	maxTokensBudget int    // --max-tokens-budget: cap total token usage; 0 = unlimited
+	model           string // --model: override resolved LLM model for this scan
+	showHelp        bool
 }
 
 func parseScanFlags(args []string) (scanOptions, error) {

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -230,6 +230,7 @@ type ResultProvider interface {
 	// scan's PROJECT_SUMMARY_TASK. Empty for review mode and for scans
 	// that skipped / failed the summary phase.
 	ProjectSummary() string
+	ToolCalls() map[string]int64
 }
 
 // emitRunResult is the post-LLM-run finalization shared by `ocr review` and
@@ -275,7 +276,7 @@ func emitRunResult(
 		return outputJSONWithWarnings(comments, ag.Warnings(), ag.FilesReviewed(),
 			ag.TotalInputTokens(), ag.TotalOutputTokens(), ag.TotalTokensUsed(),
 			ag.TotalCacheReadTokens(), ag.TotalCacheWriteTokens(), duration,
-			ag.ProjectSummary())
+			ag.ProjectSummary(), ag.ToolCalls())
 	}
 	outputTextWithWarnings(comments, ag.Warnings())
 	if summary := ag.ProjectSummary(); summary != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -35,7 +35,6 @@ func NewCommentWorkerPool(workerCount int) *CommentWorkerPool {
 	return llmloop.NewCommentWorkerPool(workerCount)
 }
 
-
 // Args holds all dependencies and configuration needed to run a review session.
 type Args struct {
 	// RepoDir is the root of the git repository.
@@ -256,6 +255,9 @@ func (a *Agent) ProjectSummary() string { return "" }
 
 // Warnings returns a copy of non-fatal warnings recorded during review.
 func (a *Agent) Warnings() []AgentWarning { return a.runner.Warnings() }
+
+// ToolCalls returns per-tool call counts accumulated during review.
+func (a *Agent) ToolCalls() map[string]int64 { return a.runner.ToolCalls() }
 
 // recordWarning adds a non-fatal warning to the agent's warning list.
 func (a *Agent) recordWarning(warningType, file, message string) {
@@ -775,7 +777,6 @@ func formatToolDefs(toolDefs []llm.ToolDef) string {
 	return sb.String()
 }
 
-
 // findDiff returns the Diff for the given file path, or nil if not found.
 func (a *Agent) findDiff(path string) *model.Diff {
 	for i := range a.diffs {
@@ -785,7 +786,6 @@ func (a *Agent) findDiff(path string) *model.Diff {
 	}
 	return nil
 }
-
 
 // BuildToolDefs converts toolsconfig.ToolConfigEntry slice into []llm.ToolDef,
 // filtering by phase (planOnly=true for plan_task, false for main_task).

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -48,6 +48,8 @@ type Runner struct {
 	totalCacheWriteTokens int64
 	warningsMu            sync.Mutex
 	warnings              []AgentWarning
+	toolCallsMu           sync.Mutex
+	toolCalls             map[string]int64
 	compressionMu         sync.Mutex
 	pendingJob            *compressionJob
 }
@@ -92,6 +94,26 @@ func (r *Runner) RecordWarning(warningType, file, message string) {
 		Type:    warningType,
 	})
 	r.warningsMu.Unlock()
+}
+
+// ToolCalls returns a snapshot of the per-tool call counts.
+func (r *Runner) ToolCalls() map[string]int64 {
+	r.toolCallsMu.Lock()
+	defer r.toolCallsMu.Unlock()
+	out := make(map[string]int64, len(r.toolCalls))
+	for k, v := range r.toolCalls {
+		out[k] = v
+	}
+	return out
+}
+
+func (r *Runner) recordToolCall(name string) {
+	r.toolCallsMu.Lock()
+	if r.toolCalls == nil {
+		r.toolCalls = make(map[string]int64)
+	}
+	r.toolCalls[name]++
+	r.toolCallsMu.Unlock()
 }
 
 // RecordUsage adds the prompt/completion/cache tokens reported by an LLM
@@ -245,6 +267,8 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 	if t == tool.TaskDone {
 		return tool.Complete()
 	}
+
+	r.recordToolCall(t.Name())
 
 	p := lookupTool(r.deps.Tools, t)
 	if p == nil {

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -268,12 +268,12 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		return tool.Complete()
 	}
 
-	r.recordToolCall(t.Name())
-
 	p := lookupTool(r.deps.Tools, t)
 	if p == nil {
 		return tool.Of(tool.NotAvailableMsg)
 	}
+
+	r.recordToolCall(t.Name())
 
 	var args map[string]any
 	if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -180,6 +180,9 @@ func (a *Agent) TotalCacheWriteTokens() int64 {
 // Warnings returns the warnings recorded by the LLM runner.
 func (a *Agent) Warnings() []llmloop.AgentWarning { return a.runner.Warnings() }
 
+// ToolCalls returns per-tool call counts accumulated during scan.
+func (a *Agent) ToolCalls() map[string]int64 { return a.runner.ToolCalls() }
+
 func (a *Agent) recordWarning(warningType, file, message string) {
 	a.runner.RecordWarning(warningType, file, message)
 }

--- a/internal/scan/batch_test.go
+++ b/internal/scan/batch_test.go
@@ -59,8 +59,8 @@ func TestGroupBatches_ByLanguage(t *testing.T) {
 	// Within a batch, input order is preserved.
 	want := [][]string{
 		{"cmd/main.go", "internal/scan/agent.go", "internal/scan/preview.go"}, // .go
-		{"docs/README.md", "docs/intro.md"},                                  // .md
-		{"scripts/build.sh"},                                                 // .sh
+		{"docs/README.md", "docs/intro.md"},                                   // .md
+		{"scripts/build.sh"},                                                  // .sh
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v\nwant %v", got, want)
@@ -69,18 +69,18 @@ func TestGroupBatches_ByLanguage(t *testing.T) {
 
 func TestGroupBatches_ByDirectory(t *testing.T) {
 	items := itemList(
-		"README.md",         // <root>
-		"cmd/main.go",       // cmd
-		"internal/a/x.go",   // internal
-		"internal/b/y.go",   // internal
-		"cmd/scan.go",       // cmd
-		"LICENSE",           // <root>
+		"README.md",       // <root>
+		"cmd/main.go",     // cmd
+		"internal/a/x.go", // internal
+		"internal/b/y.go", // internal
+		"cmd/scan.go",     // cmd
+		"LICENSE",         // <root>
 	)
 	got := batchPaths(groupBatches(items, BatchByDirectory, 0))
 	want := [][]string{
-		{"README.md", "LICENSE"},                  // <root>
-		{"cmd/main.go", "cmd/scan.go"},            // cmd
-		{"internal/a/x.go", "internal/b/y.go"},    // internal
+		{"README.md", "LICENSE"},               // <root>
+		{"cmd/main.go", "cmd/scan.go"},         // cmd
+		{"internal/a/x.go", "internal/b/y.go"}, // internal
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v\nwant %v", got, want)
@@ -118,13 +118,13 @@ func TestGroupBatches_Empty(t *testing.T) {
 
 func TestLanguageKey_ExtensionlessAndDotfiles(t *testing.T) {
 	cases := map[string]string{
-		"Makefile":              "<no-ext>",
-		"src/Dockerfile":        "<no-ext>",
-		".gitignore":            "<no-ext>", // dotfile w/o extension
-		".github/CODEOWNERS":    "<no-ext>",
-		"cmd/main.go":           ".go",
-		"docs/README.MD":        ".md",
-		"a/b/c.Test.go":         ".go",
+		"Makefile":           "<no-ext>",
+		"src/Dockerfile":     "<no-ext>",
+		".gitignore":         "<no-ext>", // dotfile w/o extension
+		".github/CODEOWNERS": "<no-ext>",
+		"cmd/main.go":        ".go",
+		"docs/README.MD":     ".md",
+		"a/b/c.Test.go":      ".go",
 	}
 	for path, want := range cases {
 		got := languageKey(model.ScanItem{Path: path})

--- a/internal/scan/budget_test.go
+++ b/internal/scan/budget_test.go
@@ -77,16 +77,16 @@ func TestBudgetGate_StopsBeforeExceeding(t *testing.T) {
 	fake := &fakeBudgetClient{perCallTokens: perCall}
 
 	a := NewAgent(Args{
-		Template:          budgetTestTemplate(),
-		LLMClient:         fake,
-		CommentCollector:  tool.NewCommentCollector(),
-		Tools:             tool.NewRegistry(),
-		MaxConcurrency:    1, // serialize so the gate is deterministic
-		MaxTokensBudget:   120_000,
-		Session:           session.New(t.TempDir(), "main", "test", session.SessionOptions{ReviewMode: session.ReviewModeFullScan}),
-		SkipPlan:          true,
-		SkipDedup:         true,
-		SkipSummary:       true,
+		Template:         budgetTestTemplate(),
+		LLMClient:        fake,
+		CommentCollector: tool.NewCommentCollector(),
+		Tools:            tool.NewRegistry(),
+		MaxConcurrency:   1, // serialize so the gate is deterministic
+		MaxTokensBudget:  120_000,
+		Session:          session.New(t.TempDir(), "main", "test", session.SessionOptions{ReviewMode: session.ReviewModeFullScan}),
+		SkipPlan:         true,
+		SkipDedup:        true,
+		SkipSummary:      true,
 	})
 	a.items = makeScanItems(10)
 	a.args.Tools.Freeze()

--- a/internal/scan/dedup_test.go
+++ b/internal/scan/dedup_test.go
@@ -61,13 +61,13 @@ func TestApplyDedupGroups_KeepCanonicalContentWhenNoMergedContent(t *testing.T) 
 func TestApplyDedupGroups_RejectsBadShapes(t *testing.T) {
 	originals := []model.LlmComment{cmt("a.go", "x"), cmt("b.go", "y")}
 	cases := map[string]string{
-		"empty input":      ``,
-		"non-json":         `not json at all`,
-		"missing id":       `{"groups": [{"members": ["c-0"]}]}`,                   // c-1 not covered
-		"duplicate id":     `{"groups": [{"members": ["c-0", "c-0"]}, {"members": ["c-1"]}]}`,
-		"unknown id":       `{"groups": [{"members": ["c-0"]}, {"members": ["c-99"]}]}`,
-		"empty members":    `{"groups": [{"members": []}, {"members": ["c-0", "c-1"]}]}`,
-		"missing one":      `{"groups": [{"members": ["c-1"]}]}`, // c-0 missing
+		"empty input":   ``,
+		"non-json":      `not json at all`,
+		"missing id":    `{"groups": [{"members": ["c-0"]}]}`, // c-1 not covered
+		"duplicate id":  `{"groups": [{"members": ["c-0", "c-0"]}, {"members": ["c-1"]}]}`,
+		"unknown id":    `{"groups": [{"members": ["c-0"]}, {"members": ["c-99"]}]}`,
+		"empty members": `{"groups": [{"members": []}, {"members": ["c-0", "c-1"]}]}`,
+		"missing one":   `{"groups": [{"members": ["c-1"]}]}`, // c-0 missing
 	}
 	for name, raw := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scan/estimate_test.go
+++ b/internal/scan/estimate_test.go
@@ -30,8 +30,8 @@ func TestEstimateCost_ScalesWithContentAndPhases(t *testing.T) {
 	items := []model.ScanItem{
 		{Path: "a.go", Content: strings.Repeat("token ", 500)}, // ~non-trivial
 		{Path: "b.go", Content: strings.Repeat("x ", 300)},
-		{Path: "bin.dat", IsBinary: true},  // skipped
-		{Path: "empty.go", Content: ""},    // skipped
+		{Path: "bin.dat", IsBinary: true}, // skipped
+		{Path: "empty.go", Content: ""},   // skipped
 	}
 
 	// Plan off, dedup off, summary off → only MAIN_TASK cost.


### PR DESCRIPTION
## Summary
- Track per-tool invocation counts in `llmloop.Runner` via a thread-safe map
- Expose `ToolCalls()` through the `ResultProvider` interface (both review and scan modes)
- Add `tool_calls` top-level field to `--format json` output with `total` and `by_tool` breakdown

## Example output
```json
{
  "tool_calls": {
    "total": 18,
    "by_tool": {
      "file_read": 8,
      "code_search": 4,
      "code_comment": 3,
      "file_find": 2,
      "file_read_diff": 1
    }
  }
}
```

## Test plan
- [x] `make check` passes (format + vet)
- [x] All related package tests pass (`cmd/opencodereview`, `internal/agent`, `internal/scan`)
- [ ] Run `ocr review --format json` and verify `tool_calls` field present in output