### PR TITLE
fix(vscode): prevent config panel render loop and refine step status styles

### DIFF
--- a/extensions/vscode/src/webview/ConfigPanelApp.tsx
+++ b/extensions/vscode/src/webview/ConfigPanelApp.tsx
@@ -1,5 +1,5 @@
 import { I18nContext, resolveLocale } from './I18nProvider';
-import { useEffect, useReducer } from 'preact/hooks';
+import { useCallback, useEffect, useReducer } from 'preact/hooks';
 import { bridge } from './bridge';
 import { ConfigView } from './views/ConfigView';
 import { configPanelInitialState, configPanelReducer } from './configStore';
@@ -12,6 +12,7 @@ function runEnvCheck(dispatch: (action: { type: 'checkingEnv' }) => void): void 
 
 export function ConfigPanelApp() {
   const [state, dispatch] = useReducer(configPanelReducer, configPanelInitialState);
+  const clearConnTest = useCallback(() => dispatch({ type: 'clearConnTest' }), []);
 
   useEffect(() => {
     const unsub = bridge.onMessage((msg) => dispatch(msg));
@@ -59,7 +60,7 @@ export function ConfigPanelApp() {
         onCopy={(text) => bridge.post({ type: 'copyToClipboard', text })}
         onTest={(entries) => { dispatch({ type: 'testingConn' }); bridge.post({ type: 'testConnection', entries }); }}
         onSave={(entries) => bridge.post({ type: 'setConfigBatch', entries })}
-        onClearConnTest={() => dispatch({ type: 'clearConnTest' })}
+        onClearConnTest={clearConnTest}
         onDeleteCustomProvider={(name) => bridge.post({ type: 'deleteCustomProvider', name })}
         onActivateCustomProvider={(name) => bridge.post({ type: 'activateCustomProvider', name })}
         onClose={() => bridge.post({ type: 'closeConfigPanel' })}

--- a/extensions/vscode/src/webview/views/ConfigView.tsx
+++ b/extensions/vscode/src/webview/views/ConfigView.tsx
@@ -74,11 +74,11 @@ export function ConfigView({
   const t = useT();
   const stepper = (
     <div class="config-stepper">
-      <div class={`config-step-pill${step === 1 ? ' active' : ''}${cliStatus === 'installed' ? ' done' : ''}`}>
+      <div class={`config-step-pill${step === 1 ? ' done' : ''}`}>
         <span class="config-step-num">1</span>
         <span>{t('view.config.step1')}</span>
       </div>
-      <div class={`config-step-pill${step === 2 ? ' active' : ''}`}>
+      <div class={`config-step-pill${step === 2 ? ' done' : ''}`}>
         <span class="config-step-num">2</span>
         <span>{t('view.config.step2')}</span>
       </div>

--- a/extensions/vscode/src/webview/views/ConfigView.tsx
+++ b/extensions/vscode/src/webview/views/ConfigView.tsx
@@ -68,7 +68,7 @@ export function ConfigView({
     setTab(next.tab);
     setCustomView(next.customView);
     setCustomSelection(next.customSelection);
-  }, [panelFocus, config, onClearConnTest]);
+  }, [panelFocus, config]);
 
   const wide = layout === 'panel';
   const t = useT();

--- a/extensions/vscode/src/webview/views/IdleView.tsx
+++ b/extensions/vscode/src/webview/views/IdleView.tsx
@@ -113,8 +113,6 @@ export function IdleView({ gitState, modeFiles, filesLoading, configured, onMode
 
       {configured && (
         <div class="setup-secondary">
-          <button type="button" class="link-btn" onClick={onOpenCustomProviders}>{t('view.idle.manageCustom')}</button>
-          <span class="setup-secondary-sep">·</span>
           <button type="button" class="link-btn" onClick={onOpenConfig}>{t('view.idle.modelConfig')}</button>
         </div>
       )}


### PR DESCRIPTION
## Description

This PR improves the VS Code configuration experience by fixing a render-loop issue in the provider configuration editor panel and aligning the step status styling logic.

### Summary

- Fix a potential UI freeze when opening the provider configuration editor panel by stabilizing the `onClearConnTest` callback (`useCallback`) and avoiding an effect dependency loop.
- Adjust the configuration stepper status classes to use `done` based on the current step (instead of mixing `active/done`), keeping the step status display consistent.
- Simplify the idle sidebar secondary actions by removing the `Manage custom providers` entry from the idle view.

### Changes Included

- `693869f5f5498b922e6d66e641455bad70045f57`
  - `extensions/vscode/src/webview/ConfigPanelApp.tsx`: memoize `clearConnTest` with `useCallback`.
  - `extensions/vscode/src/webview/views/ConfigView.tsx`: remove `onClearConnTest` from `useEffect` deps to prevent repeated triggering.
  - `extensions/vscode/src/webview/views/IdleView.tsx`: remove `Manage custom providers` button entry.

- `774edcf1e8d1130b0c734f3f387c43f5c4a8612c`
  - `extensions/vscode/src/webview/views/ConfigView.tsx`: update stepper pill class logic to mark the current step as `done`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)
  - [ ] Open the provider configuration editor panel and click **Manage custom providers** (or navigate to the custom provider list) and verify the UI does not freeze.
  - [ ] Verify the stepper status styles update correctly when switching between Step 1 and Step 2.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->