### PR TITLE
feat(viewer): dark mode + system monospace font (#304)

### DIFF
--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -1,73 +1,171 @@
+:root {
+    /* Let the browser theme native scrollbars/form controls per the active scheme */
+    color-scheme: light dark;
+
+    /* Typography */
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+    /* Surfaces */
+    --bg: #f5f7fa;
+    --surface: #fff;
+    --surface-alt: #f6f8fa;
+    --surface-alt2: #f8f9fb;
+    --response-bg: #fefefe;
+
+    /* Text */
+    --text: #333;
+    --text-strong: #24292e;
+    --text-muted: #586069;
+    --text-faint: #8b949e;
+
+    /* Borders */
+    --border: #e1e4e8;
+    --border-light: #eaecef;
+
+    /* Accents */
+    --link: #0366d6;
+    --accent: #0366d6;
+    --accent-soft: #f0f6ff;
+
+    /* Code */
+    --code-bg: #f0f0f0;
+    --inline-code-bg: #eff1f3;
+
+    /* Task accents (dot + card border) */
+    --task-main: #0366d6;
+    --task-plan: #8250df;
+    --task-memory: #8b949e;
+    --task-relocation: #e36209;
+    --task-default: #57606a;
+    --tool-name: #8250df;
+    --danger: #cf222e;
+
+    /* Badge tints (bg + fg) */
+    --badge-model-bg: #ddf4ff;    --badge-model-fg: #0550ae;
+    --badge-tokens-bg: #dafbe1;   --badge-tokens-fg: #116329;
+    --badge-duration-bg: #fff8c5; --badge-duration-fg: #6a5700;
+    --badge-error-bg: #ffebe9;    --badge-error-fg: #cf222e;
+
+    /* Misc */
+    --badge-neutral-bg: #e8ecf1;
+    --badge-neutral-fg: #586069;
+    --shadow: 0 1px 3px rgba(0,0,0,0.08);
+    --shadow-hover: 0 2px 8px rgba(0,0,0,0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0d1117;
+        --surface: #161b22;
+        --surface-alt: #21262d;
+        --surface-alt2: #1c2128;
+        --response-bg: #161b22;
+
+        --text: #c9d1d9;
+        --text-strong: #e6edf3;
+        --text-muted: #8b949e;
+        --text-faint: #7d8590;
+
+        --border: #30363d;
+        --border-light: #21262d;
+
+        --link: #58a6ff;
+        --accent: #58a6ff;
+        --accent-soft: rgba(56,139,253,0.1);
+
+        --code-bg: #21262d;
+        --inline-code-bg: #21262d;
+
+        /* Task accents — lift dim brand colors for the dark surface */
+        --task-main: #58a6ff;
+        --task-plan: #d2a8ff;
+        --task-default: #7d8590;
+        --tool-name: #d2a8ff;
+        --danger: #f85149;
+
+        /* Badge tints — translucent bg + brighter fg on dark */
+        --badge-model-bg: rgba(56,139,253,0.15);   --badge-model-fg: #79c0ff;
+        --badge-tokens-bg: rgba(46,160,67,0.15);   --badge-tokens-fg: #7ee787;
+        --badge-duration-bg: rgba(187,128,9,0.15); --badge-duration-fg: #e3b341;
+        --badge-error-bg: rgba(248,81,73,0.15);    --badge-error-fg: #ff7b72;
+
+        --badge-neutral-bg: #30363d;
+        --badge-neutral-fg: #adbac7;
+        --shadow: 0 1px 3px rgba(0,0,0,0.4);
+        --shadow-hover: 0 2px 8px rgba(0,0,0,0.5);
+    }
+}
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    background: #f5f7fa;
-    color: #333;
+    background: var(--bg);
+    color: var(--text);
     line-height: 1.6;
     padding-bottom: 2rem;
 }
 
 nav.breadcrumb {
-    background: #fff;
-    border-bottom: 1px solid #e1e4e8;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
     padding: 0.75rem 1.5rem;
     font-size: 0.9rem;
 }
 nav.breadcrumb a {
-    color: #0366d6;
+    color: var(--link);
     text-decoration: none;
 }
 nav.breadcrumb a:hover { text-decoration: underline; }
 
 main { max-width: 1200px; margin: 1.5rem auto; padding: 0 1rem; }
 
-h2 { margin-bottom: 1rem; color: #24292e; }
-h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
+h2 { margin-bottom: 1rem; color: var(--text-strong); }
+h3 { margin: 1.5rem 0 0.75rem; color: var(--text-strong); }
 
 .table {
     width: 100%;
     border-collapse: collapse;
-    background: #fff;
+    background: var(--surface);
     border-radius: 6px;
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow);
 }
 .table th {
-    background: #f6f8fa;
+    background: var(--surface-alt);
     text-align: left;
     padding: 0.6rem 1rem;
     font-size: 0.85rem;
-    color: #586069;
-    border-bottom: 1px solid #e1e4e8;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
 }
 .table td {
     padding: 0.6rem 1rem;
-    border-bottom: 1px solid #eaecef;
+    border-bottom: 1px solid var(--border-light);
     font-size: 0.9rem;
 }
 .table tr:last-child td { border-bottom: none; }
-.table tr:hover { background: #f6f8fa; }
-.table a { color: #0366d6; text-decoration: none; }
+.table tr:hover { background: var(--surface-alt); }
+.table a { color: var(--link); text-decoration: none; }
 .table a:hover { text-decoration: underline; }
 .table code {
-    background: #f0f0f0;
+    background: var(--code-bg);
     padding: 0.15em 0.4em;
     border-radius: 3px;
     font-size: 0.85em;
 }
 
 .session-header {
-    background: #fff;
+    background: var(--surface);
     border-radius: 6px;
     padding: 1.25rem;
     margin-bottom: 1rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow);
 }
 .session-header h2 { margin-bottom: 0.5rem; word-break: break-all; }
-.meta { display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.9rem; color: #586069; }
+.meta { display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.9rem; color: var(--text-muted); }
 .meta code {
-    background: #f0f0f0;
+    background: var(--code-bg);
     padding: 0.15em 0.4em;
     border-radius: 3px;
     font-size: 0.85em;
@@ -75,11 +173,11 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 
 /* Token usage summary */
 .token-summary {
-    background: #fff;
+    background: var(--surface);
     border-radius: 6px;
     padding: 1.25rem;
     margin-bottom: 1rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow);
 }
 .token-stats {
     display: grid;
@@ -91,12 +189,12 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 .token-value {
     font-size: 1.8rem;
     font-weight: 700;
-    color: #0366d6;
+    color: var(--accent);
     line-height: 1.2;
 }
 .token-label {
     font-size: 0.75rem;
-    color: #586069;
+    color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
@@ -106,24 +204,24 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     font-size: 0.85rem;
 }
 .token-table th {
-    background: #f6f8fa;
+    background: var(--surface-alt);
     text-align: left;
     padding: 0.4rem 0.75rem;
-    color: #586069;
-    border-bottom: 1px solid #e1e4e8;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
 }
 .token-table td {
     padding: 0.35rem 0.75rem;
-    border-bottom: 1px solid #eaecef;
+    border-bottom: 1px solid var(--border-light);
 }
 .token-table tr:last-child td { border-bottom: none; }
-.token-table tbody tr:hover { background: #f6f8fa; }
+.token-table tbody tr:hover { background: var(--surface-alt); }
 
 .file-list { list-style: none; padding-left: 1rem; }
 .file-list li {
     padding: 0.25rem 0;
     font-size: 0.9rem;
-    color: #586069;
+    color: var(--text-muted);
 }
 .file-list li::before { content: "\1F4C4 "; margin-right: 0.25rem; }
 
@@ -132,11 +230,11 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 
 /* File Accordion */
 .file-accordion {
-    background: #fff;
+    background: var(--surface);
     border-radius: 8px;
     margin-bottom: 0.75rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-    border: 1px solid #e1e4e8;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--border);
     overflow: hidden;
 }
 
@@ -144,7 +242,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     cursor: pointer;
     padding: 0.85rem 1rem;
     font-size: 0.95rem;
-    color: #24292e;
+    color: var(--text-strong);
     user-select: none;
     display: flex;
     align-items: center;
@@ -154,15 +252,15 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 }
 .file-accordion-header::-webkit-details-marker { display: none; }
 .file-accordion-header::marker { display: none; content: ""; }
-.file-accordion-header:hover { background: #f0f6ff; }
+.file-accordion-header:hover { background: var(--accent-soft); }
 
 /* Chevron icon */
 .chevron {
     display: inline-block;
     width: 6px;
     height: 6px;
-    border-right: 2px solid #586069;
-    border-bottom: 2px solid #586069;
+    border-right: 2px solid var(--text-muted);
+    border-bottom: 2px solid var(--text-muted);
     transform: rotate(-45deg);
     transition: transform 0.2s ease;
     flex-shrink: 0;
@@ -174,7 +272,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 
 .file-path {
     font-weight: 600;
-    font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-family: var(--mono);
     font-size: 0.88rem;
     flex: 1;
     min-width: 0;
@@ -184,8 +282,8 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 }
 
 .file-count-badge {
-    background: #e8ecf1;
-    color: #586069;
+    background: var(--badge-neutral-bg);
+    color: var(--badge-neutral-fg);
     padding: 0.15em 0.6em;
     border-radius: 10px;
     font-size: 0.72rem;
@@ -195,7 +293,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 }
 
 .file-accordion[open] > .file-accordion-header {
-    border-bottom: 1px solid #e1e4e8;
+    border-bottom: 1px solid var(--border);
 }
 
 .file-accordion-body {
@@ -209,7 +307,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 .task-type-label {
     font-size: 0.72rem;
     text-transform: uppercase;
-    color: #586069;
+    color: var(--text-muted);
     margin-bottom: 0.6rem;
     letter-spacing: 0.06em;
     display: flex;
@@ -225,42 +323,42 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     border-radius: 50%;
     flex-shrink: 0;
 }
-.task-main .task-type-dot { background: #0366d6; }
-.task-plan .task-type-dot { background: #8250df; }
-.task-memory .task-type-dot { background: #8b949e; }
-.task-relocation .task-type-dot { background: #e36209; }
-.task-default .task-type-dot { background: #57606a; }
+.task-main .task-type-dot { background: var(--task-main); }
+.task-plan .task-type-dot { background: var(--task-plan); }
+.task-memory .task-type-dot { background: var(--task-memory); }
+.task-relocation .task-type-dot { background: var(--task-relocation); }
+.task-default .task-type-dot { background: var(--task-default); }
 
 /* Card */
 .card {
-    border: 1px solid #e1e4e8;
+    border: 1px solid var(--border);
     border-radius: 8px;
     margin-bottom: 0.75rem;
     overflow: hidden;
     transition: box-shadow 0.15s;
 }
 .card:hover {
-    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-hover);
 }
-.task-main .card { border-left: 3px solid #0366d6; }
-.task-plan .card { border-left: 3px solid #8250df; }
-.task-memory .card { border-left: 3px solid #8b949e; }
-.task-relocation .card { border-left: 3px solid #e36209; }
+.task-main .card { border-left: 3px solid var(--task-main); }
+.task-plan .card { border-left: 3px solid var(--task-plan); }
+.task-memory .card { border-left: 3px solid var(--task-memory); }
+.task-relocation .card { border-left: 3px solid var(--task-relocation); }
 
 .card-header {
-    background: #f6f8fa;
+    background: var(--surface-alt);
     padding: 0.55rem 0.85rem;
     font-size: 0.85rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     flex-wrap: wrap;
-    border-bottom: 1px solid #eaecef;
+    border-bottom: 1px solid var(--border-light);
 }
 
 .request-label {
     font-weight: 600;
-    color: #24292e;
+    color: var(--text-strong);
 }
 
 /* Badges */
@@ -271,24 +369,24 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     font-weight: 500;
     white-space: nowrap;
 }
-.badge-model { background: #ddf4ff; color: #0550ae; }
-.badge-tokens { background: #dafbe1; color: #116329; }
-.badge-duration { background: #fff8c5; color: #6a5700; }
-.badge-error { background: #ffebe9; color: #cf222e; }
+.badge-model { background: var(--badge-model-bg); color: var(--badge-model-fg); }
+.badge-tokens { background: var(--badge-tokens-bg); color: var(--badge-tokens-fg); }
+.badge-duration { background: var(--badge-duration-bg); color: var(--badge-duration-fg); }
+.badge-error { background: var(--badge-error-bg); color: var(--badge-error-fg); }
 
 /* Response Content */
 .card-body {
     padding: 0;
 }
 .response-content {
-    background: #fefefe;
+    background: var(--response-bg);
     border-top: none;
 }
 .response-text {
     padding: 0.85rem 1rem;
     font-size: 0.85rem;
     line-height: 1.65;
-    color: #24292e;
+    color: var(--text-strong);
     max-height: 400px;
     overflow-y: auto;
     white-space: pre-wrap;
@@ -297,8 +395,8 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 
 /* Markdown-rendered elements */
 .response-text .code-block {
-    background: #f6f8fa;
-    border: 1px solid #e1e4e8;
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.65rem 0.85rem;
     margin: 0.5rem 0;
@@ -312,21 +410,21 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     font-size: inherit;
 }
 .response-text .inline-code {
-    background: #eff1f3;
+    background: var(--inline-code-bg);
     padding: 0.15em 0.35em;
     border-radius: 4px;
     font-size: 0.88em;
-    font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-family: var(--mono);
 }
-.response-text .md-h1 { font-size: 1.15em; font-weight: 700; margin: 0.6em 0 0.3em; color: #24292e; }
-.response-text .md-h2 { font-size: 1.05em; font-weight: 600; margin: 0.5em 0 0.25em; color: #24292e; }
-.response-text .md-h3 { font-size: 0.95em; font-weight: 600; margin: 0.4em 0 0.2em; color: #24292e; }
+.response-text .md-h1 { font-size: 1.15em; font-weight: 700; margin: 0.6em 0 0.3em; color: var(--text-strong); }
+.response-text .md-h2 { font-size: 1.05em; font-weight: 600; margin: 0.5em 0 0.25em; color: var(--text-strong); }
+.response-text .md-h3 { font-size: 0.95em; font-weight: 600; margin: 0.4em 0 0.2em; color: var(--text-strong); }
 .response-text .md-li { padding-left: 1em; text-indent: -0.8em; margin: 0.15em 0; }
 
 /* Tool Calls Section */
 .tool-calls-section {
-    background: #f8f9fb;
-    border-top: 1px solid #e1e4e8;
+    background: var(--surface-alt2);
+    border-top: 1px solid var(--border);
     padding: 0.65rem 0.85rem;
 }
 
@@ -334,14 +432,14 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     font-size: 0.72rem;
     font-weight: 600;
     text-transform: uppercase;
-    color: #586069;
+    color: var(--text-muted);
     letter-spacing: 0.04em;
     margin-bottom: 0.5rem;
 }
 
 .tool-call-item {
-    background: #fff;
-    border: 1px solid #e1e4e8;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: 6px;
     margin-bottom: 0.5rem;
     overflow: hidden;
@@ -350,7 +448,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 .tool-call-item:last-child { margin-bottom: 0; }
 
 .tool-call-error {
-    border-left: 3px solid #cf222e;
+    border-left: 3px solid var(--danger);
 }
 
 .tool-call-header {
@@ -363,19 +461,19 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
 }
 
 .tool-icon {
-    color: #8b949e;
+    color: var(--text-faint);
     font-size: 0.9em;
 }
 
 .tool-name {
-    color: #8250df;
-    font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    color: var(--tool-name);
+    font-family: var(--mono);
     font-size: 0.85em;
 }
 
 /* Tool Detail Toggle */
 .tool-detail {
-    border-top: 1px solid #eaecef;
+    border-top: 1px solid var(--border-light);
 }
 .tool-detail summary {
     list-style: none;
@@ -387,22 +485,22 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     cursor: pointer;
     padding: 0.35rem 0.7rem;
     font-size: 0.78rem;
-    color: #0366d6;
+    color: var(--link);
     display: flex;
     align-items: center;
     gap: 0.35rem;
     user-select: none;
     transition: background 0.12s;
 }
-.tool-detail-toggle:hover { background: #f0f6ff; }
+.tool-detail-toggle:hover { background: var(--accent-soft); }
 
 /* Small chevron for tool details */
 .chevron-sm {
     display: inline-block;
     width: 5px;
     height: 5px;
-    border-right: 1.5px solid #0366d6;
-    border-bottom: 1.5px solid #0366d6;
+    border-right: 1.5px solid var(--link);
+    border-bottom: 1.5px solid var(--link);
     transform: rotate(-45deg);
     transition: transform 0.2s ease;
     flex-shrink: 0;
@@ -423,14 +521,14 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
-    color: #8b949e;
+    color: var(--text-faint);
     letter-spacing: 0.04em;
     margin-bottom: 0.2rem;
 }
 
 .tool-section pre {
-    background: #f6f8fa;
-    border: 1px solid #e1e4e8;
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 0.5rem 0.65rem;
     font-size: 0.78rem;
@@ -441,4 +539,4 @@ h3 { margin: 1.5rem 0 0.75rem; color: #24292e; }
     word-break: break-word;
 }
 
-p { color: #586069; padding: 1rem 0; }
+p { color: var(--text-muted); padding: 1rem 0; }


### PR DESCRIPTION
Closes #304.

## What

Enhances the embedded viewer stylesheet (`internal/viewer/static/style.css`) to add a **dark theme** and use the **system monospace font**, as requested in #304. CSS-only — no JS, no Go, no template changes.

### Dark mode
- Automatic via `@media (prefers-color-scheme: dark)` — follows the OS setting, no toggle/JS/state to persist.
- Palette extracted into `:root` CSS variables; the dark block overrides only the variables, so **light-mode colors are unchanged**. A small extra dark block handles the badge tints (model/tokens/duration/error) that need alpha rather than a flat variable swap.
- `color-scheme: light dark` declared so **native scrollbars/form controls** theme correctly in dark (the response/tool-output scroll regions).

### System monospace font
- Replaces the hardcoded `SFMono-Regular, Consolas, …` stacks with a `--mono` variable led by `ui-monospace`, so the OS's UI monospace font is used across platforms.

### Accessibility
Dark tokens chosen to clear **WCAG AA (≥4.5:1)** for small text — measured: file-count badge 6.17:1, faint labels 4.64:1, muted labels 5.62:1.

## How it was verified
Built and ran `ocr viewer`, then rendered all three pages (repos / sessions / session) in **both light and dark** with a headless browser emulating `prefers-color-scheme`, using a fixture that exercises every themed element (token/duration/error badges, markdown code-blocks, inline-code, tool-call panes, overflow scroll regions). Programmatically asserted computed colors, `color-scheme`, and contrast ratios; visually confirmed no light-mode regression.

| Light | Dark |
|-------|------|
| pastel badges, white surfaces, unchanged | GitHub-dark palette (`#0d1117` bg, `#58a6ff` links) |