### PR TITLE
ci: bump Go image to 1.26.5 to fix GO-2026-5856 govulncheck failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     container:
-      image: golang:1.26.4
+      image: golang:1.26.5
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: self-hosted
     container:
-      image: golang:1.26.4
+      image: golang:1.26.5
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## What

Bumps the container image in `.github/workflows/ci.yml` and `.github/workflows/release.yml` from `golang:1.26.4` to `golang:1.26.5`.

## Why

The `Govulncheck` CI step fails with exit code 3 on every run, flagging:

- **GO-2026-5856** — Invoking Encrypted Client Hello privacy leak in `crypto/tls`
- Present in the Go standard library through `crypto/tls@go1.26.4`, **fixed in go1.26.5**

Because both workflows pin `golang:1.26.4`, govulncheck detects the reachable stdlib vulnerability and fails the build regardless of the PR contents. Bumping the toolchain image to `1.26.5` pulls in the fixed standard library and clears the finding.

No source or `go.mod` changes are required — the `go 1.25.5` directive in `go.mod` is a language-version floor and is unaffected.