### PR TITLE
fix(telemetry): support http:// scheme in otlp_endpoint for insecure gRPC

### DIFF
--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -25,11 +26,30 @@ func newStdoutMetricExporter() (sdkmetric.Exporter, error) {
 	return stdoutmetric.New(stdoutmetric.WithPrettyPrint())
 }
 
+// parseOTLPEndpoint strips a http:// or https:// scheme from the endpoint and
+// reports whether the connection should be insecure (plaintext gRPC).
+// Scheme matching is case-insensitive per RFC 3986. A bare host:port (no
+// scheme) is left unchanged and defaults to TLS.
+func parseOTLPEndpoint(endpoint string) (addr string, insecure bool) {
+	switch {
+	case len(endpoint) >= 7 && strings.EqualFold(endpoint[:7], "http://"):
+		return endpoint[7:], true
+	case len(endpoint) >= 8 && strings.EqualFold(endpoint[:8], "https://"):
+		return endpoint[8:], false
+	default:
+		return endpoint, false
+	}
+}
+
 // initOTLPProviders sets up OTLP gRPC exporters for traces and metrics.
 func initOTLPProviders(ctx context.Context, res *resource.Resource, cfg Config) {
-	traceExp, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
-	)
+	addr, insecure := parseOTLPEndpoint(cfg.OTLPEndpoint)
+
+	traceOpts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(addr)}
+	if insecure {
+		traceOpts = append(traceOpts, otlptracegrpc.WithInsecure())
+	}
+	traceExp, err := otlptracegrpc.New(ctx, traceOpts...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to create OTLP trace exporter: %v\n", err)
 		return
@@ -42,9 +62,11 @@ func initOTLPProviders(ctx context.Context, res *resource.Resource, cfg Config) 
 	tracerProvider = tp
 	shutdownFuncs = append(shutdownFuncs, func(ctx context.Context) error { return tp.Shutdown(ctx) })
 
-	metricExp, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithEndpoint(cfg.OTLPEndpoint),
-	)
+	metricOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(addr)}
+	if insecure {
+		metricOpts = append(metricOpts, otlpmetricgrpc.WithInsecure())
+	}
+	metricExp, err := otlpmetricgrpc.New(ctx, metricOpts...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to create OTLP metric exporter: %v\n", err)
 		return

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -29,13 +29,16 @@ func newStdoutMetricExporter() (sdkmetric.Exporter, error) {
 // parseOTLPEndpoint strips a http:// or https:// scheme from the endpoint and
 // reports whether the connection should be insecure (plaintext gRPC).
 // Scheme matching is case-insensitive per RFC 3986. A bare host:port (no
-// scheme) is left unchanged and defaults to TLS.
+// scheme) is left unchanged and defaults to TLS. Any trailing slash left
+// over from a URL-style endpoint (e.g. "http://localhost:4317/") is
+// trimmed, since otlptracegrpc/otlpmetricgrpc's WithEndpoint expects a bare
+// host:port with no path.
 func parseOTLPEndpoint(endpoint string) (addr string, insecure bool) {
 	switch {
 	case len(endpoint) >= 7 && strings.EqualFold(endpoint[:7], "http://"):
-		return endpoint[7:], true
+		return strings.TrimRight(endpoint[7:], "/"), true
 	case len(endpoint) >= 8 && strings.EqualFold(endpoint[:8], "https://"):
-		return endpoint[8:], false
+		return strings.TrimRight(endpoint[8:], "/"), false
 	default:
 		return endpoint, false
 	}

--- a/internal/telemetry/exporter_test.go
+++ b/internal/telemetry/exporter_test.go
@@ -20,6 +20,8 @@ func TestParseOTLPEndpoint(t *testing.T) {
 		{"uppercase HTTP scheme strips and is insecure", "HTTP://192.0.2.1:4317", "192.0.2.1:4317", true},
 		{"mixed-case Https scheme strips and keeps TLS", "Https://otel.example.com:4317", "otel.example.com:4317", false},
 		{"endpoint shorter than scheme prefix is unchanged", "ht", "ht", false},
+		{"http scheme with trailing slash is trimmed", "http://192.0.2.1:4317/", "192.0.2.1:4317", true},
+		{"https scheme with trailing slash is trimmed", "https://otel.example.com:4317/", "otel.example.com:4317", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/telemetry/exporter_test.go
+++ b/internal/telemetry/exporter_test.go
@@ -7,6 +7,33 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
+func TestParseOTLPEndpoint(t *testing.T) {
+	cases := []struct {
+		name         string
+		endpoint     string
+		wantAddr     string
+		wantInsecure bool
+	}{
+		{"http scheme strips and is insecure", "http://192.0.2.1:4317", "192.0.2.1:4317", true},
+		{"https scheme strips and keeps TLS", "https://otel.example.com:4317", "otel.example.com:4317", false},
+		{"bare host:port unchanged and keeps TLS", "localhost:4317", "localhost:4317", false},
+		{"uppercase HTTP scheme strips and is insecure", "HTTP://192.0.2.1:4317", "192.0.2.1:4317", true},
+		{"mixed-case Https scheme strips and keeps TLS", "Https://otel.example.com:4317", "otel.example.com:4317", false},
+		{"endpoint shorter than scheme prefix is unchanged", "ht", "ht", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, insecure := parseOTLPEndpoint(tc.endpoint)
+			if addr != tc.wantAddr {
+				t.Errorf("addr = %q, want %q", addr, tc.wantAddr)
+			}
+			if insecure != tc.wantInsecure {
+				t.Errorf("insecure = %v, want %v", insecure, tc.wantInsecure)
+			}
+		})
+	}
+}
+
 func TestNewStdoutTraceExporter(t *testing.T) {
 	exp, err := newStdoutTraceExporter()
 	if err != nil {


### PR DESCRIPTION
## Description

`initOTLPProviders` passed `cfg.OTLPEndpoint` directly to `WithEndpoint()`
without parsing the scheme, so:

- bare `host:port` forced TLS, breaking plaintext OTel Collectors
- `http://host:port` failed with "too many colons in address"

This PR parses the scheme before constructing the trace/metric exporters:
- `http://` → strip scheme, `WithInsecure()`
- `https://` → strip scheme, keep default TLS
- bare `host:port` → unchanged, keep default TLS (backward compatible)

Scheme matching is case-insensitive.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Added `TestParseOTLPEndpoint` covering http/https/bare-host/uppercase-scheme/
short-string cases. Also manually verified against a real internal OTel
Collector configured with plaintext (insecure) gRPC — `ocr review` completes
without the previous "too many colons in address" / TLS handshake failure,
and a byte-level capture confirmed the connection is plaintext HTTP/2 (not a
TLS ClientHello) when `http://` is used.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Fixes #268