### PR TITLE
fix(ci): prevent duplicate review posts on retry in ocr-review workflow

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -552,16 +552,23 @@ jobs:
                 if (items.length < PER_PAGE) break;
                 page++;
               }
-              // NOTE: Truncation here is intentional and acceptable. The cap
-              // exists as a safety valve against unbounded loops (e.g. a bug
-              // or malicious activity), not as a normal operating mode. A PR
-              // accumulating >5000 review comments is far outside expected
-              // usage; in that rare case we log a warning and proceed with
-              // partial data rather than failing the whole review. Callers
-              // that depend on completeness (isCommentAlreadyPosted,
-              // hasIssueCommentWithId) already degrade safely by returning
-              // null (unknown) on read failures, so a truncated walk does not
-              // silently produce duplicates.
+              // NOTE: Truncation here is intentional and acts as a safety
+              // valve against unbounded loops (e.g. a bug or malicious
+              // activity), not as a normal operating mode. A PR accumulating
+              // >5000 review comments is far outside expected usage; in that
+              // rare case we log a warning and proceed with partial data
+              // rather than failing the whole review.
+              //
+              // Caveat: this is NOT the same as a read failure. When the read
+              // API throws (rate limit, 5xx), isCommentAlreadyPosted and
+              // hasIssueCommentWithId catch it and return null (unknown), so
+              // the caller skips retrying and creates no duplicate. A
+              // truncated walk does not throw; it returns a partial set
+              // silently, so isCommentAlreadyPosted returns false (definitively
+              // "not posted") for any comment beyond the cap, and the retry
+              // loop will repost it, producing a duplicate. This tradeoff is
+              // accepted because the trigger is far outside expected usage; if
+              // that ceiling ever needs to rise, make maxPages configurable.
               if (page > maxPages) {
                 console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -311,12 +311,6 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
-              // Cache for the per-comment idempotency check: a single paginated
-              // walk of listReviewComments covers all inline comments on the PR,
-              // so we reuse it across retries instead of re-walking on every 5xx.
-              // The cache is best-effort: if the read API fails, the check returns
-              // null (unknown) and the caller skips retrying that comment.
-              const postedIdsCache = { value: null };
               for (const item of toRetry) {
                 const { comment, id } = item;
                 let posted = false;
@@ -385,8 +379,7 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         prNumber,
-                        id,
-                        postedIdsCache
+                        id
                       });
                       if (alreadyPosted === true) {
                         successCount++;
@@ -626,16 +619,17 @@ jobs:
             // read API is unavailable (rate limit, 5xx, etc.). Returning null
             // (rather than defaulting to false) prevents the caller from
             // assuming the comment was not posted and risking a duplicate on
-            // retry. `postedIdsCache` lets the caller reuse the result of a
-            // single paginated walk across multiple per-comment retries, so a
-            // degraded API episode does not amplify into N full walks.
-            async function isCommentAlreadyPosted({ owner, repo, prNumber, id, postedIdsCache }) {
+            // retry.
+            //
+            // Each call walks listReviewComments fresh — no cached snapshot.
+            // A snapshot reused across retries would go stale as comments land
+            // during the loop, and a stale miss for a 5xx-landed comment would
+            // trigger a retry that posts a duplicate. Read calls are paced via
+            // readAllPages/readWithPacing and degrade to null (skip retry) if the
+            // read API itself fails, so the extra walks cannot produce duplicates.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
               try {
-                let posted = postedIdsCache && postedIdsCache.value;
-                if (posted == null) {
-                  posted = await getPostedCommentIds({ owner, repo, prNumber });
-                  if (postedIdsCache) postedIdsCache.value = posted;
-                }
+                const posted = await getPostedCommentIds({ owner, repo, prNumber });
                 return posted.has(id);
               } catch (e) {
                 console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); treating as unknown to avoid duplicates.`);

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -37,6 +37,18 @@
 #                             (default: 3; GitHub best practice is to watch the header and slow down).
 #   OCR_LOW_REMAINING_SPACING - Request spacing (ms) used when remaining quota is low
 #                             (default: 10000 = 10s).
+#   OCR_READ_SUCCESS_DELAY   - Delay (ms) after a successful read API call (listReviews /
+#                             listReviewComments / listIssueComments) used for the
+#                             idempotency check. Reads are cheaper than writes, so the
+#                             default is shorter (default: 500).
+#   OCR_READ_LOW_REMAINING_SPACING - Request spacing (ms) for read calls when remaining
+#                             quota is low (default: 5000 = 5s).
+#
+# Idempotency:
+#   When the batch createReview fails with a 5xx, the request may still have landed on
+#   the server. Before retrying per-comment, the workflow queries existing reviews and
+#   review comments (tagged with a per-run HTML comment) and only retries the comments
+#   that are actually missing. This prevents duplicate review posts.
 #
 # Note: GITHUB_TOKEN is automatically provided by GitHub Actions.
 # Note: The workflow also configures llm.extra_body to '{"thinking": {"type": "disabled"}}'
@@ -116,7 +128,21 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            const crypto = require('crypto');
             const path = '/tmp/ocr-result.json';
+
+            // Unique tag for this workflow run + attempt. Embedded in review/comment
+            // bodies as an HTML comment so the idempotency check can detect whether
+            // a batch createReview actually landed on the server before retrying.
+            // context.runId / context.runAttempt are numbers from @actions/github's
+            // Context (parsed from GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT). Use
+            // Number.isFinite to guard against NaN when the env vars are missing,
+            // falling back to safe defaults.
+            const runId = Number.isFinite(context.runId) ? context.runId : 0;
+            const runAttempt = Number.isFinite(context.runAttempt) ? context.runAttempt : 1;
+            const RUN_TAG = `${runId}-${runAttempt}`;
+            const REVIEW_TAG = `<!-- ocr-review-run:${RUN_TAG} -->`;
+            const SUMMARY_TAG = `<!-- ocr-summary-run:${RUN_TAG} -->`;
 
             // Read OCR output
             let result;
@@ -203,10 +229,24 @@ jobs:
             // Add comments without line info to summary body
             summaryBody += formatSummaryComments(commentsWithoutLine);
 
+            // Prepend the run tag so the idempotency check can detect whether the
+            // batch review actually landed on the server before retrying.
+            summaryBody = REVIEW_TAG + '\n' + summaryBody;
+
             // Statistics tracking
             let successCount = 0;
             let failedCount = 0;
             const failedComments = [];
+
+            // Retry/pacing configuration (shared by write and read API calls).
+            const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
+            const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful write
+            const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
+            const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
+            const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+            // Read APIs are cheaper and have higher thresholds; use shorter pacing.
+            const READ_SUCCESS_DELAY = parseInt(process.env.OCR_READ_SUCCESS_DELAY, 10) || 500;
+            const READ_LOW_REMAINING_SPACING = parseInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 10) || 5000;
 
             try {
               const batchRes = await github.rest.pulls.createReview({
@@ -223,17 +263,44 @@ jobs:
               logRateLimitQuota(batchRes, 'after batch createReview');
             } catch (e) {
               console.log('Failed to post review with inline comments:', e.message);
-              console.log('Falling back to posting comments individually with rate-limit-aware retry...');
-              
-              // Fallback: post comments one by one with delay to avoid secondary rate limits.
-              // GitHub enforces ~80 content-generating requests per minute; spacing calls
-              // helps stay under that threshold. Retry/wait durations are derived from the
-              // rate-limit response headers per GitHub's documented strategy.
-              const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
-              const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful post
-              const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
-              const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
-              const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+              console.log('Checking whether the batch review actually landed on the server before retrying...');
+
+              // Idempotency check: the batch createReview may have succeeded on the
+              // server even though we got a 5xx. Query existing reviews to find out,
+              // so we only retry the comments that are actually missing.
+              let existingReview = null;
+              try {
+                existingReview = await findExistingBatchReview({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  prNumber,
+                  tag: REVIEW_TAG
+                });
+              } catch (checkErr) {
+                console.log(`Idempotency check failed (${checkErr.message}). ` +
+                            `Degrading to original fallback (accepting duplicate risk).`);
+              }
+
+              // Compute the list of inline comments that still need to be posted.
+              // If the batch review landed, only retry the missing ones; otherwise
+              // retry all of them.
+              let toRetry = reviewComments;
+              if (existingReview && existingReview.found) {
+                const postedIds = await getPostedCommentIds({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  prNumber
+                });
+                toRetry = reviewComments.filter(({ comment }) =>
+                  !postedIds.has(commentId(comment))
+                );
+                successCount = reviewComments.length - toRetry.length;
+                console.log(`Batch review already exists (review_id=${existingReview.review.id}). ` +
+                            `${successCount}/${reviewComments.length} inline comments already posted. ` +
+                            `${toRetry.length} missing, will retry only those.`);
+              } else {
+                console.log('Batch review not found on server. Falling back to per-comment posting...');
+              }
 
               // If the batch itself was rate-limited, honor its rate-limit headers
               // (retry-after / x-ratelimit-reset) before retrying per-comment,
@@ -248,7 +315,7 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
-              for (const { comment, reviewComment } of reviewComments) {
+              for (const { comment, reviewComment } of toRetry) {
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
                   try {
@@ -279,23 +346,82 @@ jobs:
                     // rate-limit documentation (retry-after / x-ratelimit-* headers).
                     const retryInfo = computeRetryDelayMs(innerE, attempt);
                     const willRetry = retryInfo != null && attempt < MAX_RETRIES;
-                    if (willRetry) {
+                    // Any error whose request may have reached GitHub (5xx server
+                    // errors, 408 timeout, or network-layer errors with no status)
+                    // can mean the comment was actually created but the response was
+                    // lost. Before retrying (which would post a duplicate) or before
+                    // giving up (which would wrongly list it as failed in the summary),
+                    // we must check whether it already landed.
+                    //
+                    // IMPORTANT: do the check AFTER cooling down, not immediately.
+                    // If the error is rate-limit-related (5xx under load, or a
+                    // network blip), firing read requests right away further
+                    // pressures the already-struggling API. Honor the computed
+                    // retry delay first, then query.
+                    const status = innerE.status;
+                    const maybeReachedServer =
+                      (typeof status === 'number' && (status >= 500 || status === 408)) ||
+                      status == null; // network errors (ECONNRESET, ETIMEDOUT, ...)
+                    if (maybeReachedServer) {
+                      // Cool down first: even read requests count against rate
+                      // limits, and querying during an ongoing 5xx/rate-limit
+                      // episode can worsen the situation. Use the retry delay when
+                      // available; for non-retryable errors (retryInfo == null)
+                      // there is no header-derived wait, so use a short fixed cool
+                      // down before the read.
+                      const coolDownMs = retryInfo != null ? retryInfo.delayMs : FAILURE_DELAY;
+                      if (coolDownMs > 0) {
+                        const secs = (coolDownMs / 1000).toFixed(1);
+                        console.log(
+                          `Cooling down ${secs}s before idempotency check for ${reviewComment.path} ` +
+                          `(HTTP ${innerE.status || 'n/a'}, attempt ${attempt + 1}/${MAX_RETRIES + 1}).`
+                        );
+                        await sleep(coolDownMs);
+                      }
+                      const id = commentId(comment);
+                      const alreadyPosted = await isCommentAlreadyPosted({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        prNumber,
+                        id
+                      });
+                      if (alreadyPosted) {
+                        successCount++;
+                        posted = true;
+                        console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
+                        await sleep(SUCCESS_DELAY);
+                        continue;
+                      }
+                      // Not found on server. If retries are exhausted or the
+                      // error is non-retryable, this is a real failure.
+                      if (!willRetry) {
+                        failedCount++;
+                        failedComments.push({ comment, error: innerE.message });
+                        const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
+                        console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                        await sleep(SUCCESS_DELAY);
+                        break;
+                      }
+                      // willRetry: cool down already consumed above, loop back.
+                    } else if (willRetry) {
+                      // Pure 429/403 rate-limit: the request never reached the
+                      // server, so no duplicate is possible and the idempotency
+                      // check can be skipped. Just honor the retry delay.
                       const secs = (retryInfo.delayMs / 1000).toFixed(1);
                       console.log(
-                        `Rate-limited/transient error on ${reviewComment.path} ` +
+                        `Rate-limited on ${reviewComment.path} ` +
                         `(HTTP ${innerE.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
                         `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ` +
                         `Error: ${innerE.message}`
                       );
                       await sleep(retryInfo.delayMs);
                     } else {
+                      // Non-retryable error that definitely did not reach the
+                      // server (e.g. 4xx validation error): record as failed.
                       failedCount++;
                       failedComments.push({ comment, error: innerE.message });
-                      const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
-                      console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
-                      // After exhausting retries use the success-style pace delay;
-                      // for other errors use the shorter failure pace delay.
-                      await sleep(retryInfo == null ? FAILURE_DELAY : SUCCESS_DELAY);
+                      console.log(`Failed to post comment for ${reviewComment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                      await sleep(FAILURE_DELAY);
                       break;
                     }
                   }
@@ -319,17 +445,152 @@ jobs:
                   finalBody += formatCommentMarkdown(comment, error);
                 }
               }
-              
-              await github.rest.issues.createComment({
+
+              // Prepend the summary tag and post only if no summary with this tag
+              // already exists (idempotency: the batch review may have carried the
+              // same summary body, in which case we must not duplicate it).
+              finalBody = SUMMARY_TAG + '\n' + finalBody;
+              const summaryAlreadyPosted = await hasIssueCommentWithId({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber,
-                body: finalBody
+                issueNumber: prNumber,
+                id: SUMMARY_TAG
               });
+              if (summaryAlreadyPosted) {
+                console.log('Summary comment with this run tag already exists; skipping.');
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: finalBody
+                });
+              }
             }
 
             function sleep(ms) {
               return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            // Retry wrapper shared by write and read API calls. Reuses
+            // computeRetryDelayMs so rate-limit headers (retry-after /
+            // x-ratelimit-*) are honored uniformly. Throws on final failure
+            // so the caller can decide how to degrade.
+            async function withRetry(tag, fn) {
+              for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+                try {
+                  return await fn();
+                } catch (e) {
+                  const retryInfo = computeRetryDelayMs(e, attempt);
+                  const willRetry = retryInfo != null && attempt < MAX_RETRIES;
+                  if (willRetry) {
+                    const secs = (retryInfo.delayMs / 1000).toFixed(1);
+                    console.log(
+                      `[${tag}] transient/rate-limited (HTTP ${e.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
+                      `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ${e.message}`
+                    );
+                    await sleep(retryInfo.delayMs);
+                  } else {
+                    console.log(`[${tag}] failed after ${attempt + 1} attempts: ${e.message}`);
+                    throw e;
+                  }
+                }
+              }
+            }
+
+            // Read API wrapper with retry + proactive pacing. Read requests are
+            // cheaper than writes but still consume the primary rate limit and can
+            // trigger the secondary limit when issued in a tight loop. Use shorter
+            // delays than writes (READ_SUCCESS_DELAY / READ_LOW_REMAINING_SPACING).
+            async function readWithPacing(tag, fn) {
+              const res = await withRetry(tag, fn);
+              const remaining = logRateLimitQuota(res, tag);
+              const lowQuota = remaining != null && remaining <= LOW_REMAINING_THRESHOLD;
+              if (lowQuota) {
+                console.log(`[rate-limit] quota low after read (${remaining} <= ${LOW_REMAINING_THRESHOLD}); spacing ${READ_LOW_REMAINING_SPACING}ms.`);
+                await sleep(READ_LOW_REMAINING_SPACING);
+              } else {
+                await sleep(READ_SUCCESS_DELAY);
+              }
+              return res;
+            }
+
+            // Paginated helper that walks all pages of a list endpoint with retry
+            // and pacing. Returns the concatenated array of items.
+            async function readAllPages(tag, pageFn) {
+              const all = [];
+              let page = 1;
+              const PER_PAGE = 100;
+              while (true) {
+                const res = await readWithPacing(`${tag} (page ${page})`, () => pageFn(page, PER_PAGE));
+                const items = res.data || [];
+                all.push(...items);
+                if (items.length < PER_PAGE) break;
+                page++;
+              }
+              return all;
+            }
+
+            // Idempotency check: find whether a batch review with this run tag
+            // already exists on the PR. Returns { found, review } or throws on
+            // final failure (caller degrades to original fallback).
+            async function findExistingBatchReview({ owner, repo, prNumber, tag }) {
+              const reviews = await readAllPages('listReviews', (page, per_page) =>
+                github.rest.pulls.listReviews({ owner, repo, pull_number: prNumber, per_page, page })
+              );
+              for (const r of reviews) {
+                if ((r.body || '').includes(tag)) {
+                  return { found: true, review: r };
+                }
+              }
+              return { found: false };
+            }
+
+            // Collect the set of comment-level IDs already posted on the PR
+            // (across all reviews). Uses listReviewComments (PR-level, cross-review)
+            // so a single paginated walk covers everything, avoiding the O(missing)
+            // amplification of per-comment lookups.
+            async function getPostedCommentIds({ owner, repo, prNumber }) {
+              const comments = await readAllPages('listReviewComments', (page, per_page) =>
+                github.rest.pulls.listReviewComments({ owner, repo, pull_number: prNumber, per_page, page })
+              );
+              const ids = new Set();
+              for (const c of comments) {
+                const body = c.body || '';
+                const matches = body.match(/ocr-\d+-\d+-[a-f0-9]+/g) || [];
+                for (const id of matches) ids.add(id);
+              }
+              return ids;
+            }
+
+            // Check whether a specific comment-level ID has already landed on the
+            // server. Used by the per-comment retry loop: when a createReview call
+            // fails with a transient 5xx/408, the request may have reached GitHub
+            // and succeeded even though the response was lost. Querying before
+            // retrying prevents posting a duplicate inline comment.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
+              try {
+                const posted = await getPostedCommentIds({ owner, repo, prNumber });
+                return posted.has(id);
+              } catch (e) {
+                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); assuming not posted.`);
+                return false;
+              }
+            }
+
+            // Check whether an issue comment with the given tag already exists.
+            // Used to avoid posting a duplicate summary comment when the batch
+            // review already carried the same summary body.
+            async function hasIssueCommentWithId({ owner, repo, issueNumber, id }) {
+              try {
+                const comments = await readAllPages('listIssueComments', (page, per_page) =>
+                  github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page, page })
+                );
+                return comments.some(c => (c.body || '').includes(id));
+              } catch (e) {
+                console.log(`[listIssueComments] check failed (${e.message}); assuming not posted.`);
+                return false;
+              }
             }
 
             // Case-insensitive header lookup. Octokit normalizes response headers to
@@ -438,7 +699,12 @@ jobs:
             }
 
             function formatComment(comment) {
-              let body = comment.content || '';
+              // Prepend a comment-level unique tag (HTML comment, invisible when
+              // rendered) so the idempotency check can match individual inline
+              // comments even when multiple comments target the same path/line.
+              const id = commentId(comment);
+              let body = `<!-- ${id} -->\n`;
+              body += comment.content || '';
 
               // Add code suggestion if available
               if (comment.suggestion_code && comment.existing_code) {
@@ -447,6 +713,23 @@ jobs:
               }
 
               return body;
+            }
+
+            // Stable unique ID for a comment, derived from path + line range +
+            // content hash. Stable across retries (same input => same ID) so the
+            // idempotency check can match a retried comment against the one that
+            // already landed on the server. suggestion_code is intentionally
+            // excluded from the fingerprint: it may drift on minor reformatting
+            // while the review point itself stays the same.
+            function commentId(comment) {
+              const fingerprint = [
+                comment.path || '',
+                comment.start_line != null ? String(comment.start_line) : '',
+                comment.end_line != null ? String(comment.end_line) : '',
+                comment.content || ''
+              ].join('|');
+              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 12);
+              return `ocr-${RUN_TAG}-${hash}`;
             }
 
             function formatCommentMarkdown(comment, error) {

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -803,12 +803,11 @@ jobs:
             // excluded from the fingerprint: it may drift on minor reformatting
             // while the review point itself stays the same.
             //
-            // The hash is truncated to 12 hex chars (48 bits). The collision
-            // scope is a single PR (listReviewComments is PR-scoped), and in
-            // practice a single run produces only tens to hundreds of comments,
-            // so the birthday-bound collision probability is negligible
-            // (~1e-7 even at 10k comments per PR). A longer hash would add
-            // noise to comment bodies without meaningful safety gain.
+            // The full 64-char (256-bit) sha256 hex digest is used as the hash.
+            // The collision scope is a single PR (listReviewComments is
+            // PR-scoped); a full-length hash makes the collision probability
+            // effectively zero, so the idempotency check never risks treating
+            // two distinct comments as duplicates.
             function commentId(comment) {
               const fingerprint = [
                 comment.path || '',
@@ -816,7 +815,7 @@ jobs:
                 comment.end_line != null ? String(comment.end_line) : '',
                 comment.content || ''
               ].join('|');
-              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 12);
+              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex');
               return `ocr-${RUN_TAG}-${hash}`;
             }
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -239,14 +239,22 @@ jobs:
             const failedComments = [];
 
             // Retry/pacing configuration (shared by write and read API calls).
-            const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
-            const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful write
-            const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
-            const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
-            const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+            // parseNonNegInt guards against nonsensical env values (negative,
+            // NaN, non-numeric) that `parseInt(...) || default` would let
+            // through for negative numbers, since a negative parseInt result
+            // is truthy and would bypass the `|| default` fallback.
+            function parseNonNegInt(val, defaultVal) {
+              const n = parseInt(val, 10);
+              return Number.isFinite(n) && n >= 0 ? n : defaultVal;
+            }
+            const MAX_RETRIES = parseNonNegInt(process.env.OCR_MAX_RETRIES, 3);
+            const SUCCESS_DELAY = parseNonNegInt(process.env.OCR_SUCCESS_DELAY, 2000); // delay after successful write
+            const FAILURE_DELAY = parseNonNegInt(process.env.OCR_FAILURE_DELAY, 1000); // delay after non-retryable failure
+            const LOW_REMAINING_THRESHOLD = parseNonNegInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 3);
+            const LOW_REMAINING_SPACING = parseNonNegInt(process.env.OCR_LOW_REMAINING_SPACING, 10000);
             // Read APIs are cheaper and have higher thresholds; use shorter pacing.
-            const READ_SUCCESS_DELAY = parseInt(process.env.OCR_READ_SUCCESS_DELAY, 10) || 500;
-            const READ_LOW_REMAINING_SPACING = parseInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 10) || 5000;
+            const READ_SUCCESS_DELAY = parseNonNegInt(process.env.OCR_READ_SUCCESS_DELAY, 500);
+            const READ_LOW_REMAINING_SPACING = parseNonNegInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 5000);
 
             try {
               const batchRes = await github.rest.pulls.createReview({
@@ -556,6 +564,16 @@ jobs:
                 if (items.length < PER_PAGE) break;
                 page++;
               }
+              // NOTE: Truncation here is intentional and acceptable. The cap
+              // exists as a safety valve against unbounded loops (e.g. a bug
+              // or malicious activity), not as a normal operating mode. A PR
+              // accumulating >5000 review comments is far outside expected
+              // usage; in that rare case we log a warning and proceed with
+              // partial data rather than failing the whole review. Callers
+              // that depend on completeness (isCommentAlreadyPosted,
+              // hasIssueCommentWithId) already degrade safely by returning
+              // null (unknown) on read failures, so a truncated walk does not
+              // silently produce duplicates.
               if (page > maxPages) {
                 console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }
@@ -784,6 +802,13 @@ jobs:
             // already landed on the server. suggestion_code is intentionally
             // excluded from the fingerprint: it may drift on minor reformatting
             // while the review point itself stays the same.
+            //
+            // The hash is truncated to 12 hex chars (48 bits). The collision
+            // scope is a single PR (listReviewComments is PR-scoped), and in
+            // practice a single run produces only tens to hundreds of comments,
+            // so the birthday-bound collision probability is negligible
+            // (~1e-7 even at 10k comments per PR). A longer hash would add
+            // noise to comment bodies without meaningful safety gain.
             function commentId(comment) {
               const fingerprint = [
                 comment.path || '',

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -315,6 +315,12 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
+              // Cache for the per-comment idempotency check: a single paginated
+              // walk of listReviewComments covers all inline comments on the PR,
+              // so we reuse it across retries instead of re-walking on every 5xx.
+              // The cache is best-effort: if the read API fails, the check returns
+              // null (unknown) and the caller skips retrying that comment.
+              const postedIdsCache = { value: null };
               for (const { comment, reviewComment } of toRetry) {
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
@@ -383,14 +389,28 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         prNumber,
-                        id
+                        id,
+                        postedIdsCache
                       });
-                      if (alreadyPosted) {
+                      if (alreadyPosted === true) {
                         successCount++;
                         posted = true;
                         console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
                         await sleep(SUCCESS_DELAY);
                         continue;
+                      }
+                      // Unknown (null): the read API is unavailable, so we
+                      // cannot tell whether the comment landed. To avoid a
+                      // duplicate, do NOT retry posting; record as failed so
+                      // the summary surfaces the uncertainty rather than
+                      // silently risking a duplicate.
+                      if (alreadyPosted === null) {
+                        failedCount++;
+                        const reason = 'idempotency check unavailable (read API failed)';
+                        failedComments.push({ comment, error: `${innerE.message} [${reason}]` });
+                        console.log(`Cannot verify whether comment for ${reviewComment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
+                        await sleep(SUCCESS_DELAY);
+                        break;
                       }
                       // Not found on server. If retries are exhausted or the
                       // error is non-retryable, this is a real failure.
@@ -456,8 +476,13 @@ jobs:
                 issueNumber: prNumber,
                 id: SUMMARY_TAG
               });
-              if (summaryAlreadyPosted) {
+              if (summaryAlreadyPosted === true) {
                 console.log('Summary comment with this run tag already exists; skipping.');
+              } else if (summaryAlreadyPosted === null) {
+                // Read API unavailable: cannot tell whether the summary already
+                // landed. Skip posting to avoid a duplicate; the review content
+                // is still available via inline comments / batch review.
+                console.log('Cannot verify whether summary comment already exists (read API failed); skipping to avoid duplicate.');
               } else {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
@@ -517,16 +542,22 @@ jobs:
 
             // Paginated helper that walks all pages of a list endpoint with retry
             // and pacing. Returns the concatenated array of items.
-            async function readAllPages(tag, pageFn) {
+            async function readAllPages(tag, pageFn, maxPages = 50) {
+              if (!Number.isFinite(maxPages) || maxPages < 1) {
+                throw new Error(`readAllPages: maxPages must be a positive integer, got ${maxPages}`);
+              }
               const all = [];
               let page = 1;
               const PER_PAGE = 100;
-              while (true) {
+              while (page <= maxPages) {
                 const res = await readWithPacing(`${tag} (page ${page})`, () => pageFn(page, PER_PAGE));
                 const items = res.data || [];
                 all.push(...items);
                 if (items.length < PER_PAGE) break;
                 page++;
+              }
+              if (page > maxPages) {
+                console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }
               return all;
             }
@@ -555,10 +586,19 @@ jobs:
                 github.rest.pulls.listReviewComments({ owner, repo, pull_number: prNumber, per_page, page })
               );
               const ids = new Set();
+              // Anchor the regex to the HTML comment wrapper (<!-- ocr-... -->)
+              // so user-generated content or code suggestions cannot trigger
+              // false positives in the idempotency check. The ID format is
+              // `ocr-<RUN_TAG>-<hash>` where RUN_TAG is `<runId>-<runAttempt>`.
+              // Capture group 1 holds the bare ID (ocr-<RUN_TAG>-<hash>),
+              // so we can add it directly without stripping comment markers.
+              const ID_RE = /<!--\s*(ocr-\d+-\d+-[a-f0-9]+)\s*-->/g;
               for (const c of comments) {
                 const body = c.body || '';
-                const matches = body.match(/ocr-\d+-\d+-[a-f0-9]+/g) || [];
-                for (const id of matches) ids.add(id);
+                let m;
+                while ((m = ID_RE.exec(body)) !== null) {
+                  ids.add(m[1]);
+                }
               }
               return ids;
             }
@@ -568,28 +608,51 @@ jobs:
             // fails with a transient 5xx/408, the request may have reached GitHub
             // and succeeded even though the response was lost. Querying before
             // retrying prevents posting a duplicate inline comment.
-            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
+            // Returns true/false when the check succeeds, or null when the
+            // read API is unavailable (rate limit, 5xx, etc.). Returning null
+            // (rather than defaulting to false) prevents the caller from
+            // assuming the comment was not posted and risking a duplicate on
+            // retry. `postedIdsCache` lets the caller reuse the result of a
+            // single paginated walk across multiple per-comment retries, so a
+            // degraded API episode does not amplify into N full walks.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id, postedIdsCache }) {
               try {
-                const posted = await getPostedCommentIds({ owner, repo, prNumber });
+                let posted = postedIdsCache && postedIdsCache.value;
+                if (posted == null) {
+                  posted = await getPostedCommentIds({ owner, repo, prNumber });
+                  if (postedIdsCache) postedIdsCache.value = posted;
+                }
                 return posted.has(id);
               } catch (e) {
-                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); assuming not posted.`);
-                return false;
+                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); treating as unknown to avoid duplicates.`);
+                return null;
               }
             }
 
             // Check whether an issue comment with the given tag already exists.
             // Used to avoid posting a duplicate summary comment when the batch
             // review already carried the same summary body.
+            // Returns true/false when the check succeeds, or null when the
+            // read API is unavailable. Returning null (rather than defaulting
+            // to false) lets the caller decide whether to skip posting or
+            // degrade gracefully, instead of silently risking a duplicate
+            // summary comment.
             async function hasIssueCommentWithId({ owner, repo, issueNumber, id }) {
               try {
                 const comments = await readAllPages('listIssueComments', (page, per_page) =>
                   github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page, page })
                 );
-                return comments.some(c => (c.body || '').includes(id));
+                // Match the tag anchored to its HTML comment wrapper for
+                // consistency with getPostedCommentIds and to defend against
+                // user content that happens to contain the bare tag string.
+                // `id` is an opaque tag like `<!-- ocr-summary-run:... -->`,
+                // so escape any regex metacharacters before embedding it.
+                const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const tagRe = new RegExp('<!--\\s*' + escaped + '\\s*-->');
+                return comments.some(c => tagRe.test(c.body || ''));
               } catch (e) {
-                console.log(`[listIssueComments] check failed (${e.message}); assuming not posted.`);
-                return false;
+                console.log(`[listIssueComments] check failed (${e.message}); treating as unknown to avoid duplicates.`);
+                return null;
               }
             }
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -189,35 +189,23 @@ jobs:
             const commentsWithoutLine = [];
 
             for (const comment of comments) {
-              const body = formatComment(comment);
-
               // Check if comment has valid line information for inline comment (line >= 1)
               const hasValidLine = (comment.start_line >= 1) || (comment.end_line >= 1);
               if (!hasValidLine) {
-                commentsWithoutLine.push({ comment, body });
+                commentsWithoutLine.push({ comment });
                 continue;
               }
 
-              const reviewComment = {
-                path: comment.path,
-                body: body
-              };
-
-              // Use line range if available
-              if (comment.start_line >= 1 && comment.end_line >= 1 && comment.start_line !== comment.end_line) {
-                reviewComment.start_line = comment.start_line;
-                reviewComment.line = comment.end_line;
-                reviewComment.start_side = 'RIGHT';
-                reviewComment.side = 'RIGHT';
-              } else if (comment.end_line >= 1) {
-                reviewComment.line = comment.end_line;
-                reviewComment.side = 'RIGHT';
-              } else if (comment.start_line >= 1) {
-                reviewComment.line = comment.start_line;
-                reviewComment.side = 'RIGHT';
-              }
-
-              reviewComments.push({ comment, reviewComment });
+              // Each inline comment becomes an item carrying a random ID
+              // (assigned once) and its resolved line targeting. The body is
+              // built from item.id only at API-call time (see toReviewPayload),
+              // so retry/idempotency logic reads item.id directly instead of
+              // recomputing it, and distinct comments never share an ID.
+              reviewComments.push({
+                comment,
+                id: newCommentId(),
+                lines: resolveLines(comment)
+              });
             }
 
             // Submit as a single PR review with all comments
@@ -264,7 +252,7 @@ jobs:
                 commit_id: commitSha,
                 body: summaryBody,
                 event: 'COMMENT',
-                comments: reviewComments.map(({ reviewComment }) => reviewComment)
+                comments: reviewComments.map(toReviewPayload)
               });
               successCount = reviewComments.length;
               console.log(`Successfully posted review with ${successCount} inline comments (${commentsWithoutLine.length} in summary)`);
@@ -299,8 +287,8 @@ jobs:
                   repo: context.repo.repo,
                   prNumber
                 });
-                toRetry = reviewComments.filter(({ comment }) =>
-                  !postedIds.has(commentId(comment))
+                toRetry = reviewComments.filter((item) =>
+                  !postedIds.has(item.id)
                 );
                 successCount = reviewComments.length - toRetry.length;
                 console.log(`Batch review already exists (review_id=${existingReview.review.id}). ` +
@@ -329,7 +317,8 @@ jobs:
               // The cache is best-effort: if the read API fails, the check returns
               // null (unknown) and the caller skips retrying that comment.
               const postedIdsCache = { value: null };
-              for (const { comment, reviewComment } of toRetry) {
+              for (const item of toRetry) {
+                const { comment, id } = item;
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
                   try {
@@ -340,14 +329,14 @@ jobs:
                       commit_id: commitSha,
                       body: '',
                       event: 'COMMENT',
-                      comments: [reviewComment]
+                      comments: [toReviewPayload(item)]
                     });
                     successCount++;
                     posted = true;
-                    console.log(`Successfully posted comment for ${reviewComment.path}`);
+                    console.log(`Successfully posted comment for ${comment.path}`);
                     // Proactive throttle: if remaining quota is low, slow down to
                     // avoid hitting the limit (GitHub best practice: watch the header).
-                    const remaining = logRateLimitQuota(res, `after ${reviewComment.path}`);
+                    const remaining = logRateLimitQuota(res, `after ${comment.path}`);
                     const lowQuota = remaining != null && remaining <= LOW_REMAINING_THRESHOLD;
                     if (lowQuota) {
                       console.log(`[rate-limit] quota low (remaining=${remaining} <= ${LOW_REMAINING_THRESHOLD}); increasing spacing to ${LOW_REMAINING_SPACING}ms.`);
@@ -387,12 +376,11 @@ jobs:
                       if (coolDownMs > 0) {
                         const secs = (coolDownMs / 1000).toFixed(1);
                         console.log(
-                          `Cooling down ${secs}s before idempotency check for ${reviewComment.path} ` +
+                          `Cooling down ${secs}s before idempotency check for ${comment.path} ` +
                           `(HTTP ${innerE.status || 'n/a'}, attempt ${attempt + 1}/${MAX_RETRIES + 1}).`
                         );
                         await sleep(coolDownMs);
                       }
-                      const id = commentId(comment);
                       const alreadyPosted = await isCommentAlreadyPosted({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -403,7 +391,7 @@ jobs:
                       if (alreadyPosted === true) {
                         successCount++;
                         posted = true;
-                        console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
+                        console.log(`Comment for ${comment.path} already posted (id=${id}); treating as success.`);
                         await sleep(SUCCESS_DELAY);
                         continue;
                       }
@@ -416,7 +404,7 @@ jobs:
                         failedCount++;
                         const reason = 'idempotency check unavailable (read API failed)';
                         failedComments.push({ comment, error: `${innerE.message} [${reason}]` });
-                        console.log(`Cannot verify whether comment for ${reviewComment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
+                        console.log(`Cannot verify whether comment for ${comment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
                         await sleep(SUCCESS_DELAY);
                         break;
                       }
@@ -426,7 +414,7 @@ jobs:
                         failedCount++;
                         failedComments.push({ comment, error: innerE.message });
                         const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
-                        console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                        console.log(`Failed to post comment for ${comment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
                         await sleep(SUCCESS_DELAY);
                         break;
                       }
@@ -437,7 +425,7 @@ jobs:
                       // check can be skipped. Just honor the retry delay.
                       const secs = (retryInfo.delayMs / 1000).toFixed(1);
                       console.log(
-                        `Rate-limited on ${reviewComment.path} ` +
+                        `Rate-limited on ${comment.path} ` +
                         `(HTTP ${innerE.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
                         `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ` +
                         `Error: ${innerE.message}`
@@ -448,7 +436,7 @@ jobs:
                       // server (e.g. 4xx validation error): record as failed.
                       failedCount++;
                       failedComments.push({ comment, error: innerE.message });
-                      console.log(`Failed to post comment for ${reviewComment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                      console.log(`Failed to post comment for ${comment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
                       await sleep(FAILURE_DELAY);
                       break;
                     }
@@ -607,9 +595,10 @@ jobs:
               // Anchor the regex to the HTML comment wrapper (<!-- ocr-... -->)
               // so user-generated content or code suggestions cannot trigger
               // false positives in the idempotency check. The ID format is
-              // `ocr-<RUN_TAG>-<hash>` where RUN_TAG is `<runId>-<runAttempt>`.
-              // Capture group 1 holds the bare ID (ocr-<RUN_TAG>-<hash>),
-              // so we can add it directly without stripping comment markers.
+              // `ocr-<RUN_TAG>-<random>` where RUN_TAG is `<runId>-<runAttempt>`
+              // and <random> is a per-comment random hex token. Capture group 1
+              // holds the bare ID (ocr-<RUN_TAG>-<random>), so we can add it
+              // directly without stripping comment markers.
               const ID_RE = /<!--\s*(ocr-\d+-\d+-[a-f0-9]+)\s*-->/g;
               for (const c of comments) {
                 const body = c.body || '';
@@ -779,44 +768,56 @@ jobs:
               } catch (_) { return null; }
             }
 
-            function formatComment(comment) {
-              // Prepend a comment-level unique tag (HTML comment, invisible when
-              // rendered) so the idempotency check can match individual inline
-              // comments even when multiple comments target the same path/line.
-              const id = commentId(comment);
+            // Random per-comment ID, assigned once when the inline-comment item
+            // is built and carried on the item struct. Random (rather than
+            // content-derived) so two distinct comments that share the same
+            // path/line/content still get different IDs and the idempotency
+            // check never mistakes one for the other (which would silently drop
+            // the second). Embedded in the comment body as an HTML comment so
+            // getPostedCommentIds can match it back on retry.
+            function newCommentId() {
+              return `ocr-${RUN_TAG}-${crypto.randomBytes(8).toString('hex')}`;
+            }
+
+            // Resolve the line-targeting fields for a createReview comment
+            // payload (start_line/line/start_side/side) from the comment's line
+            // range. Returned object is spread into the payload in toReviewPayload.
+            function resolveLines(comment) {
+              const start = comment.start_line;
+              const end = comment.end_line;
+              if (start >= 1 && end >= 1 && start !== end) {
+                return { start_line: start, line: end, start_side: 'RIGHT', side: 'RIGHT' };
+              } else if (end >= 1) {
+                return { line: end, side: 'RIGHT' };
+              } else if (start >= 1) {
+                return { line: start, side: 'RIGHT' };
+              }
+              return {};
+            }
+
+            // Build the createReview payload for an inline-comment item. The
+            // body is assembled here (at call time) from the item's precomputed
+            // ID, so retry/idempotency logic works directly off item.id instead
+            // of recomputing an ID each time it needs to check posting status.
+            function toReviewPayload(item) {
+              return {
+                path: item.comment.path,
+                body: buildBody(item.comment, item.id),
+                ...item.lines
+              };
+            }
+
+            // Assemble the visible comment body: the per-comment ID tag (HTML
+            // comment, invisible when rendered) prepended for idempotency
+            // matching, plus the code suggestion block if present.
+            function buildBody(comment, id) {
               let body = `<!-- ${id} -->\n`;
               body += comment.content || '';
-
-              // Add code suggestion if available
               if (comment.suggestion_code && comment.existing_code) {
                 body += '\n\n**Suggestion:**\n';
                 body += fencedBlock(comment.suggestion_code, 'suggestion');
               }
-
               return body;
-            }
-
-            // Stable unique ID for a comment, derived from path + line range +
-            // content hash. Stable across retries (same input => same ID) so the
-            // idempotency check can match a retried comment against the one that
-            // already landed on the server. suggestion_code is intentionally
-            // excluded from the fingerprint: it may drift on minor reformatting
-            // while the review point itself stays the same.
-            //
-            // The full 64-char (256-bit) sha256 hex digest is used as the hash.
-            // The collision scope is a single PR (listReviewComments is
-            // PR-scoped); a full-length hash makes the collision probability
-            // effectively zero, so the idempotency check never risks treating
-            // two distinct comments as duplicates.
-            function commentId(comment) {
-              const fingerprint = [
-                comment.path || '',
-                comment.start_line != null ? String(comment.start_line) : '',
-                comment.end_line != null ? String(comment.end_line) : '',
-                comment.content || ''
-              ].join('|');
-              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex');
-              return `ocr-${RUN_TAG}-${hash}`;
             }
 
             function formatCommentMarkdown(comment, error) {

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -93,7 +93,13 @@ Use the `--rule` flag to pass a custom rules JSON file:
 
 ### Adjust retry and delay settings
 
-When posting review comments individually (fallback mode), the workflow includes rate-limit handling with exponential backoff. The retry strategy follows GitHub's documented guidance for REST API rate limits — see [Rate limits for the REST API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10) for details on primary/secondary rate limits and recommended retry behavior. You can configure the retry and delay behavior via **repository variables** (Settings → Secrets and variables → Actions → Variables):
+When posting review comments individually (fallback mode), the workflow includes rate-limit handling with exponential backoff. The retry strategy follows GitHub's documented guidance for REST API rate limits — see [Rate limits for the REST API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10) for details on primary/secondary rate limits and recommended retry behavior:
+
+- **Primary rate limit exhausted** (`x-ratelimit-remaining=0`): wait until `x-ratelimit-reset`.
+- **Secondary rate limit with a `retry-after` header**: wait exactly that long.
+- **Secondary rate limit with no header**: wait at least one minute, then use exponential backoff on continued failures.
+
+You can configure the retry and delay behavior via **repository variables** (Settings → Secrets and variables → Actions → Variables):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -104,8 +110,18 @@ When posting review comments individually (fallback mode), the workflow includes
 | `OCR_FAILURE_DELAY` | `1000` | Delay (ms) after a non-rate-limit failure to pace subsequent requests |
 | `OCR_LOW_REMAINING_THRESHOLD` | `3` | When x-ratelimit-remaining is at or below this value, proactively increase request spacing to avoid hitting the limit |
 | `OCR_LOW_REMAINING_SPACING` | `10000` | Request spacing (ms) used when remaining quota is low |
+| `OCR_READ_SUCCESS_DELAY` | `500` | Delay (ms) after a successful read API call (`listReviews` / `listReviewComments` / `listIssueComments`) used for the idempotency check. Reads are cheaper than writes, so the default is shorter |
+| `OCR_READ_LOW_REMAINING_SPACING` | `5000` | Request spacing (ms) for read calls when remaining quota is low |
 
 These variables are optional — if not configured, sensible defaults are used. Consider increasing delays for repositories with many concurrent workflows or large PRs that generate numerous review comments.
+
+#### Idempotency: avoiding duplicate review comments
+
+When the batch `createReview` call fails with a `5xx` error, the request may still have landed on the GitHub server (the response was simply lost). Before retrying per-comment, the workflow queries existing reviews and review comments — each tagged with a per-run HTML comment (e.g. `<!-- ocr-<runId>-<attempt>-<hash> -->`) — and only retries the comments that are actually missing. This prevents duplicate review posts.
+
+The same idempotency check is applied to the summary comment: before posting, the workflow verifies whether a summary with the same run tag already exists, and skips posting if so.
+
+If the read API itself is unavailable (rate-limited or `5xx`), the check returns *unknown* rather than assuming the comment was not posted. In that case the workflow **skips retrying** to avoid risking a duplicate, and surfaces the uncertainty in the summary instead of silently producing duplicates.
 
 ### Limit concurrency
 

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -117,7 +117,7 @@ These variables are optional — if not configured, sensible defaults are used. 
 
 #### Idempotency: avoiding duplicate review comments
 
-When the batch `createReview` call fails with a `5xx` error, the request may still have landed on the GitHub server (the response was simply lost). Before retrying per-comment, the workflow queries existing reviews and review comments — each tagged with a per-run HTML comment (e.g. `<!-- ocr-<runId>-<attempt>-<hash> -->`) — and only retries the comments that are actually missing. This prevents duplicate review posts.
+When the batch `createReview` call fails with a `5xx` error, the request may still have landed on the GitHub server (the response was simply lost). Before retrying per-comment, the workflow queries existing reviews and review comments — each tagged with a per-run HTML comment (e.g. `<!-- ocr-<runId>-<attempt>-<token> -->`) — and only retries the comments that are actually missing. This prevents duplicate review posts.
 
 The same idempotency check is applied to the summary comment: before posting, the workflow verifies whether a summary with the same run tag already exists, and skips posting if so.
 

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -235,35 +235,23 @@ jobs:
             const commentsWithoutLine = [];
 
             for (const comment of comments) {
-              const body = formatComment(comment);
-
               // Check if comment has valid line information for inline comment (line >= 1)
               const hasValidLine = (comment.start_line >= 1) || (comment.end_line >= 1);
               if (!hasValidLine) {
-                commentsWithoutLine.push({ comment, body });
+                commentsWithoutLine.push({ comment });
                 continue;
               }
 
-              const reviewComment = {
-                path: comment.path,
-                body: body
-              };
-
-              // Use line range if available
-              if (comment.start_line >= 1 && comment.end_line >= 1 && comment.start_line !== comment.end_line) {
-                reviewComment.start_line = comment.start_line;
-                reviewComment.line = comment.end_line;
-                reviewComment.start_side = 'RIGHT';
-                reviewComment.side = 'RIGHT';
-              } else if (comment.end_line >= 1) {
-                reviewComment.line = comment.end_line;
-                reviewComment.side = 'RIGHT';
-              } else if (comment.start_line >= 1) {
-                reviewComment.line = comment.start_line;
-                reviewComment.side = 'RIGHT';
-              }
-
-              reviewComments.push({ comment, reviewComment });
+              // Each inline comment becomes an item carrying a random ID
+              // (assigned once) and its resolved line targeting. The body is
+              // built from item.id only at API-call time (see toReviewPayload),
+              // so retry/idempotency logic reads item.id directly instead of
+              // recomputing it, and distinct comments never share an ID.
+              reviewComments.push({
+                comment,
+                id: newCommentId(),
+                lines: resolveLines(comment)
+              });
             }
 
             // Submit as a single PR review with all comments
@@ -310,7 +298,7 @@ jobs:
                 commit_id: commitSha,
                 body: summaryBody,
                 event: 'COMMENT',
-                comments: reviewComments.map(({ reviewComment }) => reviewComment)
+                comments: reviewComments.map(toReviewPayload)
               });
               successCount = reviewComments.length;
               console.log(`Successfully posted review with ${successCount} inline comments (${commentsWithoutLine.length} in summary)`);
@@ -345,8 +333,8 @@ jobs:
                   repo: context.repo.repo,
                   prNumber
                 });
-                toRetry = reviewComments.filter(({ comment }) =>
-                  !postedIds.has(commentId(comment))
+                toRetry = reviewComments.filter((item) =>
+                  !postedIds.has(item.id)
                 );
                 successCount = reviewComments.length - toRetry.length;
                 console.log(`Batch review already exists (review_id=${existingReview.review.id}). ` +
@@ -375,7 +363,8 @@ jobs:
               // The cache is best-effort: if the read API fails, the check returns
               // null (unknown) and the caller skips retrying that comment.
               const postedIdsCache = { value: null };
-              for (const { comment, reviewComment } of toRetry) {
+              for (const item of toRetry) {
+                const { comment, id } = item;
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
                   try {
@@ -386,14 +375,14 @@ jobs:
                       commit_id: commitSha,
                       body: '',
                       event: 'COMMENT',
-                      comments: [reviewComment]
+                      comments: [toReviewPayload(item)]
                     });
                     successCount++;
                     posted = true;
-                    console.log(`Successfully posted comment for ${reviewComment.path}`);
+                    console.log(`Successfully posted comment for ${comment.path}`);
                     // Proactive throttle: if remaining quota is low, slow down to
                     // avoid hitting the limit (GitHub best practice: watch the header).
-                    const remaining = logRateLimitQuota(res, `after ${reviewComment.path}`);
+                    const remaining = logRateLimitQuota(res, `after ${comment.path}`);
                     const lowQuota = remaining != null && remaining <= LOW_REMAINING_THRESHOLD;
                     if (lowQuota) {
                       console.log(`[rate-limit] quota low (remaining=${remaining} <= ${LOW_REMAINING_THRESHOLD}); increasing spacing to ${LOW_REMAINING_SPACING}ms.`);
@@ -433,12 +422,11 @@ jobs:
                       if (coolDownMs > 0) {
                         const secs = (coolDownMs / 1000).toFixed(1);
                         console.log(
-                          `Cooling down ${secs}s before idempotency check for ${reviewComment.path} ` +
+                          `Cooling down ${secs}s before idempotency check for ${comment.path} ` +
                           `(HTTP ${innerE.status || 'n/a'}, attempt ${attempt + 1}/${MAX_RETRIES + 1}).`
                         );
                         await sleep(coolDownMs);
                       }
-                      const id = commentId(comment);
                       const alreadyPosted = await isCommentAlreadyPosted({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -449,7 +437,7 @@ jobs:
                       if (alreadyPosted === true) {
                         successCount++;
                         posted = true;
-                        console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
+                        console.log(`Comment for ${comment.path} already posted (id=${id}); treating as success.`);
                         await sleep(SUCCESS_DELAY);
                         continue;
                       }
@@ -462,7 +450,7 @@ jobs:
                         failedCount++;
                         const reason = 'idempotency check unavailable (read API failed)';
                         failedComments.push({ comment, error: `${innerE.message} [${reason}]` });
-                        console.log(`Cannot verify whether comment for ${reviewComment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
+                        console.log(`Cannot verify whether comment for ${comment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
                         await sleep(SUCCESS_DELAY);
                         break;
                       }
@@ -472,7 +460,7 @@ jobs:
                         failedCount++;
                         failedComments.push({ comment, error: innerE.message });
                         const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
-                        console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                        console.log(`Failed to post comment for ${comment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
                         await sleep(SUCCESS_DELAY);
                         break;
                       }
@@ -483,7 +471,7 @@ jobs:
                       // check can be skipped. Just honor the retry delay.
                       const secs = (retryInfo.delayMs / 1000).toFixed(1);
                       console.log(
-                        `Rate-limited on ${reviewComment.path} ` +
+                        `Rate-limited on ${comment.path} ` +
                         `(HTTP ${innerE.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
                         `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ` +
                         `Error: ${innerE.message}`
@@ -494,7 +482,7 @@ jobs:
                       // server (e.g. 4xx validation error): record as failed.
                       failedCount++;
                       failedComments.push({ comment, error: innerE.message });
-                      console.log(`Failed to post comment for ${reviewComment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                      console.log(`Failed to post comment for ${comment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
                       await sleep(FAILURE_DELAY);
                       break;
                     }
@@ -653,9 +641,10 @@ jobs:
               // Anchor the regex to the HTML comment wrapper (<!-- ocr-... -->)
               // so user-generated content or code suggestions cannot trigger
               // false positives in the idempotency check. The ID format is
-              // `ocr-<RUN_TAG>-<hash>` where RUN_TAG is `<runId>-<runAttempt>`.
-              // Capture group 1 holds the bare ID (ocr-<RUN_TAG>-<hash>),
-              // so we can add it directly without stripping comment markers.
+              // `ocr-<RUN_TAG>-<random>` where RUN_TAG is `<runId>-<runAttempt>`
+              // and <random> is a per-comment random hex token. Capture group 1
+              // holds the bare ID (ocr-<RUN_TAG>-<random>), so we can add it
+              // directly without stripping comment markers.
               const ID_RE = /<!--\s*(ocr-\d+-\d+-[a-f0-9]+)\s*-->/g;
               for (const c of comments) {
                 const body = c.body || '';
@@ -825,44 +814,56 @@ jobs:
               } catch (_) { return null; }
             }
 
-            function formatComment(comment) {
-              // Prepend a comment-level unique tag (HTML comment, invisible when
-              // rendered) so the idempotency check can match individual inline
-              // comments even when multiple comments target the same path/line.
-              const id = commentId(comment);
+            // Random per-comment ID, assigned once when the inline-comment item
+            // is built and carried on the item struct. Random (rather than
+            // content-derived) so two distinct comments that share the same
+            // path/line/content still get different IDs and the idempotency
+            // check never mistakes one for the other (which would silently drop
+            // the second). Embedded in the comment body as an HTML comment so
+            // getPostedCommentIds can match it back on retry.
+            function newCommentId() {
+              return `ocr-${RUN_TAG}-${crypto.randomBytes(8).toString('hex')}`;
+            }
+
+            // Resolve the line-targeting fields for a createReview comment
+            // payload (start_line/line/start_side/side) from the comment's line
+            // range. Returned object is spread into the payload in toReviewPayload.
+            function resolveLines(comment) {
+              const start = comment.start_line;
+              const end = comment.end_line;
+              if (start >= 1 && end >= 1 && start !== end) {
+                return { start_line: start, line: end, start_side: 'RIGHT', side: 'RIGHT' };
+              } else if (end >= 1) {
+                return { line: end, side: 'RIGHT' };
+              } else if (start >= 1) {
+                return { line: start, side: 'RIGHT' };
+              }
+              return {};
+            }
+
+            // Build the createReview payload for an inline-comment item. The
+            // body is assembled here (at call time) from the item's precomputed
+            // ID, so retry/idempotency logic works directly off item.id instead
+            // of recomputing an ID each time it needs to check posting status.
+            function toReviewPayload(item) {
+              return {
+                path: item.comment.path,
+                body: buildBody(item.comment, item.id),
+                ...item.lines
+              };
+            }
+
+            // Assemble the visible comment body: the per-comment ID tag (HTML
+            // comment, invisible when rendered) prepended for idempotency
+            // matching, plus the code suggestion block if present.
+            function buildBody(comment, id) {
               let body = `<!-- ${id} -->\n`;
               body += comment.content || '';
-
-              // Add code suggestion if available
               if (comment.suggestion_code && comment.existing_code) {
                 body += '\n\n**Suggestion:**\n';
                 body += fencedBlock(comment.suggestion_code, 'suggestion');
               }
-
               return body;
-            }
-
-            // Stable unique ID for a comment, derived from path + line range +
-            // content hash. Stable across retries (same input => same ID) so the
-            // idempotency check can match a retried comment against the one that
-            // already landed on the server. suggestion_code is intentionally
-            // excluded from the fingerprint: it may drift on minor reformatting
-            // while the review point itself stays the same.
-            //
-            // The full 64-char (256-bit) sha256 hex digest is used as the hash.
-            // The collision scope is a single PR (listReviewComments is
-            // PR-scoped); a full-length hash makes the collision probability
-            // effectively zero, so the idempotency check never risks treating
-            // two distinct comments as duplicates.
-            function commentId(comment) {
-              const fingerprint = [
-                comment.path || '',
-                comment.start_line != null ? String(comment.start_line) : '',
-                comment.end_line != null ? String(comment.end_line) : '',
-                comment.content || ''
-              ].join('|');
-              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex');
-              return `ocr-${RUN_TAG}-${hash}`;
             }
 
             function formatCommentMarkdown(comment, error) {

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -285,14 +285,22 @@ jobs:
             const failedComments = [];
 
             // Retry/pacing configuration (shared by write and read API calls).
-            const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
-            const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful write
-            const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
-            const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
-            const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+            // parseNonNegInt guards against nonsensical env values (negative,
+            // NaN, non-numeric) that `parseInt(...) || default` would let
+            // through for negative numbers, since a negative parseInt result
+            // is truthy and would bypass the `|| default` fallback.
+            function parseNonNegInt(val, defaultVal) {
+              const n = parseInt(val, 10);
+              return Number.isFinite(n) && n >= 0 ? n : defaultVal;
+            }
+            const MAX_RETRIES = parseNonNegInt(process.env.OCR_MAX_RETRIES, 3);
+            const SUCCESS_DELAY = parseNonNegInt(process.env.OCR_SUCCESS_DELAY, 2000); // delay after successful write
+            const FAILURE_DELAY = parseNonNegInt(process.env.OCR_FAILURE_DELAY, 1000); // delay after non-retryable failure
+            const LOW_REMAINING_THRESHOLD = parseNonNegInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 3);
+            const LOW_REMAINING_SPACING = parseNonNegInt(process.env.OCR_LOW_REMAINING_SPACING, 10000);
             // Read APIs are cheaper and have higher thresholds; use shorter pacing.
-            const READ_SUCCESS_DELAY = parseInt(process.env.OCR_READ_SUCCESS_DELAY, 10) || 500;
-            const READ_LOW_REMAINING_SPACING = parseInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 10) || 5000;
+            const READ_SUCCESS_DELAY = parseNonNegInt(process.env.OCR_READ_SUCCESS_DELAY, 500);
+            const READ_LOW_REMAINING_SPACING = parseNonNegInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 5000);
 
             try {
               const batchRes = await github.rest.pulls.createReview({
@@ -602,6 +610,16 @@ jobs:
                 if (items.length < PER_PAGE) break;
                 page++;
               }
+              // NOTE: Truncation here is intentional and acceptable. The cap
+              // exists as a safety valve against unbounded loops (e.g. a bug
+              // or malicious activity), not as a normal operating mode. A PR
+              // accumulating >5000 review comments is far outside expected
+              // usage; in that rare case we log a warning and proceed with
+              // partial data rather than failing the whole review. Callers
+              // that depend on completeness (isCommentAlreadyPosted,
+              // hasIssueCommentWithId) already degrade safely by returning
+              // null (unknown) on read failures, so a truncated walk does not
+              // silently produce duplicates.
               if (page > maxPages) {
                 console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }
@@ -830,6 +848,13 @@ jobs:
             // already landed on the server. suggestion_code is intentionally
             // excluded from the fingerprint: it may drift on minor reformatting
             // while the review point itself stays the same.
+            //
+            // The hash is truncated to 12 hex chars (48 bits). The collision
+            // scope is a single PR (listReviewComments is PR-scoped), and in
+            // practice a single run produces only tens to hundreds of comments,
+            // so the birthday-bound collision probability is negligible
+            // (~1e-7 even at 10k comments per PR). A longer hash would add
+            // noise to comment bodies without meaningful safety gain.
             function commentId(comment) {
               const fingerprint = [
                 comment.path || '',

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -849,12 +849,11 @@ jobs:
             // excluded from the fingerprint: it may drift on minor reformatting
             // while the review point itself stays the same.
             //
-            // The hash is truncated to 12 hex chars (48 bits). The collision
-            // scope is a single PR (listReviewComments is PR-scoped), and in
-            // practice a single run produces only tens to hundreds of comments,
-            // so the birthday-bound collision probability is negligible
-            // (~1e-7 even at 10k comments per PR). A longer hash would add
-            // noise to comment bodies without meaningful safety gain.
+            // The full 64-char (256-bit) sha256 hex digest is used as the hash.
+            // The collision scope is a single PR (listReviewComments is
+            // PR-scoped); a full-length hash makes the collision probability
+            // effectively zero, so the idempotency check never risks treating
+            // two distinct comments as duplicates.
             function commentId(comment) {
               const fingerprint = [
                 comment.path || '',
@@ -862,7 +861,7 @@ jobs:
                 comment.end_line != null ? String(comment.end_line) : '',
                 comment.content || ''
               ].join('|');
-              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 12);
+              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex');
               return `ocr-${RUN_TAG}-${hash}`;
             }
 

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -357,12 +357,6 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
-              // Cache for the per-comment idempotency check: a single paginated
-              // walk of listReviewComments covers all inline comments on the PR,
-              // so we reuse it across retries instead of re-walking on every 5xx.
-              // The cache is best-effort: if the read API fails, the check returns
-              // null (unknown) and the caller skips retrying that comment.
-              const postedIdsCache = { value: null };
               for (const item of toRetry) {
                 const { comment, id } = item;
                 let posted = false;
@@ -431,8 +425,7 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         prNumber,
-                        id,
-                        postedIdsCache
+                        id
                       });
                       if (alreadyPosted === true) {
                         successCount++;
@@ -672,16 +665,17 @@ jobs:
             // read API is unavailable (rate limit, 5xx, etc.). Returning null
             // (rather than defaulting to false) prevents the caller from
             // assuming the comment was not posted and risking a duplicate on
-            // retry. `postedIdsCache` lets the caller reuse the result of a
-            // single paginated walk across multiple per-comment retries, so a
-            // degraded API episode does not amplify into N full walks.
-            async function isCommentAlreadyPosted({ owner, repo, prNumber, id, postedIdsCache }) {
+            // retry.
+            //
+            // Each call walks listReviewComments fresh — no cached snapshot.
+            // A snapshot reused across retries would go stale as comments land
+            // during the loop, and a stale miss for a 5xx-landed comment would
+            // trigger a retry that posts a duplicate. Read calls are paced via
+            // readAllPages/readWithPacing and degrade to null (skip retry) if the
+            // read API itself fails, so the extra walks cannot produce duplicates.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
               try {
-                let posted = postedIdsCache && postedIdsCache.value;
-                if (posted == null) {
-                  posted = await getPostedCommentIds({ owner, repo, prNumber });
-                  if (postedIdsCache) postedIdsCache.value = posted;
-                }
+                const posted = await getPostedCommentIds({ owner, repo, prNumber });
                 return posted.has(id);
               } catch (e) {
                 console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); treating as unknown to avoid duplicates.`);

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -598,16 +598,23 @@ jobs:
                 if (items.length < PER_PAGE) break;
                 page++;
               }
-              // NOTE: Truncation here is intentional and acceptable. The cap
-              // exists as a safety valve against unbounded loops (e.g. a bug
-              // or malicious activity), not as a normal operating mode. A PR
-              // accumulating >5000 review comments is far outside expected
-              // usage; in that rare case we log a warning and proceed with
-              // partial data rather than failing the whole review. Callers
-              // that depend on completeness (isCommentAlreadyPosted,
-              // hasIssueCommentWithId) already degrade safely by returning
-              // null (unknown) on read failures, so a truncated walk does not
-              // silently produce duplicates.
+              // NOTE: Truncation here is intentional and acts as a safety
+              // valve against unbounded loops (e.g. a bug or malicious
+              // activity), not as a normal operating mode. A PR accumulating
+              // >5000 review comments is far outside expected usage; in that
+              // rare case we log a warning and proceed with partial data
+              // rather than failing the whole review.
+              //
+              // Caveat: this is NOT the same as a read failure. When the read
+              // API throws (rate limit, 5xx), isCommentAlreadyPosted and
+              // hasIssueCommentWithId catch it and return null (unknown), so
+              // the caller skips retrying and creates no duplicate. A
+              // truncated walk does not throw; it returns a partial set
+              // silently, so isCommentAlreadyPosted returns false (definitively
+              // "not posted") for any comment beyond the cap, and the retry
+              // loop will repost it, producing a duplicate. This tradeoff is
+              // accepted because the trigger is far outside expected usage; if
+              // that ceiling ever needs to rise, make maxPages configurable.
               if (page > maxPages) {
                 console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -37,6 +37,18 @@
 #                             (default: 3; GitHub best practice is to watch the header and slow down).
 #   OCR_LOW_REMAINING_SPACING - Request spacing (ms) used when remaining quota is low
 #                             (default: 10000 = 10s).
+#   OCR_READ_SUCCESS_DELAY   - Delay (ms) after a successful read API call (listReviews /
+#                             listReviewComments / listIssueComments) used for the
+#                             idempotency check. Reads are cheaper than writes, so the
+#                             default is shorter (default: 500).
+#   OCR_READ_LOW_REMAINING_SPACING - Request spacing (ms) for read calls when remaining
+#                             quota is low (default: 5000 = 5s).
+#
+# Idempotency:
+#   When the batch createReview fails with a 5xx, the request may still have landed on
+#   the server. Before retrying per-comment, the workflow queries existing reviews and
+#   review comments (tagged with a per-run HTML comment) and only retries the comments
+#   that are actually missing. This prevents duplicate review posts.
 #
 # Note: GITHUB_TOKEN is automatically provided by GitHub Actions.
 # Note: The workflow also configures llm.extra_body to '{"thinking": {"type": "disabled"}}'
@@ -149,7 +161,21 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            const crypto = require('crypto');
             const path = '/tmp/ocr-result.json';
+
+            // Unique tag for this workflow run + attempt. Embedded in review/comment
+            // bodies as an HTML comment so the idempotency check can detect whether
+            // a batch createReview actually landed on the server before retrying.
+            // context.runId / context.runAttempt are numbers from @actions/github's
+            // Context (parsed from GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT). Use
+            // Number.isFinite to guard against NaN when the env vars are missing,
+            // falling back to safe defaults.
+            const runId = Number.isFinite(context.runId) ? context.runId : 0;
+            const runAttempt = Number.isFinite(context.runAttempt) ? context.runAttempt : 1;
+            const RUN_TAG = `${runId}-${runAttempt}`;
+            const REVIEW_TAG = `<!-- ocr-review-run:${RUN_TAG} -->`;
+            const SUMMARY_TAG = `<!-- ocr-summary-run:${RUN_TAG} -->`;
 
             // Read OCR output
             let result;
@@ -249,10 +275,24 @@ jobs:
             // Add comments without line info to summary body
             summaryBody += formatSummaryComments(commentsWithoutLine);
 
+            // Prepend the run tag so the idempotency check can detect whether the
+            // batch review actually landed on the server before retrying.
+            summaryBody = REVIEW_TAG + '\n' + summaryBody;
+
             // Statistics tracking
             let successCount = 0;
             let failedCount = 0;
             const failedComments = [];
+
+            // Retry/pacing configuration (shared by write and read API calls).
+            const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
+            const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful write
+            const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
+            const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
+            const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+            // Read APIs are cheaper and have higher thresholds; use shorter pacing.
+            const READ_SUCCESS_DELAY = parseInt(process.env.OCR_READ_SUCCESS_DELAY, 10) || 500;
+            const READ_LOW_REMAINING_SPACING = parseInt(process.env.OCR_READ_LOW_REMAINING_SPACING, 10) || 5000;
 
             try {
               const batchRes = await github.rest.pulls.createReview({
@@ -269,17 +309,44 @@ jobs:
               logRateLimitQuota(batchRes, 'after batch createReview');
             } catch (e) {
               console.log('Failed to post review with inline comments:', e.message);
-              console.log('Falling back to posting comments individually with rate-limit-aware retry...');
-              
-              // Fallback: post comments one by one with delay to avoid secondary rate limits.
-              // GitHub enforces ~80 content-generating requests per minute; spacing calls
-              // helps stay under that threshold. Retry/wait durations are derived from the
-              // rate-limit response headers per GitHub's documented strategy.
-              const MAX_RETRIES = parseInt(process.env.OCR_MAX_RETRIES, 10) || 3;
-              const SUCCESS_DELAY = parseInt(process.env.OCR_SUCCESS_DELAY, 10) || 2000; // delay after successful post
-              const FAILURE_DELAY = parseInt(process.env.OCR_FAILURE_DELAY, 10) || 1000; // delay after non-retryable failure
-              const LOW_REMAINING_THRESHOLD = parseInt(process.env.OCR_LOW_REMAINING_THRESHOLD, 10) || 3;
-              const LOW_REMAINING_SPACING = parseInt(process.env.OCR_LOW_REMAINING_SPACING, 10) || 10000;
+              console.log('Checking whether the batch review actually landed on the server before retrying...');
+
+              // Idempotency check: the batch createReview may have succeeded on the
+              // server even though we got a 5xx. Query existing reviews to find out,
+              // so we only retry the comments that are actually missing.
+              let existingReview = null;
+              try {
+                existingReview = await findExistingBatchReview({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  prNumber,
+                  tag: REVIEW_TAG
+                });
+              } catch (checkErr) {
+                console.log(`Idempotency check failed (${checkErr.message}). ` +
+                            `Degrading to original fallback (accepting duplicate risk).`);
+              }
+
+              // Compute the list of inline comments that still need to be posted.
+              // If the batch review landed, only retry the missing ones; otherwise
+              // retry all of them.
+              let toRetry = reviewComments;
+              if (existingReview && existingReview.found) {
+                const postedIds = await getPostedCommentIds({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  prNumber
+                });
+                toRetry = reviewComments.filter(({ comment }) =>
+                  !postedIds.has(commentId(comment))
+                );
+                successCount = reviewComments.length - toRetry.length;
+                console.log(`Batch review already exists (review_id=${existingReview.review.id}). ` +
+                            `${successCount}/${reviewComments.length} inline comments already posted. ` +
+                            `${toRetry.length} missing, will retry only those.`);
+              } else {
+                console.log('Batch review not found on server. Falling back to per-comment posting...');
+              }
 
               // If the batch itself was rate-limited, honor its rate-limit headers
               // (retry-after / x-ratelimit-reset) before retrying per-comment,
@@ -294,7 +361,7 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
-              for (const { comment, reviewComment } of reviewComments) {
+              for (const { comment, reviewComment } of toRetry) {
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
                   try {
@@ -325,23 +392,82 @@ jobs:
                     // rate-limit documentation (retry-after / x-ratelimit-* headers).
                     const retryInfo = computeRetryDelayMs(innerE, attempt);
                     const willRetry = retryInfo != null && attempt < MAX_RETRIES;
-                    if (willRetry) {
+                    // Any error whose request may have reached GitHub (5xx server
+                    // errors, 408 timeout, or network-layer errors with no status)
+                    // can mean the comment was actually created but the response was
+                    // lost. Before retrying (which would post a duplicate) or before
+                    // giving up (which would wrongly list it as failed in the summary),
+                    // we must check whether it already landed.
+                    //
+                    // IMPORTANT: do the check AFTER cooling down, not immediately.
+                    // If the error is rate-limit-related (5xx under load, or a
+                    // network blip), firing read requests right away further
+                    // pressures the already-struggling API. Honor the computed
+                    // retry delay first, then query.
+                    const status = innerE.status;
+                    const maybeReachedServer =
+                      (typeof status === 'number' && (status >= 500 || status === 408)) ||
+                      status == null; // network errors (ECONNRESET, ETIMEDOUT, ...)
+                    if (maybeReachedServer) {
+                      // Cool down first: even read requests count against rate
+                      // limits, and querying during an ongoing 5xx/rate-limit
+                      // episode can worsen the situation. Use the retry delay when
+                      // available; for non-retryable errors (retryInfo == null)
+                      // there is no header-derived wait, so use a short fixed cool
+                      // down before the read.
+                      const coolDownMs = retryInfo != null ? retryInfo.delayMs : FAILURE_DELAY;
+                      if (coolDownMs > 0) {
+                        const secs = (coolDownMs / 1000).toFixed(1);
+                        console.log(
+                          `Cooling down ${secs}s before idempotency check for ${reviewComment.path} ` +
+                          `(HTTP ${innerE.status || 'n/a'}, attempt ${attempt + 1}/${MAX_RETRIES + 1}).`
+                        );
+                        await sleep(coolDownMs);
+                      }
+                      const id = commentId(comment);
+                      const alreadyPosted = await isCommentAlreadyPosted({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        prNumber,
+                        id
+                      });
+                      if (alreadyPosted) {
+                        successCount++;
+                        posted = true;
+                        console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
+                        await sleep(SUCCESS_DELAY);
+                        continue;
+                      }
+                      // Not found on server. If retries are exhausted or the
+                      // error is non-retryable, this is a real failure.
+                      if (!willRetry) {
+                        failedCount++;
+                        failedComments.push({ comment, error: innerE.message });
+                        const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
+                        console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                        await sleep(SUCCESS_DELAY);
+                        break;
+                      }
+                      // willRetry: cool down already consumed above, loop back.
+                    } else if (willRetry) {
+                      // Pure 429/403 rate-limit: the request never reached the
+                      // server, so no duplicate is possible and the idempotency
+                      // check can be skipped. Just honor the retry delay.
                       const secs = (retryInfo.delayMs / 1000).toFixed(1);
                       console.log(
-                        `Rate-limited/transient error on ${reviewComment.path} ` +
+                        `Rate-limited on ${reviewComment.path} ` +
                         `(HTTP ${innerE.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
                         `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ` +
                         `Error: ${innerE.message}`
                       );
                       await sleep(retryInfo.delayMs);
                     } else {
+                      // Non-retryable error that definitely did not reach the
+                      // server (e.g. 4xx validation error): record as failed.
                       failedCount++;
                       failedComments.push({ comment, error: innerE.message });
-                      const reason = retryInfo == null ? 'non-retryable error' : 'rate-limit retries exhausted';
-                      console.log(`Failed to post comment for ${reviewComment.path} (${reason}, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
-                      // After exhausting retries use the success-style pace delay;
-                      // for other errors use the shorter failure pace delay.
-                      await sleep(retryInfo == null ? FAILURE_DELAY : SUCCESS_DELAY);
+                      console.log(`Failed to post comment for ${reviewComment.path} (non-retryable error, HTTP ${innerE.status || 'n/a'}): ${innerE.message}`);
+                      await sleep(FAILURE_DELAY);
                       break;
                     }
                   }
@@ -365,17 +491,152 @@ jobs:
                   finalBody += formatCommentMarkdown(comment, error);
                 }
               }
-              
-              await github.rest.issues.createComment({
+
+              // Prepend the summary tag and post only if no summary with this tag
+              // already exists (idempotency: the batch review may have carried the
+              // same summary body, in which case we must not duplicate it).
+              finalBody = SUMMARY_TAG + '\n' + finalBody;
+              const summaryAlreadyPosted = await hasIssueCommentWithId({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber,
-                body: finalBody
+                issueNumber: prNumber,
+                id: SUMMARY_TAG
               });
+              if (summaryAlreadyPosted) {
+                console.log('Summary comment with this run tag already exists; skipping.');
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: finalBody
+                });
+              }
             }
 
             function sleep(ms) {
               return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            // Retry wrapper shared by write and read API calls. Reuses
+            // computeRetryDelayMs so rate-limit headers (retry-after /
+            // x-ratelimit-*) are honored uniformly. Throws on final failure
+            // so the caller can decide how to degrade.
+            async function withRetry(tag, fn) {
+              for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+                try {
+                  return await fn();
+                } catch (e) {
+                  const retryInfo = computeRetryDelayMs(e, attempt);
+                  const willRetry = retryInfo != null && attempt < MAX_RETRIES;
+                  if (willRetry) {
+                    const secs = (retryInfo.delayMs / 1000).toFixed(1);
+                    console.log(
+                      `[${tag}] transient/rate-limited (HTTP ${e.status}, attempt ${attempt + 1}/${MAX_RETRIES}). ` +
+                      `Waiting ${secs}s via '${retryInfo.source}' (${retryInfo.detail}). ${e.message}`
+                    );
+                    await sleep(retryInfo.delayMs);
+                  } else {
+                    console.log(`[${tag}] failed after ${attempt + 1} attempts: ${e.message}`);
+                    throw e;
+                  }
+                }
+              }
+            }
+
+            // Read API wrapper with retry + proactive pacing. Read requests are
+            // cheaper than writes but still consume the primary rate limit and can
+            // trigger the secondary limit when issued in a tight loop. Use shorter
+            // delays than writes (READ_SUCCESS_DELAY / READ_LOW_REMAINING_SPACING).
+            async function readWithPacing(tag, fn) {
+              const res = await withRetry(tag, fn);
+              const remaining = logRateLimitQuota(res, tag);
+              const lowQuota = remaining != null && remaining <= LOW_REMAINING_THRESHOLD;
+              if (lowQuota) {
+                console.log(`[rate-limit] quota low after read (${remaining} <= ${LOW_REMAINING_THRESHOLD}); spacing ${READ_LOW_REMAINING_SPACING}ms.`);
+                await sleep(READ_LOW_REMAINING_SPACING);
+              } else {
+                await sleep(READ_SUCCESS_DELAY);
+              }
+              return res;
+            }
+
+            // Paginated helper that walks all pages of a list endpoint with retry
+            // and pacing. Returns the concatenated array of items.
+            async function readAllPages(tag, pageFn) {
+              const all = [];
+              let page = 1;
+              const PER_PAGE = 100;
+              while (true) {
+                const res = await readWithPacing(`${tag} (page ${page})`, () => pageFn(page, PER_PAGE));
+                const items = res.data || [];
+                all.push(...items);
+                if (items.length < PER_PAGE) break;
+                page++;
+              }
+              return all;
+            }
+
+            // Idempotency check: find whether a batch review with this run tag
+            // already exists on the PR. Returns { found, review } or throws on
+            // final failure (caller degrades to original fallback).
+            async function findExistingBatchReview({ owner, repo, prNumber, tag }) {
+              const reviews = await readAllPages('listReviews', (page, per_page) =>
+                github.rest.pulls.listReviews({ owner, repo, pull_number: prNumber, per_page, page })
+              );
+              for (const r of reviews) {
+                if ((r.body || '').includes(tag)) {
+                  return { found: true, review: r };
+                }
+              }
+              return { found: false };
+            }
+
+            // Collect the set of comment-level IDs already posted on the PR
+            // (across all reviews). Uses listReviewComments (PR-level, cross-review)
+            // so a single paginated walk covers everything, avoiding the O(missing)
+            // amplification of per-comment lookups.
+            async function getPostedCommentIds({ owner, repo, prNumber }) {
+              const comments = await readAllPages('listReviewComments', (page, per_page) =>
+                github.rest.pulls.listReviewComments({ owner, repo, pull_number: prNumber, per_page, page })
+              );
+              const ids = new Set();
+              for (const c of comments) {
+                const body = c.body || '';
+                const matches = body.match(/ocr-\d+-\d+-[a-f0-9]+/g) || [];
+                for (const id of matches) ids.add(id);
+              }
+              return ids;
+            }
+
+            // Check whether a specific comment-level ID has already landed on the
+            // server. Used by the per-comment retry loop: when a createReview call
+            // fails with a transient 5xx/408, the request may have reached GitHub
+            // and succeeded even though the response was lost. Querying before
+            // retrying prevents posting a duplicate inline comment.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
+              try {
+                const posted = await getPostedCommentIds({ owner, repo, prNumber });
+                return posted.has(id);
+              } catch (e) {
+                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); assuming not posted.`);
+                return false;
+              }
+            }
+
+            // Check whether an issue comment with the given tag already exists.
+            // Used to avoid posting a duplicate summary comment when the batch
+            // review already carried the same summary body.
+            async function hasIssueCommentWithId({ owner, repo, issueNumber, id }) {
+              try {
+                const comments = await readAllPages('listIssueComments', (page, per_page) =>
+                  github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page, page })
+                );
+                return comments.some(c => (c.body || '').includes(id));
+              } catch (e) {
+                console.log(`[listIssueComments] check failed (${e.message}); assuming not posted.`);
+                return false;
+              }
             }
 
             // Case-insensitive header lookup. Octokit normalizes response headers to
@@ -484,7 +745,12 @@ jobs:
             }
 
             function formatComment(comment) {
-              let body = comment.content || '';
+              // Prepend a comment-level unique tag (HTML comment, invisible when
+              // rendered) so the idempotency check can match individual inline
+              // comments even when multiple comments target the same path/line.
+              const id = commentId(comment);
+              let body = `<!-- ${id} -->\n`;
+              body += comment.content || '';
 
               // Add code suggestion if available
               if (comment.suggestion_code && comment.existing_code) {
@@ -493,6 +759,23 @@ jobs:
               }
 
               return body;
+            }
+
+            // Stable unique ID for a comment, derived from path + line range +
+            // content hash. Stable across retries (same input => same ID) so the
+            // idempotency check can match a retried comment against the one that
+            // already landed on the server. suggestion_code is intentionally
+            // excluded from the fingerprint: it may drift on minor reformatting
+            // while the review point itself stays the same.
+            function commentId(comment) {
+              const fingerprint = [
+                comment.path || '',
+                comment.start_line != null ? String(comment.start_line) : '',
+                comment.end_line != null ? String(comment.end_line) : '',
+                comment.content || ''
+              ].join('|');
+              const hash = crypto.createHash('sha256').update(fingerprint).digest('hex').slice(0, 12);
+              return `ocr-${RUN_TAG}-${hash}`;
             }
 
             function formatCommentMarkdown(comment, error) {

--- a/examples/github_actions/ocr-review.yml
+++ b/examples/github_actions/ocr-review.yml
@@ -361,6 +361,12 @@ jobs:
                 await sleep(batchRetry.delayMs);
               }
 
+              // Cache for the per-comment idempotency check: a single paginated
+              // walk of listReviewComments covers all inline comments on the PR,
+              // so we reuse it across retries instead of re-walking on every 5xx.
+              // The cache is best-effort: if the read API fails, the check returns
+              // null (unknown) and the caller skips retrying that comment.
+              const postedIdsCache = { value: null };
               for (const { comment, reviewComment } of toRetry) {
                 let posted = false;
                 for (let attempt = 0; attempt <= MAX_RETRIES && !posted; attempt++) {
@@ -429,14 +435,28 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         prNumber,
-                        id
+                        id,
+                        postedIdsCache
                       });
-                      if (alreadyPosted) {
+                      if (alreadyPosted === true) {
                         successCount++;
                         posted = true;
                         console.log(`Comment for ${reviewComment.path} already posted (id=${id}); treating as success.`);
                         await sleep(SUCCESS_DELAY);
                         continue;
+                      }
+                      // Unknown (null): the read API is unavailable, so we
+                      // cannot tell whether the comment landed. To avoid a
+                      // duplicate, do NOT retry posting; record as failed so
+                      // the summary surfaces the uncertainty rather than
+                      // silently risking a duplicate.
+                      if (alreadyPosted === null) {
+                        failedCount++;
+                        const reason = 'idempotency check unavailable (read API failed)';
+                        failedComments.push({ comment, error: `${innerE.message} [${reason}]` });
+                        console.log(`Cannot verify whether comment for ${reviewComment.path} was posted (${reason}, HTTP ${innerE.status || 'n/a'}); skipping retry to avoid duplicate.`);
+                        await sleep(SUCCESS_DELAY);
+                        break;
                       }
                       // Not found on server. If retries are exhausted or the
                       // error is non-retryable, this is a real failure.
@@ -502,8 +522,13 @@ jobs:
                 issueNumber: prNumber,
                 id: SUMMARY_TAG
               });
-              if (summaryAlreadyPosted) {
+              if (summaryAlreadyPosted === true) {
                 console.log('Summary comment with this run tag already exists; skipping.');
+              } else if (summaryAlreadyPosted === null) {
+                // Read API unavailable: cannot tell whether the summary already
+                // landed. Skip posting to avoid a duplicate; the review content
+                // is still available via inline comments / batch review.
+                console.log('Cannot verify whether summary comment already exists (read API failed); skipping to avoid duplicate.');
               } else {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
@@ -563,16 +588,22 @@ jobs:
 
             // Paginated helper that walks all pages of a list endpoint with retry
             // and pacing. Returns the concatenated array of items.
-            async function readAllPages(tag, pageFn) {
+            async function readAllPages(tag, pageFn, maxPages = 50) {
+              if (!Number.isFinite(maxPages) || maxPages < 1) {
+                throw new Error(`readAllPages: maxPages must be a positive integer, got ${maxPages}`);
+              }
               const all = [];
               let page = 1;
               const PER_PAGE = 100;
-              while (true) {
+              while (page <= maxPages) {
                 const res = await readWithPacing(`${tag} (page ${page})`, () => pageFn(page, PER_PAGE));
                 const items = res.data || [];
                 all.push(...items);
                 if (items.length < PER_PAGE) break;
                 page++;
+              }
+              if (page > maxPages) {
+                console.log(`[${tag}] reached max page limit (${maxPages}); results may be incomplete.`);
               }
               return all;
             }
@@ -601,10 +632,19 @@ jobs:
                 github.rest.pulls.listReviewComments({ owner, repo, pull_number: prNumber, per_page, page })
               );
               const ids = new Set();
+              // Anchor the regex to the HTML comment wrapper (<!-- ocr-... -->)
+              // so user-generated content or code suggestions cannot trigger
+              // false positives in the idempotency check. The ID format is
+              // `ocr-<RUN_TAG>-<hash>` where RUN_TAG is `<runId>-<runAttempt>`.
+              // Capture group 1 holds the bare ID (ocr-<RUN_TAG>-<hash>),
+              // so we can add it directly without stripping comment markers.
+              const ID_RE = /<!--\s*(ocr-\d+-\d+-[a-f0-9]+)\s*-->/g;
               for (const c of comments) {
                 const body = c.body || '';
-                const matches = body.match(/ocr-\d+-\d+-[a-f0-9]+/g) || [];
-                for (const id of matches) ids.add(id);
+                let m;
+                while ((m = ID_RE.exec(body)) !== null) {
+                  ids.add(m[1]);
+                }
               }
               return ids;
             }
@@ -614,28 +654,51 @@ jobs:
             // fails with a transient 5xx/408, the request may have reached GitHub
             // and succeeded even though the response was lost. Querying before
             // retrying prevents posting a duplicate inline comment.
-            async function isCommentAlreadyPosted({ owner, repo, prNumber, id }) {
+            // Returns true/false when the check succeeds, or null when the
+            // read API is unavailable (rate limit, 5xx, etc.). Returning null
+            // (rather than defaulting to false) prevents the caller from
+            // assuming the comment was not posted and risking a duplicate on
+            // retry. `postedIdsCache` lets the caller reuse the result of a
+            // single paginated walk across multiple per-comment retries, so a
+            // degraded API episode does not amplify into N full walks.
+            async function isCommentAlreadyPosted({ owner, repo, prNumber, id, postedIdsCache }) {
               try {
-                const posted = await getPostedCommentIds({ owner, repo, prNumber });
+                let posted = postedIdsCache && postedIdsCache.value;
+                if (posted == null) {
+                  posted = await getPostedCommentIds({ owner, repo, prNumber });
+                  if (postedIdsCache) postedIdsCache.value = posted;
+                }
                 return posted.has(id);
               } catch (e) {
-                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); assuming not posted.`);
-                return false;
+                console.log(`[isCommentAlreadyPosted] check failed for ${id} (${e.message}); treating as unknown to avoid duplicates.`);
+                return null;
               }
             }
 
             // Check whether an issue comment with the given tag already exists.
             // Used to avoid posting a duplicate summary comment when the batch
             // review already carried the same summary body.
+            // Returns true/false when the check succeeds, or null when the
+            // read API is unavailable. Returning null (rather than defaulting
+            // to false) lets the caller decide whether to skip posting or
+            // degrade gracefully, instead of silently risking a duplicate
+            // summary comment.
             async function hasIssueCommentWithId({ owner, repo, issueNumber, id }) {
               try {
                 const comments = await readAllPages('listIssueComments', (page, per_page) =>
                   github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page, page })
                 );
-                return comments.some(c => (c.body || '').includes(id));
+                // Match the tag anchored to its HTML comment wrapper for
+                // consistency with getPostedCommentIds and to defend against
+                // user content that happens to contain the bare tag string.
+                // `id` is an opaque tag like `<!-- ocr-summary-run:... -->`,
+                // so escape any regex metacharacters before embedding it.
+                const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const tagRe = new RegExp('<!--\\s*' + escaped + '\\s*-->');
+                return comments.some(c => tagRe.test(c.body || ''));
               } catch (e) {
-                console.log(`[listIssueComments] check failed (${e.message}); assuming not posted.`);
-                return false;
+                console.log(`[listIssueComments] check failed (${e.message}); treating as unknown to avoid duplicates.`);
+                return null;
               }
             }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->

Harden the ocr-review GitHub Actions workflow so PR-review comments are never posted twice when a createReview call fails transiently, and make its retry/backoff behavior follow GitHub's documented rate-limit guidance.

When the batch createReview fails with a 5xx/408/network error, the request may still have landed on the server. This branch adds an idempotency layer that detects already-landed comments before retrying, plus rate-limit-aware retry/pacing throughout. All logic is mirrored across .github/workflows/ocr-review.yml (repo's own workflow) and examples/github_actions/ocr-review.yml (public demo).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)
Tested in real Github Actions

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
