### PR TITLE
feat(pages): update active users count from 20K+ to 30K+

### DIFF
--- a/pages/src/i18n/en.ts
+++ b/pages/src/i18n/en.ts
@@ -17,14 +17,14 @@ export const en: TranslationKeys = {
   'hero.pill3': 'Token Cost Only 1/9',
   'hero.cta1': 'Quick Start',
   'hero.cta2': 'View Benchmark',
-  'hero.users': '20K+ Active Users',
+  'hero.users': '30K+ Active Users',
   'hero.openSource': 'Fully Open Source',
   'hero.terminal': 'ocr terminal',
   'hero.badgeLabel': 'Benchmark #1',
 
   // Highlights
   'highlights.stat1Label': 'Active Users',
-  'highlights.stat1Value': '20K+',
+  'highlights.stat1Value': '30K+',
   'highlights.stat1Caption': 'Battle-tested inside Alibaba Group',
   'highlights.stat2Label': 'Real-World Tasks',
   'highlights.stat2Value': '1M+',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -24,7 +24,7 @@ export const zh: TranslationKeys = {
 
   // Highlights
   'highlights.stat1Label': '活跃用户',
-  'highlights.stat1Value': '20K+',
+  'highlights.stat1Value': '30K+',
   'highlights.stat1Caption': '阿里集团内部生产验证',
   'highlights.stat2Label': '真实场景',
   'highlights.stat2Value': '1M+',


### PR DESCRIPTION
Update the active users statistics on the landing page from 20K+ to 30K+ in both English and Chinese i18n files.