### PR TITLE
fix(vscode): retain sidebar webview context when hidden

### DIFF
--- a/extensions/vscode/src/extension/extension.ts
+++ b/extensions/vscode/src/extension/extension.ts
@@ -22,7 +22,11 @@ export function activate(context: vscode.ExtensionContext): void {
   const configPanel = new ConfigPanelProvider(extensionUri, cli, config, (cfg) => sidebar.pushConfig(cfg));
   sidebar.bindConfigPanel((focus) => configPanel.open(focus));
 
-  const viewReg = vscode.window.registerWebviewViewProvider(SIDEBAR_VIEW_ID, sidebar);
+  const viewReg = vscode.window.registerWebviewViewProvider(
+    SIDEBAR_VIEW_ID,
+    sidebar,
+    { webviewOptions: { retainContextWhenHidden: true } },
+  );
   const cmdReg = registerCommands(comments, () => configPanel.open());
 
   disposables.push(viewReg, cmdReg, comments, output, configPanel);


### PR DESCRIPTION
## Description

Set `retainContextWhenHidden` on the sidebar `WebviewViewProvider` registration so review state survives switching to other sidebar panels.

The sidebar `SidebarProvider` WebView is destroyed by default when the panel is hidden and recreated when the user switches back, which clears in-progress review state (progress, logs, etc.). The config panel (`ConfigPanelProvider`) already sets `retainContextWhenHidden: true`; this PR applies the same fix to the main review sidebar.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `cd extensions/vscode && npm test` passes locally (9 suites, 74 tests)
- [ ] Manual testing (describe below)
  - [ ] Launch the extension and click **Start Review**
  - [ ] While a review is running, switch to Explorer / Source Control / Extensions
  - [ ] Switch back to the open-code-review sidebar and confirm the review is still running and state is preserved

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #224 