### PR TITLE
fix: increase REVIEW_FILTER_TASK and RE_LOCATION_TASK timeout from 60s to 180s

### DIFF
--- a/internal/config/template/scan_template.json
+++ b/internal/config/template/scan_template.json
@@ -75,7 +75,7 @@
         "content": "Below is a unified diff and a review comment. Identify the minimal contiguous code range in the diff that the comment targets.\n\nRules:\n1. Copy the relevant lines VERBATIM from the diff — do not rewrite, reformat, or add anything.\n2. Strip leading diff markers (`+`, `-`, ` `) from each line before outputting.\n3. Include only the lines directly related to the issue — no surrounding context.\n4. If multiple disjoint locations apply, pick the single most relevant one.\n5. Output ONLY a fenced code block. No explanation, no commentary.\n\n**Diff:**\n```diff\n{diff}```\n\n**Original code snippet (failed to match):**\n```\n{existing_code}\n```\n\n**Review comment:**\n{suggestion_content}"
       }
     ],
-    "timeout": 60
+    "timeout": 180
   },
   "MAX_TOKENS": 58888,
   "MAX_TOOL_REQUEST_TIMES": 60,

--- a/internal/config/template/task_template.json
+++ b/internal/config/template/task_template.json
@@ -21,14 +21,14 @@
     ]
   },
   "REVIEW_FILTER_TASK": {
-    "timeout": 60,
+    "timeout": 180,
     "messages": [
       { "role": "system", "prompt_file": "review_filter_task_system.md" },
       { "role": "user", "prompt_file": "review_filter_task_user.md" }
     ]
   },
   "RE_LOCATION_TASK": {
-    "timeout": 60,
+    "timeout": 180,
     "messages": [
       { "role": "system", "prompt_file": "re_location_task_system.md" },
       { "role": "user", "prompt_file": "re_location_task_user.md" }


### PR DESCRIPTION
## Summary

- Increase `REVIEW_FILTER_TASK` and `RE_LOCATION_TASK` timeout from 60s to 180s in both `task_template.json` and `scan_template.json`
- Fixes the issue where slow local models hit the hardcoded 60-second timeout that the user-provided `--timeout` flag cannot override

Closes #208