### PR TITLE
fix(viewer): fix monospace font rendering in pre/code blocks on Windows

### DIFF
--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -3,7 +3,7 @@
     color-scheme: light dark;
 
     /* Typography */
-    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    --mono: "SF Mono", "Cascadia Code", Consolas, "Liberation Mono", "DejaVu Sans Mono", ui-monospace, SFMono-Regular, Menlo, "Courier New", monospace;
 
     /* Surfaces */
     --bg: #f5f7fa;
@@ -104,6 +104,10 @@ body {
     color: var(--text);
     line-height: 1.6;
     padding-bottom: 2rem;
+}
+
+code, pre {
+    font-family: var(--mono);
 }
 
 nav.breadcrumb {


### PR DESCRIPTION
## Summary
Fixes monospace font rendering in `pre` and `code` blocks on Windows
(Chrome & Edge). Closes #325.
## Root Cause
Two issues combined to break monospace rendering on Windows:
1. **Missing global rule** — bare `<pre>` and `<code>` elements had no
   explicit `font-family` declaration, so they inherited the `body`'s
   sans-serif stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`)
   instead of the monospace `--mono` variable.
2. **Wrong font priority** — the `--mono` CSS variable led with
   `ui-monospace` and `SFMono-Regular`, which are macOS-native aliases
   that don't resolve on Windows. The browser skipped all the way to
   the generic `monospace` fallback, which renders poorly.
## Changes
**`internal/viewer/static/style.css`**
- Added a global `code, pre` rule immediately after the `body` block:
  ```css
  code, pre {
      font-family: var(--mono);
  }