### PR TITLE
fix(pages): address CodeQL XSS alerts in markdown rendering

### DIFF
--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -10,6 +10,10 @@ import { generateHeadingId } from '../utils/headingId';
 // Initialize mermaid with dark theme
 mermaid.initialize({
   startOnLoad: false,
+  // 'strict' makes mermaid sanitize its own SVG output (DOMPurify internally):
+  // safe label HTML like <b>/<span> is kept, scripts/handlers are stripped.
+  // This is why we can inject the returned SVG directly below without re-sanitizing.
+  securityLevel: 'strict',
   theme: 'dark',
   themeVariables: {
     primaryColor: '#1a1a2e',
@@ -131,9 +135,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
         const id = `mermaid-diagram-${crypto.randomUUID()}`;
         const { svg } = await mermaid.render(id, code);
         if (cancelled) return;
-        // Replace the <pre> with rendered SVG
+        // Replace the <pre> with rendered SVG. The SVG is produced by mermaid with
+        // securityLevel:'strict' (see initialize above), which already sanitizes its
+        // output. Re-running DOMPurify over the whole SVG breaks it (namespaces,
+        // inline <style>, foreignObject labels), so we inject mermaid's trusted
+        // output directly.
         const wrapper = document.createElement('div');
         wrapper.className = 'mermaid-rendered';
+        // codeql[js/xss-through-dom] -- svg is mermaid's own strict-sanitized output, not raw user input
         wrapper.innerHTML = svg;
         pre.replaceWith(wrapper);
       } catch (e) {

--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -142,7 +142,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
         // output directly.
         const wrapper = document.createElement('div');
         wrapper.className = 'mermaid-rendered';
-        // codeql[js/xss-through-dom] -- svg is mermaid's own strict-sanitized output, not raw user input
+        // codeql[js/xss-through-dom] -- svg is derived from user-controlled mermaid code, but mermaid
+        // renders it with securityLevel:'strict' (see initialize above), which sanitizes the output via
+        // DOMPurify (scripts/handlers stripped). The trust boundary relies on that setting staying 'strict'.
         wrapper.innerHTML = svg;
         pre.replaceWith(wrapper);
       } catch (e) {

--- a/pages/src/utils/headingId.ts
+++ b/pages/src/utils/headingId.ts
@@ -1,10 +1,16 @@
+import DOMPurify from 'dompurify';
+
 /**
  * Shared utility to generate heading IDs from text.
  * Used by both extractHeadings (DocsPage TOC) and MarkdownRenderer (heading renderer)
  * to ensure consistent anchor IDs.
  */
 export function generateHeadingId(text: string): string {
-  // Strip HTML tags first (from marked output), then strip markdown formatting chars
-  const plain = text.replace(/<[^>]+>/g, '').replace(/[`*_\[\]()]/g, '').trim();
+  // Strip HTML tags via DOMPurify (a single-pass regex is unreliable and can be
+  // bypassed by nested tags). Keeps text content, decodes HTML entities so the
+  // TOC side (raw markdown) and renderer side (marked HTML output) agree.
+  const plain = DOMPurify.sanitize(text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
+    .replace(/[`*_\[\]()]/g, '')
+    .trim();
   return plain.toLowerCase().replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-').replace(/^-|-$/g, '');
 }


### PR DESCRIPTION
## What

Fixes two CodeQL XSS alerts in the docs pages markdown rendering path.

### Alert #4 — Incomplete multi-character sanitization (`utils/headingId.ts`)
The heading-id generator stripped HTML tags with a single-pass regex
(`text.replace(/<[^>]+>/g, '')`), which CodeQL flags as unreliable: nested
tags such as `<scr<script>ipt>` can reassemble a tag after one pass.

Replaced with `DOMPurify.sanitize(text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })`.
As a side benefit this fixes a pre-existing bug: headings containing HTML
entities (e.g. `## Tips & Tricks`) produced **different** anchor ids on the TOC
side (raw markdown) vs the renderer side (marked HTML output), so their anchor
links didn't work. DOMPurify decodes entities consistently, aligning both sides.

### Alert #5 — DOM text reinterpreted as HTML (`components/MarkdownRenderer.tsx`)
Mermaid's rendered SVG was assigned directly to `innerHTML`. Mermaid already runs
with `securityLevel: 'strict'`, which sanitizes its own output (safe label HTML
like `<b>`/`<span>` is kept, scripts/handlers are stripped). Wrapping the whole
SVG in another `DOMPurify.sanitize()` **broke rendering** — it strips namespaces,
inline `<style>`, and `foreignObject` labels, causing diagrams (e.g. the
architecture guide) to disappear.

Instead we make `securityLevel: 'strict'` explicit and inject mermaid's trusted
output directly, with a `// codeql[js/xss-through-dom]` suppression comment
documenting why the source is trusted.

## Verification
- `tsc --noEmit` passes
- Production webpack build passes
- `ocr review --audience agent` returns 0 comments
- Verified in-browser that architecture-guide mermaid diagrams render correctly
  (bold/small-font/line-break labels intact)