### PR TITLE
fix(cmd): resolve review repo dir to git top level for monorepo subdirs

### DIFF
--- a/cmd/opencodereview/git.go
+++ b/cmd/opencodereview/git.go
@@ -12,6 +12,16 @@ func runGitCmd(repoDir string, args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
+// runGitCmdStdout runs git and returns stdout only. Unlike runGitCmd it keeps
+// stderr separate, so git notices (permission warnings, deprecations, config
+// hints) cannot pollute output that is consumed as data — e.g. the path from
+// `git rev-parse --show-toplevel`.
+func runGitCmdStdout(repoDir string, args ...string) ([]byte, error) {
+	fullArgs := append([]string{"-C", repoDir}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	return cmd.Output()
+}
+
 func getCommitMessage(repoDir, commit string) (string, error) {
 	out, err := runGitCmd(repoDir, "log", "-1", "--format=%B", "--end-of-options", commit)
 	if err != nil {

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -129,7 +129,7 @@ func resolveRepoDir(input string) (string, error) {
 	}
 	// Resolve to the repository top level so paths stay repo-root relative
 	// when invoked from a monorepo subdirectory (#287).
-	out, err := runGitCmd(absPath, "rev-parse", "--show-toplevel")
+	out, err := runGitCmdStdout(absPath, "rev-parse", "--show-toplevel")
 	toplevel := strings.TrimSpace(string(out))
 	if err != nil || toplevel == "" {
 		return "", fmt.Errorf("%s is not a git repository", absPath)

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -127,11 +127,14 @@ func resolveRepoDir(input string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
 	}
-	out, err := runGitCmd(absPath, "rev-parse", "--git-dir")
-	if err != nil || len(out) == 0 {
+	// Resolve to the repository top level so paths stay repo-root relative
+	// when invoked from a monorepo subdirectory (#287).
+	out, err := runGitCmd(absPath, "rev-parse", "--show-toplevel")
+	toplevel := strings.TrimSpace(string(out))
+	if err != nil || toplevel == "" {
 		return "", fmt.Errorf("%s is not a git repository", absPath)
 	}
-	return absPath, nil
+	return toplevel, nil
 }
 
 // requireGitRepo validates that the given directory is part of a git repository.

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/open-code-review/open-code-review/internal/agent"
@@ -77,9 +78,17 @@ func loadCommonContext(repoDirInput, rulePath string, maxTools, maxGitProcs int,
 	}, nil
 }
 
-// resolveWorkingDir returns (absPath, isGitRepo, err). When requireGit is
+// resolveWorkingDir returns (repoDir, isGitRepo, err). When requireGit is
 // true, returns an error if the directory is not a git repo. When false,
 // returns IsGitRepo=false instead of erroring (scan path uses this).
+//
+// When requireGit is true (review path) and the directory is a git repo, the
+// returned path is the repository top level (`git rev-parse --show-toplevel`),
+// not the raw working directory. This keeps git diff/show paths consistent when
+// ocr runs from a monorepo subdirectory: otherwise the diff and the file_read
+// tool disagree on whether paths are relative to the subdir or the repo root
+// (#287). The scan path (requireGit=false) intentionally keeps the
+// working-directory scope so scanning a subdirectory stays limited to it.
 func resolveWorkingDir(input string, requireGit bool) (string, bool, error) {
 	if input == "" {
 		wd, err := os.Getwd()
@@ -95,12 +104,20 @@ func resolveWorkingDir(input string, requireGit bool) (string, bool, error) {
 	if _, statErr := os.Stat(absPath); statErr != nil {
 		return "", false, fmt.Errorf("stat %s: %w", absPath, statErr)
 	}
-	out, err := runGitCmd(absPath, "rev-parse", "--git-dir")
-	isGit := err == nil && len(out) > 0
-	if !isGit && requireGit {
-		return "", false, fmt.Errorf("%s is not a git repository", absPath)
+	out, err := runGitCmd(absPath, "rev-parse", "--show-toplevel")
+	toplevel := strings.TrimSpace(string(out))
+	isGit := err == nil && toplevel != ""
+	if !isGit {
+		if requireGit {
+			return "", false, fmt.Errorf("%s is not a git repository", absPath)
+		}
+		return absPath, false, nil
 	}
-	return absPath, isGit, nil
+	// Only the review path resolves to the repo root; scan keeps the subdir.
+	if requireGit {
+		return toplevel, true, nil
+	}
+	return absPath, true, nil
 }
 
 // llmRuntime bundles the LLM-side state both subcommands need once they've

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -104,7 +104,7 @@ func resolveWorkingDir(input string, requireGit bool) (string, bool, error) {
 	if _, statErr := os.Stat(absPath); statErr != nil {
 		return "", false, fmt.Errorf("stat %s: %w", absPath, statErr)
 	}
-	out, err := runGitCmd(absPath, "rev-parse", "--show-toplevel")
+	out, err := runGitCmdStdout(absPath, "rev-parse", "--show-toplevel")
 	toplevel := strings.TrimSpace(string(out))
 	isGit := err == nil && toplevel != ""
 	if !isGit {

--- a/cmd/opencodereview/shared_test.go
+++ b/cmd/opencodereview/shared_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-code-review/open-code-review/internal/config/rules"
@@ -155,6 +157,26 @@ func TestResolveWorkingDir_ScanSubdirKeepsScope(t *testing.T) {
 	gotResolved, _ := filepath.EvalSymlinks(got)
 	if gotResolved != wantSub {
 		t.Errorf("resolveWorkingDir(subdir, requireGit=false) = %q, want subdir %q", got, wantSub)
+	}
+}
+
+// TestResolveWorkingDir_BareRepoFailsLoudly ensures a bare repository (where
+// `git rev-parse --show-toplevel` yields no work tree) errors on the review
+// path instead of silently falling back to the invocation dir and reproducing
+// the #287 path mismatch.
+func TestResolveWorkingDir_BareRepoFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "--bare", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v: %s", err, out)
+	}
+
+	_, _, err := resolveWorkingDir(dir, true)
+	if err == nil {
+		t.Fatal("expected error for bare repo with requireGit=true")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/opencodereview/shared_test.go
+++ b/cmd/opencodereview/shared_test.go
@@ -109,6 +109,55 @@ func TestResolveWorkingDir_NonExistent(t *testing.T) {
 	}
 }
 
+// TestResolveWorkingDir_SubdirResolvesToToplevel locks in the #287 fix: when
+// ocr is invoked from a monorepo subdirectory, the resolved repo dir must be
+// the repository top level, not the subdir, so diff and file_read agree on
+// repo-root-relative paths.
+func TestResolveWorkingDir_SubdirResolvesToToplevel(t *testing.T) {
+	root := initTestGitRepo(t)
+	sub := filepath.Join(root, "subproject", "src")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, isGit, err := resolveWorkingDir(sub, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isGit {
+		t.Fatal("expected isGit=true for a subdir of a git repo")
+	}
+	wantRoot, _ := filepath.EvalSymlinks(root)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantRoot {
+		t.Errorf("resolveWorkingDir(subdir) = %q, want repo root %q", got, wantRoot)
+	}
+}
+
+// TestResolveWorkingDir_ScanSubdirKeepsScope guards against regressing scan's
+// scope: requireGit=false (scan path) must keep the subdirectory, not expand to
+// the whole repo, even when the subdir lives inside a git repository.
+func TestResolveWorkingDir_ScanSubdirKeepsScope(t *testing.T) {
+	root := initTestGitRepo(t)
+	sub := filepath.Join(root, "subproject", "src")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, isGit, err := resolveWorkingDir(sub, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isGit {
+		t.Fatal("expected isGit=true for a subdir of a git repo")
+	}
+	wantSub, _ := filepath.EvalSymlinks(sub)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantSub {
+		t.Errorf("resolveWorkingDir(subdir, requireGit=false) = %q, want subdir %q", got, wantSub)
+	}
+}
+
 func TestResolveWorkingDir_GitRepo(t *testing.T) {
 	dir := t.TempDir()
 	gitDir := filepath.Join(dir, ".git")


### PR DESCRIPTION
## Problem

Fixes #287.

When `ocr review` runs from a subdirectory of a monorepo, the working directory differs from the git repository root:

```
/project        # monorepo root (.git here)
  /router       # user runs `ocr review` here
  /subproject2
```

`RepoDir` was resolved to the current working directory (via `os.Getwd()` + `git rev-parse --git-dir`), so all git commands ran with `cmd.Dir` set to the subdir. With `diff.relative=true` in the user's git config, `git diff` emits subdir-relative paths (e.g. `src/...`), but the `file_read` tool reads content via `git show <ref>:<path>`, which resolves paths **relative to the repo root**. Result:

```
✘ file_read failed: git show HEAD:src/... : exit status 128:
  fatal: path 'router/src/...' exists, but not 'src/...'
```

Every `file_read` failed on the first try and only succeeded after the LLM retried with the `router/` prefix from git's hint — wasting extra LLM calls on every file.

## Fix

Resolve the review working dir to `git rev-parse --show-toplevel` (the repository top level) so `git diff` and `git show` agree on repo-root-relative paths.

- **review** (`requireGit=true`): resolves to the repo root.
- **scan** (`requireGit=false`): intentionally keeps the working-directory scope, so scanning a subdirectory stays limited to that subdirectory (no scope expansion).
- `rules check` (`resolveRepoDir`) also resolves to the top level; it does not enumerate files, so there is no scope change.

| Mode | Run location | RepoDir |
|------|--------------|---------|
| review | repo subdir | repo root (toplevel) |
| scan | repo subdir | current subdir |
| scan | non-git dir | current dir |

## Tests

- `TestResolveWorkingDir_SubdirResolvesToToplevel` — review subdir → repo root
- `TestResolveWorkingDir_ScanSubdirKeepsScope` — scan subdir → keeps subdir scope

`make check` and `make test` pass.