### PR TITLE
fix(tool): reject traversal pathspecs in code_search

### DIFF
--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -34,6 +34,9 @@ func (p *CodeSearchProvider) Execute(ctx context.Context, args map[string]any) (
 	var patterns []string
 	for _, item := range filePatternsIface {
 		if s, ok := item.(string); ok && s != "" {
+			if hasTraversalPathComponent(s) {
+				return "Error: file_patterns must not contain ..", nil
+			}
 			patterns = append(patterns, s)
 		}
 	}
@@ -83,6 +86,15 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 	cmdArgs = append(cmdArgs, pathspec...)
 
 	return cmdArgs
+}
+
+func hasTraversalPathComponent(pathspec string) bool {
+	for _, part := range strings.Split(pathspec, "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *CodeSearchProvider) runGitGrep(parentCtx context.Context, cmdArgs []string) (string, string, error) {

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -433,6 +433,54 @@ func TestCodeSearchProvider_Execute_WithFilePatterns(t *testing.T) {
 	}
 }
 
+func TestCodeSearchProvider_Execute_RejectsTraversalPattern(t *testing.T) {
+	dir := setupTestRepo(t)
+	p := NewCodeSearch(&FileReader{RepoDir: dir, Mode: ModeWorkspace})
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{name: "leading parent", pattern: "../pkg", want: "Error: file_patterns must not contain .."},
+		{name: "middle parent", pattern: "pkg/../internal", want: "Error: file_patterns must not contain .."},
+		{name: "trailing parent", pattern: "pkg/..", want: "Error: file_patterns must not contain .."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := p.Execute(context.Background(), map[string]any{
+				"search_text":   "Hello",
+				"file_patterns": []any{test.pattern},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("Execute() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCodeSearchProvider_Execute_AllowsDoubleDotInFilename(t *testing.T) {
+	dir := setupTestRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "foo..bar.go"), []byte("package main\n\nfunc DoubleDotName() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewCodeSearch(&FileReader{RepoDir: dir, Mode: ModeWorkspace})
+	got, err := p.Execute(context.Background(), map[string]any{
+		"search_text":   "DoubleDotName",
+		"file_patterns": []any{"foo..bar.go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "foo..bar.go") {
+		t.Errorf("expected foo..bar.go in result, got: %s", got)
+	}
+}
+
 func TestCodeSearchProvider_Execute_CaseSensitive(t *testing.T) {
 	dir := setupTestRepo(t)
 	p := NewCodeSearch(&FileReader{RepoDir: dir, Mode: ModeWorkspace})


### PR DESCRIPTION
## Why this change is needed
This PR is intentionally limited to the `file_patterns` guard so the existing `code_search` search behavior stays unchanged.

`git grep` already rejects real traversal outside the repository, but `code_search` currently passes traversal-style patterns through and surfaces git's error later. Rejecting those inputs at the tool boundary gives callers an earlier, clearer error message without changing the grep path itself.

## What changed
- reject `file_patterns` that contain `..` as a path component
- leave normal patterns untouched, including filenames such as `foo..bar.go`

## Tests
- reject leading, middle, and trailing `..` path components
- allow a filename containing `..`
- validate with:
  - `GOTOOLCHAIN=local /Users/munseon-ug/sdk/go1.25.5/bin/go test ./internal/tool -count=1`