### PR TITLE
fix: remove redundant font-family from .response-text .inline-code

### DIFF
--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -418,7 +418,6 @@ h3 { margin: 1.5rem 0 0.75rem; color: var(--text-strong); }
     padding: 0.15em 0.35em;
     border-radius: 4px;
     font-size: 0.88em;
-   
 }
 .response-text .md-h1 { font-size: 1.15em; font-weight: 700; margin: 0.6em 0 0.3em; color: var(--text-strong); }
 .response-text .md-h2 { font-size: 1.05em; font-weight: 600; margin: 0.5em 0 0.25em; color: var(--text-strong); }

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -418,7 +418,7 @@ h3 { margin: 1.5rem 0 0.75rem; color: var(--text-strong); }
     padding: 0.15em 0.35em;
     border-radius: 4px;
     font-size: 0.88em;
-    font-family: var(--mono);
+   
 }
 .response-text .md-h1 { font-size: 1.15em; font-weight: 700; margin: 0.6em 0 0.3em; color: var(--text-strong); }
 .response-text .md-h2 { font-size: 1.05em; font-weight: 600; margin: 0.5em 0 0.25em; color: var(--text-strong); }


### PR DESCRIPTION
Removed the redundant `font-family: var(--mono);` declaration from `.response-text .inline-code` in style.css, since it's rendered as a `<code>` element and now inherits the same font from the new global `code, pre` rule added in PR #328.

  Left `.file-path` and `.tool-name` untouched — they render as `<span>` and `<strong>`, not `<code>`/`<pre>`, so the global rule doesn't apply to them and removing their `font-family` would break monospace rendering.

  Fixes #336