### PR TITLE
feat(pages): add Docs page with search, markdown rendering, and i18n support

### DIFF
--- a/pages/src/components/HeroSection.tsx
+++ b/pages/src/components/HeroSection.tsx
@@ -169,7 +169,7 @@ const HeroSection: React.FC = () => {
       style={{
         width: '100vw',
         marginLeft: 'calc(-50vw + 50%)',
-        height: isMobile ? 820 : isTablet ? 800 : 960,
+        height: isMobile ? 850 : isTablet ? 830 : 990,
         position: 'relative',
         overflow: 'hidden',
         display: 'flex',
@@ -362,7 +362,7 @@ const HeroSection: React.FC = () => {
           {/* Terminal body */}
           <div
             style={{
-              padding: '10px 0',
+              padding: '10px 0 8px 0',
               background: 'rgba(255,255,255,0.08)',
               backdropFilter: 'blur(20px)',
               borderBottomLeftRadius: 8,

--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useEffect, useRef, useState, useCallback, useId } from 'react';
+import React, { useMemo, useEffect, useRef, useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import { Marked, Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import mermaid from 'mermaid';
 import { useTranslation } from '../i18n';
 import copyIcon from '../assets/icons/icon-copy.svg';
-import { generateHeadingId } from '../utils/headingId';
+import { createHeadingIdGenerator } from '../utils/headingId';
 
 // Initialize mermaid with dark theme
 mermaid.initialize({
@@ -76,8 +76,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   const html = useMemo(() => {
     // Custom renderer to generate heading IDs matching the TOC extraction logic
     const renderer = new Renderer();
+    const getHeadingId = createHeadingIdGenerator();
     renderer.heading = function ({ text, depth }: { text: string; depth: number }) {
-      const id = generateHeadingId(text);
+      const id = getHeadingId(text);
       // Escape id attribute value to prevent XSS
       const safeId = id.replace(/"/g, '&quot;');
       return `<h${depth} id="${safeId}">${text}</h${depth}>\n`;
@@ -110,7 +111,6 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       // Create copy button matching reference HTML
       const btn = document.createElement('div');
       btn.className = 'code-copy-btn';
-      btn.style.cssText = 'display:flex;flex-shrink:0;justify-content:flex-start;align-items:flex-start;flex-direction:column;padding-top:4px;padding-bottom:4px;cursor:pointer;';
       btn.innerHTML = `<img src="${copyIcon}" alt="copy" style="width:16px;height:16px;" />`;
       btn.addEventListener('click', () => {
         const text = codeEl.textContent || '';
@@ -123,7 +123,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
     const mermaidBlocks = containerRef.current.querySelectorAll('code.language-mermaid');
     if (mermaidBlocks.length === 0) return;
 
-    const renderPromises = Array.from(mermaidBlocks).map(async (block) => {
+    Promise.all(Array.from(mermaidBlocks).map(async (block) => {
       const pre = block.parentElement;
       if (!pre) return;
       const code = block.textContent || '';
@@ -142,6 +142,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
         (block as HTMLElement).style.display = 'block';
         console.warn('[Mermaid] render failed:', e);
       }
+    })).catch((e) => {
+      console.warn('[Mermaid] unexpected render error:', e);
     });
 
     return () => { cancelled = true; };
@@ -156,26 +158,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
         style={{ width: '100%' }}
       />
       {ReactDOM.createPortal(
-        <div
-          style={{
-            position: 'fixed',
-            top: 88,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            background: 'rgba(255,255,255,0.1)',
-            border: '1px solid rgba(255,255,255,0.2)',
-            color: 'rgba(255,255,255,0.85)',
-            padding: '5px 8px 5px 10px',
-            borderRadius: 6,
-            fontSize: 12,
-            fontWeight: 500,
-            pointerEvents: 'none',
-            opacity: toastVisible ? 1 : 0,
-            transition: 'opacity 0.15s ease',
-            zIndex: 9999,
-            backdropFilter: 'blur(8px)',
-          }}
-        >
+        <div className={`copy-toast${toastVisible ? ' visible' : ''}`}>
           {t('quickstart.copied')}
         </div>,
         document.body

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -4,43 +4,185 @@ sidebar:
   order: 5
 ---
 
-The config file lives at `~/.opencodereview/config.json`. You have three ways
-to edit it:
+## Endpoint resolution
 
-- **Interactive TUI** — `ocr config provider` / `ocr config model`, with guided menus.
-- **Command line** — `ocr config set <key> <value>`, ideal for scripts and CI.
-- **Manual edit (not recommended)** — the JSON file directly (it gets reformatted on the next `ocr config set` write).
+When `ocr review` or `ocr llm test` runs, it tries four sources **in order**
+and uses the first one that yields a complete `(URL, token, model)` triple:
 
-## Configuring a model
+| Priority | Source | What it reads |
+|---|---|---|
+| 1 | `~/.opencodereview/config.json` | If `provider` is set, resolves via the `providers`/`custom_providers` maps (provider-first; see [Built-in providers](#built-in-providers)). Only falls back to the legacy `llm` section when no provider is set. |
+| 2 | OCR environment variables | `OCR_LLM_URL`, `OCR_LLM_TOKEN`, `OCR_LLM_MODEL`, `OCR_USE_ANTHROPIC`, `OCR_LLM_AUTH_HEADER`. |
+| 3 | Claude Code environment variables | `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`. |
+| 4 | Shell rc files | `export ANTHROPIC_*=…` lines parsed out of `~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`. |
 
-### Recommended: interactive setup
+For Claude Code-style sources, if `ANTHROPIC_BASE_URL` lacks a versioned
+path (`/v1/...`), OCR appends `/v1/messages` automatically.
+
+If no strategy yields a complete triple, OCR exits with:
+
+```
+no valid LLM endpoint configured; one of OCR_LLM_URL/OCR_LLM_TOKEN/OCR_LLM_MODEL,
+~/.opencodereview/config.json, or ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN/
+ANTHROPIC_MODEL must be set
+```
+
+> Resolution stops at the first source that **errors**, not just the first
+> that's empty. In particular, if `provider` is set in `config.json` but the
+> entry is misconfigured (unknown provider name, missing `api_key` with no
+> env-var fallback, missing `model`, a custom provider lacking `url`/`protocol`),
+> OCR exits with that error and does **not** fall through to the OCR env,
+> Claude Code, or rc-file sources. To switch to env-based config, unset the
+> `provider` key first.
+
+> Source priority means the **environment overrides nothing** when the
+> config file is fully populated. To force the environment to win, either
+> delete the relevant `llm.*` keys from `~/.opencodereview/config.json` or
+> use `ocr config set` to switch to the new values.
+
+## `ocr config set` — managing `~/.opencodereview/config.json`
+
+```bash
+ocr config set <key> <value>
+```
+
+`config set` mutates the file via key/value pairs with schema-aware
+parsing. The interactive TUI commands `ocr config provider` and
+`ocr config model` also write to the same file (see
+[Interactive setup](#interactive-setup--ocr-config-provider--ocr-config-model)).
+Recognised keys:
+
+| Key | Type | Notes |
+|---|---|---|
+| `provider` | string | Set the active provider (built-in name or custom). Switching provider clears the model. |
+| `model` | string | Set the model for the active provider (stored under the provider entry, or top-level `model` if no provider is set). |
+| `providers.<name>.<field>` | varies | Per-provider fields for built-in providers: `api_key`, `url`, `protocol`, `model`, `models`, `auth_header`, `extra_body`. |
+| `custom_providers.<name>.<field>` | varies | Same fields as above, for custom (non-built-in) providers. Custom providers must set at least `url` and `protocol`. |
+| `llm.url` | string | Endpoint URL. For Anthropic, full Messages URL like `https://api.anthropic.com/v1/messages`. For OpenAI-compatible, the chat-completions URL. |
+| `llm.auth_token` | string | API key. Sent as `Authorization: Bearer …` (OpenAI) or, for the legacy Anthropic path, `Authorization: Bearer …` by default (the preset `anthropic` provider defaults to `x-api-key` instead). Use `x-api-key` only by explicitly setting `llm.auth_header`. |
+| `llm.auth_header` | string | Auth header name (`x-api-key`, `authorization`, or `bearer`). Anthropic-only; required for some Anthropic setups that need `x-api-key`. |
+| `llm.model` | string | Model name. A `[<digits>m]` suffix is stripped automatically. |
+| `llm.use_anthropic` | boolean | `true` (default) → Anthropic Messages protocol. `false` → OpenAI Chat Completions. |
+| `llm.extra_body` | JSON object | Vendor-specific request fields merged into every chat request body. Example: `'{"thinking":{"type":"disabled"}}'`. |
+| `language` | string | Forwarded into a directive appended to the system prompt; defaults to `English` when unset. See [Choosing a language](#choosing-a-language). |
+| `telemetry.enabled` | boolean | Master switch for OpenTelemetry export. Off by default. |
+| `telemetry.exporter` | string | `console` or `otlp`. |
+| `telemetry.otlp_endpoint` | string | OTLP collector address (e.g., `localhost:4317`). |
+| `telemetry.content_logging` | boolean | Include LLM prompts / responses in exported event data. |
+
+Examples:
+
+```bash
+ocr config set llm.url           https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token    sk-ant-xxxxxxxxxx
+ocr config set llm.model         claude-opus-4-6
+ocr config set llm.use_anthropic true
+ocr config set llm.extra_body   '{"thinking":{"type":"disabled"}}'
+ocr config set language          English
+ocr config set telemetry.enabled true
+ocr config set telemetry.exporter otlp
+ocr config set telemetry.otlp_endpoint localhost:4317
+
+# Provider-based setup (recommended)
+ocr config set provider          anthropic
+ocr config set model             claude-opus-4-6
+ocr config set providers.anthropic.api_key "$ANTHROPIC_API_KEY"
+
+# Custom (non-built-in) provider
+ocr config set provider          my-gateway
+ocr config set custom_providers.my-gateway.url      https://gateway.internal.com/v1
+ocr config set custom_providers.my-gateway.protocol openai
+ocr config set custom_providers.my-gateway.model    llama-3-70b
+ocr config set custom_providers.my-gateway.api_key   "$MY_API_KEY"
+```
+
+Booleans accept anything Go's `strconv.ParseBool` accepts (`true`, `false`,
+`1`, `0`, `t`, `f`, …). `llm.extra_body` must be valid JSON.
+
+## File schema reference
+
+After the commands above, `~/.opencodereview/config.json` looks like:
+
+```json
+{
+    "llm": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "auth_token": "sk-ant-xxxxxxxxxx",
+        "auth_header": "x-api-key",
+        "model": "claude-opus-4-6",
+        "use_anthropic": true,
+        "extra_body": {
+            "thinking": { "type": "disabled" }
+        }
+    },
+    "language": "English",
+    "telemetry": {
+        "enabled": true,
+        "exporter": "otlp",
+        "otlp_endpoint": "localhost:4317"
+    }
+}
+```
+
+The provider-based form uses `provider`, `model`, `providers`, and
+`custom_providers` instead of the legacy `llm` block:
+
+```json
+{
+    "provider": "anthropic",
+    "model": "claude-opus-4-6",
+    "providers": {
+        "anthropic": {
+            "api_key": "sk-ant-xxxxxxxxxx",
+            "model": "claude-opus-4-6"
+        }
+    },
+    "custom_providers": {
+        "my-gateway": {
+            "url": "https://gateway.internal.com/v1",
+            "protocol": "openai",
+            "model": "llama-3-70b",
+            "models": ["llama-3-70b", "llama-3-8b"],
+            "api_key": "gw-xxxxxxxxxx",
+            "auth_header": "authorization"
+        }
+    },
+    "language": "English"
+}
+```
+
+When `provider` is set, the `providers`/`custom_providers` maps drive
+resolution; the legacy `llm` section is ignored for that config.
+
+You can edit this file by hand if you prefer, but `ocr config set` will
+remarshal with `"    "` indent on the next write.
+
+## Interactive setup — `ocr config provider` / `ocr config model`
+
+For provider and model selection without typing keys, OCR ships two
+interactive Bubble Tea TUIs that also mutate `~/.opencodereview/config.json`.
 
 ```bash
 ocr config provider
-```
-
-It lets you pick a built-in or custom provider, enter an API key, choose a model, saves everything to the config file, and then runs `ocr llm test` once to verify the endpoint. To switch models later:
-
-```bash
 ocr config model
 ```
 
-### Non-interactive setup (CI / no-TUI environments)
+- `ocr config provider` — Interactive TUI for selecting a built-in or custom
+  provider, then entering URL / protocol / API key / model. Saves the choice
+  to config and runs `ocr llm test` automatically to verify the endpoint.
+  For built-in providers, the API key may be read from the provider's env var
+  (see [Built-in providers](#built-in-providers)) when not entered directly.
+  Selecting a manual configuration populates the legacy `llm.*` block instead.
+- `ocr config model` — Interactive TUI for selecting a model from the current
+  provider's preset list, plus any user-added models stored under
+  `providers.<name>.models` / `custom_providers.<name>.models`. Requires a
+  provider to be set first (`ocr config provider`).
 
-Write to the same config with `ocr config set`:
+## Built-in providers
 
-```bash
-ocr config set provider                    anthropic
-ocr config set model                       claude-opus-4-6
-ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
-```
-
-### Built-in providers
-
-The following providers ship with OCR, with the Base URL and protocol
-preset — once selected, you only need to fill in the API key. If
-`providers.<name>.api_key` is unset, OCR falls back to the corresponding
-environment variable.
+The following providers ship with OCR. Each has a preset `BaseURL`,
+`Protocol`, and (where applicable) an API key environment variable used as a
+fallback when `providers.<name>.api_key` is unset.
 
 | Name | Protocol | Base URL | API key env var |
 |---|---|---|---|
@@ -58,53 +200,84 @@ environment variable.
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
 
-### Custom providers
+Any other provider name is treated as custom and must be configured under
+`custom_providers` with at least `url` and `protocol`.
 
-Any provider name not in the table above is treated as custom and must
-supply at least `url` and `protocol` (`protocol` is either `anthropic` or
-`openai`):
+## Environment variable reference
+
+| Variable | Purpose |
+|---|---|
+| `OCR_LLM_URL` | Endpoint URL — same shape as `llm.url`. |
+| `OCR_LLM_TOKEN` | API key — same as `llm.auth_token`. |
+| `OCR_LLM_MODEL` | Model name. |
+| `OCR_LLM_AUTH_HEADER` | Auth header name (`x-api-key`, `authorization`, or `bearer`). Anthropic-only; same as `llm.auth_header`. Defaults to `authorization` when unset. |
+| `OCR_USE_ANTHROPIC` | Unset → Anthropic protocol (default). Set to `true` / `1` / `yes` (case-insensitive) → Anthropic. Set to anything else (`false`, `0`, `no`, typos, …) → OpenAI. |
+| `ANTHROPIC_BASE_URL` | Claude Code-compatible base URL. |
+| `ANTHROPIC_AUTH_TOKEN` | Claude Code-compatible API key. |
+| `ANTHROPIC_MODEL` | Claude Code-compatible model. |
+| `OCR_ENABLE_TELEMETRY` | `1` to enable telemetry from env. |
+| `OTEL_SERVICE_NAME` | Override service name in spans/metrics. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector address — also forces the exporter to `otlp`. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP transport protocol (`grpc`, `http/protobuf`, or `http/json`). Defaults to `grpc`. |
+| `OCR_CONTENT_LOGGING` | `1` to include prompts/responses in telemetry events. |
+
+Per-provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`DASHSCOPE_API_KEY`, …) are used as a fallback when a built-in provider's
+`api_key` field is unset. See the [Built-in providers](#built-in-providers)
+table for each provider's env var name.
+
+## Why `extra_body` exists
+
+Some hosted providers add non-standard fields to the request body (for
+example, Bedrock-style `thinking`, vendor-specific `temperature_strategy`,
+streaming options). `llm.extra_body` is merged into every outgoing request,
+so you can ship those fields without patching the source.
 
 ```bash
-ocr config set provider                             my-gateway
-ocr config set custom_providers.my-gateway.url      https://gateway.internal.com/v1
-ocr config set custom_providers.my-gateway.protocol openai
-ocr config set custom_providers.my-gateway.model    llama-3-70b
-ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+ocr config set llm.extra_body '{"thinking":{"type":"enabled","budget_tokens":2048}}'
 ```
 
-### Verify connectivity
+## Choosing a language
 
-```bash
-ocr llm test
+The `language` key controls one thing only: a directive appended to every
+system-role message in the review and `ocr llm test` prompts. The exact
+string injected is:
+
+```
+\n\nAlways respond in <language>.
 ```
 
-### Reuse existing environment variables
+- *Unset* or empty — treated as `English`.
+- `Chinese`, `English`, or any other string — passed through verbatim.
 
-If you already have Claude Code's `ANTHROPIC_*` or OCR's own `OCR_LLM_*`
-environment variables configured, OCR picks them up automatically — no
-config file needed.
+There is no language switching on built-in rule docs. The files embedded
+under `internal/config/rules/rule_docs/` are loaded by fixed filename and
+are mostly written in Chinese (with `default.md` as an English exception);
+they appear in the prompt as-is regardless of the `language` setting. When
+`language` is `English`, the prompt therefore contains an English directive
+on top of mostly-Chinese rule text — strong models honour the directive and
+produce English comments, weaker models may emit mixed output.
 
-### Send vendor-specific fields
-
-Some providers require non-standard request fields (such as Bedrock-style
-`thinking`). Use `extra_body` (merged into every request) to send them
-without patching the source:
-
-```bash
-ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
-```
-
-## Configuring the review language
-
-`language` determines which language review comments are written in;
-it defaults to English when unset:
+`language` has no environment-variable, CLI-flag, or per-project override —
+the only place it can be set is the global `~/.opencodereview/config.json`,
+via [`ocr config set`](#ocr-config-set--managing-opencodereviewconfigjson):
 
 ```bash
-ocr config set language 中文
 ocr config set language English
 ```
+
+If you need fully English rule text, supply your own rules via `--rule`,
+`<repo>/.opencodereview/rule.json`, or `~/.opencodereview/rule.json` (see
+[Review Rules](../review-rules/#priority-chain)).
+
+## Per-project vs. global config
+
+The CLI itself is configured globally (`~/.opencodereview/config.json`) —
+there is no project-local LLM config. **Review rules** *are* per-project,
+however; see [Review Rules](../review-rules/#priority-chain).
 
 ## See Also
 
 - [QuickStart](../quickstart/) — minimal setup and first review.
 - [CLI Reference](../cli-reference/) — every flag the review command accepts.
+- [Telemetry](../telemetry/) — how to wire up OTLP / console exporters.

--- a/pages/src/content/docs/en/faq.md
+++ b/pages/src/content/docs/en/faq.md
@@ -19,7 +19,7 @@ no valid LLM endpoint configured; one of OCR_LLM_URL/OCR_LLM_TOKEN/OCR_LLM_MODEL
 ANTHROPIC_MODEL must be set
 ```
 
-OCR ran the full endpoint-resolution chain ([Configuration](../configuration/#reuse-existing-environment-variables))
+OCR ran the four-source resolution chain ([Configuration](../configuration/#endpoint-resolution))
 and didn't find a complete `(URL, token, model)` triple. Either:
 
 - Run `ocr config set llm.url …` / `llm.auth_token …` / `llm.model …`

--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -4,63 +4,45 @@ sidebar:
   order: 4
 ---
 
-There are four supported ways to install the `ocr` CLI.
+There are four supported ways to install the `ocr` CLI. They all produce
+the same binary — pick whichever fits your environment.
 
 ## NPM (recommended)
-
-#### Install
 
 ```bash
 npm install -g @alibaba-group/open-code-review
 ```
 
-Pin a specific version:
+The NPM package ships a small wrapper script (`bin/ocr.js`) plus a
+[postinstall hook](https://github.com/alibaba/open-code-review/blob/main/scripts/install.js)
+that:
+
+1. Detects your platform (`darwin-amd64`, `darwin-arm64`, `linux-amd64`,
+   `linux-arm64`, `windows-amd64`, `windows-arm64`).
+2. Downloads the matching binary from GitHub Releases.
+3. Verifies it (when checksum data is present) and places it next to the
+   wrapper.
+
+If a platform-specific npm package (e.g. `@alibaba-group/ocr-darwin-arm64`)
+is installed as an optional dependency, the binary is used directly and the
+download is skipped.
+
+When you run `ocr`, the wrapper just `exec`s the downloaded binary, so the
+overhead is effectively zero after first run.
+
+### Updating
 
 ```bash
+npm update -g @alibaba-group/open-code-review
+# or pin a specific version:
 npm install -g @alibaba-group/open-code-review@<version>
 ```
 
-#### Updating
-
-When installed via NPM, `ocr` keeps itself up to date automatically by
-default (the static binary opts out of this mechanism). On each `ocr` run,
-the wrapper silently checks the registry for the latest version in the
-background and upgrades automatically when an update is found, without
-affecting the current review. There's an 18-minute cooldown between checks,
-tunable with `OCR_UPDATE_INTERVAL` (minutes).
-
-To turn off auto-updates, set `OCR_NO_UPDATE` to any non-empty value:
-
-```bash
-export OCR_NO_UPDATE=1
-```
-
-#### Uninstalling
+### Uninstalling
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
 ```
-
-## Install script (curl | sh)
-
-A convenience installer that wraps the GitHub Release binary download
-(with checksum verification) — handy for CI base images and headless
-machines:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
-```
-
-It honours two environment variables:
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `OCR_INSTALL_DIR` | `/usr/local/bin` | Where to place the `ocr` binary. |
-| `OCR_VERSION` | latest release | Pin a specific release tag (e.g. `v1.2.3`). |
-
-The script supports `darwin` and `linux` on `amd64` / `arm64`; for
-Windows, use the [GitHub Release binary](#github-release-binary) or
-[NPM](#npm-recommended) path instead.
 
 ## GitHub Release binary
 
@@ -99,18 +81,39 @@ curl -LO https://github.com/alibaba/open-code-review/releases/latest/download/sh
 shasum -a 256 -c sha256sum.txt --ignore-missing
 ```
 
+## Install script (curl | sh)
+
+A convenience installer that wraps the GitHub Release binary download
+(with checksum verification) — handy for CI base images and headless
+machines:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+It honours two environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OCR_INSTALL_DIR` | `/usr/local/bin` | Where to place the `ocr` binary. |
+| `OCR_VERSION` | latest release | Pin a specific release tag (e.g. `v1.2.3`). |
+
+The script supports `darwin` and `linux` on `amd64` / `arm64`; for
+Windows, use the [GitHub Release binary](#github-release-binary) or
+[NPM](#npm-recommended) path instead.
+
 ## Build from source
 
 You only need this path if you're hacking on OCR or running on a platform
 without a pre-built binary.
 
-#### Prerequisites
+### Prerequisites
 
 - [Go ≥ 1.25](https://go.dev/dl/)
 - [Git](https://git-scm.com/)
 - [Make](https://www.gnu.org/software/make/)
 
-#### Build
+### Build
 
 ```bash
 git clone https://github.com/alibaba/open-code-review.git
@@ -119,7 +122,7 @@ make build              # writes dist/opencodereview
 sudo cp dist/opencodereview /usr/local/bin/ocr
 ```
 
-#### Build for another platform
+### Build for another platform
 
 ```bash
 make build-linux-amd64
@@ -136,7 +139,7 @@ make sha256sum          # also produce sha256sum.txt
 file alongside the binaries — that's exactly what the release pipeline
 runs.
 
-#### Run tests
+### Run tests
 
 ```bash
 make test               # LC_ALL=C go test -v -race -count=1 ./...
@@ -167,7 +170,7 @@ echo $PATH
 | `~/.opencodereview/config.json` | LLM endpoint, language, telemetry config (managed by `ocr config set`). |
 | `~/.opencodereview/rule.json` | Optional global review rules. |
 | `~/.opencodereview/sessions/<encoded-repo-path>/<session-id>.jsonl` | Streaming JSONL transcript of every review session, used by `ocr viewer`. |
-| `~/.opencodereview/{last-update-check,update.lock,update-available}` | NPM wrapper's background update-check state. The wrapper polls for a newer release (every ~18 min by default) and prints an upgrade hint. Disable with `OCR_NO_UPDATE=1`, or tune the interval with `OCR_UPDATE_INTERVAL` (minutes). Not written by the static binary. |
+| `~/.opencodereview/{last-update-check,update.lock,update-available}` | NPM wrapper's background update-check state. The wrapper polls for a newer release (every ~18 min by default) and prints an upgrade hint. Disable with `OCR_NO_UPDATE=1`, or tune the interval with `OCR_UPDATE_INTERVAL` (seconds). Not written by the static binary. |
 | `<repo>/.opencodereview/rule.json` | Optional per-project review rules — safe to commit. |
 
 OCR never writes outside `~/.opencodereview/` (besides the transient binary

--- a/pages/src/content/docs/en/integrations.md
+++ b/pages/src/content/docs/en/integrations.md
@@ -44,10 +44,6 @@ agent platform requires MCP specifically, wrap the CLI with a thin
 shim — a 30-line Node script that exposes a single `review` tool is
 enough.
 
-The reverse direction *is* supported: OCR can act as an MCP **client** and
-pull tools from external MCP servers into a review. See
-[MCP Servers](../mcp/).
-
 ## Tips that apply to every pattern
 
 - **Always pass `--audience agent`** when the caller is non-human.

--- a/pages/src/content/docs/en/overview.md
+++ b/pages/src/content/docs/en/overview.md
@@ -1,0 +1,139 @@
+---
+title: Overview
+sidebar:
+  order: 2
+---
+
+## What is Open Code Review?
+
+Open Code Review (**OCR** for short, distinct from Optical Character
+Recognition) is an AI-powered code review CLI distributed as the
+[`@alibaba-group/open-code-review`](https://www.npmjs.com/package/@alibaba-group/open-code-review)
+NPM package and as standalone Go binaries. The CLI binary is named `ocr`.
+
+In a single command (`ocr review`) it:
+
+1. Resolves a Git diff — workspace, branch range, or single commit.
+2. Filters the changed files using both system defaults and any user rules.
+3. Spawns one **per-file sub-agent** for each changed file, in parallel.
+4. Each sub-agent runs an LLM tool-use loop, optionally preceded by a
+   **plan phase** for larger diffs.
+5. The model calls `code_comment` to record findings, optionally `file_read`,
+   `code_search`, `file_find`, `file_read_diff` to gather context, and
+   `task_done` when finished.
+6. OCR resolves each comment to exact line numbers, runs an optional
+   re-positioning pass for any comments that didn't match cleanly, and
+   prints (or JSON-emits) the final list.
+
+## The problem with general-purpose agents
+
+If you've used a general-purpose coding agent (Claude Code with a Skill,
+Cursor, Cline, etc.) for code review, you've likely run into:
+
+- **Incomplete coverage** — on larger changesets the agent quietly cuts
+  corners, reviewing only some files.
+- **Position drift** — comments don't line up with the code they refer to;
+  line numbers and file paths drift off target.
+- **Unstable quality** — natural-language Skills are hard to debug, and
+  output quality fluctuates with minor prompt edits.
+
+The root cause: a purely language-driven architecture lacks **hard
+constraints** on the review process.
+
+## Core design: deterministic engineering × agent
+
+OCR's core philosophy is to combine **deterministic engineering** with an
+**agent** — each handling what it does best.
+
+### Deterministic engineering — hard constraints
+
+For steps that *must not go wrong*, engineering logic — not the model —
+guarantees correctness:
+
+- **Precise file selection** — a [five-gate filter](../review-rules/#how-files-are-filtered)
+  decides exactly which files are reviewed, with explicit `include`/`exclude`
+  controls.
+- **Smart file bundling** — related files (e.g., `message_en.properties` and
+  `message_zh.properties`) can be grouped into a single review unit. Each
+  bundle runs as a sub-agent with isolated context — divide and conquer that
+  stays stable on very large changesets and naturally supports concurrent
+  review.
+- **Fine-grained rule matching** — review rules are matched per file path
+  with first-match-wins, keeping the model's attention sharply focused and
+  eliminating noise. Template-based matching is more stable than purely
+  language-driven rule guidance.
+- **External positioning and reflection modules** — independent comment
+  positioning ([`internal/diff/relocation.go`](https://github.com/alibaba/open-code-review/blob/main/internal/diff/relocation.go))
+  and re-location passes systematically improve both location and content
+  accuracy.
+
+### Agent — dynamic decision-making
+
+The agent's strengths are concentrated where they matter most:
+
+- **Scenario-tuned prompts** — prompt templates deeply optimized for code
+  review, improving effectiveness while reducing token consumption (see
+  [`internal/config/template/task_template.json`](https://github.com/alibaba/open-code-review/blob/main/internal/config/template/task_template.json)).
+- **Scenario-tuned toolset** — distilled from analysis of tool-call traces in
+  large-scale production data (call-frequency distributions, per-tool
+  repetition rates, the impact of each tool on the overall call chain). The
+  result is a purpose-built set of [six tools](../tools/) that is more stable
+  and predictable than a generic agent toolkit.
+
+## How the pipeline fits together
+
+```mermaid
+flowchart TD
+    Start["<b>ocr review --from main --to feature</b>"]
+    S1["<b>1. Resolve LLM endpoint</b><br/>config / env / shell rc"]
+    S2["<b>2. Load diffs from git</b><br/>workspace / commit / range"]
+    S3["<b>3. Filter files</b><br/>binary → user_exclude → user_include<br/>→ ext allowlist → default path"]
+    S4["<b>4. Drop diffs > 80% of MAX_TOKENS</b>"]
+    S5["<b>5. Dispatch per-file sub-agents</b> (concurrent)<br/><br/>For each file:<br/>&nbsp;&nbsp;a. Plan phase (if changed lines ≥ 50)<br/>&nbsp;&nbsp;b. Main loop: LLM → tool calls → … → task_done<br/>&nbsp;&nbsp;c. code_comment results collected (async via worker pool)<br/><br/>Memory compression triggers when context<br/>exceeds 60 % (async) or 80 % (sync) of MAX_TOKENS."]
+    S6["<b>6. Resolve line numbers</b><br/>from <code>existing_code</code> against diffs.<br/>Re-locate via LLM if needed."]
+    S7["<b>7. Emit text or JSON output</b><br/>(and persist session to disk)"]
+
+    Start --> S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> S7
+```
+
+## Project layout
+
+```
+open-code-review/
+├── cmd/opencodereview/   # CLI entry point: dispatch, flags, commands
+├── internal/
+│   ├── agent/            # Per-file sub-agent loop + memory compression
+│   ├── config/
+│   │   ├── allowlist/    # Default file-extension allowlist & exclusions
+│   │   ├── rules/        # Layered rule resolver, system rule docs
+│   │   ├── template/     # Plan / main / memory_compression prompts
+│   │   ├── testconnection/ # Built-in `ocr llm test` task
+│   │   └── toolsconfig/  # Tool definitions sent to the model
+│   ├── diff/             # Git diff parsing, hunk math, relocation
+│   ├── gitcmd/           # Git subprocess runner
+│   ├── llm/              # Anthropic + OpenAI protocols, retries, BPE tokens
+│   ├── model/            # Diff / Comment data structures
+│   ├── pathutil/         # Path utilities
+│   ├── release/          # Release-notes generation
+│   ├── session/          # JSONL persistence of every review session
+│   ├── stdout/           # Quiet-able stdout writer for `--audience agent`
+│   ├── suggestdiff/      # Build "Apply suggestion" diffs
+│   ├── telemetry/        # OpenTelemetry spans, metrics, exporters
+│   ├── tool/             # The six built-in tools + comment collector
+│   └── viewer/           # `ocr viewer` — local web UI for past sessions
+├── pages/                # React-based marketing landing page (separate)
+├── plugins/              # Claude Code plugin manifest + commands
+├── extensions/           # Editor extensions (VS Code)
+├── examples/             # CI recipes (GitHub Actions, GitLab CI)
+├── skills/               # Generic agent Skill manifest
+├── scripts/              # NPM install/update helpers, publish scripts
+├── npm/                  # Per-platform optional dependency packages
+└── bin/                  # NPM wrapper that shells out to the binary
+```
+
+## See Also
+
+- [QuickStart](../quickstart/) — install and run your first review.
+- [Architecture](../architecture/) — the agent loop, plan phase, and memory compression.
+- [CLI Reference](../cli-reference/) — every flag and sub-command.
+- [Integrations](../integrations/) — call OCR from Claude Code or any agent.

--- a/pages/src/content/docs/en/quickstart.md
+++ b/pages/src/content/docs/en/quickstart.md
@@ -4,44 +4,138 @@ sidebar:
   order: 3
 ---
 
-Get your first code review running in a few minutes.
+Install OCR, point it at any LLM that speaks the Anthropic Messages API or
+the OpenAI Chat Completions API, and run your first code review.
 
 ## Prerequisites
 
-- **Git ≥ 2.41**
-- **Node.js ≥ 18**
-- **LLM API key**
+- A working **Git** install — OCR drives Git as a subprocess to read diffs.
+- An **API key** for an Anthropic-compatible or OpenAI-compatible LLM.
+- One of:
+  - **Node.js ≥ 18** (recommended; minimum supported: Node 14 — installs via NPM).
+  - Or just `curl` + `chmod` to drop the static binary into `$PATH`.
+  - Or **Go ≥ 1.25** if you prefer to build from source.
 
 ## Step 1 — Install the CLI
 
+### Option A: NPM (recommended)
+
 ```bash
 npm install -g @alibaba-group/open-code-review
-ocr version
 ```
 
-> See [Installation](../installation/) for more methods.
+The NPM package installs a small wrapper that downloads the right binary for
+your OS / architecture on install (via a postinstall hook). If the binary is
+missing at run time, the wrapper errors out rather than downloading. After
+install, you have a global `ocr` command:
+
+```bash
+ocr --version
+```
+
+### Option B: GitHub Release binary
+
+Pick the binary for your platform from the
+[releases page](https://github.com/alibaba/open-code-review/releases) and
+drop it into your `$PATH`:
+
+```bash
+# macOS (Apple Silicon)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# macOS (Intel)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux x86_64
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux ARM64
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Windows (AMD64)
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-amd64.exe
+
+# Windows (ARM64)
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
+```
+
+### Option C: Build from source
+
+```bash
+git clone https://github.com/alibaba/open-code-review.git
+cd open-code-review
+make build
+sudo cp dist/opencodereview /usr/local/bin/ocr
+```
+
+> See the [Installation](../installation/) page for details on each option,
+> including how the NPM wrapper resolves the platform binary.
 
 ## Step 2 — Configure an LLM
 
-```bash
-ocr config provider
-```
+OCR will refuse to run a review until it can resolve a complete LLM
+endpoint (URL + token + model). It searches four sources in priority order:
 
-It lets you pick a built-in or custom provider, enter an API key, choose a model, saves everything to the config file, and then runs `ocr llm test` once to verify the endpoint. To switch models later:
+1. `~/.opencodereview/config.json`
+2. OCR-specific environment variables (`OCR_LLM_*`)
+3. Claude Code environment variables (`ANTHROPIC_*`)
+4. `export ANTHROPIC_*` lines parsed out of your shell rc files
+   (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`)
 
-```bash
-ocr config model
-```
-
-### Alternative: non-interactive command
-
-In CI or a no-TUI environment, write to the same config directly with `ocr config set`:
+### Quickest path: `ocr config set`
 
 ```bash
-ocr config set provider                    anthropic
-ocr config set model                       claude-opus-4-6
-ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
+ocr config set llm.url           https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token    sk-ant-xxxxxxxxxx
+ocr config set llm.model         claude-opus-4-6
+ocr config set llm.use_anthropic true
 ```
+
+These values are persisted to `~/.opencodereview/config.json`.
+
+### Alternative: environment variables
+
+Highest priority — useful in CI / containers where you don't want a config
+file on disk:
+
+```bash
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=sk-ant-xxxxxxxxxx
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true   # default true; set false for OpenAI protocol
+```
+
+### Already using Claude Code?
+
+OCR transparently picks up the same vars Claude Code uses, so no extra setup:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.anthropic.com
+export ANTHROPIC_AUTH_TOKEN=sk-ant-xxxxxxxxxx
+export ANTHROPIC_MODEL=claude-opus-4-6
+```
+
+If `ANTHROPIC_BASE_URL` lacks a versioned path, OCR appends `/v1/messages`
+automatically.
+
+### Using an OpenAI-compatible endpoint?
+
+Set `llm.use_anthropic` to `false` (or `OCR_USE_ANTHROPIC=false`):
+
+```bash
+ocr config set llm.url           https://api.openai.com/v1/chat/completions
+ocr config set llm.auth_token    sk-xxxxxxxxxx
+ocr config set llm.model         gpt-4o
+ocr config set llm.use_anthropic false
+```
+
+> See [Configuration](../configuration/) for the full key reference,
+> including `llm.extra_body` for vendor-specific request fields and
+> `language` for switching review-comment language.
 
 ## Step 3 — Test connectivity
 
@@ -49,7 +143,17 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 ocr llm test
 ```
 
-If you get an error like `no valid LLM endpoint configured`, recheck the Step 2 config. A 401 / 403 means the token is wrong or expired.
+Expected output (model name varies):
+
+```
+Source: OCR config file
+URL:    https://api.anthropic.com/v1/messages
+Model:  claude-opus-4-6
+Hello! …
+```
+
+If you instead get an error like `no valid LLM endpoint configured`, recheck
+the config keys above. A 401 / 403 means the token is wrong or expired.
 
 ## Step 4 — Run your first review
 
@@ -68,28 +172,71 @@ ocr review --from main --to feature-branch
 ocr review --commit abc123
 ```
 
-> See [CLI Reference](../cli-reference/) for the complete list of `ocr review` flags (concurrency tuning, output format, audience mode, background context, and more) plus every other sub-command.
+You should see a stream of progress lines, finishing with one or more review
+comments per file.
 
-### Want to see what would be reviewed first?
+> Workspace mode includes **untracked** files. If you only want to review
+> what you've staged, `git add` selectively beforehand.
+
+> The three modes above are the basics. See [CLI Reference](../cli-reference/)
+> for the complete list of `ocr review` flags — concurrency tuning, output
+> format, audience mode, background context, and more — plus every other
+> sub-command (`config`, `rules`, `llm test`, `viewer`).
+
+### Want to see what *would* be reviewed first?
 
 ```bash
-ocr review --preview              # workspace
-ocr review -c abc123 --preview    # commit
+ocr review --preview         # workspace
+ocr review -c abc123 -p      # commit
 ```
 
-### JSON output for systems
+`--preview` runs every filter step but never calls the LLM, so it's free.
+It prints the file list with each file's status (`added` / `modified` /
+`deleted` / `renamed` / `binary`) and, for excluded files, the reason
+(`binary`, `unsupported_ext`, `default_path`, `user_exclude`, `deleted`).
 
-`--audience agent` suppresses the human-friendly progress UI so the only thing on stdout is the JSON / final summary — exactly what an upstream agent or CI script wants.
+### JSON output for tooling
 
 ```bash
 ocr review --format json --audience agent > review.json
 ```
 
+- `--format json` emits a machine-readable array of comments, each with
+  `path`, `content`, `start_line`, `end_line`, `existing_code`,
+  `suggestion_code` and optional `thinking`.
+- `--audience agent` suppresses the human-friendly progress UI so the only
+  thing on stdout is the JSON / final summary — exactly what an upstream
+  agent or CI script wants.
+
+## Step 5 — Review the results
+
+Each comment includes:
+
+| Field | Meaning |
+|---|---|
+| `path` | File that the comment is about. |
+| `content` | The review comment itself, in the configured `language`. |
+| `start_line` / `end_line` | Line range in the **new** version of the file. Both `0` means OCR couldn't precisely position the comment — the issue is real but you'll need to find the exact spot yourself. |
+| `existing_code` | The snippet from the diff the comment refers to. Used internally for line resolution; useful when `start_line` is `0`. |
+| `suggestion_code` | Optional fix snippet. |
+| `thinking` | Optional model reasoning. Only present for some models. |
+
+## Step 6 — Inspect a past session
+
+Every review is persisted to `~/.opencodereview/sessions/...` as a
+JSONL transcript. Browse them in a local web UI:
+
+```bash
+ocr viewer            # http://localhost:5483
+ocr viewer --addr :3000
+```
+
+> See [Session Viewer](../viewer/) for the full UI tour.
+
 ## See Also
 
-- [Installation](../installation/) — every install method and OCR's state directory.
-- [Configuration](../configuration/) — every env var, config key, and built-in provider.
 - [CLI Reference](../cli-reference/) — every sub-command, flag, and output mode.
 - [Review Rules](../review-rules/) — customize what gets reviewed.
 - [Integrations](../integrations/) — embed OCR in Claude Code, an Agent skill, or CI.
+- [Telemetry](../telemetry/) — ship traces and metrics over OTLP.
 - [FAQ](../faq/) — known errors and remedies.

--- a/pages/src/content/docs/en/viewer.md
+++ b/pages/src/content/docs/en/viewer.md
@@ -166,7 +166,7 @@ The OpenTelemetry exporter is a separate concern — see
 [Telemetry](../telemetry/) for how to keep prompt content out of
 exported traces.
 
-## When the viewer is not the right tool
+## When the viewer is *not* the right tool
 
 - For programmatic post-processing (CI, dashboards), use
   `ocr review --format json --audience agent`. The viewer renders for

--- a/pages/src/content/docs/index.ts
+++ b/pages/src/content/docs/index.ts
@@ -1,6 +1,7 @@
 /* Docs content index — imports all markdown files and provides a lookup by slug + language */
 
 // English docs
+import enOverview from './en/overview.md';
 import enQuickstart from './en/quickstart.md';
 import enInstallation from './en/installation.md';
 import enConfiguration from './en/configuration.md';
@@ -8,7 +9,6 @@ import enCliReference from './en/cli-reference.md';
 import enReviewRules from './en/review-rules.md';
 import enArchitecture from './en/architecture.md';
 import enTools from './en/tools.md';
-import enMcp from './en/mcp.md';
 import enViewer from './en/viewer.md';
 import enTelemetry from './en/telemetry.md';
 import enIntegrations from './en/integrations.md';
@@ -20,6 +20,7 @@ import enContributing from './en/contributing.md';
 import enFaq from './en/faq.md';
 
 // Chinese docs
+import zhOverview from './zh/overview.md';
 import zhQuickstart from './zh/quickstart.md';
 import zhInstallation from './zh/installation.md';
 import zhConfiguration from './zh/configuration.md';
@@ -27,7 +28,6 @@ import zhCliReference from './zh/cli-reference.md';
 import zhReviewRules from './zh/review-rules.md';
 import zhArchitecture from './zh/architecture.md';
 import zhTools from './zh/tools.md';
-import zhMcp from './zh/mcp.md';
 import zhViewer from './zh/viewer.md';
 import zhTelemetry from './zh/telemetry.md';
 import zhIntegrations from './zh/integrations.md';
@@ -38,26 +38,8 @@ import zhCicd from './zh/integrations/ci.md';
 import zhContributing from './zh/contributing.md';
 import zhFaq from './zh/faq.md';
 
-// Japanese docs
-import jaQuickstart from './ja/quickstart.md';
-import jaInstallation from './ja/installation.md';
-import jaConfiguration from './ja/configuration.md';
-import jaCliReference from './ja/cli-reference.md';
-import jaReviewRules from './ja/review-rules.md';
-import jaArchitecture from './ja/architecture.md';
-import jaTools from './ja/tools.md';
-import jaMcp from './ja/mcp.md';
-import jaViewer from './ja/viewer.md';
-import jaTelemetry from './ja/telemetry.md';
-import jaIntegrations from './ja/integrations.md';
-import jaAgentSkill from './ja/integrations/agent-skill.md';
-import jaClaudeCode from './ja/integrations/claude-code.md';
-import jaSubprocess from './ja/integrations/subprocess.md';
-import jaCicd from './ja/integrations/ci.md';
-import jaContributing from './ja/contributing.md';
-import jaFaq from './ja/faq.md';
-
 export type DocSlug =
+  | 'overview'
   | 'quickstart'
   | 'installation'
   | 'configuration'
@@ -65,7 +47,6 @@ export type DocSlug =
   | 'review-rules'
   | 'architecture'
   | 'tools'
-  | 'mcp'
   | 'viewer'
   | 'telemetry'
   | 'integrations'
@@ -77,6 +58,7 @@ export type DocSlug =
   | 'faq';
 
 const enDocs: Record<DocSlug, string> = {
+  'overview': enOverview,
   'quickstart': enQuickstart,
   'installation': enInstallation,
   'configuration': enConfiguration,
@@ -84,7 +66,6 @@ const enDocs: Record<DocSlug, string> = {
   'review-rules': enReviewRules,
   'architecture': enArchitecture,
   'tools': enTools,
-  'mcp': enMcp,
   'viewer': enViewer,
   'telemetry': enTelemetry,
   'integrations': enIntegrations,
@@ -97,6 +78,7 @@ const enDocs: Record<DocSlug, string> = {
 };
 
 const zhDocs: Record<DocSlug, string> = {
+  'overview': zhOverview,
   'quickstart': zhQuickstart,
   'installation': zhInstallation,
   'configuration': zhConfiguration,
@@ -104,7 +86,6 @@ const zhDocs: Record<DocSlug, string> = {
   'review-rules': zhReviewRules,
   'architecture': zhArchitecture,
   'tools': zhTools,
-  'mcp': zhMcp,
   'viewer': zhViewer,
   'telemetry': zhTelemetry,
   'integrations': zhIntegrations,
@@ -116,43 +97,31 @@ const zhDocs: Record<DocSlug, string> = {
   'faq': zhFaq,
 };
 
-const jaDocs: Record<DocSlug, string> = {
-  'quickstart': jaQuickstart,
-  'installation': jaInstallation,
-  'configuration': jaConfiguration,
-  'cli-reference': jaCliReference,
-  'review-rules': jaReviewRules,
-  'architecture': jaArchitecture,
-  'tools': jaTools,
-  'mcp': jaMcp,
-  'viewer': jaViewer,
-  'telemetry': jaTelemetry,
-  'integrations': jaIntegrations,
-  'agent-skill': jaAgentSkill,
-  'claude-code': jaClaudeCode,
-  'subprocess': jaSubprocess,
-  'cicd': jaCicd,
-  'contributing': jaContributing,
-  'faq': jaFaq,
-};
-
 const docsMap: Record<string, Record<DocSlug, string>> = {
   en: enDocs,
   zh: zhDocs,
-  ja: jaDocs,
+  ja: enDocs, // fallback to English for Japanese
 };
+
+/**
+ * Parse YAML frontmatter from markdown content.
+ * Returns frontmatter string and body, or null if no frontmatter found.
+ */
+function parseFrontmatter(md: string): { frontmatter: string; body: string } | null {
+  if (!md.startsWith('---')) return null;
+  const end = md.indexOf('---', 3);
+  if (end === -1) return null;
+  return {
+    frontmatter: md.slice(3, end),
+    body: md.slice(end + 3).trim(),
+  };
+}
 
 /**
  * Strip YAML frontmatter from markdown content
  */
 function stripFrontmatter(md: string): string {
-  if (md.startsWith('---')) {
-    const end = md.indexOf('---', 3);
-    if (end !== -1) {
-      return md.slice(end + 3).trim();
-    }
-  }
-  return md;
+  return parseFrontmatter(md)?.body ?? md;
 }
 
 /**
@@ -175,14 +144,10 @@ export function getDocContent(slug: DocSlug, language: string): string {
  * Get the title from frontmatter
  */
 export function getDocTitle(slug: DocSlug, language: string): string {
-  const raw = getRawContent(slug, language);
-  if (raw.startsWith('---')) {
-    const end = raw.indexOf('---', 3);
-    if (end !== -1) {
-      const fm = raw.slice(3, end);
-      const match = fm.match(/title:\s*(.+)/);
-      if (match) return match[1].trim();
-    }
+  const parsed = parseFrontmatter(getRawContent(slug, language));
+  if (parsed) {
+    const match = parsed.frontmatter.match(/title:\s*(.+)/);
+    if (match) return match[1].trim();
   }
   return slug;
 }

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -4,42 +4,182 @@ sidebar:
   order: 5
 ---
 
-配置文件在 `~/.opencodereview/config.json`，你有三种方式编辑它：
+## 端点解析
 
-- **交互式 TUI** —— `ocr config provider` / `ocr config model`，带引导菜单。
-- **命令行** —— `ocr config set <key> <value>`，适合脚本与 CI。
-- **手动编辑（不推荐）** —— 该 JSON 文件（下次 `ocr config set` 写入时会重新格式化）。
+当 `ocr review` 或 `ocr llm test` 运行时，它会按顺序尝试四个来源，
+并使用第一个能给出完整 `(URL, token, model)` 三元组的来源：
 
-## 配置模型
+| 优先级 | 来源 | 读取内容 |
+|---|---|---|
+| 1 | `~/.opencodereview/config.json` | 若设置了 `provider`，则通过 `providers`/`custom_providers` 映射解析（provider 优先；见[内置 provider](#built-in-providers)）。仅当未设置 provider 时才回退到遗留的 `llm` 段。 |
+| 2 | OCR 环境变量 | `OCR_LLM_URL`、`OCR_LLM_TOKEN`、`OCR_LLM_MODEL`、`OCR_USE_ANTHROPIC`、`OCR_LLM_AUTH_HEADER`。 |
+| 3 | Claude Code 环境变量 | `ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL`。 |
+| 4 | Shell rc 文件 | 从 `~/.zshrc`、`~/.bashrc`、`~/.bash_profile`、`~/.profile` 中解析出的 `export ANTHROPIC_*=…` 行。 |
 
-### 推荐：交互式设置
+对于 Claude Code 风格的来源，若 `ANTHROPIC_BASE_URL` 缺少带版本的路径
+（`/v1/...`），OCR 会自动追加 `/v1/messages`。
+
+如果没有一种策略能给出完整三元组，OCR 会以如下信息退出：
+
+```
+no valid LLM endpoint configured; one of OCR_LLM_URL/OCR_LLM_TOKEN/OCR_LLM_MODEL,
+~/.opencodereview/config.json, or ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN/
+ANTHROPIC_MODEL must be set
+```
+
+> 解析在第一个**报错**的来源处停止，而不仅仅是第一个为空的来源。尤其要注意：
+> 如果 `config.json` 中设置了 `provider` 但该条目配置有误（未知的 provider 名、
+> 缺少 `api_key` 且无环境变量回退、缺少 `model`、自定义 provider 缺少
+> `url`/`protocol`），OCR 会以该错误退出，并**不会**继续回退到 OCR 环境变量、
+> Claude Code 或 rc 文件来源。要切换到基于环境变量的配置，请先取消
+> 设置 `provider` key。
+
+> 来源优先级意味着当配置文件已完整填充时，**环境变量不会覆盖任何值**。要让
+> 环境变量生效，要么从 `~/.opencodereview/config.json` 删除相关 `llm.*` key，
+> 要么用 `ocr config set` 切换到新值。
+
+## `ocr config set` ——管理 `~/.opencodereview/config.json`
+
+```bash
+ocr config set <key> <value>
+```
+
+`config set` 通过 key/value 对修改文件，并做具备 schema 感知的解析。交互式 TUI
+命令 `ocr config provider` 和 `ocr config model` 也写入同一个文件（见
+[交互式设置](#interactive-setup--ocr-config-provider--ocr-config-model)）。识别的
+key：
+
+| Key | 类型 | 说明 |
+|---|---|---|
+| `provider` | string | 设置当前 provider（内置名或自定义）。切换 provider 会清空 model。 |
+| `model` | string | 为当前 provider 设置 model（存在 provider 条目下；若无 provider 则存到顶层 `model`）。 |
+| `providers.<name>.<field>` | varies | 内置 provider 的按字段设置：`api_key`、`url`、`protocol`、`model`、`models`、`auth_header`、`extra_body`。 |
+| `custom_providers.<name>.<field>` | varies | 同上字段，用于自定义（非内置）provider。自定义 provider 至少要设置 `url` 和 `protocol`。 |
+| `llm.url` | string | 端点 URL。Anthropic 用完整的 Messages URL，如 `https://api.anthropic.com/v1/messages`。OpenAI 兼容则用 chat-completions URL。 |
+| `llm.auth_token` | string | API key。以 `Authorization: Bearer …` 发送（OpenAI）；遗留 Anthropic 路径默认也是 `Authorization: Bearer …`（预设 `anthropic` provider 改为默认 `x-api-key`）。仅在显式设置 `llm.auth_header` 时才用 `x-api-key`。 |
+| `llm.auth_header` | string | Auth header 名（`x-api-key`、`authorization` 或 `bearer`）。仅 Anthropic 用；某些需要 `x-api-key` 的 Anthropic 设置必需。 |
+| `llm.model` | string | 模型名。`[<数字>m]` 后缀会被自动去除。 |
+| `llm.use_anthropic` | boolean | `true`（默认）→ Anthropic Messages 协议。`false` → OpenAI Chat Completions。 |
+| `llm.extra_body` | JSON object | 厂商专属的请求字段，合并进每次 chat 请求体。示例：`'{"thinking":{"type":"disabled"}}'`。 |
+| `language` | string | 转发为追加到 system prompt 的指令；未设置时默认 `English`。见[选择语言](#choosing-a-language)。 |
+| `telemetry.enabled` | boolean | OpenTelemetry 导出的总开关。默认关闭。 |
+| `telemetry.exporter` | string | `console` 或 `otlp`。 |
+| `telemetry.otlp_endpoint` | string | OTLP collector 地址（如 `localhost:4317`）。 |
+| `telemetry.content_logging` | boolean | 在导出的事件数据中包含 LLM prompt / 响应。 |
+
+示例：
+
+```bash
+ocr config set llm.url           https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token    sk-ant-xxxxxxxxxx
+ocr config set llm.model         claude-opus-4-6
+ocr config set llm.use_anthropic true
+ocr config set llm.extra_body   '{"thinking":{"type":"disabled"}}'
+ocr config set language          English
+ocr config set telemetry.enabled true
+ocr config set telemetry.exporter otlp
+ocr config set telemetry.otlp_endpoint localhost:4317
+
+# 基于 provider 的设置（推荐）
+ocr config set provider          anthropic
+ocr config set model             claude-opus-4-6
+ocr config set providers.anthropic.api_key "$ANTHROPIC_API_KEY"
+
+# 自定义（非内置）provider
+ocr config set provider          my-gateway
+ocr config set custom_providers.my-gateway.url      https://gateway.internal.com/v1
+ocr config set custom_providers.my-gateway.protocol openai
+ocr config set custom_providers.my-gateway.model    llama-3-70b
+ocr config set custom_providers.my-gateway.api_key   "$MY_API_KEY"
+```
+
+布尔值接受 Go `strconv.ParseBool` 接受的任何形式（`true`、`false`、`1`、`0`、
+`t`、`f`……）。`llm.extra_body` 必须是合法 JSON。
+
+## 文件 schema 参考
+
+执行上述命令后，`~/.opencodereview/config.json` 形如：
+
+```json
+{
+    "llm": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "auth_token": "sk-ant-xxxxxxxxxx",
+        "auth_header": "x-api-key",
+        "model": "claude-opus-4-6",
+        "use_anthropic": true,
+        "extra_body": {
+            "thinking": { "type": "disabled" }
+        }
+    },
+    "language": "English",
+    "telemetry": {
+        "enabled": true,
+        "exporter": "otlp",
+        "otlp_endpoint": "localhost:4317"
+    }
+}
+```
+
+基于 provider 的形式使用 `provider`、`model`、`providers` 和
+`custom_providers`，而非遗留的 `llm` 块：
+
+```json
+{
+    "provider": "anthropic",
+    "model": "claude-opus-4-6",
+    "providers": {
+        "anthropic": {
+            "api_key": "sk-ant-xxxxxxxxxx",
+            "model": "claude-opus-4-6"
+        }
+    },
+    "custom_providers": {
+        "my-gateway": {
+            "url": "https://gateway.internal.com/v1",
+            "protocol": "openai",
+            "model": "llama-3-70b",
+            "models": ["llama-3-70b", "llama-3-8b"],
+            "api_key": "gw-xxxxxxxxxx",
+            "auth_header": "authorization"
+        }
+    },
+    "language": "English"
+}
+```
+
+当设置了 `provider` 时，由 `providers`/`custom_providers` 映射驱动解析；该配置下
+遗留的 `llm` 段被忽略。
+
+你也可以手动编辑此文件，但下次写入时 `ocr config set` 会以 `"    "` 缩进
+重新序列化。
+
+## 交互式设置——`ocr config provider` / `ocr config model`
+
+为免去手动键入 key 来选择 provider 和 model，OCR 提供两个交互式 Bubble Tea TUI，
+二者同样会修改 `~/.opencodereview/config.json`。
 
 ```bash
 ocr config provider
-```
-
-它会让你选择一个内置或自定义 provider、填入 API key、挑选 model，保存到配置文件后自动运行一次 `ocr llm test` 验证端点。之后想换模型：
-
-```bash
 ocr config model
 ```
 
-### 非交互设置（CI / 无 TUI 环境）
+- `ocr config provider`——选择内置或自定义 provider，并输入 URL / protocol /
+  API key / model 的交互式 TUI。选择会保存到 config，并自动运行 `ocr llm test`
+  验证端点。对于内置 provider，若未直接输入，API key 可从该 provider 的环境变量
+  读取（见[内置 provider](#built-in-providers)）。若选择手动配置，则改为填充遗留的
+  `llm.*` 块。
+- `ocr config model`——从当前 provider 的预设列表，以及
+  `providers.<name>.models` / `custom_providers.<name>.models` 下用户添加的
+  model 中选择模型的交互式 TUI。需要先设置 provider（`ocr config provider`）。
 
-用 `ocr config set` 写入同一份配置：
+## 内置 provider
 
-```bash
-ocr config set provider                    anthropic
-ocr config set model                       claude-opus-4-6
-ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
-```
+以下 provider 随 OCR 发布。每个都有预设的 `BaseURL`、`Protocol`，以及
+（如适用）一个 API key 环境变量，在 `providers.<name>.api_key` 未设置时作为
+回退。
 
-### 内置 provider
-
-下列 provider 随 OCR 发布，已预置 Base URL 与协议，选中后只需填 API key。
-若 `providers.<name>.api_key` 未设置，会自动回退到对应的环境变量。
-
-| 名称 | 协议 | Base URL | API key 环境变量 |
+| 名称 | Protocol | Base URL | API key 环境变量 |
 |---|---|---|---|
 | `anthropic` | anthropic | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
 | `openai` | openai | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
@@ -55,47 +195,78 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
 
-### 自定义 provider
+任何其他 provider 名都被视为自定义，必须在 `custom_providers` 下配置，且至少
+要有 `url` 和 `protocol`。
 
-任何不在上表中的 provider 名都视为自定义，至少要提供 `url` 和 `protocol`
-（`protocol` 取 `anthropic` 或 `openai`）：
+## 环境变量参考
+
+| 变量 | 用途 |
+|---|---|
+| `OCR_LLM_URL` | 端点 URL——与 `llm.url` 同形。 |
+| `OCR_LLM_TOKEN` | API key——与 `llm.auth_token` 相同。 |
+| `OCR_LLM_MODEL` | 模型名。 |
+| `OCR_LLM_AUTH_HEADER` | Auth header 名（`x-api-key`、`authorization` 或 `bearer`）。仅 Anthropic；与 `llm.auth_header` 相同。未设置时默认 `authorization`。 |
+| `OCR_USE_ANTHROPIC` | 未设置 → Anthropic 协议（默认）。设为 `true` / `1` / `yes`（不区分大小写）→ Anthropic。设为其他值（`false`、`0`、`no`、拼写错误……）→ OpenAI。 |
+| `ANTHROPIC_BASE_URL` | Claude Code 兼容的 base URL。 |
+| `ANTHROPIC_AUTH_TOKEN` | Claude Code 兼容的 API key。 |
+| `ANTHROPIC_MODEL` | Claude Code 兼容的 model。 |
+| `OCR_ENABLE_TELEMETRY` | `1` 表示从环境变量启用遥测。 |
+| `OTEL_SERVICE_NAME` | 覆盖 span/metric 中的 service name。 |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector 地址——同时强制 exporter 为 `otlp`。 |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP 传输协议（`grpc`、`http/protobuf` 或 `http/json`）。默认 `grpc`。 |
+| `OCR_CONTENT_LOGGING` | `1` 表示在遥测事件中包含 prompt/响应。 |
+
+各 provider 的 API key（`ANTHROPIC_API_KEY`、`OPENAI_API_KEY`、
+`DASHSCOPE_API_KEY`……）在内置 provider 的 `api_key` 字段未设置时作为回退。
+各 provider 的环境变量名见[内置 provider](#built-in-providers)表。
+
+## 为什么有 `extra_body`
+
+一些托管 provider 会在请求体中加入非标准字段（例如 Bedrock 风格的 `thinking`、
+厂商专属的 `temperature_strategy`、流式选项）。`llm.extra_body` 会被合并进每个
+发出的请求，因此你无需改源码即可发送这些字段。
 
 ```bash
-ocr config set provider                             my-gateway
-ocr config set custom_providers.my-gateway.url      https://gateway.internal.com/v1
-ocr config set custom_providers.my-gateway.protocol openai
-ocr config set custom_providers.my-gateway.model    llama-3-70b
-ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+ocr config set llm.extra_body '{"thinking":{"type":"enabled","budget_tokens":2048}}'
 ```
 
-### 验证连通性
+## 选择语言
 
-```bash
-ocr llm test
+`language` key 只控制一件事：追加到评审和 `ocr llm test` prompt 中每条
+system-role 消息的一条指令。注入的精确字符串是：
+
+```
+\n\nAlways respond in <language>.
 ```
 
-### 复用已有的环境变量
+- *未设置*或为空——按 `English` 对待。
+- `Chinese`、`English` 或任何其他字符串——原样透传。
 
-如果你已经配好了 Claude Code 的 `ANTHROPIC_*`，或 OCR 自己的 `OCR_LLM_*`环境变量，OCR 会自动识别，无需再写配置文件。
+内置 rule docs 不支持语言切换。`internal/config/rules/rule_docs/` 下嵌入的文件按
+固定文件名加载，多数以中文撰写（`default.md` 是英文例外）；无论 `language`
+如何设置，它们都原样出现在 prompt 中。因此当 `language` 设为 `English` 时，prompt
+里会是一条英文指令叠加大段中文 rule 文本——强模型会遵从指令产出英文评论，
+弱模型可能输出中英混杂的内容。
 
-### 发送厂商专属字段
-
-某些 provider 需要非标准的请求字段（如 Bedrock 风格的 `thinking`）。用`extra_body`（合并进每次请求）即可发送，无需改源码：
-
-```bash
-ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
-```
-
-## 配置评审语言
-
-`language` 决定评审评论用哪种语言输出，未设置时默认英文：
+`language` 没有环境变量、CLI 参数或项目级覆盖——唯一能设置它的地方是全局
+`~/.opencodereview/config.json`，通过
+[`ocr config set`](#ocr-config-set--managing-opencodereviewconfigjson)：
 
 ```bash
-ocr config set language 中文
 ocr config set language English
 ```
+
+如果你需要纯英文 rule 文本，请通过 `--rule`、`<repo>/.opencodereview/rule.json`
+或 `~/.opencodereview/rule.json` 提供自己的规则（见
+[评审规则](../review-rules/#priority-chain)）。
+
+## 项目级 vs 全局配置
+
+CLI 本身是全局配置的（`~/.opencodereview/config.json`）——没有项目级 LLM 配置。
+但**评审规则**是项目级的；见[评审规则](../review-rules/#priority-chain)。
 
 ## 另见
 
 - [快速开始](../quickstart/)——最小化设置与首次评审。
 - [CLI 参考](../cli-reference/)——review 命令接受的每个参数。
+- [遥测](../telemetry/)——如何接入 OTLP / console exporter。

--- a/pages/src/content/docs/zh/faq.md
+++ b/pages/src/content/docs/zh/faq.md
@@ -17,7 +17,7 @@ no valid LLM endpoint configured; one of OCR_LLM_URL/OCR_LLM_TOKEN/OCR_LLM_MODEL
 ANTHROPIC_MODEL must be set
 ```
 
-OCR 走完了整条端点解析链（[配置](../configuration/#复用已有的环境变量)）但没
+OCR 走完了四来源解析链（[配置](../configuration/#endpoint-resolution)）但没
 找到完整的 `(URL, token, model)` 三元组。要么：
 
 - 运行 `ocr config set llm.url …` / `llm.auth_token …` / `llm.model …` 填充

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -4,59 +4,43 @@ sidebar:
   order: 4
 ---
 
-安装 `ocr` CLI 有四种受支持的方式。
+安装 `ocr` CLI 有四种受支持的方式。它们产出的都是同一个二进制——按你的
+环境选择即可。
 
 ## NPM（推荐）
-
-#### 安装
 
 ```bash
 npm install -g @alibaba-group/open-code-review
 ```
 
-固定到某个版本：
+NPM 包附带一个小的 wrapper 脚本（`bin/ocr.js`）和一个
+[postinstall hook](https://github.com/alibaba/open-code-review/blob/main/scripts/install.js)，
+它会：
+
+1. 探测你的平台（`darwin-amd64`、`darwin-arm64`、`linux-amd64`、
+   `linux-arm64`、`windows-amd64`、`windows-arm64`）。
+2. 从 GitHub Releases 下载匹配的二进制。
+3. （当存在校验和数据时）验证它，并放到 wrapper 旁边。
+
+如果某个平台专属 npm 包（如 `@alibaba-group/ocr-darwin-arm64`）作为
+optional dependency 被安装，则直接使用该二进制，跳过下载。
+
+运行 `ocr` 时，wrapper 只是 `exec` 下载好的二进制，因此首次运行后实际开销
+为零。
+
+### 更新
 
 ```bash
+npm update -g @alibaba-group/open-code-review
+# 或固定到某个版本：
 npm install -g @alibaba-group/open-code-review@<version>
 ```
 
-#### 更新
-
-通过 NPM 安装时，`ocr` 默认会自动保持最新（静态二进制不参与此机制）。每次运行
-`ocr` 时，wrapper 会在后台静默检查 registry 上的最新版本，发现更新即自动升级，
-不影响本次评审。两次检查之间有 18 分钟冷却，可用 `OCR_UPDATE_INTERVAL`（分钟）调整。
-
-关闭自动更新，将 `OCR_NO_UPDATE` 设为任意非空值即可：
-
-```bash
-export OCR_NO_UPDATE=1
-```
-
-#### 卸载
+### 卸载
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
 ```
-
-## 安装脚本（curl | sh）
-
-一个便捷安装器，封装了 GitHub Release 二进制下载（带校验）——适合 CI 基础
-镜像和无界面环境：
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
-```
-
-它识别两个环境变量：
-
-| 变量 | 默认值 | 用途 |
-|---|---|---|
-| `OCR_INSTALL_DIR` | `/usr/local/bin` | 放置 `ocr` 二进制的位置。 |
-| `OCR_VERSION` | 最新 release | 固定到某个 release tag（如 `v1.2.3`）。 |
-
-该脚本支持 `darwin` 与 `linux` 的 `amd64` / `arm64`；Windows 请改用
-[GitHub Release 二进制](#github-release-binary)或 [NPM](#npm-recommended)
-方式。
 
 ## GitHub Release 二进制
 
@@ -95,17 +79,37 @@ curl -LO https://github.com/alibaba/open-code-review/releases/latest/download/sh
 shasum -a 256 -c sha256sum.txt --ignore-missing
 ```
 
+## 安装脚本（curl | sh）
+
+一个便捷安装器，封装了 GitHub Release 二进制下载（带校验）——适合 CI 基础
+镜像和无界面环境：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+```
+
+它识别两个环境变量：
+
+| 变量 | 默认值 | 用途 |
+|---|---|---|
+| `OCR_INSTALL_DIR` | `/usr/local/bin` | 放置 `ocr` 二进制的位置。 |
+| `OCR_VERSION` | 最新 release | 固定到某个 release tag（如 `v1.2.3`）。 |
+
+该脚本支持 `darwin` 与 `linux` 的 `amd64` / `arm64`；Windows 请改用
+[GitHub Release 二进制](#github-release-binary)或 [NPM](#npm-recommended)
+方式。
+
 ## 从源码构建
 
 仅当你要修改 OCR 本身，或在某个没有预编译二进制的平台上运行时才需要此方式。
 
-#### 前置条件
+### 前置条件
 
 - [Go ≥ 1.25](https://go.dev/dl/)
 - [Git](https://git-scm.com/)
 - [Make](https://www.gnu.org/software/make/)
 
-#### 构建
+### 构建
 
 ```bash
 git clone https://github.com/alibaba/open-code-review.git
@@ -114,7 +118,7 @@ make build              # 产出 dist/opencodereview
 sudo cp dist/opencodereview /usr/local/bin/ocr
 ```
 
-#### 为其他平台构建
+### 为其他平台构建
 
 ```bash
 make build-linux-amd64
@@ -130,7 +134,7 @@ make sha256sum          # 同时产出 sha256sum.txt
 `make dist` 会运行 `clean → build-all → sha256sum`，并在二进制旁写入一个
 `VERSION` 文件——这正是 release 流水线执行的步骤。
 
-#### 运行测试
+### 运行测试
 
 ```bash
 make test               # LC_ALL=C go test -v -race -count=1 ./...
@@ -160,7 +164,7 @@ echo $PATH
 | `~/.opencodereview/config.json` | LLM 端点、语言、遥测配置（由 `ocr config set` 管理）。 |
 | `~/.opencodereview/rule.json` | 可选的全局评审规则。 |
 | `~/.opencodereview/sessions/<encoded-repo-path>/<session-id>.jsonl` | 每次评审会话的流式 JSONL 转录，供 `ocr viewer` 使用。 |
-| `~/.opencodereview/{last-update-check,update.lock,update-available}` | NPM wrapper 的后台更新检查状态。wrapper 会轮询是否有更新的 release（默认约每 18 分钟一次）并打印升级提示。用 `OCR_NO_UPDATE=1` 禁用，或用 `OCR_UPDATE_INTERVAL`（分钟）调整间隔。静态二进制不写入这些文件。 |
+| `~/.opencodereview/{last-update-check,update.lock,update-available}` | NPM wrapper 的后台更新检查状态。wrapper 会轮询是否有更新的 release（默认约每 18 分钟一次）并打印升级提示。用 `OCR_NO_UPDATE=1` 禁用，或用 `OCR_UPDATE_INTERVAL`（秒）调整间隔。静态二进制不写入这些文件。 |
 | `<repo>/.opencodereview/rule.json` | 可选的项目级评审规则——可安全提交。 |
 
 OCR 永远不会写入 `~/.opencodereview/` 之外（除 NPM 临时下载二进制外）。

--- a/pages/src/content/docs/zh/integrations.md
+++ b/pages/src/content/docs/zh/integrations.md
@@ -38,9 +38,6 @@ OCR 目前不暴露 Model Context Protocol server。预期的集成方式是“a
 要求 MCP，用一个薄 shim 包裹 CLI——一个 30 行的 Node 脚本暴露单个 `review`
 工具就够了。
 
-反过来的方向**是**支持的：OCR 可以作为 MCP **客户端**，把外部 MCP server 的工具
-拉进一次审查。见 [MCP 服务器](../mcp/)。
-
 ## 适用于所有模式的提示
 
 - **始终传 `--audience agent`**，当调用方不是人时。否则进度行会污染待解析的输出。

--- a/pages/src/content/docs/zh/overview.md
+++ b/pages/src/content/docs/zh/overview.md
@@ -1,0 +1,125 @@
+---
+title: 概览
+sidebar:
+  order: 2
+---
+
+## 什么是 Open Code Review？
+
+Open Code Review（简称 **OCR**，区别于光学字符识别 Optical Character
+Recognition）是一个 AI 驱动的代码评审 CLI，以
+[`@alibaba-group/open-code-review`](https://www.npmjs.com/package/@alibaba-group/open-code-review)
+NPM 包和独立的 Go 二进制形式发布。CLI 二进制名为 `ocr`。
+
+只需一条命令（`ocr review`），它会：
+
+1. 解析 Git diff——工作区、分支区间或单个 commit。
+2. 结合系统默认规则与用户规则对变更文件进行过滤。
+3. 为每个变更文件并行启动一个 **per-file 子 agent**。
+4. 每个子 agent 运行一个 LLM 工具调用循环；对于较大的 diff，可选地先执行
+   **plan 阶段**。
+5. 模型调用 `code_comment` 记录发现，可选地调用 `file_read`、
+   `code_search`、`file_find`、`file_read_diff` 收集上下文，完成后调用
+   `task_done`。
+6. OCR 将每条评论解析到精确的行号，对未能精确匹配的评论运行可选的重新定位
+   流程，并打印（或以 JSON 输出）最终列表。
+
+## 通用 agent 的问题
+
+如果你用过通用编码 agent（Claude Code 的 Skill、Cursor、Cline 等）做代码
+评审，很可能遇到过：
+
+- **覆盖不全**——在较大的变更集上，agent 会悄悄偷工减料，只评审部分文件。
+- **位置漂移**——评论与它所指的代码对不上；行号和文件路径偏离目标。
+- **质量不稳定**——自然语言 Skill 难以调试，输出质量随 prompt 的微小改动
+  而波动。
+
+根本原因：纯语言驱动的架构缺乏对评审流程的 **硬约束**。
+
+## 核心设计：确定性工程 × agent
+
+OCR 的核心理念是把 **确定性工程** 与 **agent** 结合——各自做自己最擅长的事。
+
+### 确定性工程——硬约束
+
+对于那些 *绝不能出错* 的步骤，由工程逻辑（而非模型）保证正确性：
+
+- **精确的文件选择**——一个[五重门过滤](../review-rules/#how-files-are-filtered)
+  决定到底评审哪些文件，并提供显式的 `include`/`exclude` 控制。
+- **智能文件打包**——相关文件（如 `message_en.properties` 与
+  `message_zh.properties`）可以合并为一个评审单元。每个包作为独立上下文交给
+  子 agent 运行——分而治之，在超大变更集上依然稳定，并天然支持并发评审。
+- **细粒度规则匹配**——评审规则按文件路径匹配，首条匹配生效，让模型的注意力
+  高度聚焦并消除噪声。基于模板的匹配比纯语言驱动的规则引导更稳定。
+- **外部定位与反思模块**——独立的评论定位
+  （[`internal/diff/relocation.go`](https://github.com/alibaba/open-code-review/blob/main/internal/diff/relocation.go)）
+  与重新定位流程，系统地提升位置与内容的准确性。
+
+### Agent——动态决策
+
+agent 的优势集中在最关键的地方：
+
+- **场景化调优的 prompt**——针对代码评审场景深度调优的 prompt 模板，在降低 token
+  消耗的同时提升效果（见
+  [`internal/config/template/task_template.json`](https://github.com/alibaba/open-code-review/blob/main/internal/config/template/task_template.json)）。
+- **场景化调优的工具集**——从大规模生产数据的工具调用 trace 分析中提炼而来
+  （调用频次分布、单工具重复率、每个工具对整体调用链的影响）。最终得到一套
+  专用 [六工具](../tools/) 集，比通用 agent 工具包更稳定、更可预测。
+
+## 流水线如何衔接
+
+```mermaid
+flowchart TD
+    Start["<b>ocr review --from main --to feature</b>"]
+    S1["<b>1. Resolve LLM endpoint</b><br/>config / env / shell rc"]
+    S2["<b>2. Load diffs from git</b><br/>workspace / commit / range"]
+    S3["<b>3. Filter files</b><br/>binary → user_exclude → user_include<br/>→ ext allowlist → default path"]
+    S4["<b>4. Drop diffs > 80% of MAX_TOKENS</b>"]
+    S5["<b>5. Dispatch per-file sub-agents</b> (concurrent)<br/><br/>For each file:<br/>&nbsp;&nbsp;a. Plan phase (if changed lines ≥ 50)<br/>&nbsp;&nbsp;b. Main loop: LLM → tool calls → … → task_done<br/>&nbsp;&nbsp;c. code_comment results collected (async via worker pool)<br/><br/>Memory compression triggers when context<br/>exceeds 60 % (async) or 80 % (sync) of MAX_TOKENS."]
+    S6["<b>6. Resolve line numbers</b><br/>from <code>existing_code</code> against diffs.<br/>Re-locate via LLM if needed."]
+    S7["<b>7. Emit text or JSON output</b><br/>(and persist session to disk)"]
+
+    Start --> S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> S7
+```
+
+## 项目结构
+
+```
+open-code-review/
+├── cmd/opencodereview/   # CLI 入口：分发、参数、命令
+├── internal/
+│   ├── agent/            # 每文件子 agent 循环 + 记忆压缩
+│   ├── config/
+│   │   ├── allowlist/    # 默认文件扩展名白名单与排除项
+│   │   ├── rules/        # 分层规则解析器、系统规则文档
+│   │   ├── template/     # plan / main / memory_compression prompt
+│   │   ├── testconnection/ # 内置 `ocr llm test` 任务
+│   │   └── toolsconfig/  # 发送给模型的工具定义
+│   ├── diff/             # Git diff 解析、hunk 数学、重新定位
+│   ├── gitcmd/           # Git 子进程运行器
+│   ├── llm/              # Anthropic + OpenAI 协议、重试、BPE token
+│   ├── model/            # diff / 评论 数据结构
+│   ├── pathutil/         # 路径工具
+│   ├── release/          # Release notes 生成
+│   ├── session/          # 每次评审会话的 JSONL 持久化
+│   ├── stdout/           # `--audience agent` 下可静音的 stdout writer
+│   ├── suggestdiff/      # 构建 "Apply suggestion" diff
+│   ├── telemetry/        # OpenTelemetry span、metrics、exporter
+│   ├── tool/             # 六个内置工具 + 评论收集器
+│   └── viewer/           # `ocr viewer`——历史会话的本地 Web UI
+├── pages/                # 基于 React 的营销落地页（独立）
+├── plugins/              # Claude Code 插件清单 + 命令
+├── extensions/           # 编辑器扩展（VS Code）
+├── examples/             # CI 配方（GitHub Actions、GitLab CI）
+├── skills/               # 通用 agent Skill 清单
+├── scripts/              # NPM 安装/更新助手、发布脚本
+├── npm/                  # 各平台 optional dependency 包
+└── bin/                  # NPM wrapper，shell 调用二进制
+```
+
+## 另见
+
+- [快速开始](../quickstart/)——安装并完成首次评审。
+- [架构](../architecture/)——agent 循环、plan 阶段与记忆压缩。
+- [CLI 参考](../cli-reference/)——每个参数与子命令。
+- [集成](../integrations/)——从 Claude Code 或任意 agent 调用 OCR。

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -4,92 +4,232 @@ sidebar:
   order: 3
 ---
 
-几分钟内跑通第一次代码评审。
+安装 OCR，连接到任意支持 Anthropic Messages API 或 OpenAI Chat Completions API
+的 LLM，然后运行你的第一次代码评审。
 
 ## 前置条件
 
-- **Git ≥ 2.41**
-- **Node.js ≥ 18**
-- **LLM API key**
+- 一个可用的 **Git** 安装——OCR 以子进程方式驱动 Git 读取 diff。
+- 一个兼容 Anthropic 或 OpenAI 的 LLM 的 **API key**。
+- 以下之一：
+  - **Node.js ≥ 18**（推荐；最低支持 Node 14——通过 NPM 安装）。
+  - 或仅用 `curl` + `chmod` 把静态二进制放进 `$PATH`。
+  - 或 **Go ≥ 1.25**，如果你偏好从源码构建。
 
-## 第 1 步 —— 安装 CLI
+## 第 1 步——安装 CLI
+
+### 方式 A：NPM（推荐）
 
 ```bash
 npm install -g @alibaba-group/open-code-review
-ocr version
 ```
 
-> 更多方式见 [安装](../installation/)。
-
-## 第 2 步 —— 配置 LLM
+NPM 包安装一个小的 wrapper，它在安装时（通过 postinstall hook）为你的
+操作系统 / 架构下载正确的二进制。如果运行时二进制缺失，wrapper 会报错而
+不会去下载。安装后，你得到一个全局 `ocr` 命令：
 
 ```bash
-ocr config provider
+ocr --version
 ```
 
-它会让你选择一个内置或自定义 provider、填入 API key、挑选 model，保存到配置文件后自动运行一次 `ocr llm test` 验证端点。之后想换模型：
+### 方式 B：GitHub Release 二进制
+
+从 [releases 页面](https://github.com/alibaba/open-code-review/releases)
+选择对应平台的二进制，放进你的 `$PATH`：
 
 ```bash
-ocr config model
+# macOS (Apple Silicon)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# macOS (Intel)
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-darwin-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux x86_64
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-amd64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Linux ARM64
+curl -Lo ocr https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-linux-arm64
+chmod +x ocr && sudo mv ocr /usr/local/bin/ocr
+
+# Windows (AMD64)
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-amd64.exe
+
+# Windows (ARM64)
+curl -Lo ocr.exe https://github.com/alibaba/open-code-review/releases/latest/download/opencodereview-windows-arm64.exe
 ```
 
-### 备选:非交互命令
-
-在 CI 或无 TUI 的环境里,用 `ocr config set` 直接写入同一份配置:
+### 方式 C：从源码构建
 
 ```bash
-ocr config set provider                    anthropic
-ocr config set model                       claude-opus-4-6
-ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
+git clone https://github.com/alibaba/open-code-review.git
+cd open-code-review
+make build
+sudo cp dist/opencodereview /usr/local/bin/ocr
 ```
 
-## 第 3 步 —— 测试连通性
+> 各安装方式的详情见 [安装](../installation/)，包括 NPM wrapper 如何解析
+> 平台二进制。
+
+## 第 2 步——配置 LLM
+
+在能解析出一个完整的 LLM 端点（URL + token + model）之前，OCR 会拒绝运行
+评审。它按以下优先级顺序搜索四个来源：
+
+1. `~/.opencodereview/config.json`
+2. OCR 专属环境变量（`OCR_LLM_*`）
+3. Claude Code 环境变量（`ANTHROPIC_*`）
+4. 从你的 shell rc 文件（`~/.zshrc`、`~/.bashrc`、`~/.bash_profile`、
+   `~/.profile`）中解析出的 `export ANTHROPIC_*` 行
+
+### 最快路径：`ocr config set`
+
+```bash
+ocr config set llm.url           https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token    sk-ant-xxxxxxxxxx
+ocr config set llm.model         claude-opus-4-6
+ocr config set llm.use_anthropic true
+```
+
+这些值会持久化到 `~/.opencodereview/config.json`。
+
+### 替代方式：环境变量
+
+优先级最高——适合不想在磁盘上留配置文件的 CI / 容器：
+
+```bash
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=sk-ant-xxxxxxxxxx
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true   # 默认 true；设为 false 走 OpenAI 协议
+```
+
+### 已经在用 Claude Code？
+
+OCR 会自动读取 Claude Code 使用的同一批变量，无需额外配置：
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.anthropic.com
+export ANTHROPIC_AUTH_TOKEN=sk-ant-xxxxxxxxxx
+export ANTHROPIC_MODEL=claude-opus-4-6
+```
+
+如果 `ANTHROPIC_BASE_URL` 缺少带版本的路径，OCR 会自动追加
+`/v1/messages`。
+
+### 使用 OpenAI 兼容端点？
+
+把 `llm.use_anthropic` 设为 `false`（或 `OCR_USE_ANTHROPIC=false`）：
+
+```bash
+ocr config set llm.url           https://api.openai.com/v1/chat/completions
+ocr config set llm.auth_token    sk-xxxxxxxxxx
+ocr config set llm.model         gpt-4o
+ocr config set llm.use_anthropic false
+```
+
+> 完整的 key 参考见 [配置](../configuration/)，包括用于厂商专属请求字段
+> 的 `llm.extra_body`，以及用于切换评审评论语言的 `language`。
+
+## 第 3 步——测试连通性
 
 ```bash
 ocr llm test
 ```
 
-如果报出 `no valid LLM endpoint configured` 这类错误,请重新检查第 2 步的配置。 401 / 403 表示 token 错误或已过期。
+预期输出（模型名会有所不同）：
 
-## 第 4 步 —— 运行第一次评审
+```
+Source: OCR config file
+URL:    https://api.anthropic.com/v1/messages
+Model:  claude-opus-4-6
+Hello! …
+```
+
+如果反而报出 `no valid LLM endpoint configured` 这类错误，请重新检查上面的
+配置 key。401 / 403 表示 token 错误或已过期。
+
+## 第 4 步——运行第一次评审
 
 进入任意 Git 仓库并运行：
 
 ```bash
 cd path/to/your-repo
 
-# 工作区模式 —— 评审 staged + unstaged + untracked 变更（默认）
+# 工作区模式——评审 staged + unstaged + untracked 变更（默认）
 ocr review
 
-# 分支区间 —— 评审 `main..feature-branch`
+# 分支区间——评审 `main..feature-branch`
 ocr review --from main --to feature-branch
 
-# 单个 commit —— 评审该 commit 引入的 diff
+# 单个 commit——评审该 commit 引入的 diff
 ocr review --commit abc123
 ```
 
-> `ocr review` 的完整参数（并发调优、输出格式、audience模式、背景上下文等）及其他所有子命令见 [CLI 参考](../cli-reference/)。
+你会看到持续输出的进度信息，最后每个文件出现一条或多条评审评论。
 
-### 想先看看会评审什么？
+> 工作区模式包含 **untracked** 文件。如果你只想评审已暂存的内容，请先用
+> `git add` 选择性暂存。
+
+> 以上三种是基础用法。`ocr review` 的完整参数（并发调优、输出格式、
+> audience 模式、背景上下文等）及其他所有子命令（`config`、`rules`、
+> `llm test`、`viewer`）见 [CLI 参考](../cli-reference/)。
+
+### 想先看看 *会* 评审什么？
 
 ```bash
-ocr review --preview              # 工作区
-ocr review -c abc123 --preview    # commit
+ocr review --preview         # 工作区
+ocr review -c abc123 -p      # commit
 ```
 
-### 面向系统的 JSON 输出
+`--preview` 运行每个过滤步骤但绝不调用 LLM，因此不消耗任何 token。它打印文件列表
+及每个文件的状态（`added` / `modified` / `deleted` / `renamed` / `binary`），
+对于被排除的文件还会给出原因（`binary`、`unsupported_ext`、`default_path`、
+`user_exclude`、`deleted`）。
 
-`--audience agent` 屏蔽人性化的进度 UI,让 stdout 只剩 JSON / 最终摘要 —— 正是上游 agent 或 CI 脚本所需。
+### 给工具用的 JSON 输出
 
 ```bash
 ocr review --format json --audience agent > review.json
 ```
 
+- `--format json` 输出一个机器可读的评论数组，每条含 `path`、`content`、
+  `start_line`、`end_line`、`existing_code`、`suggestion_code` 和可选的
+  `thinking`。
+- `--audience agent` 屏蔽人性化的进度 UI，让 stdout 只剩 JSON / 最终
+  摘要——正是上游 agent 或 CI 脚本所需。
+
+## 第 5 步——查看结果
+
+每条评论包含：
+
+| 字段 | 含义 |
+|---|---|
+| `path` | 该评论所针对的文件。 |
+| `content` | 评审评论本身，使用配置的 `language`。 |
+| `start_line` / `end_line` | 文件 **新** 版本中的行范围。两者都为 `0` 表示 OCR 无法精确定位评论——问题是真实的，但需自行定位到准确位置。 |
+| `existing_code` | 评论所指的 diff 片段。内部用于行解析；在 `start_line` 为 `0` 时有用。 |
+| `suggestion_code` | 可选的修复片段。 |
+| `thinking` | 可选的模型推理。仅部分模型存在。 |
+
+## 第 6 步——查看历史会话
+
+每次评审都会以 JSONL 转录形式持久化到
+`~/.opencodereview/sessions/...`。在本地 Web UI 中浏览它们：
+
+```bash
+ocr viewer            # http://localhost:5483
+ocr viewer --addr :3000
+```
+
+> 完整 UI 介绍见 [会话查看器](../viewer/)。
+
 ## 另见
 
-- [安装](../installation/) —— 全部安装方式与 OCR 的状态目录。
-- [配置](../configuration/) —— 每个环境变量、config key 与内置 provider。
-- [CLI 参考](../cli-reference/) —— 每个子命令、参数与输出模式。
-- [评审规则](../review-rules/) —— 自定义评审内容。
-- [集成](../integrations/) —— 把 OCR 嵌入 Claude Code、Agent skill 或 CI。
-- [FAQ](../faq/) —— 已知错误与对策。
+- [CLI 参考](../cli-reference/)——每个子命令、参数与输出模式。
+- [评审规则](../review-rules/)——自定义评审内容。
+- [集成](../integrations/)——把 OCR 嵌入 Claude Code、Agent skill 或 CI。
+- [遥测](../telemetry/)——经 OTLP 上报 trace 与 metrics。
+- [FAQ](../faq/)——已知错误与对策。

--- a/pages/src/content/docs/zh/viewer.md
+++ b/pages/src/content/docs/zh/viewer.md
@@ -139,7 +139,7 @@ JSONL 转录包含发给 LLM 和从 LLM 收到的**一切**，包括 diff 中的
 OpenTelemetry exporter 是另一回事——如何让 prompt 内容不进入导出 trace 见
 [遥测](../telemetry/)。
 
-## 查看器不适用时
+## 查看器*不*适用时
 
 - 程序化后处理（CI、仪表盘）用 `ocr review --format json --audience agent`。
   查看器为人渲染，不为机器。

--- a/pages/src/i18n/en.ts
+++ b/pages/src/i18n/en.ts
@@ -100,6 +100,7 @@ export const en: TranslationKeys = {
 
   // Docs Page (keep existing)
   'docs.toc': 'Table of Contents',
+  'docs.overview': 'Overview',
   'docs.install': 'Install',
   'docs.config': 'ocr config',
   'docs.review': 'ocr review',
@@ -107,6 +108,15 @@ export const en: TranslationKeys = {
   'docs.viewer': 'ocr viewer',
   'docs.mcp': 'MCP Server',
   'docs.env': 'Claude Code Integration',
+  'docs.overviewTitle': 'Overview',
+  'docs.overviewDesc': '(short <code>ocr</code>) is an AI-powered code review CLI tool.',
+  'docs.overviewFeatures': 'Core Features:',
+  'docs.overviewFeat1': 'Supports workspace, branch diff, single-commit, and full scan review modes',
+  'docs.overviewFeat2': 'Built-in Anthropic, OpenAI, DashScope, DeepSeek, Z.AI and custom provider support',
+  'docs.overviewFeat3': 'Concurrent review with customizable timeouts',
+  'docs.overviewFeat4': 'Output format supports text and json',
+  'docs.overviewFeat5': 'Zero config for Claude Code users',
+  'docs.overviewFeat6': 'WebUI viewer for visualizing review results',
   'docs.installTitle': 'Install',
   'docs.installLabel': 'Install',
   'docs.installVerifyLabel': 'Verify Installation',
@@ -259,7 +269,8 @@ export const en: TranslationKeys = {
   // Docs Sidebar
   'docs.sidebar.gettingStarted': 'Getting Started',
   'docs.sidebar.userGuide': 'User Guide',
-  'docs.sidebar.quickstart': 'QuickStart',
+  'docs.sidebar.overview': 'Overview',
+  'docs.sidebar.quickstart': 'Quick Start',
   'docs.sidebar.installation': 'Installation',
   'docs.sidebar.configuration': 'Configuration',
   'docs.sidebar.cliReference': 'CLI Reference',

--- a/pages/src/i18n/ja.ts
+++ b/pages/src/i18n/ja.ts
@@ -102,6 +102,7 @@ export const ja: TranslationKeys = {
 
   // Docs Page
   'docs.toc': '目次',
+  'docs.overview': '概要',
   'docs.install': 'インストール',
   'docs.config': 'ocr config',
   'docs.review': 'ocr review',
@@ -109,6 +110,15 @@ export const ja: TranslationKeys = {
   'docs.viewer': 'ocr viewer',
   'docs.mcp': 'MCP Server',
   'docs.env': 'Claude Code 統合',
+  'docs.overviewTitle': '概要',
+  'docs.overviewDesc': '（略称 <code>ocr</code>）は AI 駆動のコードレビュー CLI ツールです。',
+  'docs.overviewFeatures': 'コア機能：',
+  'docs.overviewFeat1': 'ワークスペース変更、ブランチ差分、単一コミット、フルスキャンレビューモードをサポート',
+  'docs.overviewFeat2': 'Anthropic、OpenAI、DashScope、DeepSeek、Z.AI などの内蔵プロバイダーとカスタムプロバイダーをサポート',
+  'docs.overviewFeat3': 'カスタマイズ可能なタイムアウト付き並行レビュー',
+  'docs.overviewFeat4': '出力形式は text と json をサポート',
+  'docs.overviewFeat5': 'Claude Code ユーザーはゼロ設定',
+  'docs.overviewFeat6': 'WebUI ビューアーでレビュー結果を可視化',
   'docs.installTitle': 'インストール',
   'docs.installLabel': 'インストール',
   'docs.installVerifyLabel': 'インストール確認',
@@ -261,6 +271,7 @@ export const ja: TranslationKeys = {
   // Docs Sidebar
   'docs.sidebar.gettingStarted': '入門ガイド',
   'docs.sidebar.userGuide': '利用ガイド',
+  'docs.sidebar.overview': '概要',
   'docs.sidebar.quickstart': 'クイックスタート',
   'docs.sidebar.installation': 'インストール',
   'docs.sidebar.configuration': '設定',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -102,6 +102,7 @@ export const zh: TranslationKeys = {
 
   // Docs Page
   'docs.toc': '目录',
+  'docs.overview': '概览',
   'docs.install': '安装',
   'docs.config': 'ocr config',
   'docs.review': 'ocr review',
@@ -109,6 +110,15 @@ export const zh: TranslationKeys = {
   'docs.viewer': 'ocr viewer',
   'docs.mcp': 'MCP Server',
   'docs.env': 'Claude Code 集成',
+  'docs.overviewTitle': '概览',
+  'docs.overviewDesc': '（简称 <code>ocr</code>）是一款 AI 驱动的代码审查 CLI 工具。',
+  'docs.overviewFeatures': '核心功能：',
+  'docs.overviewFeat1': '支持工作区变更、分支差异、单次提交和全量扫描审查模式',
+  'docs.overviewFeat2': '内置 Anthropic、OpenAI、DashScope、DeepSeek、Z.AI 等主流供应商及自定义供应商支持',
+  'docs.overviewFeat3': '并发审查与可自定义超时',
+  'docs.overviewFeat4': '输出格式支持 text 和 json',
+  'docs.overviewFeat5': 'Claude Code 用户零配置',
+  'docs.overviewFeat6': 'WebUI 查看器可视化审查结果',
   'docs.installTitle': '安装',
   'docs.installLabel': '安装',
   'docs.installVerifyLabel': '验证安装',
@@ -261,6 +271,7 @@ export const zh: TranslationKeys = {
   // Docs Sidebar
   'docs.sidebar.gettingStarted': '入门指南',
   'docs.sidebar.userGuide': '使用指南',
+  'docs.sidebar.overview': '概览',
   'docs.sidebar.quickstart': '快速开始',
   'docs.sidebar.installation': '安装',
   'docs.sidebar.configuration': '配置',

--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import { useResponsive } from '../hooks/useResponsive';
 import { getDocContent, getDocTitle, DocSlug, searchDocs } from '../content/docs';
-import { generateHeadingId } from '../utils/headingId';
+import { createHeadingIdGenerator } from '../utils/headingId';
 import docContentsIcon from '../assets/icons/doc-contents.svg';
 import searchIcon from '../assets/icons/icon-search.svg';
 import '../styles/docs-markdown.css';
@@ -28,6 +27,7 @@ const sidebarTree: SidebarGroup[] = [
   {
     groupLabelKey: 'docs.sidebar.gettingStarted',
     items: [
+      { id: 'sb-overview', labelKey: 'docs.sidebar.overview', slug: 'overview' },
       { id: 'sb-quickstart', labelKey: 'docs.sidebar.quickstart', slug: 'quickstart' },
       { id: 'sb-installation', labelKey: 'docs.sidebar.installation', slug: 'installation' },
       { id: 'sb-configuration', labelKey: 'docs.sidebar.configuration', slug: 'configuration' },
@@ -40,7 +40,6 @@ const sidebarTree: SidebarGroup[] = [
       { id: 'sb-rules', labelKey: 'docs.sidebar.reviewRules', slug: 'review-rules' },
       { id: 'sb-arch', labelKey: 'docs.sidebar.architecture', slug: 'architecture' },
       { id: 'sb-tools', labelKey: 'docs.sidebar.tools', slug: 'tools' },
-      { id: 'sb-mcp', labelKey: 'docs.sidebar.mcp', slug: 'mcp' },
       { id: 'sb-viewer', labelKey: 'docs.sidebar.viewer', slug: 'viewer' },
       { id: 'sb-telemetry', labelKey: 'docs.sidebar.telemetry', slug: 'telemetry' },
       {
@@ -70,6 +69,7 @@ const ChevronIcon: React.FC<{ expanded: boolean }> = ({ expanded }) => (
 /* ─── Extract headings from markdown for right TOC ─── */
 function extractHeadings(markdown: string): { id: string; text: string; level: number }[] {
   const headings: { id: string; text: string; level: number }[] = [];
+  const getHeadingId = createHeadingIdGenerator();
   const lines = markdown.split('\n');
   let inCodeBlock = false;
   for (const line of lines) {
@@ -86,7 +86,7 @@ function extractHeadings(markdown: string): { id: string; text: string; level: n
         .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
         .replace(/[`*_\[\]()]/g, '')
         .trim();
-      const id = generateHeadingId(text);
+      const id = getHeadingId(text);
       headings.push({ id, text, level });
     }
   }
@@ -110,24 +110,9 @@ function buildFlatDocList(): { slug: DocSlug; labelKey: string }[] {
 }
 
 const flatDocList = buildFlatDocList();
-const validSlugs = new Set<DocSlug>(flatDocList.map(d => d.slug));
-
-/* Dev-time invariant: every sidebar slug maps to exactly one URL, so duplicates
- * (two menu entries sharing a slug) would silently collide. Fail loudly in dev. */
-if (process.env.NODE_ENV !== 'production' && validSlugs.size !== flatDocList.length) {
-  const slugs = flatDocList.map(d => d.slug);
-  const dupes = [...new Set(slugs.filter((s, i) => slugs.indexOf(s) !== i))];
-  throw new Error(
-    `[docs] Duplicate sidebar slug(s) detected: ${dupes.join(', ')} — each doc must have a unique slug for routing.`
-  );
-}
 
 const DocsPage: React.FC = () => {
-  const { slug: slugParam } = useParams<{ slug?: string }>();
-  const navigate = useNavigate();
-  /* Active doc slug is derived from the URL param, falling back to quickstart */
-  const activeSlug: DocSlug =
-    slugParam && validSlugs.has(slugParam as DocSlug) ? (slugParam as DocSlug) : 'quickstart';
+  const [activeSlug, setActiveSlug] = useState<DocSlug>('overview');
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({ 'sb-integrations': false });
   const [activeHeadingId, setActiveHeadingId] = useState<string>('');
   const [hoveredHeadingId, setHoveredHeadingId] = useState<string>('');
@@ -178,10 +163,10 @@ const DocsPage: React.FC = () => {
   }, []);
 
   const navigateToDoc = useCallback((slug: DocSlug) => {
-    navigate(`/docs/${slug}`);
+    setActiveSlug(slug);
     // Scroll page to top
     window.scrollTo(0, 0);
-  }, [navigate]);
+  }, []);
 
   /* Intercept clicks on internal doc links and convert to SPA navigation */
   const handleContentClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -210,7 +195,8 @@ const DocsPage: React.FC = () => {
     const slugMap: Record<string, DocSlug> = { 'ci': 'cicd' };
     const slug = (slugMap[lastSegment] || lastSegment) as DocSlug;
     // Verify it's a valid doc slug
-    if (validSlugs.has(slug)) {
+    const validSlugs = flatDocList.map(d => d.slug);
+    if (validSlugs.includes(slug)) {
       e.preventDefault();
       navigateToDoc(slug);
       // Handle anchor scroll after navigation with reliable retry

--- a/pages/src/styles/docs-markdown.css
+++ b/pages/src/styles/docs-markdown.css
@@ -75,7 +75,6 @@
   margin: 0 0 16px 0;
   overflow-x: auto;
   display: flex;
-  align-self: stretch;
   justify-content: space-between;
   align-items: center;
 }
@@ -239,4 +238,40 @@
 .docs-markdown pre::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.15);
   border-radius: 3px;
+}
+
+/* Copy button in code blocks */
+.code-copy-btn {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: column;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  cursor: pointer;
+}
+
+/* Copy toast notification */
+.copy-toast {
+  position: fixed;
+  top: 88px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 5px 8px 5px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 9999;
+  backdrop-filter: blur(8px);
+}
+
+.copy-toast.visible {
+  opacity: 1;
 }

--- a/pages/src/utils/headingId.ts
+++ b/pages/src/utils/headingId.ts
@@ -8,3 +8,18 @@ export function generateHeadingId(text: string): string {
   const plain = text.replace(/<[^>]+>/g, '').replace(/[`*_\[\]()]/g, '').trim();
   return plain.toLowerCase().replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-').replace(/^-|-$/g, '');
 }
+
+/**
+ * Creates a stateful heading ID generator that deduplicates IDs by appending
+ * a numeric suffix (-1, -2, etc.) when the same heading text appears multiple times.
+ * Call createHeadingIdGenerator() once per document render to track seen IDs.
+ */
+export function createHeadingIdGenerator(): (text: string) => string {
+  const seen = new Map<string, number>();
+  return (text: string): string => {
+    const baseId = generateHeadingId(text);
+    const count = seen.get(baseId) || 0;
+    seen.set(baseId, count + 1);
+    return count === 0 ? baseId : `${baseId}-${count}`;
+  };
+}


### PR DESCRIPTION
- Add DocsPage with full-text search modal and keyboard shortcuts (⌘K)
- Add MarkdownRenderer with DOMPurify sanitization and mermaid support
- Add bilingual docs content (en/zh) for all sections
- Add shared headingId utility with deduplication for consistent TOC anchors
- Add search keyboard hints with i18n support
- Update Navbar with Docs navigation link
- Configure webpack for markdown imports
- Extract parseFrontmatter helper to eliminate DRY violation
- Move copy button and toast inline styles to CSS classes
- Adjust HeroSection terminal section height and bottom padding