### PR TITLE
fix(tui): persist official-tab models and refine saved secret hint

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -435,21 +435,11 @@ func ensureModelInList(models []string, model string) []string {
 	if model == "" {
 		return models
 	}
-	if modelListContains(models, model) {
+	if llm.ModelListContains(models, model) {
 		return models
 	}
 	out := append([]string(nil), models...)
 	return append(out, model)
-}
-
-func modelListContains(models []string, target string) bool {
-	target = strings.TrimSpace(target)
-	for _, model := range models {
-		if model == target {
-			return true
-		}
-	}
-	return false
 }
 
 func setProviderValue(cfg *Config, key, value string) error {

--- a/cmd/opencodereview/provider_cmd.go
+++ b/cmd/opencodereview/provider_cmd.go
@@ -32,13 +32,9 @@ func runConfigProvider() error {
 	final := finalModel.(providerTUIModel)
 
 	if !final.confirmed {
-		// TUI persists changes (create/edit/model/add/delete) directly to disk
-		// during the session, so the on-disk file is already up to date for any
-		// savedInSession operation. No additional post-TUI apply step is needed.
-		if final.savedInSession {
-			return nil
-		}
-		fmt.Println("Cancelled.")
+		// TUI persists changes during the session; Esc only abandons the final
+		// provider/API-key confirmation step.
+		printWizardCancelled(final.savedInSession, "Configuration changes")
 		return nil
 	}
 
@@ -53,6 +49,16 @@ func runConfigProvider() error {
 	}
 
 	return applyOfficialProviderConfig(configPath, cfg, result)
+}
+
+// printWizardCancelled prints the standard Esc-cancel message for config wizards.
+// changesDescription is a short noun phrase, e.g. "Configuration changes".
+func printWizardCancelled(savedInSession bool, changesDescription string) {
+	if savedInSession {
+		fmt.Printf("Cancelled. (%s made during this session were kept.)\n", changesDescription)
+		return
+	}
+	fmt.Println("Cancelled.")
 }
 
 func applyProviderDeletions(configPath string, cfg *Config, names []string) (bool, error) {
@@ -274,8 +280,10 @@ func runConfigModel() error {
 	currentModel := ""
 	provider := llm.Provider{Name: cfg.Provider, DisplayName: cfg.Provider}
 	isCustom := false
+	registryModels := []string(nil)
 	if preset, isPreset := llm.LookupProvider(cfg.Provider); isPreset {
 		provider = preset
+		registryModels = append([]string(nil), preset.Models...)
 		if entry, ok := cfg.Providers[cfg.Provider]; ok {
 			currentModel = activeModelForProvider(cfg, cfg.Provider, entry)
 			provider.Models = mergeModelLists(provider.Models, entry.Models)
@@ -293,7 +301,15 @@ func runConfigModel() error {
 		provider.Models = mergeModelLists(entry.Models)
 	}
 
-	m := newModelTUI(provider, currentModel)
+	m := newModelTUIConfig(modelTUIConfig{
+		Provider:       provider,
+		CurrentModel:   currentModel,
+		RegistryModels: registryModels,
+		ExistingCfg:    cfg,
+		ConfigPath:     configPath,
+		ProviderName:   cfg.Provider,
+		IsCustom:       isCustom,
+	})
 	p := tea.NewProgram(m)
 	finalModel, err := p.Run()
 	if err != nil {
@@ -302,7 +318,7 @@ func runConfigModel() error {
 
 	final := finalModel.(modelTUIModel)
 	if final.cancelled {
-		fmt.Println("Cancelled.")
+		printWizardCancelled(final.savedInSession, "Model list changes")
 		return nil
 	}
 
@@ -325,7 +341,9 @@ func runConfigModel() error {
 		}
 		entry := cfg.Providers[cfg.Provider]
 		entry.Model = selectedModel
-		if !modelListContains(provider.Models, selectedModel) {
+		// Use registry-only list: provider.Models was captured before the TUI and
+		// may include stale entry.Models from add/delete during the session.
+		if !llm.ModelListContains(registryModels, selectedModel) {
 			entry.Models = ensureModelInList(entry.Models, selectedModel)
 		}
 		cfg.Providers[cfg.Provider] = entry

--- a/cmd/opencodereview/provider_cmd.go
+++ b/cmd/opencodereview/provider_cmd.go
@@ -139,7 +139,8 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 	if result.provider == "" {
 		return fmt.Errorf("provider name is required")
 	}
-	if result.model == "" {
+	model := result.resolvedModel()
+	if model == "" {
 		return fmt.Errorf("model is required")
 	}
 
@@ -148,11 +149,11 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 	}
 
 	entry := cfg.CustomProviders[result.provider]
-	entry.Model = result.model
+	entry.Model = model
 	if len(result.models) > 0 {
 		entry.Models = append([]string(nil), result.models...)
 	}
-	entry.Models = ensureModelInList(entry.Models, result.model)
+	entry.Models = ensureModelInList(entry.Models, model)
 	if result.url != "" {
 		entry.URL = result.url
 	}
@@ -168,14 +169,16 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 	}
 	if result.apiKey != "" {
 		entry.APIKey = result.apiKey
+	} else {
+		entry.APIKey = ""
 	}
 	cfg.CustomProviders[result.provider] = entry
 
 	if !result.isEdit {
 		cfg.Provider = result.provider
-		cfg.Model = result.model
+		cfg.Model = model
 	} else if cfg.Provider == result.provider {
-		cfg.Model = result.model
+		cfg.Model = model
 	}
 
 	if err := saveConfig(configPath, cfg); err != nil {
@@ -188,13 +191,13 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 		} else {
 			fmt.Printf("\nCustom provider %q updated (not currently active).\n", result.provider)
 		}
-		fmt.Printf("Model: %s\n", result.model)
+		fmt.Printf("Model: %s\n", model)
 		fmt.Println("\nTip: run 'ocr config model' to switch model later.")
 		return nil
 	}
 
 	fmt.Printf("\nProvider set to: %s (custom)\n", result.provider)
-	fmt.Printf("Model: %s\n", result.model)
+	fmt.Printf("Model: %s\n", model)
 
 	fmt.Println("\nTesting connection...")
 	if err := runLLMTest(); err != nil {
@@ -208,7 +211,11 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 }
 
 func applyOfficialProviderConfig(configPath string, cfg *Config, result providerTUIResult) error {
-	if result.provider == "" || result.model == "" {
+	if result.provider == "" {
+		return fmt.Errorf("provider and model are required")
+	}
+	model := result.resolvedModel()
+	if model == "" {
 		return fmt.Errorf("provider and model are required")
 	}
 
@@ -229,12 +236,15 @@ func applyOfficialProviderConfig(configPath string, cfg *Config, result provider
 	}
 
 	entry := cfg.Providers[result.provider]
-	entry.Model = result.model
+	entry.Model = model
 	if len(result.models) > 0 {
 		entry.Models = mergeModelLists(entry.Models, result.models)
 	}
 	if result.apiKey != "" {
 		entry.APIKey = result.apiKey
+	} else {
+		// Confirmed empty key: clear saved api_key so resolver falls back to $ENV_VAR.
+		entry.APIKey = ""
 	}
 	cfg.Providers[result.provider] = entry
 
@@ -242,14 +252,14 @@ func applyOfficialProviderConfig(configPath string, cfg *Config, result provider
 		cfg.Model = ""
 	}
 	cfg.Provider = result.provider
-	cfg.Model = result.model
+	cfg.Model = model
 
 	if err := saveConfig(configPath, cfg); err != nil {
 		return err
 	}
 
 	fmt.Printf("\nProvider set to: %s\n", result.provider)
-	fmt.Printf("Model: %s\n", result.model)
+	fmt.Printf("Model: %s\n", model)
 
 	fmt.Println("\nTesting connection...")
 	if err := runLLMTest(); err != nil {

--- a/cmd/opencodereview/provider_cmd_test.go
+++ b/cmd/opencodereview/provider_cmd_test.go
@@ -205,6 +205,130 @@ func TestApplyOfficialProviderConfig_MissingFields(t *testing.T) {
 	}
 }
 
+func TestApplyOfficialProviderConfig_EmptyKeyClearsSavedAPIKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "sk-from-env")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {
+				APIKey: "old-saved-key",
+				Model:  "deepseek-v4-flash",
+			},
+		},
+	}
+
+	err := applyOfficialProviderConfig(configPath, cfg, providerTUIResult{
+		provider: "deepseek",
+		model:    "deepseek-v4-flash",
+		apiKey:   "",
+	})
+	if err != nil {
+		t.Fatalf("applyOfficialProviderConfig: %v", err)
+	}
+	if got := cfg.Providers["deepseek"].APIKey; got != "" {
+		t.Errorf("in-memory APIKey = %q, want empty", got)
+	}
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := diskCfg.Providers["deepseek"].APIKey; got != "" {
+		t.Errorf("persisted APIKey = %q, want empty", got)
+	}
+}
+
+func TestApplyCustomProviderConfig_EmptyKeyClearsSavedAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "aaa",
+		Model:    "test",
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:      "https://example.com/v1",
+				Protocol: "openai",
+				APIKey:   "old-saved-key",
+				Model:    "test",
+				Models:   []string{"test"},
+			},
+		},
+	}
+
+	err := applyCustomProviderConfig(configPath, cfg, providerTUIResult{
+		provider: "aaa",
+		model:    "test",
+		models:   []string{"test"},
+		apiKey:   "",
+		isCustom: true,
+		url:      "https://example.com/v1",
+		protocol: "openai",
+	})
+	if err != nil {
+		t.Fatalf("applyCustomProviderConfig: %v", err)
+	}
+	if got := cfg.CustomProviders["aaa"].APIKey; got != "" {
+		t.Errorf("APIKey = %q, want empty", got)
+	}
+}
+
+func TestProviderTUIResult_ResolvedModel(t *testing.T) {
+	r := providerTUIResult{
+		provider: "baidu-qianfan",
+		model:    "glm-5",
+	}
+	if got := r.resolvedModel(); got != "glm-5" {
+		t.Errorf("resolvedModel() = %q, want glm-5", got)
+	}
+
+	r = providerTUIResult{
+		provider: "baidu-qianfan",
+		sessionModelPick: map[string]string{
+			"baidu-qianfan": "glm-5",
+		},
+	}
+	if got := r.resolvedModel(); got != "glm-5" {
+		t.Errorf("resolvedModel() from session pick = %q, want glm-5", got)
+	}
+
+	r = providerTUIResult{provider: "baidu-qianfan"}
+	if got := r.resolvedModel(); got != "" {
+		t.Errorf("resolvedModel() = %q, want empty", got)
+	}
+}
+
+func TestApplyOfficialProviderConfig_UsesSessionModelPick(t *testing.T) {
+	t.Setenv("QIANFAN_API_KEY", "sk-from-env")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+
+	err := applyOfficialProviderConfig(configPath, cfg, providerTUIResult{
+		provider: "baidu-qianfan",
+		apiKey:   "",
+		sessionModelPick: map[string]string{
+			"baidu-qianfan": "glm-5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("applyOfficialProviderConfig: %v", err)
+	}
+	if cfg.Provider != "baidu-qianfan" {
+		t.Errorf("Provider = %q, want baidu-qianfan", cfg.Provider)
+	}
+	if cfg.Model != "glm-5" {
+		t.Errorf("Model = %q, want glm-5", cfg.Model)
+	}
+}
+
 func TestPrintWizardCancelled(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cmd/opencodereview/provider_cmd_test.go
+++ b/cmd/opencodereview/provider_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -201,5 +202,53 @@ func TestApplyOfficialProviderConfig_MissingFields(t *testing.T) {
 	err := applyOfficialProviderConfig("", &Config{}, providerTUIResult{provider: "", model: ""})
 	if err == nil {
 		t.Fatal("expected error for missing provider/model")
+	}
+}
+
+func TestPrintWizardCancelled(t *testing.T) {
+	tests := []struct {
+		name           string
+		savedInSession bool
+		scope          string
+		want           string
+	}{
+		{
+			name:           "no changes",
+			savedInSession: false,
+			scope:          "Configuration changes",
+			want:           "Cancelled.\n",
+		},
+		{
+			name:           "provider wizard kept changes",
+			savedInSession: true,
+			scope:          "Configuration changes",
+			want:           "Cancelled. (Configuration changes made during this session were kept.)\n",
+		},
+		{
+			name:           "model wizard kept changes",
+			savedInSession: true,
+			scope:          "Model list changes",
+			want:           "Cancelled. (Model list changes made during this session were kept.)\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := os.Stdout
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = w
+			printWizardCancelled(tc.savedInSession, tc.scope)
+			w.Close()
+			os.Stdout = old
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("output = %q, want %q", string(got), tc.want)
+			}
+		})
 	}
 }

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -287,7 +287,7 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 		if cfg.Llm.AuthToken != "" {
 			m.manualTokenOriginal = cfg.Llm.AuthToken
 			m.manualTokenMasked = true
-			m.manualTokenInput.SetValue(strings.Repeat("*", 20))
+			m.manualTokenInput.SetValue(maskedSecretPlaceholder())
 		}
 		if cfg.Llm.UseAnthropic == nil || *cfg.Llm.UseAnthropic {
 			m.manualProtocolIdx = 0 // anthropic
@@ -555,6 +555,9 @@ func (m providerTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.passThroughManualInput(msg)
 		}
 		if m.step == stepAPIKey {
+			if m.apiKeyMasked && isUserEditMsg(msg) {
+				m.beginAPIKeyReplace()
+			}
 			var cmd tea.Cmd
 			m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
 			return m, cmd
@@ -588,8 +591,14 @@ func (m providerTUIModel) updateCustomModelInput(key string, msg tea.KeyPressMsg
 			}
 		}
 		m.formError = ""
-		if err := m.addCustomModelToSession(name); err != nil {
+		persisted, err := m.persistCustomModelName(name)
+		if err != nil {
 			m.formError = err.Error()
+			return m, nil
+		}
+		if !persisted {
+			// No active provider context — refuse with an error message.
+			m.formError = "no active provider to attach this model to"
 			return m, nil
 		}
 		m.customModel = false
@@ -607,37 +616,109 @@ func (m providerTUIModel) updateCustomModelInput(key string, msg tea.KeyPressMsg
 	}
 }
 
-// addCustomModelToSession appends a single model name to the current custom
-// provider's Models list and persists in-memory state to disk. It does not
-// change the active model — the user picks that explicitly from the list
-// afterwards.
-func (m *providerTUIModel) addCustomModelToSession(name string) error {
+// persistCustomModelName appends a single model name to the active provider's
+// Models list (official or custom) and saves the config. It does not change
+// the active model — the user picks that explicitly from the list afterwards.
+//
+// Returns (persisted, error). When no provider is active (neither official
+// nor custom), persisted is false and the caller decides how to handle it.
+func (m *providerTUIModel) persistCustomModelName(name string) (bool, error) {
+	if name == "" {
+		return false, fmt.Errorf("model name must not be empty")
+	}
 	if m.existingCfg == nil {
-		return nil
+		return false, nil
 	}
-	cp, ok := m.selectedCustomProvider()
-	if !ok {
-		return nil
-	}
-	entry := m.customProviderEntry(cp.name, cp.entry)
-	prevEntry := cloneProviderEntry(entry)
-	entry.Models = append(entry.Models, name)
-	if m.existingCfg.CustomProviders == nil {
-		m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
-	}
-	m.existingCfg.CustomProviders[cp.name] = entry
-	cp.entry = entry
-	m.customProviders[m.customIdx] = cp
-	if m.configPath != "" {
-		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
-			m.existingCfg.CustomProviders[cp.name] = prevEntry
-			cp.entry = prevEntry
-			m.customProviders[m.customIdx] = cp
-			return fmt.Errorf("failed to save models: %w", err)
+	switch m.activeTab {
+	case tabCustom:
+		cp, ok := m.selectedCustomProvider()
+		if !ok {
+			return false, nil
 		}
+		entry := m.customProviderEntry(cp.name, cp.entry)
+		prevEntry := cloneProviderEntry(entry)
+		entry.Models = append(entry.Models, name)
+		if m.existingCfg.CustomProviders == nil {
+			m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
+		}
+		m.existingCfg.CustomProviders[cp.name] = entry
+		cp.entry = entry
+		m.customProviders[m.customIdx] = cp
+		if m.configPath != "" {
+			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+				m.existingCfg.CustomProviders[cp.name] = prevEntry
+				cp.entry = prevEntry
+				m.customProviders[m.customIdx] = cp
+				return false, fmt.Errorf("failed to save models: %w", err)
+			}
+		}
+		m.savedInSession = true
+		return true, nil
+	case tabOfficial:
+		provider := m.currentProvider()
+		if provider.Name == "" {
+			return false, nil
+		}
+		if m.existingCfg.Providers == nil {
+			m.existingCfg.Providers = make(map[string]ProviderEntry)
+		}
+		entry := m.existingCfg.Providers[provider.Name]
+		prevEntry := cloneProviderEntry(entry)
+		entry.Models = append(entry.Models, name)
+		m.existingCfg.Providers[provider.Name] = entry
+		// Intentionally do not mutate m.providers[officialIdx].Models: that slice
+		// is a read-only snapshot from the provider registry (llm.ListProviders).
+		// User-added models live only in existingCfg.Providers; models() merges both
+		// at display time, unlike custom tab where customProviders is the sole list.
+		if m.configPath != "" {
+			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+				m.existingCfg.Providers[provider.Name] = prevEntry
+				return false, fmt.Errorf("failed to save models: %w", err)
+			}
+		}
+		m.savedInSession = true
+		return true, nil
+	default:
+		return false, fmt.Errorf("unsupported tab for custom model: %v", m.activeTab)
 	}
-	m.savedInSession = true
-	return nil
+}
+
+const maskedSecretDisplayLen = 20
+
+func maskedSecretPlaceholder() string {
+	return strings.Repeat("*", maskedSecretDisplayLen)
+}
+
+// isUserEditMsg reports whether msg represents user text input (typing or paste).
+func isUserEditMsg(msg tea.Msg) bool {
+	switch msg.(type) {
+	case tea.KeyPressMsg, tea.PasteMsg:
+		return true
+	default:
+		return false
+	}
+}
+
+// beginAPIKeyReplace switches from the fixed-length mask placeholder to edit
+// mode so the next keystroke or paste fully replaces the saved key. While
+// editing, EchoPassword shows one '*' per typed character.
+func (m *providerTUIModel) beginAPIKeyReplace() {
+	if !m.apiKeyMasked {
+		return
+	}
+	m.apiKeyMasked = false
+	m.apiKeyOriginal = ""
+	m.apiKeyInput.SetValue("")
+}
+
+// beginManualTokenReplace is the manual-tab equivalent of beginAPIKeyReplace.
+func (m *providerTUIModel) beginManualTokenReplace() {
+	if !m.manualTokenMasked {
+		return
+	}
+	m.manualTokenMasked = false
+	m.manualTokenOriginal = ""
+	m.manualTokenInput.SetValue("")
 }
 
 // refreshModelSelectionForCustom moves the cursor to "Enter custom model name..."
@@ -666,12 +747,7 @@ func (m providerTUIModel) updateAPIKeyInput(key string, msg tea.KeyPressMsg) (te
 		return m, tea.Quit
 	default:
 		if m.apiKeyMasked {
-			if len(key) == 1 {
-				m.apiKeyMasked = false
-				m.apiKeyInput.SetValue("")
-			} else {
-				return m, nil
-			}
+			m.beginAPIKeyReplace()
 		}
 		var cmd tea.Cmd
 		m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
@@ -727,12 +803,7 @@ func (m providerTUIModel) updateCustomProviderForm(key string, msg tea.KeyPressM
 		}
 		if m.cpStep == cpStepAPIKey {
 			if m.apiKeyMasked {
-				if len(key) == 1 {
-					m.apiKeyMasked = false
-					m.apiKeyInput.SetValue("")
-				} else {
-					return m, nil
-				}
+				m.beginAPIKeyReplace()
 			}
 			var cmd tea.Cmd
 			m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
@@ -760,7 +831,7 @@ func (m *providerTUIModel) enterEditCustomProvider() {
 	if entry.APIKey != "" {
 		m.apiKeyOriginal = entry.APIKey
 		m.apiKeyMasked = true
-		m.apiKeyInput.SetValue(strings.Repeat("*", 20))
+		m.apiKeyInput.SetValue(maskedSecretPlaceholder())
 	} else {
 		m.apiKeyInput.SetValue("")
 		m.apiKeyMasked = false
@@ -1059,7 +1130,9 @@ func (m providerTUIModel) passThroughCPInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case cpStepBaseURL:
 		m.cpURLInput, cmd = m.cpURLInput.Update(msg)
 	case cpStepAPIKey:
-		// masked unlock is handled in updateCustomProviderForm default branch
+		if m.apiKeyMasked && isUserEditMsg(msg) {
+			m.beginAPIKeyReplace()
+		}
 		m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
 	case cpStepAuthHeader:
 		m.cpAuthInput, cmd = m.cpAuthInput.Update(msg)
@@ -1086,7 +1159,7 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 				if m.existingCfg.Llm.AuthToken != "" {
 					m.manualTokenOriginal = m.existingCfg.Llm.AuthToken
 					m.manualTokenMasked = true
-					m.manualTokenInput.SetValue(strings.Repeat("*", 20))
+					m.manualTokenInput.SetValue(maskedSecretPlaceholder())
 				} else {
 					m.manualTokenInput.SetValue("")
 					m.manualTokenMasked = false
@@ -1125,12 +1198,7 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 			}
 		}
 		if m.manualStep == manualStepAuthToken && m.manualTokenMasked {
-			if len(key) == 1 {
-				m.manualTokenMasked = false
-				m.manualTokenInput.SetValue("")
-			} else {
-				return m, nil
-			}
+			m.beginManualTokenReplace()
 		}
 		return m.passThroughManualInput(msg)
 	}
@@ -1322,6 +1390,9 @@ func (m providerTUIModel) passThroughManualInput(msg tea.Msg) (tea.Model, tea.Cm
 	case manualStepModel:
 		m.manualModelInput, cmd = m.manualModelInput.Update(msg)
 	case manualStepAuthToken:
+		if m.manualTokenMasked && isUserEditMsg(msg) {
+			m.beginManualTokenReplace()
+		}
 		m.manualTokenInput, cmd = m.manualTokenInput.Update(msg)
 	case manualStepAuthHeader:
 		m.manualAuthHeaderInput, cmd = m.manualAuthHeaderInput.Update(msg)
@@ -1452,7 +1523,7 @@ func (m *providerTUIModel) loadExistingAPIKey() {
 		if cp, ok := m.selectedCustomProvider(); ok && cp.entry.APIKey != "" {
 			m.apiKeyOriginal = cp.entry.APIKey
 			m.apiKeyMasked = true
-			m.apiKeyInput.SetValue(strings.Repeat("*", 20))
+			m.apiKeyInput.SetValue(maskedSecretPlaceholder())
 		}
 		return
 	}
@@ -1463,7 +1534,7 @@ func (m *providerTUIModel) loadExistingAPIKey() {
 	if entry, ok := m.existingCfg.Providers[p.Name]; ok && entry.APIKey != "" {
 		m.apiKeyOriginal = entry.APIKey
 		m.apiKeyMasked = true
-		m.apiKeyInput.SetValue(strings.Repeat("*", 20))
+		m.apiKeyInput.SetValue(maskedSecretPlaceholder())
 	}
 }
 
@@ -1750,6 +1821,9 @@ func (m providerTUIModel) viewCustomProviderForm(s *strings.Builder) {
 				s.WriteString("    " + m.cpURLInput.View() + "\n")
 			case cpStepAPIKey:
 				s.WriteString("    " + m.apiKeyInput.View() + "\n")
+				if m.apiKeyMasked && m.apiKeyOriginal != "" {
+					s.WriteString(tuiDimStyle.Render("    "+savedSecretReplaceHint(m.apiKeyOriginal)) + "\n")
+				}
 			case cpStepAuthHeader:
 				s.WriteString("    " + m.cpAuthInput.View() + "\n")
 			}
@@ -1827,6 +1901,9 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 				s.WriteString("    " + m.manualModelInput.View() + "\n")
 			case manualStepAuthToken:
 				s.WriteString("    " + m.manualTokenInput.View() + "\n")
+				if m.manualTokenMasked && m.manualTokenOriginal != "" {
+					s.WriteString(tuiDimStyle.Render("    "+savedSecretReplaceHint(m.manualTokenOriginal)) + "\n")
+				}
 			case manualStepAuthHeader:
 				s.WriteString("    " + m.manualAuthHeaderInput.View() + "\n")
 			}
@@ -1910,6 +1987,16 @@ func (m providerTUIModel) viewAPIKey(s *strings.Builder) {
 	s.WriteString("  " + m.apiKeyInput.View())
 	s.WriteString("\n")
 
+	// When an API key is already saved, the input starts masked. Surface a
+	// hint so the user knows typing or pasting will replace the saved key,
+	// and show a short prefix fingerprint so they can sanity-check which key
+	// is currently saved without exposing it.
+	if m.apiKeyMasked && m.apiKeyOriginal != "" {
+		s.WriteString("\n")
+		s.WriteString(tuiDimStyle.Render(savedSecretReplaceHintLine(m.apiKeyOriginal)))
+		s.WriteString("\n")
+	}
+
 	if m.activeTab == tabOfficial {
 		provider := m.currentProvider()
 		if envKey := os.Getenv(provider.EnvVar); envKey != "" {
@@ -1926,6 +2013,48 @@ func (m providerTUIModel) viewAPIKey(s *strings.Builder) {
 	s.WriteString("\n")
 	s.WriteString(tuiHelpStyle.Render("  Enter Confirm  Esc Back"))
 	s.WriteString("\n")
+}
+
+// savedSecretFingerprintMinHiddenLen is the minimum number of runes that must
+// sit between the visible prefix and suffix so the fingerprint does not expose
+// the entire key (e.g. a 10-rune key with prefix 6 + suffix 4).
+const savedSecretFingerprintMinHiddenLen = 5
+
+// savedSecretFingerprintMinLen is the minimum trimmed secret length required
+// before a fingerprint is shown. Shorter keys hide the parenthetical hint.
+const savedSecretFingerprintMinLen = savedSecretFingerprintPrefixLen + savedSecretFingerprintSuffixLen + savedSecretFingerprintMinHiddenLen
+
+// savedSecretFingerprintPrefixLen is how many leading runes to show.
+const savedSecretFingerprintPrefixLen = 6
+
+// savedSecretFingerprintSuffixLen is how many trailing runes to show.
+const savedSecretFingerprintSuffixLen = 4
+
+// savedSecretFingerprint returns a short fingerprint for display, e.g.
+// "sk-a1b2...wxyz" (first 6 + "..." + last 4). Returns "" when the trimmed
+// secret is shorter than savedSecretFingerprintMinLen runes.
+func savedSecretFingerprint(s string) string {
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) < savedSecretFingerprintMinLen {
+		return ""
+	}
+	prefix := string(runes[:savedSecretFingerprintPrefixLen])
+	suffix := string(runes[len(runes)-savedSecretFingerprintSuffixLen:])
+	return prefix + "..." + suffix
+}
+
+// savedSecretReplaceHint builds the replace hint text without leading indent.
+func savedSecretReplaceHint(original string) string {
+	hint := "Type or paste to replace the saved key."
+	if fp := savedSecretFingerprint(original); fp != "" {
+		hint += fmt.Sprintf("  (saved: %s)", fp)
+	}
+	return hint
+}
+
+func savedSecretReplaceHintLine(original string) string {
+	return "  " + savedSecretReplaceHint(original)
 }
 
 // --- Styles ---

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -330,12 +330,97 @@ func (m providerTUIModel) modelProviderName() string {
 	return provider.Name
 }
 
+func isUserAddedOfficialModelName(name, providerName string, registryModels []string, cfg *Config) bool {
+	if providerName == "" || cfg == nil {
+		return false
+	}
+	if llm.ModelListContains(registryModels, name) {
+		return false
+	}
+	entry, ok := cfg.Providers[providerName]
+	if !ok {
+		return false
+	}
+	return llm.ModelListContains(entry.Models, name)
+}
+
+func registryModelsForProvider(name string, fallback []string) []string {
+	if preset, ok := llm.LookupProvider(name); ok {
+		return append([]string(nil), preset.Models...)
+	}
+	if len(fallback) == 0 {
+		return nil
+	}
+	return append([]string(nil), fallback...)
+}
+
+func applyModelDeleteToEntry(entry ProviderEntry, name string) ProviderEntry {
+	entry.Models = removeModels(entry.Models, []string{name})
+	if entry.Model == name {
+		entry.Model = ""
+	}
+	return entry
+}
+
+func clearCfgActiveModelIfDeleted(cfg *Config, providerName, name string) {
+	if cfg != nil && cfg.Provider == providerName && cfg.Model == name {
+		cfg.Model = ""
+	}
+}
+
+func rollbackCfgActiveModel(cfg *Config, providerName, prevModel string) {
+	if cfg != nil && cfg.Provider == providerName {
+		cfg.Model = prevModel
+	}
+}
+
+func (m *modelTUIModel) rollbackModelDelete(prevEntry ProviderEntry, prevCfgModel string) {
+	if m.existingCfg == nil {
+		return
+	}
+	if m.isCustomProvider {
+		m.existingCfg.CustomProviders[m.providerName] = prevEntry
+		m.syncModelsFromConfig()
+	} else {
+		m.existingCfg.Providers[m.providerName] = prevEntry
+	}
+	rollbackCfgActiveModel(m.existingCfg, m.providerName, prevCfgModel)
+}
+
+func (m providerTUIModel) isUserAddedOfficialModel(name string) bool {
+	if m.activeTab != tabOfficial {
+		return false
+	}
+	provider := m.currentProvider()
+	return isUserAddedOfficialModelName(name, provider.Name, registryModelsForProvider(provider.Name, provider.Models), m.existingCfg)
+}
+
+// cursorOnDeletableModel reports whether the model-step cursor is on a row that
+// can be deleted (not on "Enter custom model name...").
+func (m providerTUIModel) cursorOnDeletableModel() bool {
+	if m.step != stepModel || m.confirmingDeleteModel {
+		return false
+	}
+	models := m.models()
+	if m.modelIdx >= len(models) {
+		return false
+	}
+	switch m.activeTab {
+	case tabCustom:
+		return m.customIdx < len(m.customProviders)
+	case tabOfficial:
+		return m.isUserAddedOfficialModel(models[m.modelIdx])
+	default:
+		return false
+	}
+}
+
 func (m providerTUIModel) models() []string {
 	switch m.activeTab {
 	case tabOfficial:
-		models := m.currentProvider().Models
+		provider := m.currentProvider()
+		models := registryModelsForProvider(provider.Name, provider.Models)
 		if m.existingCfg != nil {
-			provider := m.currentProvider()
 			if entry, ok := m.existingCfg.Providers[provider.Name]; ok {
 				models = mergeModelLists(models, entry.Models)
 			}
@@ -530,12 +615,11 @@ func (m providerTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.deleteTargetName = m.customProviders[m.customIdx].name
 				return m, nil
 			}
-			if m.step == stepModel && m.activeTab == tabCustom && m.customIdx < len(m.customProviders) {
+			if m.step == stepModel && m.cursorOnDeletableModel() {
 				models := m.models()
-				if m.modelIdx < len(models) {
-					m.confirmingDeleteModel = true
-					m.deleteModelName = models[m.modelIdx]
-				}
+				m.confirmingDeleteModel = true
+				m.deleteModelName = models[m.modelIdx]
+				return m, nil
 			}
 			return m, nil
 
@@ -584,11 +668,9 @@ func (m providerTUIModel) updateCustomModelInput(key string, msg tea.KeyPressMsg
 		if name == "" {
 			return m, nil
 		}
-		for _, existing := range m.models() {
-			if existing == name {
-				m.formError = fmt.Sprintf("Already in list: %s", name)
-				return m, nil
-			}
+		if llm.ModelListContains(m.models(), name) {
+			m.formError = fmt.Sprintf("Already in list: %s", name)
+			return m, nil
 		}
 		m.formError = ""
 		persisted, err := m.persistCustomModelName(name)
@@ -646,9 +728,11 @@ func (m *providerTUIModel) persistCustomModelName(name string) (bool, error) {
 		m.customProviders[m.customIdx] = cp
 		if m.configPath != "" {
 			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
-				m.existingCfg.CustomProviders[cp.name] = prevEntry
-				cp.entry = prevEntry
-				m.customProviders[m.customIdx] = cp
+				if !m.reloadConfigAfterSaveFailure() {
+					m.existingCfg.CustomProviders[cp.name] = prevEntry
+					cp.entry = prevEntry
+					m.customProviders[m.customIdx] = cp
+				}
 				return false, fmt.Errorf("failed to save models: %w", err)
 			}
 		}
@@ -672,7 +756,9 @@ func (m *providerTUIModel) persistCustomModelName(name string) (bool, error) {
 		// at display time, unlike custom tab where customProviders is the sole list.
 		if m.configPath != "" {
 			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
-				m.existingCfg.Providers[provider.Name] = prevEntry
+				if !m.reloadConfigAfterSaveFailure() {
+					m.existingCfg.Providers[provider.Name] = prevEntry
+				}
 				return false, fmt.Errorf("failed to save models: %w", err)
 			}
 		}
@@ -1255,50 +1341,14 @@ func (m providerTUIModel) updateDeleteConfirm(key string) (tea.Model, tea.Cmd) {
 func (m providerTUIModel) updateDeleteModelConfirm(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "y", "Y":
-		if m.customIdx >= len(m.customProviders) {
+		switch m.activeTab {
+		case tabCustom:
+			return m.confirmDeleteCustomModel()
+		case tabOfficial:
+			return m.confirmDeleteOfficialModel()
+		default:
 			m.confirmingDeleteModel = false
-			return m, nil
 		}
-		models := m.models()
-		if m.modelIdx < len(models) {
-			cp := m.customProviders[m.customIdx]
-			cp.entry.Models = removeModels(cp.entry.Models, []string{m.deleteModelName})
-			if cp.entry.Model == m.deleteModelName {
-				cp.entry.Model = ""
-			}
-			if m.existingCfg != nil && m.existingCfg.Provider == cp.name &&
-				m.existingCfg.Model == m.deleteModelName {
-				m.existingCfg.Model = ""
-			}
-			m.customProviders[m.customIdx] = cp
-			if m.existingCfg != nil {
-				if m.existingCfg.CustomProviders == nil {
-					m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
-				}
-				m.existingCfg.CustomProviders[cp.name] = cp.entry
-			}
-			if m.configPath != "" {
-				if err := saveConfig(m.configPath, m.existingCfg); err != nil {
-					if reloaded, reloadErr := loadOrCreateConfig(m.configPath); reloadErr == nil {
-						m.existingCfg = reloaded
-						m.customProviders = collectCustomProviders(reloaded)
-					}
-					m.formError = fmt.Sprintf("failed to save: %v", err)
-					m.confirmingDeleteModel = false
-					return m, nil
-				}
-			}
-			updated := m.models()
-			if m.modelIdx >= len(updated) {
-				if len(updated) > 0 {
-					m.modelIdx = len(updated) - 1
-				} else {
-					m.modelIdx = 0
-				}
-			}
-		}
-		m.savedInSession = true
-		m.confirmingDeleteModel = false
 		return m, nil
 	case "n", "N", "esc":
 		m.confirmingDeleteModel = false
@@ -1308,6 +1358,118 @@ func (m providerTUIModel) updateDeleteModelConfirm(key string) (tea.Model, tea.C
 		return m, tea.Quit
 	}
 	return m, nil
+}
+
+func (m providerTUIModel) confirmDeleteCustomModel() (tea.Model, tea.Cmd) {
+	if m.customIdx >= len(m.customProviders) {
+		m.confirmingDeleteModel = false
+		return m, nil
+	}
+	models := m.models()
+	if m.modelIdx < len(models) {
+		cp := m.customProviders[m.customIdx]
+		prevEntry := cloneProviderEntry(cp.entry)
+		prevCfgModel := ""
+		if m.existingCfg != nil && m.existingCfg.Provider == cp.name {
+			prevCfgModel = m.existingCfg.Model
+		}
+		cp.entry = applyModelDeleteToEntry(cp.entry, m.deleteModelName)
+		clearCfgActiveModelIfDeleted(m.existingCfg, cp.name, m.deleteModelName)
+		m.customProviders[m.customIdx] = cp
+		if m.existingCfg != nil {
+			if m.existingCfg.CustomProviders == nil {
+				m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
+			}
+			m.existingCfg.CustomProviders[cp.name] = cp.entry
+		}
+		if m.configPath != "" {
+			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+				if !m.reloadConfigAfterSaveFailure() {
+					cp.entry = prevEntry
+					m.customProviders[m.customIdx] = cp
+					if m.existingCfg != nil {
+						m.existingCfg.CustomProviders[cp.name] = prevEntry
+						rollbackCfgActiveModel(m.existingCfg, cp.name, prevCfgModel)
+					}
+				}
+				m.formError = fmt.Sprintf("failed to save: %v", err)
+				m.adjustModelIdxAfterDelete()
+				m.confirmingDeleteModel = false
+				return m, nil
+			}
+		}
+		m.adjustModelIdxAfterDelete()
+		m.savedInSession = true
+	}
+	m.confirmingDeleteModel = false
+	return m, nil
+}
+
+func (m providerTUIModel) confirmDeleteOfficialModel() (tea.Model, tea.Cmd) {
+	if !m.isUserAddedOfficialModel(m.deleteModelName) {
+		m.confirmingDeleteModel = false
+		return m, nil
+	}
+	provider := m.currentProvider()
+	if m.existingCfg == nil || provider.Name == "" {
+		m.confirmingDeleteModel = false
+		return m, nil
+	}
+	if m.existingCfg.Providers == nil {
+		m.existingCfg.Providers = make(map[string]ProviderEntry)
+	}
+	prevEntry := cloneProviderEntry(m.existingCfg.Providers[provider.Name])
+	prevCfgModel := ""
+	if m.existingCfg.Provider == provider.Name {
+		prevCfgModel = m.existingCfg.Model
+	}
+	entry := applyModelDeleteToEntry(m.existingCfg.Providers[provider.Name], m.deleteModelName)
+	clearCfgActiveModelIfDeleted(m.existingCfg, provider.Name, m.deleteModelName)
+	m.existingCfg.Providers[provider.Name] = entry
+	if m.configPath != "" {
+		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+			if !m.reloadConfigAfterSaveFailure() {
+				m.existingCfg.Providers[provider.Name] = prevEntry
+				rollbackCfgActiveModel(m.existingCfg, provider.Name, prevCfgModel)
+			}
+			m.formError = fmt.Sprintf("failed to save: %v", err)
+			m.adjustModelIdxAfterDelete()
+			m.confirmingDeleteModel = false
+			return m, nil
+		}
+	}
+	m.adjustModelIdxAfterDelete()
+	// In-memory delete succeeded; configPath may be empty in tests (no disk write).
+	m.savedInSession = true
+	m.confirmingDeleteModel = false
+	return m, nil
+}
+
+func (m *providerTUIModel) adjustModelIdxAfterDelete() {
+	updated := m.models()
+	if m.modelIdx >= len(updated) {
+		if len(updated) > 0 {
+			m.modelIdx = len(updated) - 1
+		} else {
+			m.modelIdx = 0
+		}
+	}
+}
+
+// reloadConfigAfterSaveFailure reloads on-disk config and refreshes derived
+// provider TUI state so the UI matches persisted data after a failed save.
+// Returns false when reload could not run (e.g. missing/invalid config path).
+func (m *providerTUIModel) reloadConfigAfterSaveFailure() bool {
+	if m.configPath == "" {
+		return false
+	}
+	reloaded, err := loadOrCreateConfig(m.configPath)
+	if err != nil {
+		return false
+	}
+	m.existingCfg = reloaded
+	m.customProviders = collectCustomProviders(reloaded)
+	return true
 }
 
 func (m providerTUIModel) handleManualFormEnter() (tea.Model, tea.Cmd) {
@@ -1647,11 +1809,28 @@ func listCursorPrefix(isCursor bool) string {
 	return "    "
 }
 
+func listCursorPrefixForModel(isCursor, userAdded bool) string {
+	if !isCursor {
+		return "    "
+	}
+	if userAdded {
+		return "  " + tuiUserModelCursorStyle.Render(tuiCursor) + " "
+	}
+	return listCursorPrefix(true)
+}
+
 func renderListName(name string, isCursor bool) string {
 	if isCursor {
 		return tuiSelectedItemStyle.Render(name)
 	}
 	return tuiItemStyle.Render(name)
+}
+
+func renderModelName(name string, isCursor, userAdded bool) string {
+	if isCursor && userAdded {
+		return tuiUserModelSelectedStyle.Render(name)
+	}
+	return renderListName(name, isCursor)
 }
 
 // --- View ---
@@ -1744,8 +1923,11 @@ func (m providerTUIModel) viewCustomTab(s *strings.Builder) {
 	for i, cp := range m.customProviders {
 		isCursor := i == m.customIdx
 		activeModel := m.customProviderActiveModel(cp)
+		// userAdded here means "green highlight when selected" for user-managed rows.
+		highlight := isCursor
 
-		s.WriteString(listCursorPrefix(isCursor) + renderListName(cp.name, isCursor))
+		s.WriteString(listCursorPrefixForModel(isCursor, highlight))
+		s.WriteString(renderModelName(cp.name, isCursor, highlight))
 		if activeModel != "" {
 			s.WriteString("  " + tuiDimStyle.Render("("+activeModel+")"))
 		}
@@ -1935,7 +2117,16 @@ func (m providerTUIModel) viewModel(s *strings.Builder) {
 
 	for i, model := range models {
 		isCursor := i == m.modelIdx
-		s.WriteString(listCursorPrefix(isCursor) + renderListName(model, isCursor))
+		if m.activeTab == tabOfficial {
+			userAdded := m.isUserAddedOfficialModel(model)
+			s.WriteString(listCursorPrefixForModel(isCursor, userAdded))
+			s.WriteString(renderModelName(model, isCursor, userAdded))
+		} else {
+			// Custom tab: all models are user-managed; pass isCursor as userAdded
+			// so green highlight applies only to the selected row (not registry semantics).
+			s.WriteString(listCursorPrefixForModel(isCursor, isCursor))
+			s.WriteString(renderModelName(model, isCursor, isCursor))
+		}
 		s.WriteString("\n")
 	}
 
@@ -1965,7 +2156,7 @@ func (m providerTUIModel) viewModel(s *strings.Builder) {
 		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))
 		s.WriteString("\n")
 		s.WriteString(tuiHelpStyle.Render("  y Confirm · n/Esc Cancel"))
-	} else if m.activeTab == tabCustom && m.customIdx < len(m.customProviders) {
+	} else if m.cursorOnDeletableModel() {
 		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  d Delete  Esc Back"))
 	} else {
 		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  Esc Back"))
@@ -2073,6 +2264,13 @@ var (
 				Bold(true).
 				Foreground(lipgloss.Color("12"))
 
+	tuiUserModelSelectedStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("10"))
+
+	tuiUserModelCursorStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("10"))
+
 	tuiItemStyle = lipgloss.NewStyle()
 
 	tuiDimStyle = lipgloss.NewStyle().
@@ -2094,6 +2292,16 @@ var (
 
 // --- Model-only TUI (for `ocr config model`) ---
 
+type modelTUIConfig struct {
+	Provider       llm.Provider
+	CurrentModel   string
+	RegistryModels []string
+	ExistingCfg    *Config
+	ConfigPath     string
+	ProviderName   string
+	IsCustom       bool
+}
+
 type modelTUIModel struct {
 	width  int
 	height int
@@ -2105,40 +2313,219 @@ type modelTUIModel struct {
 	modelInput  textinput.Model
 	activeModel string
 
+	registryModels   []string
+	existingCfg      *Config
+	configPath       string
+	providerName     string
+	isCustomProvider bool
+
+	confirmingDeleteModel bool
+	deleteModelName       string
+	formError             string
+
 	confirmed bool
 	cancelled bool
+
+	// savedInSession is true after a model add/delete was persisted during the session.
+	savedInSession bool
 }
 
+// newModelTUI builds a model-only TUI for tests. It has no config path or existing
+// config, so add/delete/persist operations are unavailable — use newModelTUIConfig
+// in production (ocr config model). IsCustom follows whether the provider is a preset.
 func newModelTUI(provider llm.Provider, currentModel string) modelTUIModel {
+	registryModels := append([]string(nil), provider.Models...)
+	isCustom := true
+	if preset, ok := llm.LookupProvider(provider.Name); ok {
+		isCustom = false
+		registryModels = append([]string(nil), preset.Models...)
+	}
+	return newModelTUIConfig(modelTUIConfig{
+		Provider:       provider,
+		CurrentModel:   currentModel,
+		ProviderName:   provider.Name,
+		RegistryModels: registryModels,
+		IsCustom:       isCustom,
+	})
+}
+
+func newModelTUIConfig(cfg modelTUIConfig) modelTUIModel {
 	mi := textinput.New()
 	mi.Placeholder = "model name(s), comma-separated"
 	mi.SetWidth(50)
 
 	m := modelTUIModel{
-		provider:    provider,
-		models:      provider.Models,
-		width:       80,
-		height:      24,
-		modelInput:  mi,
-		activeModel: currentModel,
+		provider:         cfg.Provider,
+		width:            80,
+		height:           24,
+		modelInput:       mi,
+		activeModel:      cfg.CurrentModel,
+		registryModels:   append([]string(nil), cfg.RegistryModels...),
+		existingCfg:      cfg.ExistingCfg,
+		configPath:       cfg.ConfigPath,
+		providerName:     cfg.ProviderName,
+		isCustomProvider: cfg.IsCustom,
 	}
 
-	if currentModel != "" {
+	if cfg.IsCustom {
+		m.models = append([]string(nil), cfg.Provider.Models...)
+	}
+
+	if cfg.CurrentModel != "" {
 		found := false
-		for i, model := range m.models {
-			if model == currentModel {
+		models := m.displayModels()
+		for i, model := range models {
+			if model == cfg.CurrentModel {
 				m.modelIdx = i
 				found = true
 				break
 			}
 		}
 		if !found {
-			m.modelIdx = len(m.models)
-			m.modelInput.SetValue(currentModel)
+			m.modelIdx = len(models)
+			m.modelInput.SetValue(cfg.CurrentModel)
 		}
 	}
 
 	return m
+}
+
+func (m modelTUIModel) displayModels() []string {
+	// Custom providers store the list in m.models (updated on add/delete).
+	// Official providers derive the list from registry + config on each call.
+	if m.isCustomProvider {
+		return m.models
+	}
+	models := append([]string(nil), m.registryModels...)
+	if m.existingCfg != nil && m.providerName != "" {
+		if entry, ok := m.existingCfg.Providers[m.providerName]; ok {
+			models = mergeModelLists(models, entry.Models)
+		}
+	}
+	return models
+}
+
+func (m modelTUIModel) isUserAddedModel(name string) bool {
+	if m.isCustomProvider {
+		// Custom providers have no llm registry; every model comes from config and
+		// is user-managed. List membership guards confirm against stale names.
+		return llm.ModelListContains(m.displayModels(), name)
+	}
+	return isUserAddedOfficialModelName(name, m.providerName, m.registryModels, m.existingCfg)
+}
+
+func (m modelTUIModel) cursorOnUserAddedModel() bool {
+	if m.confirmingDeleteModel {
+		return false
+	}
+	models := m.displayModels()
+	if m.modelIdx >= len(models) {
+		return false
+	}
+	if m.isCustomProvider {
+		return true
+	}
+	return m.isUserAddedModel(models[m.modelIdx])
+}
+
+func (m *modelTUIModel) adjustModelIdxAfterDelete() {
+	m.syncModelsFromConfig()
+	models := m.displayModels()
+	if m.modelIdx >= len(models) {
+		if len(models) > 0 {
+			m.modelIdx = len(models) - 1
+		} else {
+			m.modelIdx = 0
+		}
+	}
+}
+
+// reloadConfigAfterSaveFailure reloads on-disk config so in-memory state matches
+// persisted data after a failed save. Returns false when reload could not run.
+func (m *modelTUIModel) reloadConfigAfterSaveFailure() bool {
+	if m.configPath == "" {
+		return false
+	}
+	reloaded, err := loadOrCreateConfig(m.configPath)
+	if err != nil {
+		return false
+	}
+	m.existingCfg = reloaded
+	m.syncModelsFromConfig()
+	return true
+}
+
+func (m *modelTUIModel) syncModelsFromConfig() {
+	if !m.isCustomProvider || m.existingCfg == nil || m.providerName == "" {
+		return
+	}
+	if entry, ok := m.existingCfg.CustomProviders[m.providerName]; ok {
+		m.models = append([]string(nil), entry.Models...)
+	}
+}
+
+func (m *modelTUIModel) refreshModelSelectionAfterAdd(name string) {
+	models := m.displayModels()
+	for i, model := range models {
+		if model == name {
+			m.modelIdx = i
+			return
+		}
+	}
+	if len(models) > 0 {
+		m.modelIdx = len(models) - 1
+	} else {
+		m.modelIdx = 0
+	}
+}
+
+// persistAddedModelName appends a model to the provider's Models list in config
+// and saves to disk. It does not change the active model.
+func (m *modelTUIModel) persistAddedModelName(name string) error {
+	if name == "" {
+		return fmt.Errorf("model name must not be empty")
+	}
+	if m.existingCfg == nil || m.providerName == "" {
+		return fmt.Errorf("config not available")
+	}
+	if m.isCustomProvider {
+		if m.existingCfg.CustomProviders == nil {
+			m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
+		}
+		entry := m.existingCfg.CustomProviders[m.providerName]
+		prevEntry := cloneProviderEntry(entry)
+		entry.Models = ensureModelInList(entry.Models, name)
+		m.existingCfg.CustomProviders[m.providerName] = entry
+		if m.configPath != "" {
+			if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+				if !m.reloadConfigAfterSaveFailure() {
+					m.existingCfg.CustomProviders[m.providerName] = prevEntry
+					m.models = append([]string(nil), prevEntry.Models...)
+				}
+				return fmt.Errorf("failed to save models: %w", err)
+			}
+		}
+		m.models = append([]string(nil), entry.Models...)
+		m.savedInSession = true
+		return nil
+	}
+	if m.existingCfg.Providers == nil {
+		m.existingCfg.Providers = make(map[string]ProviderEntry)
+	}
+	entry := m.existingCfg.Providers[m.providerName]
+	prevEntry := cloneProviderEntry(entry)
+	entry.Models = ensureModelInList(entry.Models, name)
+	m.existingCfg.Providers[m.providerName] = entry
+	if m.configPath != "" {
+		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+			if !m.reloadConfigAfterSaveFailure() {
+				m.existingCfg.Providers[m.providerName] = prevEntry
+			}
+			return fmt.Errorf("failed to save models: %w", err)
+		}
+	}
+	m.savedInSession = true
+	return nil
 }
 
 func (m modelTUIModel) Init() tea.Cmd {
@@ -2146,11 +2533,11 @@ func (m modelTUIModel) Init() tea.Cmd {
 }
 
 func (m modelTUIModel) isCustomItem(idx int) bool {
-	return idx == len(m.models)
+	return idx == len(m.displayModels())
 }
 
 func (m modelTUIModel) itemCount() int {
-	return len(m.models) + 1
+	return len(m.displayModels()) + 1
 }
 
 func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -2163,6 +2550,10 @@ func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		key := msg.String()
 
+		if m.confirmingDeleteModel {
+			return m.updateDeleteModelConfirm(key)
+		}
+
 		if m.customModel {
 			switch key {
 			case "esc":
@@ -2171,14 +2562,28 @@ func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.modelInput.SetValue("")
 				return m, nil
 			case "enter":
-				if m.modelInput.Value() != "" {
-					m.confirmed = true
-					return m, tea.Quit
+				name := strings.TrimSpace(m.modelInput.Value())
+				if name == "" {
+					return m, nil
 				}
+				if llm.ModelListContains(m.displayModels(), name) {
+					m.formError = fmt.Sprintf("Already in list: %s", name)
+					return m, nil
+				}
+				m.formError = ""
+				if err := m.persistAddedModelName(name); err != nil {
+					m.formError = err.Error()
+					return m, nil
+				}
+				m.customModel = false
+				m.modelInput.Blur()
+				m.modelInput.SetValue("")
+				m.refreshModelSelectionAfterAdd(name)
 				return m, nil
 			default:
 				var cmd tea.Cmd
 				m.modelInput, cmd = m.modelInput.Update(msg)
+				m.formError = ""
 				return m, cmd
 			}
 		}
@@ -2208,6 +2613,13 @@ func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.modelIdx = 0
 			}
 			return m, nil
+		case "d":
+			if m.cursorOnUserAddedModel() {
+				models := m.displayModels()
+				m.confirmingDeleteModel = true
+				m.deleteModelName = models[m.modelIdx]
+			}
+			return m, nil
 		}
 
 	default:
@@ -2220,12 +2632,116 @@ func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *modelTUIModel) updateDeleteModelConfirm(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "y", "Y":
+		return m.confirmDeleteModel()
+	case "n", "N", "esc":
+		m.confirmingDeleteModel = false
+		return *m, nil
+	case "ctrl+c":
+		m.cancelled = true
+		return *m, tea.Quit
+	}
+	return *m, nil
+}
+
+func (m *modelTUIModel) confirmDeleteModel() (tea.Model, tea.Cmd) {
+	if m.isCustomProvider {
+		return m.confirmDeleteCustomProviderModel()
+	}
+	return m.confirmDeleteOfficialModel()
+}
+
+func (m *modelTUIModel) confirmDeleteCustomProviderModel() (tea.Model, tea.Cmd) {
+	if !m.isUserAddedModel(m.deleteModelName) {
+		m.confirmingDeleteModel = false
+		return *m, nil
+	}
+	if m.existingCfg == nil || m.providerName == "" {
+		m.confirmingDeleteModel = false
+		return *m, nil
+	}
+	if m.existingCfg.CustomProviders == nil {
+		m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
+	}
+	prevEntry := cloneProviderEntry(m.existingCfg.CustomProviders[m.providerName])
+	prevCfgModel := ""
+	if m.existingCfg.Provider == m.providerName {
+		prevCfgModel = m.existingCfg.Model
+	}
+	entry := applyModelDeleteToEntry(m.existingCfg.CustomProviders[m.providerName], m.deleteModelName)
+	clearCfgActiveModelIfDeleted(m.existingCfg, m.providerName, m.deleteModelName)
+	m.existingCfg.CustomProviders[m.providerName] = entry
+	if m.configPath != "" {
+		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+			if !m.reloadConfigAfterSaveFailure() {
+				m.rollbackModelDelete(prevEntry, prevCfgModel)
+			}
+			m.formError = fmt.Sprintf("failed to save: %v", err)
+			m.adjustModelIdxAfterDelete()
+			m.confirmingDeleteModel = false
+			return *m, nil
+		}
+	}
+	m.adjustModelIdxAfterDelete()
+	m.resetCustomModelInput()
+	m.savedInSession = true
+	m.confirmingDeleteModel = false
+	return *m, nil
+}
+
+func (m *modelTUIModel) confirmDeleteOfficialModel() (tea.Model, tea.Cmd) {
+	if !m.isUserAddedModel(m.deleteModelName) {
+		m.confirmingDeleteModel = false
+		return *m, nil
+	}
+	if m.existingCfg == nil || m.providerName == "" {
+		m.confirmingDeleteModel = false
+		return *m, nil
+	}
+	if m.existingCfg.Providers == nil {
+		m.existingCfg.Providers = make(map[string]ProviderEntry)
+	}
+	prevEntry := cloneProviderEntry(m.existingCfg.Providers[m.providerName])
+	prevCfgModel := ""
+	if m.existingCfg.Provider == m.providerName {
+		prevCfgModel = m.existingCfg.Model
+	}
+	entry := applyModelDeleteToEntry(m.existingCfg.Providers[m.providerName], m.deleteModelName)
+	clearCfgActiveModelIfDeleted(m.existingCfg, m.providerName, m.deleteModelName)
+	m.existingCfg.Providers[m.providerName] = entry
+	if m.configPath != "" {
+		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
+			if !m.reloadConfigAfterSaveFailure() {
+				m.rollbackModelDelete(prevEntry, prevCfgModel)
+			}
+			m.formError = fmt.Sprintf("failed to save: %v", err)
+			m.adjustModelIdxAfterDelete()
+			m.confirmingDeleteModel = false
+			return *m, nil
+		}
+	}
+	m.adjustModelIdxAfterDelete()
+	m.resetCustomModelInput()
+	m.savedInSession = true
+	m.confirmingDeleteModel = false
+	return *m, nil
+}
+
+func (m *modelTUIModel) resetCustomModelInput() {
+	m.customModel = false
+	m.modelInput.SetValue("")
+	m.modelInput.Blur()
+}
+
 func (m modelTUIModel) selectedModel() string {
 	if m.customModel || m.isCustomItem(m.modelIdx) {
 		return m.modelInput.Value()
 	}
-	if m.modelIdx < len(m.models) {
-		return m.models[m.modelIdx]
+	models := m.displayModels()
+	if m.modelIdx < len(models) {
+		return models[m.modelIdx]
 	}
 	return ""
 }
@@ -2236,13 +2752,22 @@ func (m modelTUIModel) View() tea.View {
 	s.WriteString(tuiTitleStyle.Render(fmt.Sprintf("  Select a model (%s)", m.provider.DisplayName)))
 	s.WriteString("\n\n")
 
-	for i, model := range m.models {
+	models := m.displayModels()
+	for i, model := range models {
 		isCursor := i == m.modelIdx
-		s.WriteString(listCursorPrefix(isCursor) + renderListName(model, isCursor))
+		if m.isCustomProvider {
+			// All models are user-managed; isCursor drives green highlight on selection.
+			s.WriteString(listCursorPrefixForModel(isCursor, isCursor))
+			s.WriteString(renderModelName(model, isCursor, isCursor))
+		} else {
+			userAdded := m.isUserAddedModel(model)
+			s.WriteString(listCursorPrefixForModel(isCursor, userAdded))
+			s.WriteString(renderModelName(model, isCursor, userAdded))
+		}
 		s.WriteString("\n")
 	}
 
-	customIdx := len(m.models)
+	customIdx := len(models)
 	isCursor := m.modelIdx == customIdx
 	customLabel := "Enter custom model name..."
 	if isCursor {
@@ -2258,8 +2783,23 @@ func (m modelTUIModel) View() tea.View {
 		s.WriteString("\n")
 	}
 
+	if m.formError != "" {
+		s.WriteString("\n")
+		s.WriteString(tuiErrorStyle.Render("  " + m.formError))
+		s.WriteString("\n")
+	}
+
 	s.WriteString("\n")
-	s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  Esc Cancel"))
+
+	if m.confirmingDeleteModel {
+		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))
+		s.WriteString("\n")
+		s.WriteString(tuiHelpStyle.Render("  y Confirm · n/Esc Cancel"))
+	} else if m.cursorOnUserAddedModel() {
+		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  d Delete  Esc Cancel"))
+	} else {
+		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  Esc Cancel"))
+	}
 	s.WriteString("\n")
 
 	v := tea.NewView(s.String())

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -182,6 +182,17 @@ func (m providerTUIModel) customProviderActiveModel(cp customProviderListItem) s
 	return activeModelForProvider(m.existingCfg, cp.name, entry)
 }
 
+func (m providerTUIModel) officialProviderActiveModel(p llm.Provider) string {
+	if m.existingCfg == nil || m.existingCfg.Provider != p.Name {
+		return ""
+	}
+	entry := ProviderEntry{}
+	if m.existingCfg.Providers != nil {
+		entry = m.existingCfg.Providers[p.Name]
+	}
+	return activeModelForProvider(m.existingCfg, p.Name, entry)
+}
+
 func collectCustomProviders(cfg *Config) []customProviderListItem {
 	if cfg == nil || cfg.CustomProviders == nil {
 		return nil
@@ -1997,6 +2008,9 @@ func (m providerTUIModel) viewOfficialTab(s *strings.Builder) {
 	for i, p := range m.providers {
 		isCursor := i == m.officialIdx
 		s.WriteString(listCursorPrefix(isCursor) + renderListName(p.DisplayName, isCursor))
+		if activeModel := m.officialProviderActiveModel(p); activeModel != "" {
+			s.WriteString("  " + tuiDimStyle.Render("("+activeModel+")"))
+		}
 		s.WriteString("\n")
 	}
 }

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -58,17 +58,50 @@ type customProviderListItem struct {
 }
 
 type providerTUIResult struct {
-	provider       string
-	model          string
-	models         []string
-	apiKey         string
-	isCustom       bool
-	isEdit         bool
-	editTargetName string
-	isManual       bool
-	url            string
-	protocol       string
-	authHeader     string
+	provider         string
+	model            string
+	models           []string
+	apiKey           string
+	isCustom         bool
+	isEdit           bool
+	editTargetName   string
+	isManual         bool
+	url              string
+	protocol         string
+	authHeader       string
+	sessionModelPick map[string]string
+}
+
+// resolvedModel returns the model to persist, falling back to the in-session pick
+// for the provider being finalized when result.model is empty.
+func (r providerTUIResult) resolvedModel() string {
+	if r.model != "" {
+		return r.model
+	}
+	if r.sessionModelPick != nil {
+		if pick, ok := r.sessionModelPick[r.provider]; ok && pick != "" {
+			return pick
+		}
+	}
+	return ""
+}
+
+func (m providerTUIModel) sessionModelPickFor(providerName string) string {
+	if providerName == "" || m.sessionModelPick == nil {
+		return ""
+	}
+	return m.sessionModelPick[providerName]
+}
+
+func (m providerTUIModel) sessionModelPickSnapshot() map[string]string {
+	if len(m.sessionModelPick) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m.sessionModelPick))
+	for k, v := range m.sessionModelPick {
+		out[k] = v
+	}
+	return out
 }
 
 type providerTUIModel struct {
@@ -120,6 +153,9 @@ type providerTUIModel struct {
 	cancelled      bool
 	formError      string
 	savedInSession bool
+	// sessionModelPick remembers model choices per provider during a wizard run
+	// without persisting inactive-provider selections to disk.
+	sessionModelPick map[string]string
 
 	// --- delete confirmation ---
 	confirmingDelete      bool
@@ -434,11 +470,18 @@ func (m providerTUIModel) models() []string {
 	return nil
 }
 
-func (m *providerTUIModel) prepareModelSelection(currentModel string) {
+func (m *providerTUIModel) prepareModelSelection(providerName, configModel string) {
 	m.modelIdx = 0
 	m.customModel = false
 	m.modelInput.Blur()
 	m.modelInput.SetValue("")
+
+	currentModel := configModel
+	if providerName != "" && m.sessionModelPick != nil {
+		if pick, ok := m.sessionModelPick[providerName]; ok && pick != "" {
+			currentModel = pick
+		}
+	}
 
 	models := m.models()
 	if currentModel == "" {
@@ -453,6 +496,32 @@ func (m *providerTUIModel) prepareModelSelection(currentModel string) {
 	}
 	m.modelIdx = len(models)
 	m.modelInput.SetValue(currentModel)
+}
+
+func (m providerTUIModel) providerNameForModelStep() string {
+	switch m.activeTab {
+	case tabOfficial:
+		return m.currentProvider().Name
+	case tabCustom:
+		if cp, ok := m.selectedCustomProvider(); ok {
+			return cp.name
+		}
+	}
+	return ""
+}
+
+func (m *providerTUIModel) recordSessionModelPick(model string) {
+	if model == "" {
+		return
+	}
+	name := m.providerNameForModelStep()
+	if name == "" {
+		return
+	}
+	if m.sessionModelPick == nil {
+		m.sessionModelPick = make(map[string]string)
+	}
+	m.sessionModelPick[name] = model
 }
 
 func (m *providerTUIModel) customProviderEntry(name string, fallback ProviderEntry) ProviderEntry {
@@ -472,43 +541,9 @@ func (m *providerTUIModel) syncSessionModelSelection() error {
 	if model == "" {
 		return nil
 	}
-
-	switch m.activeTab {
-	case tabCustom:
-		cp, ok := m.selectedCustomProvider()
-		if !ok {
-			return nil
-		}
-		entry := m.customProviderEntry(cp.name, cp.entry)
-		entry.Model = model
-		if m.existingCfg.CustomProviders == nil {
-			m.existingCfg.CustomProviders = make(map[string]ProviderEntry)
-		}
-		m.existingCfg.CustomProviders[cp.name] = entry
-		cp.entry = entry
-		m.customProviders[m.customIdx] = cp
-		if m.existingCfg.Provider == cp.name {
-			m.existingCfg.Model = model
-		}
-	case tabOfficial:
-		provider := m.currentProvider()
-		if m.existingCfg.Providers == nil {
-			m.existingCfg.Providers = make(map[string]ProviderEntry)
-		}
-		entry := m.existingCfg.Providers[provider.Name]
-		entry.Model = model
-		m.existingCfg.Providers[provider.Name] = entry
-		if m.existingCfg.Provider == provider.Name {
-			m.existingCfg.Model = model
-		}
-	}
-
-	if m.configPath != "" {
-		if err := saveConfig(m.configPath, m.existingCfg); err != nil {
-			return fmt.Errorf("failed to save: %w", err)
-		}
-	}
-	m.savedInSession = true
+	// Remember the pick for in-wizard navigation only; persist provider/model on
+	// final confirm (applyOfficialProviderConfig / applyCustomProviderConfig).
+	m.recordSessionModelPick(model)
 	return nil
 }
 
@@ -797,6 +832,15 @@ func (m *providerTUIModel) beginAPIKeyReplace() {
 	m.apiKeyInput.SetValue("")
 }
 
+// customAPIKeyForSave reports the API key to persist and whether the user edited
+// the field (vs left the masked placeholder untouched).
+func (m providerTUIModel) customAPIKeyForSave() (key string, edited bool) {
+	if m.apiKeyMasked {
+		return m.apiKeyOriginal, false
+	}
+	return strings.TrimSpace(m.apiKeyInput.Value()), true
+}
+
 // beginManualTokenReplace is the manual-tab equivalent of beginAPIKeyReplace.
 func (m *providerTUIModel) beginManualTokenReplace() {
 	if !m.manualTokenMasked {
@@ -818,6 +862,34 @@ func (m *providerTUIModel) refreshModelSelectionForCustom() {
 	m.modelIdx = len(models) // land on "Enter custom model name..."
 }
 
+func officialProviderEnvKeySet(p llm.Provider) bool {
+	return p.EnvVar != "" && os.Getenv(p.EnvVar) != ""
+}
+
+func officialAPIKeyRequiredError(p llm.Provider) string {
+	if p.EnvVar != "" {
+		return fmt.Sprintf("API key is required (or set $%s)", p.EnvVar)
+	}
+	return "API key is required"
+}
+
+func (m providerTUIModel) apiKeyStepCanConfirm() (ok bool, errMsg string) {
+	if m.apiKeyOriginal != "" {
+		return true, ""
+	}
+	if !m.apiKeyMasked && strings.TrimSpace(m.apiKeyInput.Value()) != "" {
+		return true, ""
+	}
+	if m.activeTab == tabOfficial {
+		p := m.currentProvider()
+		if officialProviderEnvKeySet(p) {
+			return true, ""
+		}
+		return false, officialAPIKeyRequiredError(p)
+	}
+	return false, "API key is required"
+}
+
 func (m providerTUIModel) updateAPIKeyInput(key string, msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc":
@@ -826,6 +898,11 @@ func (m providerTUIModel) updateAPIKeyInput(key string, msg tea.KeyPressMsg) (te
 		m.formError = ""
 		return m, nil
 	case "enter":
+		if ok, errMsg := m.apiKeyStepCanConfirm(); !ok {
+			m.formError = errMsg
+			return m, nil
+		}
+		m.formError = ""
 		m.confirmed = true
 		return m, tea.Quit
 	case "ctrl+c":
@@ -932,6 +1009,8 @@ func authHeaderFormError(raw string) string {
 	)
 }
 
+const manualAuthTokenRequiredError = "Auth token is required (whitespace-only input is not accepted)"
+
 func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 	switch m.cpStep {
 	case cpStepName:
@@ -984,11 +1063,14 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 			// Edit succeeded — drop the user into the model list for this provider.
 			m.editingCustom = false
 			m.editTargetName = ""
+			m.apiKeyInput.SetValue("")
+			m.apiKeyMasked = false
+			m.apiKeyOriginal = ""
 			if idx := m.findCustomIdx(r.provider); idx >= 0 {
 				m.customIdx = idx
 			}
 			m.step = stepModel
-			m.prepareModelSelection(m.customProviderEntry(r.provider, ProviderEntry{}).Model)
+			m.prepareModelSelection(r.provider, m.customProviderEntry(r.provider, ProviderEntry{}).Model)
 			return m, nil
 		}
 		if m.creatingCustom {
@@ -1029,9 +1111,7 @@ func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
 		URL:        r.url,
 		Protocol:   r.protocol,
 		AuthHeader: r.authHeader,
-	}
-	if r.apiKey != "" {
-		entry.APIKey = r.apiKey
+		APIKey:     strings.TrimSpace(m.apiKeyInput.Value()),
 	}
 	m.existingCfg.CustomProviders[r.provider] = entry
 
@@ -1057,7 +1137,7 @@ func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
 	// Drop into the model selection step so the user picks/adds a model for
 	// the newly created provider right away.
 	m.step = stepModel
-	m.prepareModelSelection("")
+	m.prepareModelSelection(r.provider, "")
 	return m, nil
 }
 
@@ -1134,8 +1214,8 @@ func (m *providerTUIModel) applyEditCustomProviderSave() error {
 	entry.URL = r.url
 	entry.Protocol = r.protocol
 	entry.AuthHeader = r.authHeader
-	if r.apiKey != "" {
-		entry.APIKey = r.apiKey
+	if key, edited := m.customAPIKeyForSave(); edited {
+		entry.APIKey = key
 	}
 	// If name changed, delete old key
 	if r.editTargetName != "" && r.editTargetName != r.provider {
@@ -1492,9 +1572,11 @@ func (m providerTUIModel) handleManualFormEnter() (tea.Model, tea.Cmd) {
 		m.manualStep = manualStepAuthToken
 		return m, m.manualTokenInput.Focus()
 	case manualStepAuthToken:
-		if m.manualTokenInput.Value() == "" && m.manualTokenOriginal == "" {
+		if strings.TrimSpace(m.manualTokenInput.Value()) == "" && m.manualTokenOriginal == "" {
+			m.formError = manualAuthTokenRequiredError
 			return m, nil
 		}
+		m.formError = ""
 		m.manualTokenInput.Blur()
 		m.manualStep = manualStepAuthHeader
 		return m, m.manualAuthHeaderInput.Focus()
@@ -1577,7 +1659,7 @@ func (m providerTUIModel) handleEnter() (tea.Model, tea.Cmd) {
 					currentModel = activeModelForProvider(m.existingCfg, m.currentProvider().Name, entry)
 				}
 			}
-			m.prepareModelSelection(currentModel)
+			m.prepareModelSelection(m.currentProvider().Name, currentModel)
 			return m, nil
 
 		case tabCustom:
@@ -1597,7 +1679,7 @@ func (m providerTUIModel) handleEnter() (tea.Model, tea.Cmd) {
 			cp := m.customProviders[m.customIdx]
 			m.step = stepModel
 			entry := m.customProviderEntry(cp.name, cp.entry)
-			m.prepareModelSelection(activeModelForProvider(m.existingCfg, cp.name, entry))
+			m.prepareModelSelection(cp.name, activeModelForProvider(m.existingCfg, cp.name, entry))
 			return m, nil
 
 		case tabManual:
@@ -1716,24 +1798,28 @@ func (m providerTUIModel) result() providerTUIResult {
 	case tabOfficial:
 		p := m.currentProvider()
 		model := m.selectedModelFromState()
+		if model == "" {
+			model = m.sessionModelPickFor(p.Name)
+		}
 
 		apiKey := ""
 		if m.apiKeyMasked {
 			apiKey = m.apiKeyOriginal
 		} else {
-			apiKey = m.apiKeyInput.Value()
+			apiKey = strings.TrimSpace(m.apiKeyInput.Value())
 		}
 
 		return providerTUIResult{
-			provider: p.Name,
-			model:    model,
-			apiKey:   apiKey,
+			provider:         p.Name,
+			model:            model,
+			apiKey:           apiKey,
+			sessionModelPick: m.sessionModelPickSnapshot(),
 		}
 
 	case tabCustom:
 		if m.creatingCustom || m.editingCustom {
 			protocol := cpProtocols[m.cpProtocolIdx]
-			apiKey := m.apiKeyInput.Value()
+			apiKey := strings.TrimSpace(m.apiKeyInput.Value())
 			if m.apiKeyMasked {
 				apiKey = m.apiKeyOriginal
 			}
@@ -1762,23 +1848,27 @@ func (m providerTUIModel) result() providerTUIResult {
 			cp := m.customProviders[m.customIdx]
 			model := m.selectedModelFromState()
 			if model == "" {
+				model = m.sessionModelPickFor(cp.name)
+			}
+			if model == "" {
 				model = cp.entry.Model
 			}
 			apiKey := ""
 			if m.apiKeyMasked {
 				apiKey = m.apiKeyOriginal
 			} else {
-				apiKey = m.apiKeyInput.Value()
+				apiKey = strings.TrimSpace(m.apiKeyInput.Value())
 			}
 			return providerTUIResult{
-				provider:   cp.name,
-				model:      model,
-				models:     append([]string(nil), cp.entry.Models...),
-				apiKey:     apiKey,
-				isCustom:   true,
-				url:        cp.entry.URL,
-				protocol:   cp.entry.Protocol,
-				authHeader: cp.entry.AuthHeader,
+				provider:         cp.name,
+				model:            model,
+				models:           append([]string(nil), cp.entry.Models...),
+				apiKey:           apiKey,
+				isCustom:         true,
+				url:              cp.entry.URL,
+				protocol:         cp.entry.Protocol,
+				authHeader:       cp.entry.AuthHeader,
+				sessionModelPick: m.sessionModelPickSnapshot(),
 			}
 		}
 		return providerTUIResult{}
@@ -2192,13 +2282,20 @@ func (m providerTUIModel) viewAPIKey(s *strings.Builder) {
 		provider := m.currentProvider()
 		if envKey := os.Getenv(provider.EnvVar); envKey != "" {
 			s.WriteString("\n")
-			s.WriteString(tuiDimStyle.Render(fmt.Sprintf("  $%s is set", provider.EnvVar)))
+			hasSavedKey := m.apiKeyMasked && m.apiKeyOriginal != ""
+			s.WriteString(tuiDimStyle.Render(officialAPIKeyEnvSetHintLine(provider.EnvVar, hasSavedKey)))
 			s.WriteString("\n")
 		} else {
 			s.WriteString("\n")
 			s.WriteString(tuiDimStyle.Render(fmt.Sprintf("  Tip: You can also set via env var %s", provider.EnvVar)))
 			s.WriteString("\n")
 		}
+	}
+
+	if m.formError != "" {
+		s.WriteString("\n")
+		s.WriteString(tuiErrorStyle.Render("  " + m.formError))
+		s.WriteString("\n")
 	}
 
 	s.WriteString("\n")
@@ -2246,6 +2343,17 @@ func savedSecretReplaceHint(original string) string {
 
 func savedSecretReplaceHintLine(original string) string {
 	return "  " + savedSecretReplaceHint(original)
+}
+
+func officialAPIKeyEnvSetHint(envVar string, hasSavedKey bool) string {
+	if hasSavedKey {
+		return fmt.Sprintf("$%s is set; used only when no key is saved here.", envVar)
+	}
+	return fmt.Sprintf("$%s is set. Leave empty to use it; enter a key here to override.", envVar)
+}
+
+func officialAPIKeyEnvSetHintLine(envVar string, hasSavedKey bool) string {
+	return "  " + officialAPIKeyEnvSetHint(envVar, hasSavedKey)
 }
 
 // --- Styles ---

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1522,6 +1523,269 @@ func TestSyncSessionModelSelection_EmptyModel(t *testing.T) {
 	err := m.syncSessionModelSelection()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSyncSessionModelSelection_CrossOfficialProviderNoPersist(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "baidu-qianfan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.modelIdx = 0
+	for i, name := range m.models() {
+		if name == "glm-5" {
+			m.modelIdx = i
+			break
+		}
+	}
+
+	if err := m.syncSessionModelSelection(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.savedInSession {
+		t.Error("savedInSession should be false when browsing a non-active provider")
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config file should not be written for cross-provider navigation")
+	}
+	if got := cfg.Providers["baidu-qianfan"].Model; got != "" {
+		t.Errorf("in-memory baidu model = %q, want empty", got)
+	}
+}
+
+func TestSyncSessionModelSelection_ActiveOfficialProviderDefersPersist(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, name := range m.models() {
+		if name == "deepseek-v4-pro" {
+			m.modelIdx = i
+			break
+		}
+	}
+
+	if err := m.syncSessionModelSelection(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.savedInSession {
+		t.Error("savedInSession should be false before wizard confirm")
+	}
+	if got := m.sessionModelPick["deepseek"]; got != "deepseek-v4-pro" {
+		t.Errorf("sessionModelPick = %q, want deepseek-v4-pro", got)
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config file should not be written before wizard confirm")
+	}
+	if cfg.Model != "deepseek-v4-flash" {
+		t.Errorf("cfg.Model = %q, want deepseek-v4-flash", cfg.Model)
+	}
+}
+
+func TestSyncSessionModelSelection_CrossCustomProviderNoPersist(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "stepfun",
+		Model:    "step-3.5-flash",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {
+				URL:    "https://api.stepfun.com/v1",
+				Model:  "step-3.5-flash",
+				Models: []string{"step-3.5-flash", "step-3.7-flash"},
+			},
+			"other": {
+				URL:    "https://example.com/v1",
+				Model:  "step-3.7-flash",
+				Models: []string{"step-3.7-flash"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	for i, cp := range m.customProviders {
+		if cp.name == "other" {
+			m.customIdx = i
+			break
+		}
+	}
+	m.modelIdx = 0
+
+	if err := m.syncSessionModelSelection(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.savedInSession {
+		t.Error("savedInSession should be false when browsing a non-active custom provider")
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config file should not be written for cross-provider navigation")
+	}
+}
+
+func TestSyncSessionModelSelection_RecordsSessionPickForInactiveOfficialProvider(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "baidu-qianfan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	for i, name := range m.models() {
+		if name == "glm-5" {
+			m.modelIdx = i
+			break
+		}
+	}
+
+	if err := m.syncSessionModelSelection(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.savedInSession {
+		t.Error("savedInSession should be false for inactive provider")
+	}
+	if got := m.sessionModelPick["baidu-qianfan"]; got != "glm-5" {
+		t.Errorf("sessionModelPick = %q, want glm-5", got)
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config file should not be written for inactive provider")
+	}
+}
+
+func TestProviderTUI_ResultUsesSessionModelPickWhenSelectionEmpty(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "baidu-qianfan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.sessionModelPick = map[string]string{"baidu-qianfan": "glm-5"}
+	m.modelIdx = 9999 // force selectedModelFromState() empty
+
+	r := m.result()
+	if r.model != "glm-5" {
+		t.Errorf("result().model = %q, want glm-5", r.model)
+	}
+	if got := r.resolvedModel(); got != "glm-5" {
+		t.Errorf("resolvedModel() = %q, want glm-5", got)
+	}
+}
+
+func TestApiKeyStepCanConfirm_OfficialEmptyWithoutEnv(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	m.step = stepAPIKey
+
+	ok, errMsg := m.apiKeyStepCanConfirm()
+	if ok {
+		t.Fatal("expected confirmation to be blocked")
+	}
+	if errMsg != "API key is required (or set $DEEPSEEK_API_KEY)" {
+		t.Errorf("errMsg = %q", errMsg)
+	}
+}
+
+func TestApiKeyStepCanConfirm_OfficialEmptyWithEnv(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "sk-from-env")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	m.step = stepAPIKey
+
+	ok, errMsg := m.apiKeyStepCanConfirm()
+	if !ok {
+		t.Fatalf("expected confirmation allowed, errMsg = %q", errMsg)
+	}
+}
+
+func TestApiKeyStepCanConfirm_CustomEmpty(t *testing.T) {
+	cfg := &Config{
+		Provider: "stepfun",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {APIKey: ""},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepAPIKey
+
+	ok, errMsg := m.apiKeyStepCanConfirm()
+	if ok {
+		t.Fatal("expected confirmation to be blocked")
+	}
+	if errMsg != "API key is required" {
+		t.Errorf("errMsg = %q", errMsg)
+	}
+}
+
+func TestApiKeyStepCanConfirm_MaskedSavedKey(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {APIKey: "keep-me"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+
+	ok, errMsg := m.apiKeyStepCanConfirm()
+	if !ok {
+		t.Fatalf("expected confirmation allowed, errMsg = %q", errMsg)
 	}
 }
 

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -46,6 +46,73 @@ func TestCustomProviderActiveModel_MatchingProvider(t *testing.T) {
 	}
 }
 
+func TestOfficialProviderActiveModel_NilCfg(t *testing.T) {
+	m := providerTUIModel{existingCfg: nil}
+	got := m.officialProviderActiveModel(llm.Provider{Name: "anthropic"})
+	if got != "" {
+		t.Errorf("expected empty string for nil cfg, got %q", got)
+	}
+}
+
+func TestOfficialProviderActiveModel_DifferentProvider(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	got := m.officialProviderActiveModel(llm.Provider{Name: "anthropic", DisplayName: "Anthropic Claude API"})
+	if got != "" {
+		t.Errorf("expected empty string for non-active provider, got %q", got)
+	}
+}
+
+func TestOfficialProviderActiveModel_MatchingProvider(t *testing.T) {
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-8",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {Model: "claude-opus-4-8"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	got := m.officialProviderActiveModel(llm.Provider{Name: "anthropic", DisplayName: "Anthropic Claude API"})
+	if got != "claude-opus-4-8" {
+		t.Errorf("expected claude-opus-4-8, got %q", got)
+	}
+}
+
+func TestOfficialProviderActiveModel_EmptyModel(t *testing.T) {
+	cfg := &Config{
+		Provider: "anthropic",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	got := m.officialProviderActiveModel(llm.Provider{Name: "anthropic"})
+	if got != "" {
+		t.Errorf("expected empty model, got %q", got)
+	}
+}
+
+func TestProviderTUIView_OfficialTab_ShowsActiveModelSuffix(t *testing.T) {
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-8",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {Model: "claude-opus-4-8"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "(claude-opus-4-8)") {
+		t.Errorf("view missing active model suffix; got:\n%s", got)
+	}
+}
+
 func TestModelProviderName_OfficialTab(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	name := m.modelProviderName()

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -547,6 +548,12 @@ func TestNewModelTUI(t *testing.T) {
 		t.Skip("no providers")
 	}
 	m := newModelTUI(p[0], "")
+	if m.isCustomProvider {
+		t.Error("preset provider test helper should set isCustomProvider=false")
+	}
+	if len(m.registryModels) == 0 {
+		t.Error("registryModels should be populated for preset provider")
+	}
 	if m.modelIdx != 0 {
 		t.Errorf("modelIdx = %d, want 0 for empty currentModel", m.modelIdx)
 	}
@@ -861,6 +868,447 @@ func TestModelTUI_View_CustomModel(t *testing.T) {
 	}
 }
 
+func officialConfigModelTUI(t *testing.T, configPath string, extraModels []string) modelTUIModel {
+	t.Helper()
+	preset, ok := llm.LookupProvider("dashscope")
+	if !ok {
+		t.Skip("dashscope provider not in registry")
+	}
+	models := []string{"qwen3.7-max"}
+	models = append(models, extraModels...)
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {
+				Model:  "qwen3.7-max",
+				Models: models,
+			},
+		},
+	}
+	provider := preset
+	provider.Models = mergeModelLists(preset.Models, cfg.Providers["dashscope"].Models)
+	return newModelTUIConfig(modelTUIConfig{
+		Provider:       provider,
+		RegistryModels: preset.Models,
+		ExistingCfg:    cfg,
+		ConfigPath:     configPath,
+		ProviderName:   "dashscope",
+		IsCustom:       false,
+	})
+}
+
+func customConfigModelTUI(t *testing.T, configPath string, models []string) modelTUIModel {
+	t.Helper()
+	cfg := &Config{
+		Provider: "my-llm",
+		Model:    "m1",
+		CustomProviders: map[string]ProviderEntry{
+			"my-llm": {
+				URL:      "https://custom.api/v1",
+				Protocol: "openai",
+				Model:    "m1",
+				Models:   append([]string(nil), models...),
+			},
+		},
+	}
+	provider := llm.Provider{
+		Name:        "my-llm",
+		DisplayName: "my-llm (custom)",
+		Models:      mergeModelLists(models),
+	}
+	return newModelTUIConfig(modelTUIConfig{
+		Provider:     provider,
+		CurrentModel: "m1",
+		ExistingCfg:  cfg,
+		ConfigPath:   configPath,
+		ProviderName: "my-llm",
+		IsCustom:     true,
+	})
+}
+
+func asModelTUIModel(t *testing.T, m tea.Model) modelTUIModel {
+	t.Helper()
+	switch v := m.(type) {
+	case modelTUIModel:
+		return v
+	case *modelTUIModel:
+		return *v
+	default:
+		t.Fatalf("expected modelTUIModel, got %T", m)
+		return modelTUIModel{}
+	}
+}
+
+func modelTUIEnterCustomModelName(t *testing.T, m modelTUIModel, name string) modelTUIModel {
+	t.Helper()
+	m.modelIdx = len(m.displayModels())
+	result, _ := m.Update(enterKey())
+	m2 := result.(modelTUIModel)
+	if !m2.customModel {
+		t.Fatal("expected customModel after enter on custom item")
+	}
+	m2.modelInput.SetValue(name)
+	result, _ = m2.Update(enterKey())
+	return result.(modelTUIModel)
+}
+
+func modelTUIIdxForName(t *testing.T, m modelTUIModel, name string) int {
+	t.Helper()
+	for i, model := range m.displayModels() {
+		if model == name {
+			return i
+		}
+	}
+	t.Fatalf("model %q not found in %v", name, m.displayModels())
+	return -1
+}
+
+func TestModelTUI_Official_AddCustomModelStaysOnList(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialConfigModelTUI(t, configPath, nil)
+	m3 := modelTUIEnterCustomModelName(t, m, "new-model")
+
+	if m3.confirmed {
+		t.Error("adding a model should not confirm and quit")
+	}
+	if m3.customModel {
+		t.Error("customModel should be cleared after add")
+	}
+	got := m3.existingCfg.Providers["dashscope"].Models
+	if !llm.ModelListContains(got, "new-model") {
+		t.Errorf("Models = %v, want new-model appended", got)
+	}
+	if m3.existingCfg.Model != "qwen3.7-max" {
+		t.Errorf("cfg.Model = %q, want active model unchanged", m3.existingCfg.Model)
+	}
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load disk config: %v", err)
+	}
+	if !llm.ModelListContains(diskCfg.Providers["dashscope"].Models, "new-model") {
+		t.Errorf("disk Models = %v, want new-model persisted", diskCfg.Providers["dashscope"].Models)
+	}
+}
+
+func TestModelTUI_Official_ListEnterConfirmsSelection(t *testing.T) {
+	m := officialConfigModelTUI(t, "", nil)
+	m2 := modelTUIEnterCustomModelName(t, m, "picked-model")
+	m2.modelIdx = modelTUIIdxForName(t, m2, "picked-model")
+	result, _ := m2.Update(enterKey())
+	m3 := result.(modelTUIModel)
+	if !m3.confirmed {
+		t.Error("enter on list item should confirm selection")
+	}
+	if m3.selectedModel() != "picked-model" {
+		t.Errorf("selectedModel() = %q, want picked-model", m3.selectedModel())
+	}
+}
+
+func TestModelTUI_CustomProvider_AddCustomModelStaysOnList(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := customConfigModelTUI(t, configPath, []string{"m1"})
+	m3 := modelTUIEnterCustomModelName(t, m, "new-custom-model")
+
+	if m3.confirmed {
+		t.Error("adding a model should not confirm and quit")
+	}
+	if !llm.ModelListContains(m3.existingCfg.CustomProviders["my-llm"].Models, "new-custom-model") {
+		t.Errorf("Models = %v, want new-custom-model appended", m3.existingCfg.CustomProviders["my-llm"].Models)
+	}
+	if m3.existingCfg.CustomProviders["my-llm"].Model != "m1" {
+		t.Errorf("entry.Model = %q, want active model unchanged", m3.existingCfg.CustomProviders["my-llm"].Model)
+	}
+	if !m3.savedInSession {
+		t.Error("savedInSession should be true after add")
+	}
+}
+
+func TestModelTUI_EscCancelWithoutChangesNoSavedInSession(t *testing.T) {
+	m := officialConfigModelTUI(t, "", nil)
+	result, _ := m.Update(escKey())
+	m2 := result.(modelTUIModel)
+	if !m2.cancelled {
+		t.Fatal("esc should cancel")
+	}
+	if m2.savedInSession {
+		t.Error("savedInSession should be false when no add/delete occurred")
+	}
+}
+
+func TestModelTUI_DeleteSetsSavedInSession(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := customConfigModelTUI(t, configPath, []string{"m1", "aaa"})
+	m.modelIdx = modelTUIIdxForName(t, m, "aaa")
+	m.deleteModelName = "aaa"
+	m.confirmingDeleteModel = true
+
+	result, _ := m.confirmDeleteCustomProviderModel()
+	m2 := asModelTUIModel(t, result)
+	if !m2.savedInSession {
+		t.Error("savedInSession should be true after delete")
+	}
+}
+
+func TestModelTUI_AddCustomModelRejectsDuplicate(t *testing.T) {
+	m := officialConfigModelTUI(t, "", []string{"dup-model"})
+	m.modelIdx = len(m.displayModels())
+	result, _ := m.Update(enterKey())
+	m2 := result.(modelTUIModel)
+	m2.modelInput.SetValue("dup-model")
+	result, _ = m2.Update(enterKey())
+	m3 := result.(modelTUIModel)
+	if m3.formError != "Already in list: dup-model" {
+		t.Errorf("formError = %q, want duplicate message", m3.formError)
+	}
+	if !m3.customModel {
+		t.Error("customModel should stay open after duplicate reject")
+	}
+}
+
+func TestModelTUI_Official_DeleteUserAddedModel(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialConfigModelTUI(t, configPath, []string{"my-custom-model"})
+	m.modelIdx = modelTUIIdxForName(t, m, "my-custom-model")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if !m2.confirmingDeleteModel {
+		t.Fatal("pressing d on user-added model should set confirmingDeleteModel = true")
+	}
+
+	result, _ = m2.Update(yKey())
+	m3 := result.(modelTUIModel)
+	got := m3.existingCfg.Providers["dashscope"].Models
+	if len(got) != 1 || got[0] != "qwen3.7-max" {
+		t.Errorf("Models = %v, want [qwen3.7-max]", got)
+	}
+
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load disk config: %v", err)
+	}
+	if len(diskCfg.Providers["dashscope"].Models) != 1 {
+		t.Errorf("disk Models = %v, want [qwen3.7-max]", diskCfg.Providers["dashscope"].Models)
+	}
+}
+
+func TestModelTUI_Official_DeleteBuiltInModelIgnored(t *testing.T) {
+	m := officialConfigModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = modelTUIIdxForName(t, m, "qwen3.7-max")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on built-in model should not trigger delete confirmation")
+	}
+}
+
+func TestIsUserAddedOfficialModelName_RegistryDuplicateNotUserAdded(t *testing.T) {
+	preset, ok := llm.LookupProvider("dashscope")
+	if !ok {
+		t.Skip("dashscope provider not in registry")
+	}
+	cfg := &Config{
+		Providers: map[string]ProviderEntry{
+			"dashscope": {Models: []string{"qwen3.7-max", "my-custom-model"}},
+		},
+	}
+	if isUserAddedOfficialModelName("qwen3.7-max", "dashscope", preset.Models, cfg) {
+		t.Error("registry model should not be treated as user-added even when listed in config")
+	}
+	if !isUserAddedOfficialModelName("my-custom-model", "dashscope", preset.Models, cfg) {
+		t.Error("config-only model should be user-added")
+	}
+}
+
+func TestModelTUI_Official_RegistryModelNotDeletable(t *testing.T) {
+	m := officialConfigModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = modelTUIIdxForName(t, m, "qwen3.7-max")
+
+	if m.isUserAddedModel("qwen3.7-max") {
+		t.Error("qwen3.7-max should not be user-added when it is in the registry")
+	}
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on registry model should not trigger delete confirmation")
+	}
+}
+
+func TestModelTUI_Official_DeleteOnCustomModelInputIgnored(t *testing.T) {
+	m := officialConfigModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = len(m.displayModels())
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on Enter custom model name... should not trigger delete confirmation")
+	}
+}
+
+func TestModelTUI_CustomProvider_DeleteOnCustomModelInputIgnored(t *testing.T) {
+	m := customConfigModelTUI(t, "", []string{"m1", "aaa"})
+	m.modelIdx = len(m.displayModels())
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on Enter custom model name... should not trigger delete confirmation")
+	}
+}
+
+func TestModelTUI_Official_UserAddedModelShowsDeleteHint(t *testing.T) {
+	m := officialConfigModelTUI(t, "", []string{"my-custom-model"})
+
+	m.modelIdx = modelTUIIdxForName(t, m, "qwen3.7-max")
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "d Delete") {
+		t.Errorf("built-in model should not show d Delete hint; got:\n%s", got)
+	}
+
+	m.modelIdx = modelTUIIdxForName(t, m, "my-custom-model")
+	got = stripANSI(m.View().Content)
+	if !strings.Contains(got, "d Delete") {
+		t.Errorf("user-added model should show d Delete hint; got:\n%s", got)
+	}
+}
+
+func TestModelTUI_CustomProvider_ShowsDeleteHint(t *testing.T) {
+	m := customConfigModelTUI(t, "", []string{"m1", "aaa"})
+
+	m.modelIdx = len(m.displayModels())
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "d Delete") {
+		t.Errorf("custom input row should not show d Delete hint; got:\n%s", got)
+	}
+
+	m.modelIdx = modelTUIIdxForName(t, m, "aaa")
+	got = stripANSI(m.View().Content)
+	if !strings.Contains(got, "d Delete") {
+		t.Errorf("custom model row should show d Delete hint; got:\n%s", got)
+	}
+}
+
+func TestModelTUI_CustomProvider_DeleteClearsCustomInput(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := customConfigModelTUI(t, configPath, []string{"m1", "aaa"})
+	m.modelIdx = modelTUIIdxForName(t, m, "aaa")
+	m.customModel = true
+	m.modelInput.SetValue("aaa")
+	m.deleteModelName = "aaa"
+	m.confirmingDeleteModel = true
+
+	result, _ := m.confirmDeleteCustomProviderModel()
+	m2 := asModelTUIModel(t, result)
+
+	if m2.customModel {
+		t.Error("customModel should be false after delete")
+	}
+	if m2.modelInput.Value() != "" {
+		t.Errorf("modelInput = %q, want empty after delete", m2.modelInput.Value())
+	}
+}
+
+func TestModelTUI_CustomProvider_DeleteModelViaDKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := customConfigModelTUI(t, configPath, []string{"m1", "aaa"})
+	m.modelIdx = modelTUIIdxForName(t, m, "aaa")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	if !m2.confirmingDeleteModel || m2.deleteModelName != "aaa" {
+		t.Fatalf("after d: confirming=%v deleteModelName=%q", m2.confirmingDeleteModel, m2.deleteModelName)
+	}
+
+	result, _ = m2.Update(yKey())
+	m3 := result.(modelTUIModel)
+	got := m3.existingCfg.CustomProviders["my-llm"].Models
+	if len(got) != 1 || got[0] != "m1" {
+		t.Errorf("Models = %v, want [m1]", got)
+	}
+}
+
+func TestModelTUI_CustomProvider_DeleteCancel(t *testing.T) {
+	m := customConfigModelTUI(t, "", []string{"m1", "aaa"})
+	m.modelIdx = modelTUIIdxForName(t, m, "aaa")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	result, _ = m2.Update(nKey())
+	m3 := result.(modelTUIModel)
+	if m3.confirmingDeleteModel {
+		t.Error("confirmingDeleteModel should be false after n")
+	}
+	got := m3.existingCfg.CustomProviders["my-llm"].Models
+	if len(got) != 2 {
+		t.Errorf("Models = %v, want unchanged", got)
+	}
+}
+
+func TestModelTUI_Official_DeleteCancel(t *testing.T) {
+	cancelKeys := []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"n", nKey()},
+		{"esc", escKey()},
+	}
+	for _, tc := range cancelKeys {
+		t.Run(tc.name, func(t *testing.T) {
+			m := officialConfigModelTUI(t, "", []string{"my-custom-model"})
+			m.modelIdx = modelTUIIdxForName(t, m, "my-custom-model")
+
+			result, _ := m.Update(dKey())
+			m2 := result.(modelTUIModel)
+			if !m2.confirmingDeleteModel {
+				t.Fatal("expected confirmingDeleteModel after d")
+			}
+
+			result, _ = m2.Update(tc.key)
+			m3 := result.(modelTUIModel)
+			if m3.confirmingDeleteModel {
+				t.Error("confirmingDeleteModel should be false after cancel")
+			}
+			got := m3.existingCfg.Providers["dashscope"].Models
+			if len(got) != 2 || got[1] != "my-custom-model" {
+				t.Errorf("Models = %v, want model unchanged", got)
+			}
+		})
+	}
+}
+
+func TestModelTUI_Official_DeleteActiveUserModelClearsCfg(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialConfigModelTUI(t, configPath, []string{"my-custom-model"})
+	m.existingCfg.Model = "my-custom-model"
+	m.existingCfg.Providers["dashscope"] = ProviderEntry{
+		Model:  "my-custom-model",
+		Models: []string{"qwen3.7-max", "my-custom-model"},
+	}
+	m.modelIdx = modelTUIIdxForName(t, m, "my-custom-model")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(modelTUIModel)
+	result, _ = m2.Update(yKey())
+	m3 := result.(modelTUIModel)
+
+	if m3.existingCfg.Providers["dashscope"].Model != "" {
+		t.Errorf("entry.Model = %q, want empty", m3.existingCfg.Providers["dashscope"].Model)
+	}
+	if m3.existingCfg.Model != "" {
+		t.Errorf("cfg.Model = %q, want empty", m3.existingCfg.Model)
+	}
+}
+
 // --- result() tests ---
 
 func TestResult_OfficialTab(t *testing.T) {
@@ -1146,15 +1594,23 @@ func TestProviderTUIView_ManualTab_WithExistingConfig(t *testing.T) {
 func TestProviderTUIView_StepModel_CustomTabDeleteHelp(t *testing.T) {
 	cfg := &Config{
 		CustomProviders: map[string]ProviderEntry{
-			"cp": {URL: "http://cp", Models: []string{"m1"}},
+			"cp": {URL: "http://cp", Models: []string{"m1", "m2"}},
 		},
 	}
 	m := newProviderTUI(cfg, "")
 	m.step = stepModel
 	m.activeTab = tabCustom
 	m.customIdx = 0
-	v := m.View()
-	if !strings.Contains(v.Content, "Delete") {
-		t.Errorf("expected delete help for custom tab model view")
+
+	m.modelIdx = len(m.models())
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "d Delete") {
+		t.Errorf("custom input row should not show d Delete hint; got:\n%s", got)
+	}
+
+	m.modelIdx = 0
+	got = stripANSI(m.View().Content)
+	if !strings.Contains(got, "d Delete") {
+		t.Errorf("custom model row should show d Delete hint; got:\n%s", got)
 	}
 }

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -1112,6 +1112,104 @@ func TestProviderTUI_CustomModelInput_RejectsDuplicate(t *testing.T) {
 	}
 }
 
+func TestProviderTUI_OfficialTab_CustomModelInput_PersistsName(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {
+				Model:  "qwen3.7-max",
+				Models: []string{"qwen3.7-max"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+
+	// Land the cursor on the official provider we configured.
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	m.modelIdx = len(m.models()) // "Enter custom model name..."
+	m.customModel = true
+	m.modelInput.SetValue("my-custom-model")
+	m.modelInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+
+	if m2.customModel {
+		t.Error("customModel should be cleared after Enter")
+	}
+	if m2.formError != "" {
+		t.Errorf("formError = %q, want empty", m2.formError)
+	}
+	if !m2.savedInSession {
+		t.Error("savedInSession should be true after successful add")
+	}
+	got := m2.existingCfg.Providers["dashscope"].Models
+	want := []string{"qwen3.7-max", "my-custom-model"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("official Models = %v, want %v", got, want)
+	}
+
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load disk config: %v", err)
+	}
+	diskModels := diskCfg.Providers["dashscope"].Models
+	if len(diskModels) != 2 || diskModels[1] != "my-custom-model" {
+		t.Errorf("disk Models = %v, want [qwen3.7-max my-custom-model]", diskModels)
+	}
+}
+
+func TestProviderTUI_OfficialTab_CustomModelInput_RejectsDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {
+				Model:  "qwen3.7-max",
+				Models: []string{"qwen3.7-max"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	m.modelIdx = len(m.models())
+	m.customModel = true
+	m.modelInput.SetValue("qwen3.7-max")
+	m.modelInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+
+	if !m2.customModel {
+		t.Error("customModel should stay true after duplicate reject")
+	}
+	if m2.formError != "Already in list: qwen3.7-max" {
+		t.Errorf("formError = %q, want %q", m2.formError, "Already in list: qwen3.7-max")
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Errorf("disk file should not exist; duplicate did not persist")
+	}
+}
+
 func TestProviderTUI_ManualFormPassesKToAuthHeaderInput(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
@@ -1165,6 +1263,242 @@ func TestProviderTUI_CustomFormPassesKToAuthHeaderInput(t *testing.T) {
 	if got := m4.cpAuthInput.Value(); got != "key" {
 		t.Errorf("cpAuthInput.Value() = %q, want %q", got, "key")
 	}
+}
+
+func TestProviderTUI_ViewAPIKey_MaskedShowsReplaceHintAndLastFour(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {APIKey: "sk-secret-1234567890abcd"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	if !m.apiKeyMasked {
+		t.Fatal("apiKeyMasked should be true when an existing key is loaded")
+	}
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "Type or paste to replace the saved key") {
+		t.Errorf("view missing replace hint; got:\n%s", got)
+	}
+	if !strings.Contains(got, "(saved: sk-sec...abcd)") {
+		t.Errorf("view missing prefix+suffix fingerprint; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_ShortKeyOmitsFingerprint(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {APIKey: "12345678901234"}, // 14 runes — below min length 15
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "Type or paste to replace the saved key") {
+		t.Errorf("view missing replace hint; got:\n%s", got)
+	}
+	if strings.Contains(got, "(saved:") {
+		t.Errorf("view should omit fingerprint for keys shorter than 15 runes; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_MinLenKeyShowsFingerprint(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {APIKey: "123456789012345"}, // 15 runes — at min length
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "(saved: 123456...2345)") {
+		t.Errorf("view should show fingerprint at min length 15; got:\n%s", got)
+	}
+}
+
+func TestSavedSecretFingerprint_TrimsLeadingWhitespace(t *testing.T) {
+	const key = "sk-secret-1234567890abcd"
+	got := savedSecretFingerprint("  " + key)
+	want := "sk-sec...abcd"
+	if got != want {
+		t.Errorf("savedSecretFingerprint(%q) = %q, want %q", "  "+key, got, want)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_FreshHidesReplaceHint(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+
+	if m.apiKeyMasked {
+		t.Fatal("apiKeyMasked should be false when no key is loaded")
+	}
+
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "Type or paste to replace the saved key") {
+		t.Errorf("view should not show replace hint when fresh; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_ApiKeyPasteReplacesMaskedKey(t *testing.T) {
+	cfg := &Config{
+		Provider: "stepfun",
+		Model:    "step-3.5-flash",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {
+				URL:    "https://api.stepfun.com/v1",
+				APIKey: "old-key-ssss",
+				Model:  "step-3.5-flash",
+				Models: []string{"step-3.5-flash"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	if !m.apiKeyMasked {
+		t.Fatal("expected masked key on load")
+	}
+	if m.apiKeyInput.Value() != maskedSecretPlaceholder() {
+		t.Fatalf("placeholder = %q, want fixed %d asterisks", m.apiKeyInput.Value(), maskedSecretDisplayLen)
+	}
+
+	result, _ := m.Update(tea.PasteMsg{Content: "sk-new-pasted-key"})
+	m2 := result.(providerTUIModel)
+
+	if m2.apiKeyMasked {
+		t.Fatal("paste should unmask the field")
+	}
+	if got := m2.apiKeyInput.Value(); got != "sk-new-pasted-key" {
+		t.Errorf("input value = %q, want pasted key", got)
+	}
+	if r := m2.result(); r.apiKey != "sk-new-pasted-key" {
+		t.Errorf("result().apiKey = %q, want pasted key", r.apiKey)
+	}
+}
+
+func TestProviderTUI_ApiKeyTypingShowsOneStarPerChar(t *testing.T) {
+	cfg := &Config{
+		Provider: "stepfun",
+		Model:    "step-3.5-flash",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {APIKey: "old-key-ssss", Model: "step-3.5-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	for _, ch := range []rune("abc") {
+		result, _ := m.Update(charKey(ch))
+		m = result.(providerTUIModel)
+	}
+	if m.apiKeyInput.Value() != "abc" {
+		t.Errorf("value = %q, want abc", m.apiKeyInput.Value())
+	}
+	// EchoPassword renders one '*' per character in the input view.
+	masked := stripANSI(m.apiKeyInput.View())
+	starCount := strings.Count(masked, "*")
+	if starCount != 3 {
+		t.Errorf("masked view has %d asterisks, want 3 (one * per char)", starCount)
+	}
+}
+
+func TestProviderTUI_ApiKeyEnterWithoutEditKeepsOriginal(t *testing.T) {
+	cfg := &Config{
+		Provider: "stepfun",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {APIKey: "keep-me"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+
+	if r := m.result(); r.apiKey != "keep-me" {
+		t.Fatalf("before edit result().apiKey = %q", r.apiKey)
+	}
+}
+
+// stripANSI removes ANSI escape sequences from a string so tests can assert
+// against plain text content.
+func stripANSI(s string) string {
+	var b strings.Builder
+	inEscape := false
+	for _, r := range s {
+		if r == 0x1b {
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			if r == 'm' {
+				inEscape = false
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 func TestProviderTUI_DeleteModelPreservesActiveModel(t *testing.T) {

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -445,10 +445,75 @@ func TestProviderTUI_ManualFormRequiresTokenOnFirstSetup(t *testing.T) {
 	m.manualTokenInput.SetValue("")
 	m.manualTokenInput.Focus()
 
-	result, _ := m.Update(enterKey())
+	result, cmd := m.Update(enterKey())
 	m2 := result.(providerTUIModel)
 	if m2.manualStep != manualStepAuthToken {
 		t.Errorf("should stay on auth token step, got %d", m2.manualStep)
+	}
+	if m2.formError != manualAuthTokenRequiredError {
+		t.Errorf("formError = %q, want %q", m2.formError, manualAuthTokenRequiredError)
+	}
+	if cmd != nil {
+		t.Error("Enter with empty token should not quit")
+	}
+}
+
+func TestProviderTUI_ManualFormRejectsWhitespaceOnlyToken(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.inManualForm = true
+	m.manualStep = manualStepAuthToken
+	m.manualTokenInput.SetValue("   ")
+	m.manualTokenInput.Focus()
+
+	result, cmd := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.manualStep != manualStepAuthToken {
+		t.Errorf("should stay on auth token step, got %d", m2.manualStep)
+	}
+	if m2.formError != manualAuthTokenRequiredError {
+		t.Errorf("formError = %q, want %q", m2.formError, manualAuthTokenRequiredError)
+	}
+	if cmd != nil {
+		t.Error("Enter with whitespace-only token should not quit")
+	}
+}
+
+func TestProviderTUI_SessionModelPickSurvivesOfficialProviderSwitch(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "baidu-qianfan" {
+			m.officialIdx = i
+			break
+		}
+	}
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	m2.modelIdx = modelIdxForName(t, m2, "glm-5")
+
+	result, _ = m2.Update(enterKey())
+	m3 := result.(providerTUIModel)
+	if got := m3.sessionModelPick["baidu-qianfan"]; got != "glm-5" {
+		t.Errorf("sessionModelPick = %q, want glm-5", got)
+	}
+
+	result, _ = m3.Update(escKey())
+	m4 := result.(providerTUIModel)
+	result, _ = m4.Update(escKey())
+	m5 := result.(providerTUIModel)
+
+	result, _ = m5.Update(enterKey())
+	m6 := result.(providerTUIModel)
+	if got := m6.models()[m6.modelIdx]; got != "glm-5" {
+		t.Errorf("model cursor = %q, want glm-5", got)
 	}
 }
 
@@ -680,6 +745,180 @@ func TestProviderTUI_EditCustomProviderSaveRejectsDuplicateRename(t *testing.T) 
 	}
 	if cfg.CustomProviders["other"].URL != "https://other.example.com" {
 		t.Errorf("provider 'other' URL = %q, want unchanged", cfg.CustomProviders["other"].URL)
+	}
+}
+
+func TestApplyEditCustomProviderSave_ClearsAPIKeyWhenEditedEmpty(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:      "https://example.com/v1",
+				Protocol: "anthropic",
+				APIKey:   "old-saved-key",
+				Model:    "test",
+				Models:   []string{"test"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.editingCustom = true
+	m.editTargetName = "aaa"
+	m.cpProtocolIdx = 0
+	m.cpNameInput.SetValue("aaa")
+	m.cpURLInput.SetValue("https://example.com/v1")
+	m.beginAPIKeyReplace()
+
+	if err := m.applyEditCustomProviderSave(); err != nil {
+		t.Fatalf("applyEditCustomProviderSave: %v", err)
+	}
+	if got := cfg.CustomProviders["aaa"].APIKey; got != "" {
+		t.Errorf("APIKey = %q, want empty", got)
+	}
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := diskCfg.CustomProviders["aaa"].APIKey; got != "" {
+		t.Errorf("persisted APIKey = %q, want empty", got)
+	}
+}
+
+func TestApplyEditCustomProviderSave_PreservesAPIKeyWhenMasked(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:      "https://example.com/v1",
+				Protocol: "anthropic",
+				APIKey:   "keep-me",
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.enterEditCustomProvider()
+
+	if err := m.applyEditCustomProviderSave(); err != nil {
+		t.Fatalf("applyEditCustomProviderSave: %v", err)
+	}
+	if got := cfg.CustomProviders["aaa"].APIKey; got != "keep-me" {
+		t.Errorf("APIKey = %q, want keep-me", got)
+	}
+}
+
+func TestProviderTUI_EditCustomClearKey_NoMaskedOnStepAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:      "https://example.com/v1",
+				Protocol: "anthropic",
+				APIKey:   "old-saved-key",
+				Model:    "test",
+				Models:   []string{"test", "aaa"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	for i, cp := range m.customProviders {
+		if cp.name == "aaa" {
+			m.customIdx = i
+			break
+		}
+	}
+	m.enterEditCustomProvider()
+	m.cpStep = cpStepAPIKey
+	m.beginAPIKeyReplace()
+	m.cpStep = cpStepAuthHeader
+	m.cpAuthInput.SetValue("")
+	m.cpAuthInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.step != stepModel {
+		t.Fatalf("step = %d, want stepModel", m2.step)
+	}
+	if got := m2.customProviders[m2.customIdx].entry.APIKey; got != "" {
+		t.Errorf("saved APIKey = %q, want empty", got)
+	}
+
+	m2.modelIdx = modelIdxForName(t, m2, "test")
+	result, _ = m2.Update(enterKey())
+	m3 := result.(providerTUIModel)
+	if m3.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m3.step)
+	}
+	if m3.apiKeyMasked {
+		t.Error("apiKeyMasked should be false after clearing key in edit")
+	}
+	got := stripANSI(m3.View().Content)
+	if strings.Contains(got, "Type or paste to replace the saved key") {
+		t.Errorf("view should not show replace hint; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_ReenterEditAfterClearKey_ShowsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:      "https://example.com/v1",
+				Protocol: "anthropic",
+				APIKey:   "old-saved-key",
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.editingCustom = true
+	m.editTargetName = "aaa"
+	m.cpProtocolIdx = 0
+	m.cpNameInput.SetValue("aaa")
+	m.cpURLInput.SetValue("https://example.com/v1")
+	m.beginAPIKeyReplace()
+	if err := m.applyEditCustomProviderSave(); err != nil {
+		t.Fatalf("applyEditCustomProviderSave: %v", err)
+	}
+
+	m.enterEditCustomProvider()
+	if m.apiKeyMasked {
+		t.Error("apiKeyMasked should be false when key was cleared")
+	}
+	if got := m.apiKeyInput.Value(); got != "" {
+		t.Errorf("apiKeyInput = %q, want empty", got)
+	}
+}
+
+func TestCustomAPIKeyForSave(t *testing.T) {
+	m := providerTUIModel{
+		apiKeyMasked:   true,
+		apiKeyOriginal: "keep-me",
+	}
+	key, edited := m.customAPIKeyForSave()
+	if edited {
+		t.Fatal("masked key should not count as edited")
+	}
+	if key != "keep-me" {
+		t.Errorf("key = %q, want keep-me", key)
+	}
+
+	m.apiKeyMasked = false
+	m.apiKeyInput.SetValue("  ")
+	key, edited = m.customAPIKeyForSave()
+	if !edited {
+		t.Fatal("cleared field should count as edited")
+	}
+	if key != "" {
+		t.Errorf("key = %q, want empty", key)
 	}
 }
 
@@ -1767,6 +2006,78 @@ func TestProviderTUI_ViewAPIKey_FreshHidesReplaceHint(t *testing.T) {
 	}
 }
 
+func TestOfficialAPIKeyEnvSetHint(t *testing.T) {
+	const envVar = "DEEPSEEK_API_KEY"
+	if got := officialAPIKeyEnvSetHint(envVar, false); got != "$DEEPSEEK_API_KEY is set. Leave empty to use it; enter a key here to override." {
+		t.Errorf("no saved key hint = %q", got)
+	}
+	if got := officialAPIKeyEnvSetHint(envVar, true); got != "$DEEPSEEK_API_KEY is set; used only when no key is saved here." {
+		t.Errorf("saved key hint = %q", got)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_EnvSetNoSavedKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "sk-from-env")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "deepseek" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	got := stripANSI(m.View().Content)
+	want := "$DEEPSEEK_API_KEY is set. Leave empty to use it; enter a key here to override."
+	if !strings.Contains(got, want) {
+		t.Errorf("view missing env hint; want %q; got:\n%s", want, got)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_EnvSetWithSavedKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "sk-from-env")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {APIKey: "sk-secret-1234567890abcd", Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "deepseek" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "Type or paste to replace the saved key") {
+		t.Errorf("view missing replace hint; got:\n%s", got)
+	}
+	want := "$DEEPSEEK_API_KEY is set; used only when no key is saved here."
+	if !strings.Contains(got, want) {
+		t.Errorf("view missing env hint; want %q; got:\n%s", want, got)
+	}
+	if strings.Contains(got, "Leave empty to use it") {
+		t.Errorf("saved-key view should not show empty-env hint; got:\n%s", got)
+	}
+}
+
 func TestProviderTUI_ApiKeyPasteReplacesMaskedKey(t *testing.T) {
 	cfg := &Config{
 		Provider: "stepfun",
@@ -1885,9 +2196,352 @@ func TestProviderTUI_ApiKeyEnterWithoutEditKeepsOriginal(t *testing.T) {
 	m.customIdx = 0
 	m.step = stepAPIKey
 	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
 
 	if r := m.result(); r.apiKey != "keep-me" {
 		t.Fatalf("before edit result().apiKey = %q", r.apiKey)
+	}
+
+	result, cmd := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if !m2.confirmed {
+		t.Error("Enter without edit should confirm")
+	}
+	if cmd == nil {
+		t.Error("Enter without edit should quit")
+	}
+	if r := m2.result(); r.apiKey != "keep-me" {
+		t.Errorf("after Enter result().apiKey = %q, want keep-me", r.apiKey)
+	}
+}
+
+func TestProviderTUI_ApiKeyClearSavedKeyReturnsEmpty(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {APIKey: "old-saved-key", Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "deepseek" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.beginAPIKeyReplace()
+
+	if r := m.result(); r.apiKey != "" {
+		t.Errorf("result().apiKey = %q, want empty after clearing saved key", r.apiKey)
+	}
+}
+
+func TestProviderTUI_ApiKeyResultTrimSpace(t *testing.T) {
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "deepseek" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.apiKeyInput.SetValue("   ")
+
+	if r := m.result(); r.apiKey != "" {
+		t.Errorf("result().apiKey = %q, want empty for whitespace-only input", r.apiKey)
+	}
+}
+
+func TestProviderTUI_OfficialApiKeyEmptyWithoutEnvBlocksEnter(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	t.Setenv("DASHSCOPE_API_KEY", "")
+
+	result, cmd := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.step != stepAPIKey {
+		t.Errorf("step = %d, want stepAPIKey", m2.step)
+	}
+	if m2.formError != "API key is required (or set $DASHSCOPE_API_KEY)" {
+		t.Errorf("formError = %q", m2.formError)
+	}
+	if cmd != nil {
+		t.Error("Enter without key or env should not quit")
+	}
+}
+
+func TestProviderTUI_OfficialApiKeyEmptyWithEnvAllowsEnter(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+
+	t.Setenv("DASHSCOPE_API_KEY", "sk-from-env")
+
+	result, cmd := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if !m2.confirmed {
+		t.Error("Enter with env set should confirm")
+	}
+	if cmd == nil {
+		t.Error("Enter with env set should quit")
+	}
+	if m2.formError != "" {
+		t.Errorf("formError = %q, want empty", m2.formError)
+	}
+}
+
+func TestProviderTUI_CustomExistingApiKeyEmptyBlocksEnter(t *testing.T) {
+	cfg := &Config{
+		Provider: "stepfun",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {APIKey: "old-key"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.apiKeyInput.Focus()
+	m.beginAPIKeyReplace()
+
+	result, cmd := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.step != stepAPIKey {
+		t.Errorf("step = %d, want stepAPIKey", m2.step)
+	}
+	if m2.formError != "API key is required" {
+		t.Errorf("formError = %q, want %q", m2.formError, "API key is required")
+	}
+	if cmd != nil {
+		t.Error("Enter with cleared key should not quit")
+	}
+}
+
+func TestProviderTUI_CustomCreateApiKeyOptional(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabCustom
+	m.creatingCustom = true
+	m.cpStep = cpStepAPIKey
+	m.apiKeyInput.SetValue("")
+	m.apiKeyInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.cpStep != cpStepAuthHeader {
+		t.Errorf("cpStep = %d, want cpStepAuthHeader", m2.cpStep)
+	}
+	if m2.formError != "" {
+		t.Errorf("formError = %q, want empty for optional API key", m2.formError)
+	}
+}
+
+func TestProviderTUI_ViewAPIKey_ShowsFormError(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.loadExistingAPIKey()
+	m.formError = "API key is required (or set $DASHSCOPE_API_KEY)"
+	m.apiKeyInput.Focus()
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, "API key is required (or set $DASHSCOPE_API_KEY)") {
+		t.Errorf("view missing formError; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_CancelIncompleteOfficialProviderSwitch_NoPersistedChanges(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "baidu-qianfan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	m.modelIdx = modelIdxForName(t, m, "glm-5")
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.savedInSession {
+		t.Error("savedInSession should be false for cross-provider navigation")
+	}
+	if m2.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m2.step)
+	}
+
+	result, _ = m2.Update(escKey())
+	m3 := result.(providerTUIModel)
+	result, _ = m3.Update(escKey())
+	m4 := result.(providerTUIModel)
+	result, cmd := m4.Update(escKey())
+	m5 := result.(providerTUIModel)
+	if !m5.cancelled {
+		t.Error("expected cancelled = true")
+	}
+	if m5.savedInSession {
+		t.Error("savedInSession should remain false after cancel")
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit on final Esc")
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		diskCfg, err := loadOrCreateConfig(configPath)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if diskCfg.Provider != "deepseek" {
+			t.Errorf("Provider = %q, want deepseek", diskCfg.Provider)
+		}
+		if entry, ok := diskCfg.Providers["baidu-qianfan"]; ok && entry.Model != "" {
+			t.Errorf("baidu-qianfan model = %q, want no cross-provider draft persisted", entry.Model)
+		}
+	}
+}
+
+func TestProviderTUI_SameOfficialProviderModelChange_DefersPersistUntilConfirm(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "deepseek",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"deepseek": {Model: "deepseek-v4-flash"},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	m.step = stepModel
+	m.modelIdx = modelIdxForName(t, m, "deepseek-v4-pro")
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.savedInSession {
+		t.Error("savedInSession should be false before API key confirm")
+	}
+	if m2.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m2.step)
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config should not be written before wizard confirm")
+	}
+	if cfg.Model != "deepseek-v4-flash" {
+		t.Errorf("cfg.Model = %q, want deepseek-v4-flash", cfg.Model)
+	}
+}
+
+func TestProviderTUI_OfficialModelChangeBlockedAtAPIKey_KeepsGlobalModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-8",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {
+				Model:  "claude-opus-4-8",
+				APIKey: "sk-test-key",
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "anthropic" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	m.modelIdx = modelIdxForName(t, m, "claude-opus-4-7")
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	m2.beginAPIKeyReplace()
+
+	result, cmd := m2.Update(enterKey())
+	m3 := result.(providerTUIModel)
+	if cmd != nil {
+		t.Error("Enter without key or env should not quit")
+	}
+	if m3.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m3.step)
+	}
+	if cfg.Model != "claude-opus-4-8" {
+		t.Errorf("cfg.Model = %q, want claude-opus-4-8", cfg.Model)
+	}
+	if got := cfg.Providers["anthropic"].Model; got != "claude-opus-4-8" {
+		t.Errorf("providers.anthropic.Model = %q, want claude-opus-4-8", got)
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		t.Fatal("config should not be written when API key validation fails")
 	}
 }
 

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/open-code-review/open-code-review/internal/llm"
 )
 
 func escKey() tea.KeyPressMsg {
@@ -1210,6 +1212,380 @@ func TestProviderTUI_OfficialTab_CustomModelInput_RejectsDuplicate(t *testing.T)
 	}
 }
 
+func officialDashscopeModelTUI(t *testing.T, configPath string, extraModels []string) providerTUIModel {
+	t.Helper()
+	models := []string{"qwen3.7-max"}
+	models = append(models, extraModels...)
+	cfg := &Config{
+		Provider: "dashscope",
+		Model:    "qwen3.7-max",
+		Providers: map[string]ProviderEntry{
+			"dashscope": {
+				Model:  "qwen3.7-max",
+				Models: models,
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	return m
+}
+
+func customStepfunModelTUI(t *testing.T, configPath string, models []string) providerTUIModel {
+	t.Helper()
+	if len(models) == 0 {
+		models = []string{"step-3.5-flash"}
+	}
+	cfg := &Config{
+		Provider: "stepfun",
+		Model:    models[0],
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {
+				URL:      "https://api.stepfun.com/v1",
+				Protocol: "openai",
+				Model:    models[0],
+				Models:   models,
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	for i, cp := range m.customProviders {
+		if cp.name == "stepfun" {
+			m.customIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	return m
+}
+
+func modelIdxForName(t *testing.T, m providerTUIModel, name string) int {
+	t.Helper()
+	for i, model := range m.models() {
+		if model == name {
+			return i
+		}
+	}
+	t.Fatalf("model %q not found in %v", name, m.models())
+	return -1
+}
+
+func TestProviderTUI_OfficialTab_DeleteUserAddedModel(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialDashscopeModelTUI(t, configPath, []string{"my-custom-model"})
+	m.modelIdx = modelIdxForName(t, m, "my-custom-model")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if !m2.confirmingDeleteModel {
+		t.Fatal("pressing d on user-added model should set confirmingDeleteModel = true")
+	}
+	if m2.deleteModelName != "my-custom-model" {
+		t.Errorf("deleteModelName = %q, want my-custom-model", m2.deleteModelName)
+	}
+
+	result, _ = m2.Update(yKey())
+	m3 := result.(providerTUIModel)
+	if m3.confirmingDeleteModel {
+		t.Error("confirmingDeleteModel should be false after y")
+	}
+	got := m3.existingCfg.Providers["dashscope"].Models
+	if len(got) != 1 || got[0] != "qwen3.7-max" {
+		t.Errorf("Models = %v, want [qwen3.7-max]", got)
+	}
+	if !m3.savedInSession {
+		t.Error("savedInSession should be true after delete")
+	}
+
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load disk config: %v", err)
+	}
+	if len(diskCfg.Providers["dashscope"].Models) != 1 {
+		t.Errorf("disk Models = %v, want [qwen3.7-max]", diskCfg.Providers["dashscope"].Models)
+	}
+}
+
+func TestProviderTUI_OfficialTab_DeleteBuiltInModelIgnored(t *testing.T) {
+	m := officialDashscopeModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = modelIdxForName(t, m, "qwen3.7-max")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on built-in model should not trigger delete confirmation")
+	}
+}
+
+func TestProviderTUI_OfficialTab_RegistryModelNotDeletable(t *testing.T) {
+	m := officialDashscopeModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = modelIdxForName(t, m, "qwen3.7-max")
+
+	if m.isUserAddedOfficialModel("qwen3.7-max") {
+		t.Error("qwen3.7-max should not be user-added when it is in the registry")
+	}
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on registry model should not trigger delete confirmation")
+	}
+}
+
+func TestProviderTUI_OfficialTab_DeleteOnCustomModelInputIgnored(t *testing.T) {
+	m := officialDashscopeModelTUI(t, "", []string{"my-custom-model"})
+	m.modelIdx = len(m.models())
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on Enter custom model name... should not trigger delete confirmation")
+	}
+}
+
+func TestProviderTUI_CustomTab_DeleteOnCustomModelInputIgnored(t *testing.T) {
+	m := customStepfunModelTUI(t, "", []string{"step-3.5-flash", "aaa"})
+	m.modelIdx = len(m.models())
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if m2.confirmingDeleteModel {
+		t.Error("pressing d on Enter custom model name... should not trigger delete confirmation")
+	}
+}
+
+func TestProviderTUI_CustomTab_ModelShowsDeleteHint(t *testing.T) {
+	m := customStepfunModelTUI(t, "", []string{"step-3.5-flash", "aaa"})
+
+	m.modelIdx = len(m.models())
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "d Delete") {
+		t.Errorf("custom input row should not show d Delete hint; got:\n%s", got)
+	}
+
+	m.modelIdx = modelIdxForName(t, m, "aaa")
+	got = stripANSI(m.View().Content)
+	if !strings.Contains(got, "d Delete") {
+		t.Errorf("custom model row should show d Delete hint; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_OfficialTab_UserAddedModelShowsDeleteHint(t *testing.T) {
+	m := officialDashscopeModelTUI(t, "", []string{"my-custom-model"})
+
+	m.modelIdx = modelIdxForName(t, m, "qwen3.7-max")
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "d Delete") {
+		t.Errorf("built-in model should not show d Delete hint; got:\n%s", got)
+	}
+
+	m.modelIdx = modelIdxForName(t, m, "my-custom-model")
+	got = stripANSI(m.View().Content)
+	if !strings.Contains(got, "d Delete") {
+		t.Errorf("user-added model should show d Delete hint; got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_OfficialTab_DeleteModelPreservesActiveModel(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialDashscopeModelTUI(t, configPath, []string{"my-custom-model"})
+	m.existingCfg.Model = "qwen3.7-max"
+	m.existingCfg.Providers["dashscope"] = ProviderEntry{
+		Model:  "qwen3.7-max",
+		Models: []string{"qwen3.7-max", "my-custom-model"},
+	}
+	m.modelIdx = modelIdxForName(t, m, "my-custom-model")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	result, _ = m2.Update(yKey())
+	m3 := result.(providerTUIModel)
+
+	if m3.existingCfg.Providers["dashscope"].Model != "qwen3.7-max" {
+		t.Errorf("entry.Model = %q, want qwen3.7-max", m3.existingCfg.Providers["dashscope"].Model)
+	}
+	if m3.existingCfg.Model != "qwen3.7-max" {
+		t.Errorf("cfg.Model = %q, want qwen3.7-max", m3.existingCfg.Model)
+	}
+}
+
+func TestProviderTUI_OfficialTab_DeleteUserAddedModelCancel(t *testing.T) {
+	cancelKeys := []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"n", nKey()},
+		{"esc", escKey()},
+	}
+	for _, tc := range cancelKeys {
+		t.Run(tc.name, func(t *testing.T) {
+			m := officialDashscopeModelTUI(t, "", []string{"my-custom-model"})
+			m.modelIdx = modelIdxForName(t, m, "my-custom-model")
+
+			result, _ := m.Update(dKey())
+			m2 := result.(providerTUIModel)
+			if !m2.confirmingDeleteModel {
+				t.Fatal("expected confirmingDeleteModel after d")
+			}
+
+			result, _ = m2.Update(tc.key)
+			m3 := result.(providerTUIModel)
+			if m3.confirmingDeleteModel {
+				t.Error("confirmingDeleteModel should be false after cancel")
+			}
+			got := m3.existingCfg.Providers["dashscope"].Models
+			if len(got) != 2 || got[1] != "my-custom-model" {
+				t.Errorf("Models = %v, want model unchanged", got)
+			}
+		})
+	}
+}
+
+func TestProviderTUI_OfficialTab_DeleteActiveUserModelClearsCfg(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	m := officialDashscopeModelTUI(t, configPath, []string{"my-custom-model"})
+	m.existingCfg.Model = "my-custom-model"
+	m.existingCfg.Providers["dashscope"] = ProviderEntry{
+		Model:  "my-custom-model",
+		Models: []string{"qwen3.7-max", "my-custom-model"},
+	}
+	m.modelIdx = modelIdxForName(t, m, "my-custom-model")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	result, _ = m2.Update(yKey())
+	m3 := result.(providerTUIModel)
+
+	if m3.existingCfg.Providers["dashscope"].Model != "" {
+		t.Errorf("entry.Model = %q, want empty", m3.existingCfg.Providers["dashscope"].Model)
+	}
+	if m3.existingCfg.Model != "" {
+		t.Errorf("cfg.Model = %q, want empty", m3.existingCfg.Model)
+	}
+}
+
+func TestOfficialSelectedModelUsesRegistryNotStaleMerge(t *testing.T) {
+	registry := []string{"built-in"}
+	deletedCustom := "my-custom"
+	staleMerged := mergeModelLists(registry, []string{deletedCustom})
+
+	if llm.ModelListContains(registry, deletedCustom) {
+		t.Fatal("test setup: custom name should not be in registry")
+	}
+	if !llm.ModelListContains(staleMerged, deletedCustom) {
+		t.Fatal("test setup: stale merge should still list deleted custom name")
+	}
+	// runConfigModel must use registryModels, not staleMerged, or re-selected custom
+	// names would skip ensureModelInList when still present in the pre-TUI merge.
+	if llm.ModelListContains(staleMerged, deletedCustom) && llm.ModelListContains(registry, deletedCustom) {
+		t.Error("would skip persisting re-selected custom model")
+	}
+	if llm.ModelListContains(registry, deletedCustom) {
+		t.Error("registry-only check must not treat custom model as built-in")
+	}
+}
+
+func TestProviderTUI_CustomTab_DeleteModelSkipsSavedInSessionWhenNoModelDeleted(t *testing.T) {
+	m := customStepfunModelTUI(t, "", []string{"step-3.5-flash", "aaa"})
+	m.modelIdx = len(m.models()) // out of range — no model row selected
+	m.deleteModelName = "aaa"
+	m.confirmingDeleteModel = true
+
+	result, _ := m.confirmDeleteCustomModel()
+	m2 := result.(providerTUIModel)
+	if m2.savedInSession {
+		t.Error("savedInSession should be false when modelIdx is out of range")
+	}
+}
+
+func TestProviderTUI_CustomTab_DeleteModelViaDKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "stepfun",
+		Model:    "step-3.5-flash",
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun": {
+				URL:      "https://api.stepfun.com/v1",
+				Protocol: "openai",
+				Model:    "step-3.5-flash",
+				Models:   []string{"step-3.5-flash", "aaa"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	for i, cp := range m.customProviders {
+		if cp.name == "stepfun" {
+			m.customIdx = i
+			break
+		}
+	}
+	m.step = stepModel
+	m.modelIdx = modelIdxForName(t, m, "aaa")
+
+	result, _ := m.Update(dKey())
+	m2 := result.(providerTUIModel)
+	if !m2.confirmingDeleteModel || m2.deleteModelName != "aaa" {
+		t.Fatalf("after d: confirming=%v deleteModelName=%q", m2.confirmingDeleteModel, m2.deleteModelName)
+	}
+
+	result, _ = m2.Update(yKey())
+	m3 := result.(providerTUIModel)
+	got := m3.existingCfg.CustomProviders["stepfun"].Models
+	if len(got) != 1 || got[0] != "step-3.5-flash" {
+		t.Errorf("Models = %v, want [step-3.5-flash]", got)
+	}
+
+	diskCfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load disk config: %v", err)
+	}
+	if len(diskCfg.CustomProviders["stepfun"].Models) != 1 {
+		t.Errorf("disk Models = %v, want [step-3.5-flash]", diskCfg.CustomProviders["stepfun"].Models)
+	}
+}
+
+func TestProviderTUI_PersistCustomModelName_SaveFailureRollsBack(t *testing.T) {
+	blockPath := filepath.Join(t.TempDir(), "blocked")
+	if err := os.Mkdir(blockPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := officialDashscopeModelTUI(t, blockPath, nil)
+	before := append([]string(nil), m.existingCfg.Providers["dashscope"].Models...)
+	m.modelIdx = len(m.models())
+	m.customModel = true
+	m.modelInput.SetValue("failed-model")
+	m.modelInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.formError == "" {
+		t.Fatal("expected formError on save failure")
+	}
+	if !strings.Contains(m2.formError, "failed to save") {
+		t.Errorf("formError = %q, want save failure message", m2.formError)
+	}
+	got := m2.existingCfg.Providers["dashscope"].Models
+	if len(got) != len(before) {
+		t.Errorf("Models = %v, want unchanged %v", got, before)
+	}
+	if m2.savedInSession {
+		t.Error("savedInSession should be false after failed persist")
+	}
+}
+
 func TestProviderTUI_ManualFormPassesKToAuthHeaderInput(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
@@ -1429,6 +1805,41 @@ func TestProviderTUI_ApiKeyPasteReplacesMaskedKey(t *testing.T) {
 	}
 	if r := m2.result(); r.apiKey != "sk-new-pasted-key" {
 		t.Errorf("result().apiKey = %q, want pasted key", r.apiKey)
+	}
+}
+
+func TestProviderTUI_ManualTokenPasteReplacesMaskedToken(t *testing.T) {
+	cfg := &Config{
+		Llm: LlmConfig{
+			URL:       "https://example.com/v1",
+			Model:     "m",
+			AuthToken: "old-token-secret",
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabManual
+	m.inManualForm = true
+	m.manualStep = manualStepAuthToken
+	m.manualTokenMasked = true
+	m.manualTokenOriginal = "old-token-secret"
+	m.manualTokenInput.SetValue(maskedSecretPlaceholder())
+	m.manualTokenInput.Focus()
+
+	if !m.manualTokenMasked {
+		t.Fatal("expected masked token on load")
+	}
+
+	result, _ := m.Update(tea.PasteMsg{Content: "new-pasted-token"})
+	m2 := result.(providerTUIModel)
+
+	if m2.manualTokenMasked {
+		t.Fatal("paste should unmask the token field")
+	}
+	if got := m2.manualTokenInput.Value(); got != "new-pasted-token" {
+		t.Errorf("input value = %q, want pasted token", got)
+	}
+	if r := m2.result(); r.apiKey != "new-pasted-token" {
+		t.Errorf("result().apiKey = %q, want pasted token", r.apiKey)
 	}
 }
 

--- a/internal/llm/message_test.go
+++ b/internal/llm/message_test.go
@@ -288,16 +288,16 @@ func TestParseShellRC_NonexistentFile(t *testing.T) {
 
 func TestModelListContains(t *testing.T) {
 	models := []string{"gpt-4", " claude-3-opus ", "gemini-pro"}
-	if !modelListContains(models, "claude-3-opus") {
+	if !ModelListContains(models, "claude-3-opus") {
 		t.Error("expected true for claude-3-opus")
 	}
-	if !modelListContains(models, "gpt-4") {
+	if !ModelListContains(models, "gpt-4") {
 		t.Error("expected true for gpt-4")
 	}
-	if modelListContains(models, "gpt-3.5") {
+	if ModelListContains(models, "gpt-3.5") {
 		t.Error("expected false for gpt-3.5")
 	}
-	if modelListContains(nil, "anything") {
+	if ModelListContains(nil, "anything") {
 		t.Error("expected false for nil list")
 	}
 }

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -311,7 +311,7 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 	// Apply model override with validation.
 	if modelOverride != "" {
 		if len(availableModels) > 0 {
-			if !modelListContains(availableModels, modelOverride) {
+			if !ModelListContains(availableModels, modelOverride) {
 				return ResolvedEndpoint{}, false, fmt.Errorf(
 					"model %q is not available for provider %q; available models: %s",
 					modelOverride,
@@ -524,8 +524,8 @@ func defaultAuthHeader(protocol string) string {
 	return ""
 }
 
-// modelListContains checks if a model exists in the available models list.
-func modelListContains(models []string, target string) bool {
+// ModelListContains reports whether target matches any entry in models (trimmed).
+func ModelListContains(models []string, target string) bool {
 	target = strings.TrimSpace(target)
 	for _, model := range models {
 		if strings.TrimSpace(model) == target {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->

Persist user-added models to providers.<name>.models on the official tab. When an API key or auth token is already saved, show a replace hint with a prefix/suffix fingerprint (skipped for short keys), use a fixed mask placeholder, and ensure typing or paste replaces the saved value instead of re-saving it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

Official tab model persistence — Custom models added on the Official tab are now saved to providers.<name>.models in config, matching the behavior users already had on the Custom tab.

<img width="681" height="276" alt="image" src="https://github.com/user-attachments/assets/08f1040c-e965-4985-a4b6-3d8643300787" />

<img width="671" height="265" alt="image" src="https://github.com/user-attachments/assets/4dc32134-4109-4551-af80-0d238e5762eb" />


Saved API key hint — When a key is already configured, the TUI shows a line like Type or paste to replace the saved key. (saved: 4vJSE8...yCAp) so users know the field is masked and how to update it.

<img width="680" height="158" alt="image" src="https://github.com/user-attachments/assets/899ed42d-c895-42d8-8f6f-d108855072d1" />


## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
