### PR TITLE
docs: remove broken Star History section from all READMEs

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -785,10 +785,6 @@ ocr config set telemetry.otlp_endpoint localhost:4317
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
 </a>
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
-
 ## ライセンス
 
 [Apache-2.0](LICENSE) — Copyright 2026 Alibaba

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -742,10 +742,6 @@ exported data에 LLM prompt와 response를 포함하려면 `telemetry.content_lo
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
 </a>
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
-
 ## License
 
 [Apache-2.0](LICENSE) Copyright 2026 Alibaba

--- a/README.md
+++ b/README.md
@@ -791,10 +791,6 @@ This project exists thanks to all the people who contribute. See [CONTRIBUTING.m
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
 </a>
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
-
 ## License
 
 [Apache-2.0](LICENSE) — Copyright 2026 Alibaba

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -787,10 +787,6 @@ ocr config set telemetry.otlp_endpoint localhost:4317
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
 </a>
 
-## История звёзд
-
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
-
 ## Лицензия
 
 [Apache-2.0](LICENSE) — Copyright 2026 Alibaba

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -775,10 +775,6 @@ ocr config set telemetry.otlp_endpoint localhost:4317
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />
 </a>
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date)](https://star-history.com/#alibaba/open-code-review&Date)
-
 ## 许可证
 
 [Apache-2.0](LICENSE) — Copyright 2026 Alibaba


### PR DESCRIPTION
## What

Removes the `## Star History` section (heading + embedded star-history.com chart) from `README.md` and all localized versions (`README.zh-CN.md`, `README.ja-JP.md`, `README.ko-KR.md`, `README.ru-RU.md`).

## Why

GitHub restricted the stargazers API in July 2026 so that only a repository's own admins and collaborators can read the stargazers endpoint. The README embeds the chart as an anonymous image request:

```
https://api.star-history.com/svg?repos=alibaba/open-code-review&type=Date
```

That request carries no token (a token cannot be committed to a public README), so star-history.com can no longer fetch star data on refresh and the chart renders broken/blank for README viewers. Rather than embed a badge that no longer works, we remove the section. It can be reintroduced later as a static committed image if desired.

The Contributing section now flows directly into License.