### PR TITLE
feat: add Cursor plugin support

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -24,6 +24,7 @@
   <a href="#supported-platforms"><img alt="Linux" src="https://img.shields.io/badge/Linux-supported-blue.svg" /></a>
   <a href="#supported-agents"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-supported-blueviolet.svg" /></a>
   <a href="#supported-agents"><img alt="Codex" src="https://img.shields.io/badge/Codex-supported-blueviolet.svg" /></a>
+  <a href="#supported-agents"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-supported-blueviolet.svg" /></a>
 </p>
 <p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語 | <a href="README.ko-KR.md">한국어</a> | <a href="README.ru-RU.md">Русский</a>
@@ -315,7 +316,39 @@ ocr review --audience agent
 
 韓国語ガイド：[`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
 
-#### オプション4: コマンドファイルを直接コピー
+#### オプション4: Cursorプラグインとしてインストール
+
+[Cursor](https://www.cursor.com/)では、このリポジトリからOpen Code Reviewプラグインをインストールできます：
+
+```
+cursor-plugin marketplace add alibaba/open-code-review
+```
+
+手動でmarketplaceを追加することもできます。Cursorで`/plugins`を開き、`Open Code Review`を検索してインストールしてください。
+
+ローカルcheckoutまたはforkの場合：
+
+```
+cursor-plugin marketplace add .
+```
+
+インストール後、Cursorで次のように呼び出します：
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+これにより、ローカルOCR CLIを実行するCursor skillが登録されます：
+
+```bash
+ocr review --audience agent
+```
+
+この統合はOCRの内部LLM backendを変更しません。OCR自体には、CLI setupセクションで説明されている`ocr` CLIのインストールと設定が引き続き必要です。
+
+#### オプション5: コマンドファイルを直接コピー
 
 パッケージマネージャーを使わずに素早くセットアップしたい場合は、コマンドファイルをコピーするだけでClaude Codeで`/open-code-review`スラッシュコマンドを使えるようになります。
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -24,6 +24,7 @@
   <a href="#supported-platforms"><img alt="Linux" src="https://img.shields.io/badge/Linux-supported-blue.svg" /></a>
   <a href="#supported-agents"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-supported-blueviolet.svg" /></a>
   <a href="#supported-agents"><img alt="Codex" src="https://img.shields.io/badge/Codex-supported-blueviolet.svg" /></a>
+  <a href="#supported-agents"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-supported-blueviolet.svg" /></a>
 </p>
 <p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a> | 한국어 | <a href="README.ru-RU.md">Русский</a>
@@ -315,7 +316,39 @@ ocr review --audience agent
 
 한국어 가이드: [`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
 
-#### Option 4: Command 파일 직접 복사
+#### Option 4: Cursor Plugin으로 설치
+
+[Cursor](https://www.cursor.com/)에서는 이 repository에서 Open Code Review plugin을 설치합니다:
+
+```
+cursor-plugin marketplace add alibaba/open-code-review
+```
+
+수동으로 marketplace를 추가할 수도 있습니다. Cursor에서 `/plugins`를 열고 `Open Code Review`를 검색하여 설치합니다.
+
+local checkout이나 fork에서는 다음을 사용할 수 있습니다:
+
+```
+cursor-plugin marketplace add .
+```
+
+설치 후, Cursor에서 다음과 같이 호출합니다:
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+이 plugin은 local OCR CLI를 실행하는 Cursor skill을 등록합니다:
+
+```bash
+ocr review --audience agent
+```
+
+이 통합은 OCR의 내부 LLM backend를 변경하지 않습니다. OCR 자체는 CLI 설정 섹션에 설명된 대로 `ocr` CLI 설치와 설정이 필요합니다.
+
+#### Option 5: Command 파일 직접 복사
 
 package manager 없이 빠르게 설정하려면 command 파일을 복사해 Claude Code에서 `/open-code-review` slash command를 사용할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#supported-platforms"><img alt="Linux" src="https://img.shields.io/badge/Linux-supported-blue.svg" /></a>
   <a href="#supported-agents"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-supported-blueviolet.svg" /></a>
   <a href="#supported-agents"><img alt="Codex" src="https://img.shields.io/badge/Codex-supported-blueviolet.svg" /></a>
+  <a href="#supported-agents"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-supported-blueviolet.svg" /></a>
 </p>
 <p align="center">
   English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a> | <a href="README.ko-KR.md">한국어</a> | <a href="README.ru-RU.md">Русский</a>
@@ -315,7 +316,39 @@ This integration does not change OCR's internal LLM backend and does not require
 
 Korean guide: [`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
 
-#### Option 4: Copy the Command File Directly
+#### Option 4: Install as a Cursor Plugin
+
+For [Cursor](https://www.cursor.com/), install the Open Code Review plugin from this repository:
+
+```
+cursor-plugin marketplace add alibaba/open-code-review
+```
+
+Or add the marketplace manually. In Cursor, open `/plugins`, search for `Open Code Review`, and install it.
+
+For a local checkout or fork:
+
+```
+cursor-plugin marketplace add .
+```
+
+After installation, invoke it in Cursor:
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+This registers a Cursor skill that runs the local OCR CLI:
+
+```bash
+ocr review --audience agent
+```
+
+This integration does not change OCR's internal LLM backend. OCR itself still requires the `ocr` CLI to be installed and configured as described in the CLI setup section.
+
+#### Option 5: Copy the Command File Directly
 
 For a quick setup without any package manager, simply copy the command file to use the `/open-code-review` slash command in Claude Code.
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -24,6 +24,7 @@
   <a href="#supported-platforms"><img alt="Linux" src="https://img.shields.io/badge/Linux-supported-blue.svg" /></a>
   <a href="#supported-agents"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-supported-blueviolet.svg" /></a>
   <a href="#supported-agents"><img alt="Codex" src="https://img.shields.io/badge/Codex-supported-blueviolet.svg" /></a>
+  <a href="#supported-agents"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-supported-blueviolet.svg" /></a>
 </p>
 <p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja-JP.md">日本語</a> | <a href="README.ko-KR.md">한국어</a> | Русский
@@ -315,7 +316,39 @@ ocr review --audience agent
 
 Руководство на корейском: [`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
 
-#### Вариант 4: просто скопировать файл команды
+#### Вариант 4: установка как плагин Cursor
+
+Для [Cursor](https://www.cursor.com/) установите плагин Open Code Review из этого репозитория:
+
+```
+cursor-plugin marketplace add alibaba/open-code-review
+```
+
+Или добавьте маркетплейс вручную. В Cursor откройте `/plugins`, найдите `Open Code Review` и установите.
+
+Для локального чекаута или форка:
+
+```
+cursor-plugin marketplace add .
+```
+
+После установки вызывайте плагин в Cursor:
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+Это зарегистрирует Cursor-скилл, запускающий локальный CLI OCR:
+
+```bash
+ocr review --audience agent
+```
+
+Эта интеграция не меняет внутренний LLM-бэкенд OCR. Самому OCR по-прежнему нужен установленный и настроенный CLI `ocr`, как описано в разделе про настройку CLI.
+
+#### Вариант 5: просто скопировать файл команды
 
 Для быстрой настройки без пакетных менеджеров достаточно скопировать файл команды, чтобы использовать slash-команду `/open-code-review` в Claude Code.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,7 @@
   <a href="#supported-platforms"><img alt="Linux" src="https://img.shields.io/badge/Linux-supported-blue.svg" /></a>
   <a href="#supported-agents"><img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-supported-blueviolet.svg" /></a>
   <a href="#supported-agents"><img alt="Codex" src="https://img.shields.io/badge/Codex-supported-blueviolet.svg" /></a>
+  <a href="#supported-agents"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-supported-blueviolet.svg" /></a>
 </p>
 <p align="center">
   <a href="README.md">English</a> | 简体中文 | <a href="README.ja-JP.md">日本語</a> | <a href="README.ko-KR.md">한국어</a> | <a href="README.ru-RU.md">Русский</a>
@@ -315,7 +316,39 @@ ocr review --audience agent
 
 韩文指南：[`plugins/open-code-review/CODEX.ko-KR.md`](plugins/open-code-review/CODEX.ko-KR.md)
 
-#### 方式四：直接复制命令文件
+#### 方式四：作为 Cursor Plugin 安装
+
+对于 [Cursor](https://www.cursor.com/)，可以从此仓库安装 Open Code Review plugin：
+
+```
+cursor-plugin marketplace add alibaba/open-code-review
+```
+
+也可以手动添加 marketplace。在 Cursor 中打开 `/plugins`，搜索 `Open Code Review` 并安装。
+
+对于本地 checkout 或 fork：
+
+```
+cursor-plugin marketplace add .
+```
+
+安装后，在 Cursor 中调用：
+
+```text
+@Open Code Review review my current changes
+@Open Code Review review this branch against main
+@Open Code Review review and fix high-confidence issues
+```
+
+这会注册一个 Cursor skill，用于运行本地 OCR CLI：
+
+```bash
+ocr review --audience agent
+```
+
+此集成不会改变 OCR 的内部 LLM backend。OCR 本身仍需要按照 CLI setup 部分安装并配置 `ocr` CLI。
+
+#### 方式五：直接复制命令文件
 
 如果不想使用任何包管理器，可以直接复制命令文件，在 Claude Code 中使用 `/open-code-review` 斜杠命令。
 

--- a/plugins/open-code-review/.cursor-plugin/plugin.json
+++ b/plugins/open-code-review/.cursor-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "open-code-review",
+  "displayName": "Open Code Review",
+  "version": "1.0.0",
+  "description": "AI-powered code review on Git diffs — supports workspace changes, branch ranges, and single commits with concurrent per-file analysis, codebase search, and deep context-aware review.",
+  "author": {
+    "name": "Alibaba"
+  },
+  "homepage": "https://github.com/alibaba/open-code-review",
+  "repository": "https://github.com/alibaba/open-code-review",
+  "license": "Apache-2.0",
+  "keywords": [
+    "code-review",
+    "cursor",
+    "ocr",
+    "open-code-review",
+    "ai-review",
+    "git-diff"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "review",
+    "quality",
+    "automation"
+  ],
+  "skills": "../skills/"
+}


### PR DESCRIPTION
## Summary

- Add `.cursor-plugin/plugin.json` manifest alongside existing Claude Code and Codex plugin integrations, reusing the shared `skills/open-code-review/SKILL.md`
- Add Cursor supported badge to all README versions (EN, zh-CN, ja-JP, ko-KR, ru-RU)
- Add "Install as a Cursor Plugin" section (Option 4) to the agent integration docs in all README versions

## Test plan

- [ ] Verify `plugin.json` conforms to Cursor's [plugin.schema.json](https://github.com/cursor/plugins/blob/main/schemas/plugin.schema.json)
- [ ] Verify skill path in `plugin.json` resolves to the existing `skills/open-code-review/SKILL.md`
- [ ] Verify all 5 README files have consistent Cursor badge and Option numbering (Option 4 = Cursor, Option 5 = Copy Command File)
- [ ] Run `make check` — passes