### PR TITLE
fix(review-filter): add `submit_filter_result` func for review filter stage

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/alibaba/open-code-review/internal/telemetry"
 	"github.com/alibaba/open-code-review/internal/tool"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
 
@@ -1338,6 +1339,28 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, *subtas
 	return true, nil, nil
 }
 
+// submitFilterTool is the tool definition that constrains the review filter
+var submitFilterTool = llm.ToolDef{
+	Type: "function",
+	Function: llm.FunctionDef{
+		Name:        "submit_filter_result",
+		Description: "Submit the list of review comments that are provably incorrect based on the diff",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"comment_ids": map[string]any{
+					"type":        "array",
+					"description": "IDs of review comments confirmed as incorrect return an empty array when none, e.g. [\"c-0\", \"c-2\"]",
+					"items": map[string]any{
+						"type": "string",
+					},
+				},
+			},
+			"required": []any{"comment_ids"},
+		},
+	},
+}
+
 // executeReviewFilter runs the REVIEW_FILTER_TASK to remove comments that are
 // provably incorrect based solely on the diff. Errors are logged and silently ignored.
 func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath string) {
@@ -1384,6 +1407,7 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	resp, err := a.args.LLMClient.CompletionsWithCtx(reqCtx, llm.ChatRequest{
 		Model:     a.args.Model,
 		Messages:  messages,
+		Tools:     []llm.ToolDef{submitFilterTool},
 		MaxTokens: a.args.Template.CompletionTokenLimit(),
 	})
 	duration := time.Since(startTime)
@@ -1405,13 +1429,24 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	rec.SetResponse(resp, duration)
 	a.runner.RecordUsage(resp.Usage)
 
-	indices := parseFilterResponse(resp.Content(), len(comments))
+	indices := parseFilterToolCalls(resp.ToolCalls(), len(comments))
+	if indices == nil {
+		indices = parseFilterResponse(resp.Content(), len(comments))
+	}
 	telemetry.SetAttr(span, "comments.filtered", len(indices))
 	if len(indices) == 0 {
+		telemetry.Event(ctx, "review_filter.completed",
+			attribute.String("file.path", newPath),
+			attribute.Int("total_comments", len(comments)),
+			attribute.Int("removed", 0))
 		return
 	}
 
 	a.args.CommentCollector.RemoveByPathAndIndices(newPath, indices)
+	telemetry.Event(ctx, "review_filter.completed",
+		attribute.String("file.path", newPath),
+		attribute.Int("total_comments", len(comments)),
+		attribute.Int("removed", len(indices)))
 	fmt.Fprintf(stdout.Writer(), "[ocr] Review filter removed %d comment(s) for %s\n", len(indices), newPath)
 }
 
@@ -1432,6 +1467,32 @@ func buildFilterCommentsJSON(comments []model.LlmComment) string {
 	}
 	data, _ := json.Marshal(items)
 	return string(data)
+}
+
+// parseFilterToolCalls extracts comment indices from the LLM's tool call
+// response to submit_filter_result. Returns nil if no matching tool call
+// is found, allowing fallback to text-based parsing.
+func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
+	for _, call := range calls {
+		if call.Function.Name != "submit_filter_result" {
+			continue
+		}
+		var args struct {
+			CommentIDs []string `json:"comment_ids"`
+		}
+		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+			continue
+		}
+		indices := make(map[int]struct{})
+		for _, id := range args.CommentIDs {
+			var idx int
+			if _, err := fmt.Sscanf(id, "c-%d", &idx); err == nil && idx >= 0 && idx < total {
+				indices[idx] = struct{}{}
+			}
+		}
+		return indices
+	}
+	return nil
 }
 
 // parseFilterResponse extracts comment indices from the LLM filter response.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1339,24 +1339,36 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, *subtas
 	return true, nil, nil
 }
 
-// submitFilterTool is the tool definition that constrains the review filter
-var submitFilterTool = llm.ToolDef{
-	Type: "function",
-	Function: llm.FunctionDef{
-		Name:        "submit_filter_result",
-		Description: "Submit the list of review comments that are provably incorrect based on the diff",
-		Parameters: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"comment_ids": map[string]any{
-					"type":        "array",
-					"description": "IDs of review comments confirmed as incorrect return an empty array when none, e.g. [\"c-0\", \"c-2\"]",
-					"items": map[string]any{
-						"type": "string",
+// filterTools defines the two mutually exclusive tools for the review filter.
+// The model MUST call exactly one: either report incorrect comments, or approve all.
+var filterTools = []llm.ToolDef{
+	{
+		Type: "function",
+		Function: llm.FunctionDef{
+			Name:        "report_incorrect_comments",
+			Description: "Report review comments that are provably incorrect based on the diff. Call this when one or more comments can be confirmed as wrong.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"comment_ids": map[string]any{
+						"type":        "array",
+						"description": "IDs of incorrect comments, e.g. [\"c-0\", \"c-2\"]. Must not be empty.",
+						"items":       map[string]any{"type": "string"},
 					},
 				},
+				"required": []any{"comment_ids"},
 			},
-			"required": []any{"comment_ids"},
+		},
+	},
+	{
+		Type: "function",
+		Function: llm.FunctionDef{
+			Name:        "approve_all_comments",
+			Description: "Confirm that all review comments are correct or cannot be disproved from the diff alone. Call this when no comment can be confirmed as incorrect.",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
 		},
 	},
 }
@@ -1407,7 +1419,8 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	resp, err := a.args.LLMClient.CompletionsWithCtx(reqCtx, llm.ChatRequest{
 		Model:     a.args.Model,
 		Messages:  messages,
-		Tools:     []llm.ToolDef{submitFilterTool},
+		Tools:      filterTools,
+		ToolChoice: "required",
 		MaxTokens: a.args.Template.CompletionTokenLimit(),
 	})
 	duration := time.Since(startTime)
@@ -1469,31 +1482,37 @@ func buildFilterCommentsJSON(comments []model.LlmComment) string {
 	return string(data)
 }
 
-// parseFilterToolCalls extracts comment indices from the LLM's tool call
-// response to submit_filter_result. Returns nil if no matching tool call
-// is found, allowing fallback to text-based parsing.
+// parseFilterToolCalls extracts comment indices from the filter tool call response.
+// Returns nil if no matching tool call is found, allowing fallback to text-based parsing.
+// Returns an empty map (non-nil) for approve_all_comments or an empty comment_ids list.
 func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
+	var indices map[int]struct{}
 	for _, call := range calls {
-		if call.Function.Name != "submit_filter_result" {
-			continue
-		}
-		var args struct {
-			CommentIDs []string `json:"comment_ids"`
-		}
-		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
-			fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: failed to parse tool call arguments: %v\n", err)
-			continue
-		}
-		indices := make(map[int]struct{})
-		for _, id := range args.CommentIDs {
-			var idx int
-			if _, err := fmt.Sscanf(id, "c-%d", &idx); err == nil && idx >= 0 && idx < total {
-				indices[idx] = struct{}{}
+		switch call.Function.Name {
+		case "approve_all_comments":
+			if indices == nil {
+				indices = make(map[int]struct{})
+			}
+		case "report_incorrect_comments":
+			var args struct {
+				CommentIDs []string `json:"comment_ids"`
+			}
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+				fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: failed to parse tool call arguments: %v\n", err)
+				continue
+			}
+			if indices == nil {
+				indices = make(map[int]struct{})
+			}
+			for _, id := range args.CommentIDs {
+				var idx int
+				if _, err := fmt.Sscanf(id, "c-%d", &idx); err == nil && idx >= 0 && idx < total {
+					indices[idx] = struct{}{}
+				}
 			}
 		}
-		return indices
 	}
-	return nil
+	return indices
 }
 
 // parseFilterResponse extracts comment indices from the LLM filter response.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1481,6 +1481,7 @@ func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
 			CommentIDs []string `json:"comment_ids"`
 		}
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+			fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: failed to parse tool call arguments: %v\n", err)
 			continue
 		}
 		indices := make(map[int]struct{})

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1345,26 +1345,46 @@ var filterTools = []llm.ToolDef{
 	{
 		Type: "function",
 		Function: llm.FunctionDef{
-			Name:        "report_incorrect_comments",
-			Description: "Report review comments that are provably incorrect based on the diff. Call this when one or more comments can be confirmed as wrong.",
+			Name: "report_incorrect_comments",
+			Description: "Report review comments that this diff proves to be factually wrong: either the code they target is absent from the diff, " +
+				"or one diff line literally contradicts their central claim. For every id listed you must be able to name that line. " +
+				"Do not use this for comments you merely find unconvincing, unverifiable, or low-value, nor for comments about memory safety, " +
+				"concurrency, linkage consistency, unused parameters, or behavioral changes.",
+			// Field order matters and is load-bearing. Go serializes these
+			// properties alphabetically, so "analysis" is emitted before
+			// "comment_ids" and the model reasons before it commits. With the
+			// order reversed it picks ids first and cannot retract them: replaying
+			// recorded sessions showed it writing "this is a protected subject, I
+			// should not remove it" in the later field while the id stayed in the
+			// earlier one. Do not rename these fields into a different relative
+			// order.
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
+					"analysis": map[string]any{
+						"type": "array",
+						"description": "Work through every candidate comment BEFORE deciding. One entry per candidate: its id, " +
+							"whether its subject hits the protected-subject veto (Step 1) or the value veto (Step 2), " +
+							"the exact diff line that refutes it if any, and your final call. " +
+							"Only ids you conclude here as removable may appear in comment_ids.",
+						"items": map[string]any{"type": "string"},
+					},
 					"comment_ids": map[string]any{
 						"type":        "array",
-						"description": "IDs of incorrect comments, e.g. [\"c-0\", \"c-2\"]. Must not be empty.",
+						"description": "IDs concluded removable in analysis, e.g. [\"c-0\", \"c-2\"]. Must not be empty.",
 						"items":       map[string]any{"type": "string"},
 					},
 				},
-				"required": []any{"comment_ids"},
+				"required": []any{"analysis", "comment_ids"},
 			},
 		},
 	},
 	{
 		Type: "function",
 		Function: llm.FunctionDef{
-			Name:        "approve_all_comments",
-			Description: "Confirm that all review comments are correct or cannot be disproved from the diff alone. Call this when no comment can be confirmed as incorrect.",
+			Name: "approve_all_comments",
+			Description: "Keep every review comment. Call this whenever no comment clears the removal bar — including when comments look doubtful, " +
+				"cannot be verified from the diff alone, or seem minor. This is the expected outcome for most files.",
 			Parameters: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{},
@@ -1417,11 +1437,11 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 
 	_, llmSpan := telemetry.StartLLMSpan(ctx, a.args.Model)
 	resp, err := a.args.LLMClient.CompletionsWithCtx(reqCtx, llm.ChatRequest{
-		Model:     a.args.Model,
-		Messages:  messages,
+		Model:      a.args.Model,
+		Messages:   messages,
 		Tools:      filterTools,
 		ToolChoice: "required",
-		MaxTokens: a.args.Template.CompletionTokenLimit(),
+		MaxTokens:  a.args.Template.CompletionTokenLimit(),
 	})
 	duration := time.Since(startTime)
 	if err != nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -223,6 +223,96 @@ func TestParseFilterResponse(t *testing.T) {
 	}
 }
 
+func TestParseFilterToolCalls(t *testing.T) {
+	tests := []struct {
+		name    string
+		calls   []llm.ToolCall
+		total   int
+		wantSet map[int]struct{}
+	}{
+		{
+			name:    "no tool calls",
+			calls:   nil,
+			total:   5,
+			wantSet: nil,
+		},
+		{
+			name: "submit_filter_result with IDs",
+			calls: []llm.ToolCall{{
+				Function: llm.FunctionCall{
+					Name:      "submit_filter_result",
+					Arguments: `{"comment_ids": ["c-0", "c-2"]}`,
+				},
+			}},
+			total:   5,
+			wantSet: map[int]struct{}{0: {}, 2: {}},
+		},
+		{
+			name: "submit_filter_result empty array",
+			calls: []llm.ToolCall{{
+				Function: llm.FunctionCall{
+					Name:      "submit_filter_result",
+					Arguments: `{"comment_ids": []}`,
+				},
+			}},
+			total:   5,
+			wantSet: map[int]struct{}{},
+		},
+		{
+			name: "ignores non-matching tool names",
+			calls: []llm.ToolCall{{
+				Function: llm.FunctionCall{
+					Name:      "other_tool",
+					Arguments: `{"comment_ids": ["c-0"]}`,
+				},
+			}},
+			total:   5,
+			wantSet: nil,
+		},
+		{
+			name: "out-of-range indices ignored",
+			calls: []llm.ToolCall{{
+				Function: llm.FunctionCall{
+					Name:      "submit_filter_result",
+					Arguments: `{"comment_ids": ["c-0", "c-10"]}`,
+				},
+			}},
+			total:   5,
+			wantSet: map[int]struct{}{0: {}},
+		},
+		{
+			name: "invalid JSON arguments returns nil",
+			calls: []llm.ToolCall{{
+				Function: llm.FunctionCall{
+					Name:      "submit_filter_result",
+					Arguments: `not json`,
+				},
+			}},
+			total:   5,
+			wantSet: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilterToolCalls(tt.calls, tt.total)
+			if tt.wantSet == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tt.wantSet) {
+				t.Fatalf("len = %d, want %d; got %v", len(got), len(tt.wantSet), got)
+			}
+			for idx := range tt.wantSet {
+				if _, ok := got[idx]; !ok {
+					t.Errorf("missing index %d in result", idx)
+				}
+			}
+		})
+	}
+}
+
 func TestExtFromPath(t *testing.T) {
 	a := New(Args{})
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -237,10 +237,10 @@ func TestParseFilterToolCalls(t *testing.T) {
 			wantSet: nil,
 		},
 		{
-			name: "submit_filter_result with IDs",
+			name: "report_incorrect_comments with IDs",
 			calls: []llm.ToolCall{{
 				Function: llm.FunctionCall{
-					Name:      "submit_filter_result",
+					Name:      "report_incorrect_comments",
 					Arguments: `{"comment_ids": ["c-0", "c-2"]}`,
 				},
 			}},
@@ -248,11 +248,11 @@ func TestParseFilterToolCalls(t *testing.T) {
 			wantSet: map[int]struct{}{0: {}, 2: {}},
 		},
 		{
-			name: "submit_filter_result empty array",
+			name: "approve_all_comments returns empty map",
 			calls: []llm.ToolCall{{
 				Function: llm.FunctionCall{
-					Name:      "submit_filter_result",
-					Arguments: `{"comment_ids": []}`,
+					Name:      "approve_all_comments",
+					Arguments: `{}`,
 				},
 			}},
 			total:   5,
@@ -273,7 +273,7 @@ func TestParseFilterToolCalls(t *testing.T) {
 			name: "out-of-range indices ignored",
 			calls: []llm.ToolCall{{
 				Function: llm.FunctionCall{
-					Name:      "submit_filter_result",
+					Name:      "report_incorrect_comments",
 					Arguments: `{"comment_ids": ["c-0", "c-10"]}`,
 				},
 			}},
@@ -281,10 +281,10 @@ func TestParseFilterToolCalls(t *testing.T) {
 			wantSet: map[int]struct{}{0: {}},
 		},
 		{
-			name: "invalid JSON arguments returns nil",
+			name: "invalid JSON arguments falls through",
 			calls: []llm.ToolCall{{
 				Function: llm.FunctionCall{
-					Name:      "submit_filter_result",
+					Name:      "report_incorrect_comments",
 					Arguments: `not json`,
 				},
 			}},

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -269,11 +269,19 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
 
-	filterResp := `["c-1"]`
 	client := &fakeAgentClient{
 		responses: []*llm.ChatResponse{{
 			Choices: []llm.Choice{{
-				Message: llm.ResponseMessage{Content: &filterResp},
+				Message: llm.ResponseMessage{
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "report_incorrect_comments",
+							Arguments: `{"comment_ids":["c-1"]}`,
+						},
+					}},
+				},
 			}},
 			Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
 		}},
@@ -418,11 +426,19 @@ func TestExecuteReviewFilter_SkipFilter(t *testing.T) {
 		tmpDir := t.TempDir()
 		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
 
-		filterResp := `["c-1"]`
 		client := &fakeAgentClient{
 			responses: []*llm.ChatResponse{{
 				Choices: []llm.Choice{{
-					Message: llm.ResponseMessage{Content: &filterResp},
+					Message: llm.ResponseMessage{
+						ToolCalls: []llm.ToolCall{{
+							ID:   "call_1",
+							Type: "function",
+							Function: llm.FunctionCall{
+								Name:      "report_incorrect_comments",
+								Arguments: `{"comment_ids":["c-1"]}`,
+							},
+						}},
+					},
 				}},
 				Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
 			}},
@@ -775,11 +791,21 @@ func TestExecuteReviewFilter_WithTimeout(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
 
-	filterResp := `[]`
 	client := &fakeAgentClient{
 		responses: []*llm.ChatResponse{{
-			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &filterResp}}},
-			Usage:   &llm.UsageInfo{PromptTokens: 5, CompletionTokens: 2},
+			Choices: []llm.Choice{{
+				Message: llm.ResponseMessage{
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "approve_all_comments",
+							Arguments: `{}`,
+						},
+					}},
+				},
+			}},
+			Usage: &llm.UsageInfo{PromptTokens: 5, CompletionTokens: 2},
 		}},
 	}
 

--- a/internal/config/template/prompts/review_filter_task_system.md
+++ b/internal/config/template/prompts/review_filter_task_system.md
@@ -1,7 +1,12 @@
 You are a fact-checker for code review comments.
 
-These review comments come from an Agent that can invoke tools to obtain the full code context. You can currently only see the code diff.
+These review comments come from an Agent that could invoke tools to read the full codebase. You can see only a single diff. Anything you cannot see, the Agent may well have seen.
 
-Therefore, your task is NOT to verify whether all review comments are correct, but to **filter out only those review comments that can be confirmed as incorrect based solely on the current diff**.
+Your task is narrow: remove only the comments that this diff **proves** to be factually wrong. You are not judging whether a comment is useful, well-prioritized, or worth a reviewer's time.
 
-For review comments whose correctness cannot be determined from the diff alone, even if you find them suspicious, you should let them pass — because the Agent may have access to context that you cannot see.
+The two mistakes available to you are not equally bad:
+
+- Keeping an incorrect comment costs a reviewer a few seconds of attention.
+- Removing a correct comment silently destroys a real finding. It never reaches anyone, and nobody learns that it was dropped.
+
+So when your evidence falls short of proof, approve. "Suspicious", "I cannot verify this", "low value", "the flagged code looks fine to me", and "I would not have raised this" all mean approve.

--- a/internal/config/template/prompts/review_filter_task_user.md
+++ b/internal/config/template/prompts/review_filter_task_user.md
@@ -42,14 +42,4 @@ After confirming that the facts visible in the diff are accurate, determine whet
 
 ### Output
 
-Return all incorrect review comment IDs directly, without any explanation. Use JSON array format:
-
-```json
-["id-xxx", "id-yyy"]
-```
-
-If there are no review comments that can be confirmed as incorrect, return an empty array:
-
-```json
-[]
-```
+Call the `submit_filter_result` tool with the IDs of all review comments that can be confirmed as incorrect, without any explanation.

--- a/internal/config/template/prompts/review_filter_task_user.md
+++ b/internal/config/template/prompts/review_filter_task_user.md
@@ -1,34 +1,69 @@
 ### Task
 
-Given a code diff and a set of review comments, identify those that are **provably incorrect based solely on the diff**.
+Below is one file's diff and a set of review comments about it. Identify only the comments that this diff **proves** to be wrong.
 
-### Evaluation Principles
+Your default answer is to approve everything. On most files that is the correct answer.
 
-**Core principle: You need to falsify, not verify.**
+### The only two grounds for removal
 
-- ✅ Should flag: The diff contains **direct counter-evidence** that proves the key claim of the review comment is wrong
-- ❌ Should NOT flag: The review comment references context not visible in the diff (may have been obtained by the Agent via tools)
-- ❌ Should NOT flag: You merely "cannot verify" but also cannot disprove the review comment
+**Ground A — the comment targets code that is not in this diff.**
 
-### Evaluation Method
+The symbol, statement, or construct the comment describes appears nowhere in the diff below. Typical shapes:
 
-For each review comment, perform the following two steps:
+- it discusses the body of a function, on a file that only declares or references it
+- it discusses host-language logic on a file that holds none — a query, build, markup, or configuration file
+- it claims code was removed, or an error is handled, and this diff contains no such change
 
-#### Step 1: Fact Check (Veto Rule)
+**Ground B — a specific line of the diff literally contradicts the comment's central claim.**
 
-- Only verify claims that are verifiable within the diff
-- Only determine a comment as incorrect when the diff provides counter-evidence. **If a claim involves information outside the diff (such as logic in other files, business semantics, runtime behavior), and the diff contains no evidence contradicting it, do not make a determination.**
+The comment asserts a concrete fact and the diff shows the opposite in plain text. The contradiction must be readable straight off the diff, not derived through a chain of reasoning. Typical shapes:
 
-⚠️ Fact check fails → Immediately determine as incorrect, skip Step 2.
+- it says an identifier is unused, and the diff shows it in use
+- it says a check, assertion, or branch is missing, and the diff contains it
+- it says a value is hardcoded, and the diff shows it read from a variable
+- it says something is declared twice and shadows an outer name, and the diff holds exactly one declaration
+- it states a condition or type relationship that the diff's own text refutes
 
-#### Step 2: Issue Classification
+If you cannot point to the specific diff line that establishes Ground A or Ground B, approve the comment.
 
-After confirming that the facts visible in the diff are accurate, determine whether the description contains a **significant deviation that can be disproved from the diff**:
+### Protected subjects — never remove
 
-- Does it misidentify clearly normal code in the diff as a defect?
-- Does it attribute behavior visible in the diff in a way that contradicts the code?
+These are vetoes, applied before you judge correctness at all. Whatever you conclude about the comment, approve it if its subject is:
 
-⚠️ Only determine as incorrect when the diff can directly prove the description is wrong.
+- **Memory safety** — allocation size, buffer length, index bounds, off-by-one, use-after-free, null dereference
+- **Concurrency** — locks and lock modes, atomics, data races, synchronization arguments that are not honored
+- **Linkage and declaration consistency** — `static` versus non-`static`, a declaration that disagrees with its definition, missing `extern`
+- **Behavioral or compatibility change** — a message, field, status, or default that the old code produced and the new code no longer does; an altered error path; a counter whose update moved to a different point in the lifecycle
+- **A parameter the function accepts and never uses**
+
+These are the categories where a wrongly removed comment is most expensive, and where your own confidence is least trustworthy — including confidence that the language, compiler, or runtime does not behave the way the comment claims. On a protected subject you do not get to be confident. Approve.
+
+### Not grounds for removal
+
+- The comment is about style, formatting, naming, blank lines, the wording of a code comment, or readability — **provided what it states is true**. Low value is not incorrectness, and filtering by value is not your job.
+- The comment reasons about runtime behavior, business semantics, or code in files you cannot see. The Agent had access you do not.
+- You disagree with its recommendation, or you consider the flagged code acceptable as written.
+- You cannot confirm it. Unverifiable is not incorrect.
+- It identifies a real problem but quotes a slightly wrong line or snippet. Judge the claim, not the citation.
+- It is imprecise in passing while its central claim holds.
+
+### Method
+
+Run these steps in order for every comment. Stop at the first step that applies — do not revisit a decision a later step would have made differently.
+
+**Step 1 — protected-subject veto.** Is the comment's subject one of the protected categories above (memory safety, concurrency, linkage and declaration consistency, behavioral or compatibility change, an unused parameter)? → **approve and stop.** Do not assess whether it is correct. This veto outranks Ground A and Ground B: a comment on a protected subject stays even when you are confident it is wrong.
+
+**Step 2 — value veto.** Is the comment about style, formatting, naming, blank lines, the wording of a code comment, or readability, and is what it states true of this diff? → **approve and stop.** Its low value is not your concern.
+
+**Step 3 — Ground A.** Is the code it describes absent from the diff? → **remove it.**
+
+**Step 4 — Ground B.** Is there one diff line that literally contradicts its central claim, requiring no chain of reasoning to see? → **remove it.** Steps 3 and 4 are not optional: once a comment reaches them and qualifies, report it.
+
+Before concluding a contradiction in Step 4, search the whole diff for what the comment describes — not only the snippet it quoted. A comment that cites the wrong line while describing something the diff does contain is correct, and stays.
+
+**Step 5 —** approve.
+
+Reaching Step 4 and needing more than a single inferential step to reach the contradiction means there is none. Approve.
 
 ### Code Diff
 
@@ -44,5 +79,5 @@ After confirming that the facts visible in the diff are accurate, determine whet
 
 You must call exactly one tool:
 
-- If any comments are provably incorrect: call `report_incorrect_comments` with their IDs.
-- If all comments are correct or cannot be disproved from the diff: call `approve_all_comments`.
+- `report_incorrect_comments` — only for comments meeting Ground A or Ground B, and only if you could name the diff line that disproves each one.
+- `approve_all_comments` — in every other case, including when comments look doubtful, unverifiable, or minor.

--- a/internal/config/template/prompts/review_filter_task_user.md
+++ b/internal/config/template/prompts/review_filter_task_user.md
@@ -42,4 +42,7 @@ After confirming that the facts visible in the diff are accurate, determine whet
 
 ### Output
 
-Call the `submit_filter_result` tool with the IDs of all review comments that can be confirmed as incorrect, without any explanation.
+You must call exactly one tool:
+
+- If any comments are provably incorrect: call `report_incorrect_comments` with their IDs.
+- If all comments are correct or cannot be disproved from the diff: call `approve_all_comments`.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -403,6 +403,7 @@ type ChatRequest struct {
 	Model       string    `json:"model"`
 	Messages    []Message `json:"messages"`
 	Tools       []ToolDef `json:"tools,omitempty"`
+	ToolChoice  string    `json:"tool_choice,omitempty"` // "auto", "required", or "none"; empty means provider default
 	Temperature *float64  `json:"temperature,omitempty"`
 	MaxTokens   int       `json:"max_tokens,omitempty"`
 	SessionID   string    `json:"-"` // per-file agent loop session ID; used as prompt_cache_key by the Responses API client
@@ -645,6 +646,11 @@ func (c *OpenAIClient) buildOpenAIParams(model string, req ChatRequest) openai.C
 
 	if len(tools) > 0 {
 		params.Tools = tools
+	}
+	if req.ToolChoice != "" && len(tools) > 0 {
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String(req.ToolChoice),
+		}
 	}
 	if req.MaxTokens > 0 {
 		params.MaxCompletionTokens = openai.Int(int64(req.MaxTokens))
@@ -946,6 +952,11 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 	if len(tools) > 0 {
 		tools[len(tools)-1].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
 		params.Tools = tools
+		if req.ToolChoice == "required" {
+			params.ToolChoice = anthropic.ToolChoiceUnionParam{
+				OfAny: &anthropic.ToolChoiceAnyParam{},
+			}
+		}
 	}
 	// Dynamic breakpoint on the latest message so multi-turn history is
 	// cached incrementally: read the full previous prefix, write only the delta.

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -11,6 +11,7 @@ import (
 
 	openai "github.com/openai/openai-go/v3"
 	openaiopt "github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
 )
 
@@ -224,6 +225,11 @@ func (c *OpenAIResponsesClient) buildResponsesParams(model string, req ChatReque
 	}
 	if len(tools) > 0 {
 		params.Tools = tools
+		if req.ToolChoice == "required" {
+			params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+				OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
+			}
+		}
 	}
 	if req.MaxTokens > 0 {
 		params.MaxOutputTokens = openai.Int(int64(req.MaxTokens))

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -432,7 +432,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 							info := ToolCallInfo{Name: name, Arguments: args}
 							if name == "task_done" {
 								info.Ok = taskDoneSucceeded(args)
-							} else if name == "submit_filter_result" {
+							} else if name == "report_incorrect_comments" || name == "approve_all_comments" {
 								info.Ok = true
 							}
 							card.ToolCalls = append(card.ToolCalls, info)

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -432,6 +432,8 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 							info := ToolCallInfo{Name: name, Arguments: args}
 							if name == "task_done" {
 								info.Ok = taskDoneSucceeded(args)
+							} else if name == "submit_filter_result" {
+								info.Ok = true
 							}
 							card.ToolCalls = append(card.ToolCalls, info)
 						}


### PR DESCRIPTION
fix(review-filter): add `submit_filter_result` func for review filter stage

At review filter stage, LLM(test GLM5.2) may return natural language content such as:
"""
Looking at each comment...
- commit 1: ...
- commit 2: ...

Summary:
```json [...]```
"""

add function calling for LLM will get more stable result for some model of providers.
and this tool only appears at review filter stage, so it does no harm for review quality.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
