### PR TITLE
fix(review-filter): apply language for review filter stage

### DIFF
--- a/internal/config/template/template.go
+++ b/internal/config/template/template.go
@@ -157,7 +157,7 @@ func resolveLang(lang string) string {
 }
 
 // ApplyLanguage injects a language directive into all system-role messages
-// across MAIN_TASK, PLAN_TASK (if set), and MEMORY_COMPRESSION_TASK.
+// across MAIN_TASK, PLAN_TASK (if set), MEMORY_COMPRESSION_TASK, and REVIEW_FILTER_TASK (if set).
 func (t *Template) ApplyLanguage(lang string) {
 	instruction := "\n\nAlways respond in " + resolveLang(lang) + "."
 	applyLanguage(&t.MainTask, instruction)
@@ -165,6 +165,9 @@ func (t *Template) ApplyLanguage(lang string) {
 		applyLanguage(t.PlanTask, instruction)
 	}
 	applyLanguage(&t.MemoryCompressionTask, instruction)
+	if t.ReviewFilterTask != nil {
+		applyLanguage(t.ReviewFilterTask, instruction)
+	}
 }
 
 // ApplyLanguage injects a language directive into all system-role messages

--- a/internal/config/template/template_test.go
+++ b/internal/config/template/template_test.go
@@ -146,6 +146,12 @@ func TestApplyLanguage(t *testing.T) {
 	if !strings.HasSuffix(tpl.MemoryCompressionTask.Messages[0].Content, suffix) {
 		t.Errorf("MemoryCompressionTask system message does not end with %q", suffix)
 	}
+	if tpl.ReviewFilterTask == nil {
+		t.Fatal("ReviewFilterTask should be present in default template")
+	}
+	if !strings.HasSuffix(tpl.ReviewFilterTask.Messages[0].Content, suffix) {
+		t.Errorf("ReviewFilterTask system message does not end with %q", suffix)
+	}
 }
 
 func TestApplyLanguage_DefaultEnglish(t *testing.T) {
@@ -316,6 +322,18 @@ func TestApplyLanguage_SkipsNonSystemMessages(t *testing.T) {
 	tpl.ApplyLanguage("French")
 	if strings.Contains(tpl.MainTask.Messages[1].Content, "French") {
 		t.Error("user-role message should not get language directive")
+	}
+}
+
+func TestApplyLanguage_NilReviewFilterTask(t *testing.T) {
+	// ApplyLanguage should not panic when ReviewFilterTask is nil.
+	tpl := &Template{
+		MainTask:              LlmConversation{Messages: []ChatMessage{{Role: "system", Content: "sys"}}},
+		MemoryCompressionTask: LlmConversation{Messages: []ChatMessage{{Role: "system", Content: "compress"}}},
+	}
+	tpl.ApplyLanguage("German")
+	if !strings.Contains(tpl.MainTask.Messages[0].Content, "German") {
+		t.Error("MainTask should contain language directive")
 	}
 }
 


### PR DESCRIPTION
## Description

the review filter stage was not respond in `language` for some model who deny the rule of `without any explanation`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
