### PR TITLE
docs: add contributors image to Contributing section

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -779,7 +779,11 @@ ocr config set telemetry.otlp_endpoint localhost:4317
 
 ## コントリビューション
 
-開発環境のセットアップ、コーディングガイドライン、プルリクエストの提出方法については[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+このプロジェクトは、貢献してくださるすべての方々のおかげで成り立っています。開発環境のセットアップ、コーディングガイドライン、プルリクエストの提出方法については[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+
+<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
+</a>
 
 ## Star History
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -736,7 +736,11 @@ exported data에 LLM prompt와 response를 포함하려면 `telemetry.content_lo
 
 ## Contributing
 
-개발 환경 설정, coding guideline, pull request 제출 방법은 [CONTRIBUTING.ko-KR.md](CONTRIBUTING.ko-KR.md)를 참고하세요.
+이 프로젝트는 기여해 주신 모든 분들 덕분에 존재합니다. 개발 환경 설정, coding guideline, pull request 제출 방법은 [CONTRIBUTING.ko-KR.md](CONTRIBUTING.ko-KR.md)를 참고하세요.
+
+<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
+</a>
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -785,7 +785,11 @@ Set `telemetry.content_logging` to include LLM prompts and responses in exported
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding guidelines, and how to submit pull requests.
+This project exists thanks to all the people who contribute. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding guidelines, and how to submit pull requests.
+
+<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
+</a>
 
 ## Star History
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -781,7 +781,11 @@ ocr config set telemetry.otlp_endpoint localhost:4317
 
 ## Участие в разработке
 
-В [CONTRIBUTING.ru-RU.md](CONTRIBUTING.ru-RU.md) описаны настройка окружения разработки, рекомендации по коду и порядок отправки pull request'ов.
+Этот проект существует благодаря всем, кто вносит свой вклад. В [CONTRIBUTING.ru-RU.md](CONTRIBUTING.ru-RU.md) описаны настройка окружения разработки, рекомендации по коду и порядок отправки pull request'ов.
+
+<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
+</a>
 
 ## История звёзд
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -769,7 +769,11 @@ ocr config set telemetry.otlp_endpoint localhost:4317
 
 ## 贡献
 
-参见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md) 了解开发环境搭建、编码规范以及如何提交 Pull Request。
+感谢所有为本项目做出贡献的人。参见 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md) 了解开发环境搭建、编码规范以及如何提交 Pull Request。
+
+<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
+</a>
 
 ## Star History
 


### PR DESCRIPTION
## What

Add a contributors image (via [contrib.rocks](https://contrib.rocks/)) to the **Contributing** section of all five README locales (`README.md`, `README.zh-CN.md`, `README.ja-JP.md`, `README.ko-KR.md`, `README.ru-RU.md`).

Each section now opens with a short thank-you line followed by the existing `CONTRIBUTING` link, with the contributors image rendered right below:

```markdown
This project exists thanks to all the people who contribute. See CONTRIBUTING.md ...

<a href="https://github.com/alibaba/open-code-review/graphs/contributors">
  <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
</a>
```

## Why

- Recognizes community contributors and encourages participation.
- Uses **contrib.rocks**, which reads GitHub contributors directly — no OpenCollective or other third-party account required (unlike the golangci-lint OpenCollective approach).
- Thank-you line precedes the CONTRIBUTING link so the wording flows naturally into the contributor image below it.
- Localized wording is applied per language.