### PR TITLE
feat: add toggle for model thinking capability

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -376,9 +376,6 @@ func setConfigValue(cfg *Config, key, value string) error {
 		if err := json.Unmarshal([]byte(value), &m); err != nil {
 			return fmt.Errorf("invalid JSON for llm.extra_body: %w", err)
 		}
-		if err := llm.ValidateExtraBody(m); err != nil {
-			return fmt.Errorf("invalid llm.extra_body: %w", err)
-		}
 		cfg.Llm.ExtraBody = m
 	default:
 		return fmt.Errorf("unknown config key: %s\nSupported keys: provider, model, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, models_thinking\nMCP server fields: command, args, env, tools, setup", key)
@@ -426,9 +423,6 @@ func applyProviderField(entry *ProviderEntry, isPreset bool, providerName, field
 		var m map[string]any
 		if err := json.Unmarshal([]byte(value), &m); err != nil {
 			return fmt.Errorf("invalid JSON for %s: %w", key, err)
-		}
-		if err := llm.ValidateExtraBody(m); err != nil {
-			return fmt.Errorf("invalid %s: %w", key, err)
 		}
 		entry.ExtraBody = m
 	case "models_thinking":

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -196,6 +196,10 @@ type ProviderEntry struct {
 	AuthHeader   string            `json:"auth_header,omitempty"`
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	// ModelsThinking maps model names to thinking mode overrides ("on" or "off").
+	// When a model has an entry, it takes precedence over extra_body at runtime.
+	// Models without an entry use extra_body as-is. Applied via llm.ApplyModelsThinking.
+	ModelsThinking map[string]string `json:"models_thinking,omitempty"`
 }
 
 // MCPServerConfig holds configuration for a single MCP server (stdio transport).
@@ -372,14 +376,17 @@ func setConfigValue(cfg *Config, key, value string) error {
 		if err := json.Unmarshal([]byte(value), &m); err != nil {
 			return fmt.Errorf("invalid JSON for llm.extra_body: %w", err)
 		}
+		if err := llm.ValidateExtraBody(m); err != nil {
+			return fmt.Errorf("invalid llm.extra_body: %w", err)
+		}
 		cfg.Llm.ExtraBody = m
 	default:
-		return fmt.Errorf("unknown config key: %s\nSupported keys: provider, model, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\nMCP server fields: command, args, env, tools, setup", key)
+		return fmt.Errorf("unknown config key: %s\nSupported keys: provider, model, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, models_thinking\nMCP server fields: command, args, env, tools, setup", key)
 	}
 	return nil
 }
 
-func applyProviderField(entry *ProviderEntry, field, key, value string) error {
+func applyProviderField(entry *ProviderEntry, isPreset bool, providerName, field, key, value string) error {
 	switch field {
 	case "api_key":
 		entry.APIKey = value
@@ -392,12 +399,23 @@ func applyProviderField(entry *ProviderEntry, field, key, value string) error {
 		entry.Protocol = value
 	case "model":
 		entry.Model = value
+		allowed := allowedModelsForThinking(isPreset, providerName, *entry)
+		before := len(entry.ModelsThinking)
+		entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowed)
+		if before > len(entry.ModelsThinking) {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: some models_thinking entries were pruned for provider %q after model change\n", providerName)
+		}
 	case "models":
 		models, err := parseModelListValue(value)
 		if err != nil {
 			return fmt.Errorf("invalid model list for %s: %w", key, err)
 		}
 		entry.Models = models
+		before := len(entry.ModelsThinking)
+		entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowedModelsForThinking(isPreset, providerName, *entry))
+		if before > len(entry.ModelsThinking) {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: some models_thinking entries were pruned for provider %q after models change\n", providerName)
+		}
 	case "auth_header":
 		normalized, err := llm.NormalizeAuthHeader(value)
 		if err != nil {
@@ -409,7 +427,46 @@ func applyProviderField(entry *ProviderEntry, field, key, value string) error {
 		if err := json.Unmarshal([]byte(value), &m); err != nil {
 			return fmt.Errorf("invalid JSON for %s: %w", key, err)
 		}
+		if err := llm.ValidateExtraBody(m); err != nil {
+			return fmt.Errorf("invalid %s: %w", key, err)
+		}
 		entry.ExtraBody = m
+	case "models_thinking":
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			entry.ModelsThinking = nil
+			return nil
+		}
+		var m map[string]string
+		if err := json.Unmarshal([]byte(trimmed), &m); err != nil {
+			return fmt.Errorf("invalid JSON for %s: %w", key, err)
+		}
+		if err := llm.ValidateModelsThinking(m); err != nil {
+			return fmt.Errorf("invalid %s: %w", key, err)
+		}
+		// NormalizeModelsThinking and ApplyModelsThinking share the same key
+		// canonicalization (lowercase + trimmed) so persisted entries match runtime.
+		normalized, err := llm.NormalizeModelsThinking(m)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", key, err)
+		}
+		allowed := allowedModelsForThinking(isPreset, providerName, *entry)
+		stored := llm.PruneModelsThinking(normalized, allowed)
+		if len(stored) == 0 && len(normalized) > 0 {
+			if len(allowed) == 0 {
+				// No models configured yet: keep entries so CLI set order is flexible.
+				// Prune runs when models/model is later set; until then entries still
+				// apply at runtime if the active model name matches a stored key.
+				stored = normalized
+				fmt.Fprintf(os.Stderr, "[ocr] WARNING: no models configured for provider %q yet; models_thinking entries are kept and will apply if a matching model name is used at runtime\n", providerName)
+			} else {
+				return fmt.Errorf("invalid %s: none of the specified models are available for provider %q", key, providerName)
+			}
+		}
+		if len(stored) < len(normalized) {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: some models in %s were not recognized for provider %q and were discarded\n", key, providerName)
+		}
+		entry.ModelsThinking = stored
 	case "extra_headers":
 		parsed, err := llm.ParseExtraHeaders(value)
 		if err != nil {
@@ -417,7 +474,7 @@ func applyProviderField(entry *ProviderEntry, field, key, value string) error {
 		}
 		entry.ExtraHeaders = parsed
 	default:
-		return fmt.Errorf("unknown provider field %q: supported fields are api_key, url, protocol, model, models, auth_header, extra_body, extra_headers", field)
+		return fmt.Errorf("unknown provider field %q: supported fields are api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, models_thinking", field)
 	}
 	return nil
 }
@@ -487,6 +544,27 @@ func ensureModelInList(models []string, model string) []string {
 	return append(out, model)
 }
 
+// allowedModelsForThinking returns model names that may have models_thinking entries.
+// isPreset reflects the config scope (providers.* vs custom_providers.*), not
+// LookupProvider(name), so a custom provider named like a preset is not mistaken
+// for the preset registry.
+func allowedModelsForThinking(isPreset bool, providerName string, entry ProviderEntry) []string {
+	if isPreset {
+		if preset, ok := llm.LookupProvider(providerName); ok {
+			models := mergeModelLists(preset.Models, entry.Models)
+			if entry.Model != "" {
+				models = ensureModelInList(models, entry.Model)
+			}
+			return models
+		}
+	}
+	models := mergeModelLists(entry.Models)
+	if entry.Model != "" {
+		models = ensureModelInList(models, entry.Model)
+	}
+	return models
+}
+
 func setProviderValue(cfg *Config, key, value string) error {
 	parts := strings.SplitN(key, ".", 3)
 	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
@@ -499,7 +577,7 @@ func setProviderValue(cfg *Config, key, value string) error {
 		cfg.Providers = make(map[string]ProviderEntry)
 	}
 	entry := cfg.Providers[parts[1]]
-	if err := applyProviderField(&entry, parts[2], key, value); err != nil {
+	if err := applyProviderField(&entry, true, parts[1], parts[2], key, value); err != nil {
 		return err
 	}
 	cfg.Providers[parts[1]] = entry
@@ -519,7 +597,7 @@ func setCustomProviderField(cfg *Config, name, field, key, value string) error {
 		cfg.CustomProviders = make(map[string]ProviderEntry)
 	}
 	entry := cfg.CustomProviders[name]
-	if err := applyProviderField(&entry, field, key, value); err != nil {
+	if err := applyProviderField(&entry, false, name, field, key, value); err != nil {
 		return err
 	}
 	cfg.CustomProviders[name] = entry

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/llm"
 )
 
 func TestSetConfigValueAuthHeaderNormalizesKnownValues(t *testing.T) {
@@ -200,6 +202,111 @@ func TestSetConfigValueProviderEntryExtraBody(t *testing.T) {
 	}
 	if _, ok := cfg.Providers["anthropic"].ExtraBody["thinking"]; !ok {
 		t.Error("extra_body missing 'thinking' key")
+	}
+}
+
+func TestSetConfigValueProviderEntryModelsThinking(t *testing.T) {
+	cfg := &Config{}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"claude-sonnet-4-6":"off"}`); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	if got := cfg.Providers["anthropic"].ModelsThinking["claude-sonnet-4-6"]; got != "off" {
+		t.Fatalf("ModelsThinking = %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"m":"enabled"}`); err == nil {
+		t.Fatal("expected error for invalid models_thinking value")
+	}
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"":"off"}`); err == nil {
+		t.Fatal("expected error for empty models_thinking model key")
+	}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", ""); err != nil {
+		t.Fatalf("clear models_thinking: %v", err)
+	}
+	if cfg.Providers["anthropic"].ModelsThinking != nil {
+		t.Fatalf("empty input should clear models_thinking, got %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"Claude-Sonnet-4-6":"off"}`); err != nil {
+		t.Fatalf("mixed-case key: %v", err)
+	}
+	if got := cfg.Providers["anthropic"].ModelsThinking["claude-sonnet-4-6"]; got != llm.ModelsThinkingOff {
+		t.Fatalf("ModelsThinking key should be normalized to lowercase, got %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"claude-sonnet-4-6":"on"}`); err != nil {
+		t.Fatalf("all-on input should be accepted: %v", err)
+	}
+	if got := cfg.Providers["anthropic"].ModelsThinking["claude-sonnet-4-6"]; got != llm.ModelsThinkingOn {
+		t.Fatalf("ModelsThinking = %#v, want on", cfg.Providers["anthropic"].ModelsThinking)
+	}
+
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"stale-model":"off"}`); err == nil {
+		t.Fatal("expected error when models_thinking models are not in allowed list")
+	}
+
+	cfg.Providers["anthropic"] = ProviderEntry{Model: "claude-opus-4-8"}
+	if err := setConfigValue(cfg, "providers.anthropic.models_thinking", `{"claude-opus-4-8":"off"}`); err != nil {
+		t.Fatalf("active model not in preset list: %v", err)
+	}
+	if got := cfg.Providers["anthropic"].ModelsThinking["claude-opus-4-8"]; got != llm.ModelsThinkingOff {
+		t.Fatalf("entry.Model should be allowed for preset providers, got %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+}
+
+func TestSetConfigValueProviderEntryModelPrunesModelsThinking(t *testing.T) {
+	cfg := &Config{
+		Providers: map[string]ProviderEntry{
+			"anthropic": {
+				Model:          "model-x",
+				ModelsThinking: map[string]string{"model-x": llm.ModelsThinkingOff},
+			},
+		},
+	}
+	if err := setConfigValue(cfg, "providers.anthropic.model", "model-y"); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	if cfg.Providers["anthropic"].ModelsThinking != nil {
+		t.Fatalf("stale model-x thinking entry should be pruned, got %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+	if cfg.Providers["anthropic"].Model != "model-y" {
+		t.Fatalf("Model = %q", cfg.Providers["anthropic"].Model)
+	}
+}
+
+func TestSetConfigValueCustomProviderModelsThinking(t *testing.T) {
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"foo": {URL: "https://example.com/v1", Protocol: "openai", Model: "m"},
+		},
+	}
+	if err := setConfigValue(cfg, "custom_providers.foo.models_thinking", `{"m":"off"}`); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	if got := cfg.CustomProviders["foo"].ModelsThinking["m"]; got != llm.ModelsThinkingOff {
+		t.Fatalf("ModelsThinking = %#v", cfg.CustomProviders["foo"].ModelsThinking)
+	}
+}
+
+func TestSetConfigValueCustomProviderNamedLikePreset_KeepsModelsThinking(t *testing.T) {
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"openai": {
+				URL:      "https://gw.example.com/v1",
+				Protocol: "openai",
+				Model:    "my-custom-model",
+				Models:   []string{"my-custom-model"},
+			},
+		},
+	}
+	if err := setConfigValue(cfg, "custom_providers.openai.models_thinking", `{"my-custom-model":"on"}`); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	got := cfg.CustomProviders["openai"].ModelsThinking
+	if got["my-custom-model"] != llm.ModelsThinkingOn {
+		t.Fatalf("ModelsThinking = %#v, want my-custom-model:on", got)
 	}
 }
 

--- a/cmd/opencodereview/provider_cmd.go
+++ b/cmd/opencodereview/provider_cmd.go
@@ -40,6 +40,7 @@ func runConfigProvider() error {
 
 	result := final.result()
 
+	// existingCfg is the same pointer as cfg (set in newProviderTUI).
 	if result.isManual {
 		return applyManualConfig(configPath, cfg, result)
 	}
@@ -115,6 +116,14 @@ func applyManualConfig(configPath string, cfg *Config, result providerTUIResult)
 	cfg.Llm.AuthHeader = authHeader
 	useAnthropic := result.protocol == "anthropic"
 	cfg.Llm.UseAnthropic = &useAnthropic
+	if err := llm.ValidateExtraBody(result.extraBody); err != nil {
+		return fmt.Errorf("invalid extra_body: %w", err)
+	}
+	if err := llm.ValidateExtraHeadersMap(result.extraHeaders); err != nil {
+		return fmt.Errorf("invalid extra_headers: %w", err)
+	}
+	cfg.Llm.ExtraBody = result.extraBody
+	cfg.Llm.ExtraHeaders = result.extraHeaders
 
 	if err := saveConfig(configPath, cfg); err != nil {
 		return err
@@ -171,6 +180,24 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 		entry.APIKey = result.apiKey
 	} else {
 		entry.APIKey = ""
+	}
+	if err := llm.ValidateExtraBody(result.extraBody); err != nil {
+		return fmt.Errorf("invalid extra_body: %w", err)
+	}
+	if err := llm.ValidateExtraHeadersMap(result.extraHeaders); err != nil {
+		return fmt.Errorf("invalid extra_headers: %w", err)
+	}
+	entry.ExtraBody = result.extraBody
+	entry.ExtraHeaders = result.extraHeaders
+	// modelThinkingModes is not merged here because the TUI disables
+	// thinking toggle for custom providers, so result.modelThinkingModes is always nil.
+	if err := llm.ValidateModelsThinking(entry.ModelsThinking); err != nil {
+		return fmt.Errorf("invalid models_thinking: %w", err)
+	}
+	beforeThinking := len(entry.ModelsThinking)
+	entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowedModelsForThinking(false, result.provider, entry))
+	if beforeThinking > len(entry.ModelsThinking) {
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: some models_thinking entries were pruned for custom provider %q (thinking toggle is not supported for custom providers)\n", result.provider)
 	}
 	cfg.CustomProviders[result.provider] = entry
 
@@ -246,6 +273,12 @@ func applyOfficialProviderConfig(configPath string, cfg *Config, result provider
 		// Confirmed empty key: clear saved api_key so resolver falls back to $ENV_VAR.
 		entry.APIKey = ""
 	}
+	entry.ModelsThinking = llm.MergeModelsThinking(entry.ModelsThinking, result.modelThinkingModes)
+	if err := llm.ValidateModelsThinking(entry.ModelsThinking); err != nil {
+		return fmt.Errorf("invalid models_thinking: %w", err)
+	}
+	allowedModels := allowedModelsForThinking(true, result.provider, entry)
+	entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowedModels)
 	cfg.Providers[result.provider] = entry
 
 	if cfg.Provider != result.provider {
@@ -344,6 +377,10 @@ func runConfigModel() error {
 		entry := cfg.CustomProviders[cfg.Provider]
 		entry.Model = selectedModel
 		entry.Models = ensureModelInList(entry.Models, selectedModel)
+		if err := llm.ValidateModelsThinking(entry.ModelsThinking); err != nil {
+			return fmt.Errorf("invalid models_thinking: %w", err)
+		}
+		entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowedModelsForThinking(false, cfg.Provider, entry))
 		cfg.CustomProviders[cfg.Provider] = entry
 	} else {
 		if cfg.Providers == nil {
@@ -356,6 +393,12 @@ func runConfigModel() error {
 		if !llm.ModelListContains(registryModels, selectedModel) {
 			entry.Models = ensureModelInList(entry.Models, selectedModel)
 		}
+		entry.ModelsThinking = llm.MergeModelsThinking(entry.ModelsThinking, final.modelsThinkingSnapshotForSave())
+		if err := llm.ValidateModelsThinking(entry.ModelsThinking); err != nil {
+			return fmt.Errorf("invalid models_thinking: %w", err)
+		}
+		allowedModels := allowedModelsForThinking(true, cfg.Provider, entry)
+		entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, allowedModels)
 		cfg.Providers[cfg.Provider] = entry
 	}
 	cfg.Model = selectedModel

--- a/cmd/opencodereview/provider_cmd.go
+++ b/cmd/opencodereview/provider_cmd.go
@@ -116,14 +116,6 @@ func applyManualConfig(configPath string, cfg *Config, result providerTUIResult)
 	cfg.Llm.AuthHeader = authHeader
 	useAnthropic := result.protocol == "anthropic"
 	cfg.Llm.UseAnthropic = &useAnthropic
-	if err := llm.ValidateExtraBody(result.extraBody); err != nil {
-		return fmt.Errorf("invalid extra_body: %w", err)
-	}
-	if err := llm.ValidateExtraHeadersMap(result.extraHeaders); err != nil {
-		return fmt.Errorf("invalid extra_headers: %w", err)
-	}
-	cfg.Llm.ExtraBody = result.extraBody
-	cfg.Llm.ExtraHeaders = result.extraHeaders
 
 	if err := saveConfig(configPath, cfg); err != nil {
 		return err
@@ -181,14 +173,6 @@ func applyCustomProviderConfig(configPath string, cfg *Config, result providerTU
 	} else {
 		entry.APIKey = ""
 	}
-	if err := llm.ValidateExtraBody(result.extraBody); err != nil {
-		return fmt.Errorf("invalid extra_body: %w", err)
-	}
-	if err := llm.ValidateExtraHeadersMap(result.extraHeaders); err != nil {
-		return fmt.Errorf("invalid extra_headers: %w", err)
-	}
-	entry.ExtraBody = result.extraBody
-	entry.ExtraHeaders = result.extraHeaders
 	// modelThinkingModes is not merged here because the TUI disables
 	// thinking toggle for custom providers, so result.modelThinkingModes is always nil.
 	if err := llm.ValidateModelsThinking(entry.ModelsThinking); err != nil {

--- a/cmd/opencodereview/provider_cmd_test.go
+++ b/cmd/opencodereview/provider_cmd_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/open-code-review/open-code-review/internal/llm"
@@ -205,23 +204,6 @@ func TestApplyOfficialProviderConfig_MissingFields(t *testing.T) {
 	err := applyOfficialProviderConfig("", &Config{}, providerTUIResult{provider: "", model: ""})
 	if err == nil {
 		t.Fatal("expected error for missing provider/model")
-	}
-}
-
-func TestApplyManualConfig_RejectsReservedExtraBodyKey(t *testing.T) {
-	cfg := &Config{}
-	err := applyManualConfig("", cfg, providerTUIResult{
-		isManual:  true,
-		url:       "https://example.com/v1",
-		model:     "test-model",
-		protocol:  "openai",
-		extraBody: map[string]any{"model": "override"},
-	})
-	if err == nil {
-		t.Fatal("expected error for reserved extra_body key")
-	}
-	if !strings.Contains(err.Error(), "model") {
-		t.Fatalf("error = %q, want reserved key mention", err)
 	}
 }
 

--- a/cmd/opencodereview/provider_cmd_test.go
+++ b/cmd/opencodereview/provider_cmd_test.go
@@ -5,7 +5,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/llm"
 )
 
 func TestMaskKey(t *testing.T) {
@@ -205,6 +208,116 @@ func TestApplyOfficialProviderConfig_MissingFields(t *testing.T) {
 	}
 }
 
+func TestApplyManualConfig_RejectsReservedExtraBodyKey(t *testing.T) {
+	cfg := &Config{}
+	err := applyManualConfig("", cfg, providerTUIResult{
+		isManual:  true,
+		url:       "https://example.com/v1",
+		model:     "test-model",
+		protocol:  "openai",
+		extraBody: map[string]any{"model": "override"},
+	})
+	if err == nil {
+		t.Fatal("expected error for reserved extra_body key")
+	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Fatalf("error = %q, want reserved key mention", err)
+	}
+}
+
+func TestApplyCustomProviderConfig_RejectsInvalidModelsThinking(t *testing.T) {
+	cfg := &Config{CustomProviders: make(map[string]ProviderEntry)}
+	cfg.CustomProviders["foo"] = ProviderEntry{
+		URL:            "https://example.com/v1",
+		Protocol:       "openai",
+		Model:          "m",
+		Models:         []string{"m"},
+		ModelsThinking: map[string]string{"m": "bogus"},
+	}
+	err := applyCustomProviderConfig("", cfg, providerTUIResult{
+		provider: "foo",
+		model:    "m",
+		models:   []string{"m"},
+		isCustom: true,
+		url:      "https://example.com/v1",
+		protocol: "openai",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid models_thinking mode")
+	}
+}
+
+func TestApplyOfficialProviderConfig_MergesModelsThinking(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-from-env")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-6",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {
+				APIKey: "sk-ant-test",
+				Model:  "claude-sonnet-4-6",
+				ModelsThinking: map[string]string{
+					"claude-opus-4-6": "off",
+				},
+			},
+		},
+	}
+
+	err := applyOfficialProviderConfig(configPath, cfg, providerTUIResult{
+		provider: "anthropic",
+		model:    "claude-sonnet-4-6",
+		apiKey:   "sk-ant-test",
+		modelThinkingModes: map[string]string{
+			"claude-opus-4-6":   "on",
+			"claude-sonnet-4-6": "off",
+		},
+	})
+	if err != nil {
+		t.Fatalf("applyOfficialProviderConfig: %v", err)
+	}
+
+	got := cfg.Providers["anthropic"].ModelsThinking
+	if got["claude-sonnet-4-6"] != "off" {
+		t.Fatalf("ModelsThinking = %#v, want claude-sonnet-4-6:off", got)
+	}
+	if got["claude-opus-4-6"] != llm.ModelsThinkingOn {
+		t.Fatalf("ModelsThinking = %#v, want claude-opus-4-6:on", got)
+	}
+}
+
+func TestApplyOfficialProviderConfig_PrunesStaleModelsThinking(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-from-env")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-6",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {
+				APIKey: "sk-ant-test",
+				Model:  "claude-sonnet-4-6",
+				ModelsThinking: map[string]string{
+					"removed-user-model": "off",
+				},
+			},
+		},
+	}
+
+	err := applyOfficialProviderConfig(configPath, cfg, providerTUIResult{
+		provider: "anthropic",
+		model:    "claude-sonnet-4-6",
+		apiKey:   "sk-ant-test",
+	})
+	if err != nil {
+		t.Fatalf("applyOfficialProviderConfig: %v", err)
+	}
+	if _, ok := cfg.Providers["anthropic"].ModelsThinking["removed-user-model"]; ok {
+		t.Fatalf("stale ModelsThinking should be pruned: %#v", cfg.Providers["anthropic"].ModelsThinking)
+	}
+}
+
 func TestApplyOfficialProviderConfig_EmptyKeyClearsSavedAPIKey(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "sk-from-env")
 	dir := t.TempDir()
@@ -374,5 +487,33 @@ func TestPrintWizardCancelled(t *testing.T) {
 				t.Errorf("output = %q, want %q", string(got), tc.want)
 			}
 		})
+	}
+}
+
+// TestProviderEntryModelsThinkingMerge documents the merge wiring used by
+// applyOfficialProviderConfig and runConfigModel for official providers.
+func TestProviderEntryModelsThinkingMerge(t *testing.T) {
+	entry := ProviderEntry{
+		ModelsThinking: map[string]string{
+			"model-a": "off",
+		},
+	}
+	entry.ModelsThinking = llm.MergeModelsThinking(entry.ModelsThinking, map[string]string{
+		"model-a": "on",
+		"model-b": "off",
+	})
+	got := entry.ModelsThinking
+	if got["model-a"] != llm.ModelsThinkingOn || got["model-b"] != "off" {
+		t.Fatalf("ModelsThinking = %#v, want model-a:on model-b:off", got)
+	}
+
+	entry = ProviderEntry{
+		Models:         []string{"model-a"},
+		ModelsThinking: map[string]string{"model-a": "off", "model-b": "off"},
+	}
+	entry.ModelsThinking = llm.PruneModelsThinking(entry.ModelsThinking, mergeModelLists([]string{"model-a"}, entry.Models))
+	got = entry.ModelsThinking
+	if len(got) != 1 || got["model-a"] != "off" {
+		t.Fatalf("PruneModelsThinking = %#v", got)
 	}
 }

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -39,8 +38,6 @@ const (
 	cpStepBaseURL
 	cpStepAPIKey
 	cpStepAuthHeader
-	cpStepExtraBody
-	cpStepExtraHeaders
 )
 
 type manualStep int
@@ -51,19 +48,9 @@ const (
 	manualStepModel
 	manualStepAuthToken
 	manualStepAuthHeader
-	manualStepExtraBody
-	manualStepExtraHeaders
 )
 
 var cpProtocols = []string{"anthropic", "openai"}
-
-const (
-	// textinput.CharLimit counts runes, so for multi-byte input the UI layer may
-	// allow up to ~4x bytes before the byte check in parseExtraBodyInput fires.
-	// These constants are the authoritative byte budget validated on Enter.
-	maxExtraBodyBytes    = 8 * 1024
-	maxExtraHeadersBytes = 8 * 1024
-)
 
 type customProviderListItem struct {
 	name  string
@@ -82,8 +69,6 @@ type providerTUIResult struct {
 	url                string
 	protocol           string
 	authHeader         string
-	extraBody          map[string]any
-	extraHeaders       map[string]string
 	modelThinkingModes map[string]string
 	sessionModelPick   map[string]string
 }
@@ -132,34 +117,27 @@ type providerTUIModel struct {
 	officialIdx int
 
 	// --- tab: custom ---
-	customProviders     []customProviderListItem
-	customIdx           int
-	creatingCustom      bool
-	editingCustom       bool
-	editTargetName      string
-	cpStep              customProviderStep
-	cpProtocolIdx       int
-	cpNameInput         textinput.Model
-	cpURLInput          textinput.Model
-	cpAuthInput         textinput.Model
-	cpExtraBodyInput    textinput.Model
-	cpExtraHeadersInput textinput.Model
-	cpExtraBody         map[string]any
+	customProviders []customProviderListItem
+	customIdx       int
+	creatingCustom  bool
+	editingCustom   bool
+	editTargetName  string
+	cpStep          customProviderStep
+	cpProtocolIdx   int
+	cpNameInput     textinput.Model
+	cpURLInput      textinput.Model
+	cpAuthInput     textinput.Model
 
 	// --- tab: manual ---
-	inManualForm            bool
-	manualStep              manualStep
-	manualProtocolIdx       int
-	manualURLInput          textinput.Model
-	manualModelInput        textinput.Model
-	manualAuthHeaderInput   textinput.Model
-	manualTokenInput        textinput.Model
-	manualExtraBodyInput    textinput.Model
-	manualExtraHeadersInput textinput.Model
-	manualExtraBody         map[string]any
-	manualExtraHeaders      map[string]string
-	manualTokenMasked       bool
-	manualTokenOriginal     string
+	inManualForm          bool
+	manualStep            manualStep
+	manualProtocolIdx     int
+	manualURLInput        textinput.Model
+	manualModelInput      textinput.Model
+	manualAuthHeaderInput textinput.Model
+	manualTokenInput      textinput.Model
+	manualTokenMasked     bool
+	manualTokenOriginal   string
 
 	// --- shared model/api-key steps (official + existing custom) ---
 	modelIdx    int
@@ -262,16 +240,6 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 	cpAuth.Placeholder = "optional, leave empty for default (Authorization)"
 	cpAuth.SetWidth(55)
 
-	cpExtraBody := textinput.New()
-	cpExtraBody.Placeholder = `optional, e.g. {"enable_thinking": false}`
-	cpExtraBody.CharLimit = maxExtraBodyBytes
-	cpExtraBody.SetWidth(60)
-
-	cpExtraHeaders := textinput.New()
-	cpExtraHeaders.Placeholder = `optional, e.g. {"X-Org-ID": "org-123"}`
-	cpExtraHeaders.CharLimit = maxExtraHeadersBytes
-	cpExtraHeaders.SetWidth(60)
-
 	manualURL := textinput.New()
 	manualURL.Placeholder = "enter your API base URL"
 	manualURL.SetWidth(50)
@@ -290,37 +258,23 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 	manualToken.EchoMode = textinput.EchoPassword
 	manualToken.EchoCharacter = '*'
 
-	manualExtraBody := textinput.New()
-	manualExtraBody.Placeholder = `optional, e.g. {"enable_thinking": false}`
-	manualExtraBody.CharLimit = maxExtraBodyBytes
-	manualExtraBody.SetWidth(60)
-
-	manualExtraHeaders := textinput.New()
-	manualExtraHeaders.Placeholder = `optional, e.g. {"X-Org-ID": "org-123"}`
-	manualExtraHeaders.CharLimit = maxExtraHeadersBytes
-	manualExtraHeaders.SetWidth(60)
-
 	m := providerTUIModel{
-		providers:               providers,
-		existingCfg:             cfg,
-		modelInput:              mi,
-		apiKeyInput:             ai,
-		cpNameInput:             cpName,
-		cpURLInput:              cpURL,
-		cpAuthInput:             cpAuth,
-		cpExtraBodyInput:        cpExtraBody,
-		cpExtraHeadersInput:     cpExtraHeaders,
-		manualURLInput:          manualURL,
-		manualModelInput:        manualModel,
-		manualAuthHeaderInput:   manualAuthHeader,
-		manualTokenInput:        manualToken,
-		manualExtraBodyInput:    manualExtraBody,
-		manualExtraHeadersInput: manualExtraHeaders,
-		width:                   80,
-		height:                  24,
-		activeTab:               tabOfficial,
-		customProviders:         collectCustomProviders(cfg),
-		configPath:              configPath,
+		providers:             providers,
+		existingCfg:           cfg,
+		modelInput:            mi,
+		apiKeyInput:           ai,
+		cpNameInput:           cpName,
+		cpURLInput:            cpURL,
+		cpAuthInput:           cpAuth,
+		manualURLInput:        manualURL,
+		manualModelInput:      manualModel,
+		manualAuthHeaderInput: manualAuthHeader,
+		manualTokenInput:      manualToken,
+		width:                 80,
+		height:                24,
+		activeTab:             tabOfficial,
+		customProviders:       collectCustomProviders(cfg),
+		configPath:            configPath,
 	}
 
 	providerFound := false
@@ -395,8 +349,6 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 		} else {
 			m.manualProtocolIdx = 1 // openai
 		}
-		m.manualExtraBodyInput.SetValue(formatExtraBodyJSON(cfg.Llm.ExtraBody))
-		m.manualExtraHeadersInput.SetValue(formatExtraHeadersJSON(cfg.Llm.ExtraHeaders))
 	}
 
 	return m
@@ -1004,9 +956,6 @@ func (m providerTUIModel) updateCustomProviderForm(key string, msg tea.KeyPressM
 			m.cpNameInput.SetValue("")
 			m.cpURLInput.SetValue("")
 			m.cpAuthInput.SetValue("")
-			m.cpExtraBodyInput.SetValue("")
-			m.cpExtraHeadersInput.SetValue("")
-			m.cpExtraBody = nil
 			m.apiKeyInput.SetValue("")
 			m.apiKeyMasked = false
 			m.apiKeyOriginal = ""
@@ -1074,13 +1023,6 @@ func (m *providerTUIModel) enterEditCustomProvider() {
 		m.apiKeyMasked = false
 		m.apiKeyOriginal = ""
 	}
-	m.cpExtraBodyInput.SetValue(formatExtraBodyJSON(entry.ExtraBody))
-	m.cpExtraHeadersInput.SetValue(formatExtraHeadersJSON(entry.ExtraHeaders))
-	if entry.ExtraBody != nil {
-		m.cpExtraBody = deepCloneMap(entry.ExtraBody)
-	} else {
-		m.cpExtraBody = nil
-	}
 }
 
 func authHeaderFormError(raw string) string {
@@ -1136,44 +1078,12 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.cpAuthInput.Blur()
-		m.cpStep = cpStepExtraBody
-		return m, m.cpExtraBodyInput.Focus()
-	case cpStepExtraBody:
-		extraBody, err := parseExtraBodyInput(m.cpExtraBodyInput.Value())
-		if err != nil {
-			m.formError = ""
-			return m, nil
-		}
-		m.cpExtraBody = extraBody
-		m.cpExtraBodyInput.Blur()
-		m.formError = ""
-		m.cpStep = cpStepExtraHeaders
-		return m, m.cpExtraHeadersInput.Focus()
-	case cpStepExtraHeaders:
-		// Re-parse from input so saved Extra Body matches what the user sees if they
-		// edited the field after advancing from cpStepExtraBody (inline draft hints
-		// surface parse errors; formError stays empty to avoid duplicate messages).
-		extraBody, err := parseExtraBodyInput(m.cpExtraBodyInput.Value())
-		if err != nil {
-			m.formError = ""
-			m.cpExtraHeadersInput.Blur()
-			m.cpStep = cpStepExtraBody
-			return m, m.cpExtraBodyInput.Focus()
-		}
-		m.cpExtraBody = extraBody
-		extraHeaders, err := parseExtraHeadersInput(m.cpExtraHeadersInput.Value())
-		if err != nil {
-			m.formError = ""
-			return m, nil
-		}
-		m.cpExtraHeadersInput.Blur()
 		m.formError = ""
 		if m.editingCustom {
-			r := m.result()
-			if err := m.applyEditCustomProviderSaveWithExtras(r, extraBody, extraHeaders, true); err != nil {
+			if err := m.applyEditCustomProviderSave(); err != nil {
 				return m, nil
 			}
-			// Edit succeeded — drop the user into the model list for this provider.
+			r := m.result()
 			m.editingCustom = false
 			m.editTargetName = ""
 			m.apiKeyInput.SetValue("")
@@ -1187,7 +1097,7 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.creatingCustom {
-			return m.applyCreateCustomProvider(extraBody, extraHeaders)
+			return m.applyCreateCustomProvider()
 		}
 		m.confirmed = true
 		return m, tea.Quit
@@ -1195,7 +1105,7 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m providerTUIModel) applyCreateCustomProvider(extraBody map[string]any, extraHeaders map[string]string) (tea.Model, tea.Cmd) {
+func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
 	if m.existingCfg == nil {
 		m.formError = "failed to save: config not loaded"
 		return m, nil
@@ -1221,24 +1131,10 @@ func (m providerTUIModel) applyCreateCustomProvider(extraBody map[string]any, ex
 	}
 
 	entry := ProviderEntry{
-		URL:          r.url,
-		Protocol:     r.protocol,
-		AuthHeader:   r.authHeader,
-		APIKey:       strings.TrimSpace(m.apiKeyInput.Value()),
-		ExtraBody:    extraBody,
-		ExtraHeaders: extraHeaders,
-	}
-	if entry.ExtraBody != nil {
-		if err := llm.ValidateExtraBody(entry.ExtraBody); err != nil {
-			m.formError = err.Error()
-			return m, nil
-		}
-	}
-	if len(entry.ExtraHeaders) > 0 {
-		if err := llm.ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
-			m.formError = err.Error()
-			return m, nil
-		}
+		URL:        r.url,
+		Protocol:   r.protocol,
+		AuthHeader: r.authHeader,
+		APIKey:     strings.TrimSpace(m.apiKeyInput.Value()),
 	}
 	m.existingCfg.CustomProviders[r.provider] = entry
 
@@ -1255,9 +1151,6 @@ func (m providerTUIModel) applyCreateCustomProvider(extraBody map[string]any, ex
 	m.cpNameInput.SetValue("")
 	m.cpURLInput.SetValue("")
 	m.cpAuthInput.SetValue("")
-	m.cpExtraBodyInput.SetValue("")
-	m.cpExtraHeadersInput.SetValue("")
-	m.cpExtraBody = nil
 	m.apiKeyInput.SetValue("")
 	m.apiKeyMasked = false
 	m.apiKeyOriginal = ""
@@ -1319,12 +1212,9 @@ func cloneCustomProviderList(src []customProviderListItem) []customProviderListI
 	return out
 }
 
-// applyEditCustomProviderSave persists edits without touching ExtraBody/ExtraHeaders.
+// applyEditCustomProviderSave persists provider form edits without touching ExtraBody/ExtraHeaders.
 func (m *providerTUIModel) applyEditCustomProviderSave() error {
-	return m.applyEditCustomProviderSaveWithExtras(m.result(), nil, nil, false)
-}
-
-func (m *providerTUIModel) applyEditCustomProviderSaveWithExtras(r providerTUIResult, extraBody map[string]any, extraHeaders map[string]string, updateExtras bool) error {
+	r := m.result()
 	if m.existingCfg == nil {
 		m.formError = "failed to save: config not loaded"
 		return fmt.Errorf("config not loaded")
@@ -1352,14 +1242,6 @@ func (m *providerTUIModel) applyEditCustomProviderSaveWithExtras(r providerTUIRe
 	entry.URL = r.url
 	entry.Protocol = r.protocol
 	entry.AuthHeader = r.authHeader
-	if updateExtras {
-		if extraBody != nil {
-			entry.ExtraBody = deepCloneMap(extraBody)
-		} else {
-			entry.ExtraBody = nil
-		}
-		entry.ExtraHeaders = cloneExtraHeadersMap(extraHeaders)
-	}
 	if entry.ExtraBody != nil {
 		if err := llm.ValidateExtraBody(entry.ExtraBody); err != nil {
 			m.formError = err.Error()
@@ -1429,10 +1311,6 @@ func (m *providerTUIModel) blurCPStep() {
 		m.apiKeyInput.Blur()
 	case cpStepAuthHeader:
 		m.cpAuthInput.Blur()
-	case cpStepExtraBody:
-		m.cpExtraBodyInput.Blur()
-	case cpStepExtraHeaders:
-		m.cpExtraHeadersInput.Blur()
 	}
 }
 
@@ -1446,10 +1324,6 @@ func (m *providerTUIModel) focusCPStep() tea.Cmd {
 		return m.apiKeyInput.Focus()
 	case cpStepAuthHeader:
 		return m.cpAuthInput.Focus()
-	case cpStepExtraBody:
-		return m.cpExtraBodyInput.Focus()
-	case cpStepExtraHeaders:
-		return m.cpExtraHeadersInput.Focus()
 	}
 	return nil
 }
@@ -1468,10 +1342,6 @@ func (m providerTUIModel) passThroughCPInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
 	case cpStepAuthHeader:
 		m.cpAuthInput, cmd = m.cpAuthInput.Update(msg)
-	case cpStepExtraBody:
-		m.cpExtraBodyInput, cmd = m.cpExtraBodyInput.Update(msg)
-	case cpStepExtraHeaders:
-		m.cpExtraHeadersInput, cmd = m.cpExtraHeadersInput.Update(msg)
 	}
 	if _, ok := msg.(tea.KeyPressMsg); ok {
 		m.formError = ""
@@ -1492,14 +1362,6 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 				m.manualURLInput.SetValue(m.existingCfg.Llm.URL)
 				m.manualModelInput.SetValue(m.existingCfg.Llm.Model)
 				m.manualAuthHeaderInput.SetValue(m.existingCfg.Llm.AuthHeader)
-				m.manualExtraBodyInput.SetValue(formatExtraBodyJSON(m.existingCfg.Llm.ExtraBody))
-				m.manualExtraHeadersInput.SetValue(formatExtraHeadersJSON(m.existingCfg.Llm.ExtraHeaders))
-				if m.existingCfg.Llm.ExtraBody != nil {
-					m.manualExtraBody = deepCloneMap(m.existingCfg.Llm.ExtraBody)
-				} else {
-					m.manualExtraBody = nil
-				}
-				m.manualExtraHeaders = cloneExtraHeadersMap(m.existingCfg.Llm.ExtraHeaders)
 				if m.existingCfg.Llm.AuthToken != "" {
 					m.manualTokenOriginal = m.existingCfg.Llm.AuthToken
 					m.manualTokenMasked = true
@@ -1513,13 +1375,9 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 				m.manualURLInput.SetValue("")
 				m.manualModelInput.SetValue("")
 				m.manualAuthHeaderInput.SetValue("")
-				m.manualExtraBodyInput.SetValue("")
-				m.manualExtraHeadersInput.SetValue("")
 				m.manualTokenInput.SetValue("")
 				m.manualTokenMasked = false
 				m.manualTokenOriginal = ""
-				m.manualExtraBody = nil
-				m.manualExtraHeaders = nil
 			}
 			m.formError = ""
 			return m, nil
@@ -1769,39 +1627,7 @@ func (m providerTUIModel) handleManualFormEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.blurManualStep()
-		m.manualStep = manualStepExtraBody
-		return m, m.focusManualStep()
-	case manualStepExtraBody:
-		extraBody, err := parseExtraBodyInput(m.manualExtraBodyInput.Value())
-		if err != nil {
-			m.formError = ""
-			return m, nil
-		}
-		m.manualExtraBodyInput.Blur()
 		m.formError = ""
-		m.manualExtraBody = extraBody
-		m.manualStep = manualStepExtraHeaders
-		return m, m.focusManualStep()
-	case manualStepExtraHeaders:
-		// Re-parse from input so saved Extra Body matches what the user sees if they
-		// edited the field after advancing from manualStepExtraBody (inline draft hints
-		// surface parse errors; formError stays empty to avoid duplicate messages).
-		extraBody, err := parseExtraBodyInput(m.manualExtraBodyInput.Value())
-		if err != nil {
-			m.formError = ""
-			m.manualExtraHeadersInput.Blur()
-			m.manualStep = manualStepExtraBody
-			return m, m.focusManualStep()
-		}
-		m.manualExtraBody = extraBody
-		extraHeaders, err := parseExtraHeadersInput(m.manualExtraHeadersInput.Value())
-		if err != nil {
-			m.formError = ""
-			return m, nil
-		}
-		m.manualExtraHeadersInput.Blur()
-		m.formError = ""
-		m.manualExtraHeaders = extraHeaders
 		m.confirmed = true
 		return m, tea.Quit
 	}
@@ -1820,10 +1646,6 @@ func (m *providerTUIModel) blurManualStep() {
 		m.manualTokenInput.Blur()
 	case manualStepAuthHeader:
 		m.manualAuthHeaderInput.Blur()
-	case manualStepExtraBody:
-		m.manualExtraBodyInput.Blur()
-	case manualStepExtraHeaders:
-		m.manualExtraHeadersInput.Blur()
 	}
 }
 
@@ -1839,10 +1661,6 @@ func (m *providerTUIModel) focusManualStep() tea.Cmd {
 		return m.manualTokenInput.Focus()
 	case manualStepAuthHeader:
 		return m.manualAuthHeaderInput.Focus()
-	case manualStepExtraBody:
-		return m.manualExtraBodyInput.Focus()
-	case manualStepExtraHeaders:
-		return m.manualExtraHeadersInput.Focus()
 	}
 	return nil
 }
@@ -1863,10 +1681,6 @@ func (m providerTUIModel) passThroughManualInput(msg tea.Msg) (tea.Model, tea.Cm
 		m.manualTokenInput, cmd = m.manualTokenInput.Update(msg)
 	case manualStepAuthHeader:
 		m.manualAuthHeaderInput, cmd = m.manualAuthHeaderInput.Update(msg)
-	case manualStepExtraBody:
-		m.manualExtraBodyInput, cmd = m.manualExtraBodyInput.Update(msg)
-	case manualStepExtraHeaders:
-		m.manualExtraHeadersInput, cmd = m.manualExtraHeadersInput.Update(msg)
 	}
 	if _, ok := msg.(tea.KeyPressMsg); ok {
 		m.formError = ""
@@ -2096,8 +1910,6 @@ func (m providerTUIModel) result() providerTUIResult {
 				url:              cp.entry.URL,
 				protocol:         cp.entry.Protocol,
 				authHeader:       cp.entry.AuthHeader,
-				extraBody:        cp.entry.ExtraBody,
-				extraHeaders:     cp.entry.ExtraHeaders,
 				sessionModelPick: m.sessionModelPickSnapshot(),
 			}
 		}
@@ -2110,29 +1922,16 @@ func (m providerTUIModel) result() providerTUIResult {
 		}
 		authHeader, _ := llm.NormalizeAuthHeader(m.manualAuthHeaderInput.Value())
 		return providerTUIResult{
-			isManual:     true,
-			url:          strings.TrimSpace(m.manualURLInput.Value()),
-			model:        strings.TrimSpace(m.manualModelInput.Value()),
-			apiKey:       apiKey,
-			protocol:     cpProtocols[m.manualProtocolIdx],
-			authHeader:   authHeader,
-			extraBody:    m.manualExtraBody,
-			extraHeaders: m.manualExtraHeaders,
+			isManual:   true,
+			url:        strings.TrimSpace(m.manualURLInput.Value()),
+			model:      strings.TrimSpace(m.manualModelInput.Value()),
+			apiKey:     apiKey,
+			protocol:   cpProtocols[m.manualProtocolIdx],
+			authHeader: authHeader,
 		}
 	}
 
 	return providerTUIResult{}
-}
-
-func formatExtraBodyJSON(m map[string]any) string {
-	if len(m) == 0 {
-		return ""
-	}
-	b, err := json.Marshal(m)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }
 
 func deepCloneMap(m map[string]any) map[string]any {
@@ -2163,38 +1962,6 @@ func deepCloneAny(v any) any {
 	}
 }
 
-func parseExtraBodyInput(raw string) (map[string]any, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, nil
-	}
-	if len(raw) > maxExtraBodyBytes {
-		return nil, fmt.Errorf("extra body too large (max %d bytes)", maxExtraBodyBytes)
-	}
-	var out map[string]any
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-	if len(out) == 0 {
-		return nil, nil
-	}
-	if err := llm.ValidateExtraBody(out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func formatExtraHeadersJSON(m map[string]string) string {
-	if len(m) == 0 {
-		return ""
-	}
-	b, err := json.Marshal(m)
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 func cloneExtraHeadersMap(m map[string]string) map[string]string {
 	if len(m) == 0 {
 		return nil
@@ -2204,38 +1971,6 @@ func cloneExtraHeadersMap(m map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
-}
-
-func parseExtraHeadersInput(raw string) (map[string]string, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, nil
-	}
-	if len(raw) > maxExtraHeadersBytes {
-		return nil, fmt.Errorf("extra headers too large (max %d bytes)", maxExtraHeadersBytes)
-	}
-	var out map[string]string
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-	if len(out) == 0 {
-		return nil, nil
-	}
-	if err := llm.ValidateExtraHeadersMap(out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func extraHeadersErrorFromDraft(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "{}" {
-		return ""
-	}
-	if _, err := parseExtraHeadersInput(raw); err != nil {
-		return tuiErrorStyle.Render("  " + err.Error())
-	}
-	return ""
 }
 
 func (m providerTUIModel) currentModelName() string {
@@ -2499,64 +2234,6 @@ func (m modelTUIModel) modelsThinkingSnapshotForSave() map[string]string {
 	return modelsThinkingSnapshotForSave(m.modelThinkingModes, m.modelThinkingState(), m.currentModelName())
 }
 
-func (m providerTUIModel) customProviderExtraBodyConfigured() bool {
-	return len(m.customProviderExtraBody()) > 0
-}
-
-func (m providerTUIModel) customProviderExtraBody() map[string]any {
-	if m.activeTab != tabCustom {
-		return nil
-	}
-	cp, ok := m.selectedCustomProvider()
-	if !ok {
-		return nil
-	}
-	entry := m.customProviderEntry(cp.name, cp.entry)
-	return entry.ExtraBody
-}
-
-func (m providerTUIModel) customProviderExtraBodyHint() string {
-	if m.activeTab != tabCustom {
-		return ""
-	}
-	return extraBodyHintLine(m.customProviderExtraBody())
-}
-
-func extraBodyHintLine(extraBody map[string]any) string {
-	if len(extraBody) == 0 {
-		return ""
-	}
-	return tuiDimStyle.Render("  Extra body: " + formatExtraBodyJSON(extraBody))
-}
-
-func extraBodyHintFromDraft(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "{}" {
-		return ""
-	}
-	body, err := parseExtraBodyInput(raw)
-	if err != nil {
-		return tuiErrorStyle.Render("  " + err.Error())
-	}
-	if len(body) == 0 {
-		return ""
-	}
-	return extraBodyHintLine(body)
-}
-
-// extraBodyErrorFromDraft returns a validation error for invalid draft JSON only.
-// Valid JSON is omitted because the active form field already shows the input.
-func extraBodyErrorFromDraft(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "{}" {
-		return ""
-	}
-	if _, err := parseExtraBodyInput(raw); err != nil {
-		return tuiErrorStyle.Render("  " + err.Error())
-	}
-	return ""
-}
-
 func listCursorPrefix(isCursor bool) string {
 	if isCursor {
 		return "  " + tuiCursorStyle.Render(tuiCursor) + " "
@@ -2739,8 +2416,6 @@ func (m providerTUIModel) viewCustomProviderForm(s *strings.Builder) {
 		{"Base URL", m.cpURLInput.Value(), m.cpStep == cpStepBaseURL},
 		{"API Key", strings.Repeat("*", len(m.apiKeyInput.Value())), m.cpStep == cpStepAPIKey},
 		{"Auth Header", m.cpAuthInput.Value(), m.cpStep == cpStepAuthHeader},
-		{"Extra Body", m.cpExtraBodyInput.Value(), m.cpStep == cpStepExtraBody},
-		{"Extra Headers", m.cpExtraHeadersInput.Value(), m.cpStep == cpStepExtraHeaders},
 	}
 
 	for _, f := range fields {
@@ -2768,16 +2443,6 @@ func (m providerTUIModel) viewCustomProviderForm(s *strings.Builder) {
 				}
 			case cpStepAuthHeader:
 				s.WriteString("    " + m.cpAuthInput.View() + "\n")
-			case cpStepExtraBody:
-				s.WriteString("    " + m.cpExtraBodyInput.View() + "\n")
-				if errHint := extraBodyErrorFromDraft(m.cpExtraBodyInput.Value()); errHint != "" {
-					s.WriteString(errHint + "\n")
-				}
-			case cpStepExtraHeaders:
-				s.WriteString("    " + m.cpExtraHeadersInput.View() + "\n")
-				if errHint := extraHeadersErrorFromDraft(m.cpExtraHeadersInput.Value()); errHint != "" {
-					s.WriteString(errHint + "\n")
-				}
 			}
 		} else {
 			display := f.value
@@ -2831,8 +2496,6 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 		{"Model", m.manualModelInput.Value(), m.manualStep == manualStepModel},
 		{"Auth Token", strings.Repeat("*", len(m.manualTokenInput.Value())), m.manualStep == manualStepAuthToken},
 		{"Auth Header", m.manualAuthHeaderInput.Value(), m.manualStep == manualStepAuthHeader},
-		{"Extra Body", m.manualExtraBodyInput.Value(), m.manualStep == manualStepExtraBody},
-		{"Extra Headers", m.manualExtraHeadersInput.Value(), m.manualStep == manualStepExtraHeaders},
 	}
 
 	for _, f := range fields {
@@ -2860,16 +2523,6 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 				}
 			case manualStepAuthHeader:
 				s.WriteString("    " + m.manualAuthHeaderInput.View() + "\n")
-			case manualStepExtraBody:
-				s.WriteString("    " + m.manualExtraBodyInput.View() + "\n")
-				if errHint := extraBodyErrorFromDraft(m.manualExtraBodyInput.Value()); errHint != "" {
-					s.WriteString(errHint + "\n")
-				}
-			case manualStepExtraHeaders:
-				s.WriteString("    " + m.manualExtraHeadersInput.View() + "\n")
-				if errHint := extraHeadersErrorFromDraft(m.manualExtraHeadersInput.Value()); errHint != "" {
-					s.WriteString(errHint + "\n")
-				}
 			}
 		} else {
 			display := f.value
@@ -2940,12 +2593,6 @@ func (m providerTUIModel) viewModel(s *strings.Builder) {
 	}
 
 	s.WriteString("\n")
-
-	if hint := m.customProviderExtraBodyHint(); hint != "" && m.activeTab == tabCustom {
-		s.WriteString(hint)
-		s.WriteString("\n")
-		s.WriteString("\n")
-	}
 
 	if m.confirmingDeleteModel {
 		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))
@@ -3585,16 +3232,6 @@ func (m modelTUIModel) currentModelName() string {
 	return m.selectedModel()
 }
 
-func (m modelTUIModel) customProviderExtraBody() map[string]any {
-	if !m.isCustomProvider || m.existingCfg == nil {
-		return nil
-	}
-	if entry, ok := m.existingCfg.CustomProviders[m.providerName]; ok {
-		return entry.ExtraBody
-	}
-	return nil
-}
-
 func (m modelTUIModel) View() tea.View {
 	var s strings.Builder
 	s.WriteString("\n")
@@ -3647,12 +3284,6 @@ func (m modelTUIModel) View() tea.View {
 	}
 
 	s.WriteString("\n")
-
-	if hint := extraBodyHintLine(m.customProviderExtraBody()); hint != "" && m.isCustomProvider {
-		s.WriteString(hint)
-		s.WriteString("\n")
-		s.WriteString("\n")
-	}
 
 	if m.confirmingDeleteModel {
 		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1783,6 +1783,17 @@ func (m providerTUIModel) handleManualFormEnter() (tea.Model, tea.Cmd) {
 		m.manualStep = manualStepExtraHeaders
 		return m, m.focusManualStep()
 	case manualStepExtraHeaders:
+		// Re-parse from input so saved Extra Body matches what the user sees if they
+		// edited the field after advancing from manualStepExtraBody (inline draft hints
+		// surface parse errors; formError stays empty to avoid duplicate messages).
+		extraBody, err := parseExtraBodyInput(m.manualExtraBodyInput.Value())
+		if err != nil {
+			m.formError = ""
+			m.manualExtraHeadersInput.Blur()
+			m.manualStep = manualStepExtraBody
+			return m, m.focusManualStep()
+		}
+		m.manualExtraBody = extraBody
 		extraHeaders, err := parseExtraHeadersInput(m.manualExtraHeadersInput.Value())
 		if err != nil {
 			m.formError = ""

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1242,18 +1242,6 @@ func (m *providerTUIModel) applyEditCustomProviderSave() error {
 	entry.URL = r.url
 	entry.Protocol = r.protocol
 	entry.AuthHeader = r.authHeader
-	if entry.ExtraBody != nil {
-		if err := llm.ValidateExtraBody(entry.ExtraBody); err != nil {
-			m.formError = err.Error()
-			return err
-		}
-	}
-	if len(entry.ExtraHeaders) > 0 {
-		if err := llm.ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
-			m.formError = err.Error()
-			return err
-		}
-	}
 	if key, edited := m.customAPIKeyForSave(); edited {
 		entry.APIKey = key
 	}

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -38,6 +39,8 @@ const (
 	cpStepBaseURL
 	cpStepAPIKey
 	cpStepAuthHeader
+	cpStepExtraBody
+	cpStepExtraHeaders
 )
 
 type manualStep int
@@ -48,9 +51,19 @@ const (
 	manualStepModel
 	manualStepAuthToken
 	manualStepAuthHeader
+	manualStepExtraBody
+	manualStepExtraHeaders
 )
 
 var cpProtocols = []string{"anthropic", "openai"}
+
+const (
+	// textinput.CharLimit counts runes, so for multi-byte input the UI layer may
+	// allow up to ~4x bytes before the byte check in parseExtraBodyInput fires.
+	// These constants are the authoritative byte budget validated on Enter.
+	maxExtraBodyBytes    = 8 * 1024
+	maxExtraHeadersBytes = 8 * 1024
+)
 
 type customProviderListItem struct {
 	name  string
@@ -58,18 +71,21 @@ type customProviderListItem struct {
 }
 
 type providerTUIResult struct {
-	provider         string
-	model            string
-	models           []string
-	apiKey           string
-	isCustom         bool
-	isEdit           bool
-	editTargetName   string
-	isManual         bool
-	url              string
-	protocol         string
-	authHeader       string
-	sessionModelPick map[string]string
+	provider           string
+	model              string
+	models             []string
+	apiKey             string
+	isCustom           bool
+	isEdit             bool
+	editTargetName     string
+	isManual           bool
+	url                string
+	protocol           string
+	authHeader         string
+	extraBody          map[string]any
+	extraHeaders       map[string]string
+	modelThinkingModes map[string]string
+	sessionModelPick   map[string]string
 }
 
 // resolvedModel returns the model to persist, falling back to the in-session pick
@@ -116,27 +132,34 @@ type providerTUIModel struct {
 	officialIdx int
 
 	// --- tab: custom ---
-	customProviders []customProviderListItem
-	customIdx       int
-	creatingCustom  bool
-	editingCustom   bool
-	editTargetName  string
-	cpStep          customProviderStep
-	cpProtocolIdx   int
-	cpNameInput     textinput.Model
-	cpURLInput      textinput.Model
-	cpAuthInput     textinput.Model
+	customProviders     []customProviderListItem
+	customIdx           int
+	creatingCustom      bool
+	editingCustom       bool
+	editTargetName      string
+	cpStep              customProviderStep
+	cpProtocolIdx       int
+	cpNameInput         textinput.Model
+	cpURLInput          textinput.Model
+	cpAuthInput         textinput.Model
+	cpExtraBodyInput    textinput.Model
+	cpExtraHeadersInput textinput.Model
+	cpExtraBody         map[string]any
 
 	// --- tab: manual ---
-	inManualForm          bool
-	manualStep            manualStep
-	manualProtocolIdx     int
-	manualURLInput        textinput.Model
-	manualModelInput      textinput.Model
-	manualAuthHeaderInput textinput.Model
-	manualTokenInput      textinput.Model
-	manualTokenMasked     bool
-	manualTokenOriginal   string
+	inManualForm            bool
+	manualStep              manualStep
+	manualProtocolIdx       int
+	manualURLInput          textinput.Model
+	manualModelInput        textinput.Model
+	manualAuthHeaderInput   textinput.Model
+	manualTokenInput        textinput.Model
+	manualExtraBodyInput    textinput.Model
+	manualExtraHeadersInput textinput.Model
+	manualExtraBody         map[string]any
+	manualExtraHeaders      map[string]string
+	manualTokenMasked       bool
+	manualTokenOriginal     string
 
 	// --- shared model/api-key steps (official + existing custom) ---
 	modelIdx    int
@@ -155,7 +178,8 @@ type providerTUIModel struct {
 	savedInSession bool
 	// sessionModelPick remembers model choices per provider during a wizard run
 	// without persisting inactive-provider selections to disk.
-	sessionModelPick map[string]string
+	sessionModelPick   map[string]string
+	modelThinkingModes map[string]string
 
 	// --- delete confirmation ---
 	confirmingDelete      bool
@@ -238,6 +262,16 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 	cpAuth.Placeholder = "optional, leave empty for default (Authorization)"
 	cpAuth.SetWidth(55)
 
+	cpExtraBody := textinput.New()
+	cpExtraBody.Placeholder = `optional, e.g. {"enable_thinking": false}`
+	cpExtraBody.CharLimit = maxExtraBodyBytes
+	cpExtraBody.SetWidth(60)
+
+	cpExtraHeaders := textinput.New()
+	cpExtraHeaders.Placeholder = `optional, e.g. {"X-Org-ID": "org-123"}`
+	cpExtraHeaders.CharLimit = maxExtraHeadersBytes
+	cpExtraHeaders.SetWidth(60)
+
 	manualURL := textinput.New()
 	manualURL.Placeholder = "enter your API base URL"
 	manualURL.SetWidth(50)
@@ -256,23 +290,37 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 	manualToken.EchoMode = textinput.EchoPassword
 	manualToken.EchoCharacter = '*'
 
+	manualExtraBody := textinput.New()
+	manualExtraBody.Placeholder = `optional, e.g. {"enable_thinking": false}`
+	manualExtraBody.CharLimit = maxExtraBodyBytes
+	manualExtraBody.SetWidth(60)
+
+	manualExtraHeaders := textinput.New()
+	manualExtraHeaders.Placeholder = `optional, e.g. {"X-Org-ID": "org-123"}`
+	manualExtraHeaders.CharLimit = maxExtraHeadersBytes
+	manualExtraHeaders.SetWidth(60)
+
 	m := providerTUIModel{
-		providers:             providers,
-		existingCfg:           cfg,
-		modelInput:            mi,
-		apiKeyInput:           ai,
-		cpNameInput:           cpName,
-		cpURLInput:            cpURL,
-		cpAuthInput:           cpAuth,
-		manualURLInput:        manualURL,
-		manualModelInput:      manualModel,
-		manualAuthHeaderInput: manualAuthHeader,
-		manualTokenInput:      manualToken,
-		width:                 80,
-		height:                24,
-		activeTab:             tabOfficial,
-		customProviders:       collectCustomProviders(cfg),
-		configPath:            configPath,
+		providers:               providers,
+		existingCfg:             cfg,
+		modelInput:              mi,
+		apiKeyInput:             ai,
+		cpNameInput:             cpName,
+		cpURLInput:              cpURL,
+		cpAuthInput:             cpAuth,
+		cpExtraBodyInput:        cpExtraBody,
+		cpExtraHeadersInput:     cpExtraHeaders,
+		manualURLInput:          manualURL,
+		manualModelInput:        manualModel,
+		manualAuthHeaderInput:   manualAuthHeader,
+		manualTokenInput:        manualToken,
+		manualExtraBodyInput:    manualExtraBody,
+		manualExtraHeadersInput: manualExtraHeaders,
+		width:                   80,
+		height:                  24,
+		activeTab:               tabOfficial,
+		customProviders:         collectCustomProviders(cfg),
+		configPath:              configPath,
 	}
 
 	providerFound := false
@@ -318,6 +366,12 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 			m.apiKeyOriginal = entry.APIKey
 			m.apiKeyMasked = true
 		}
+		if entry, ok := cfg.Providers[cfg.Provider]; ok && len(entry.ModelsThinking) > 0 {
+			m.modelThinkingModes = make(map[string]string, len(entry.ModelsThinking))
+			for model, mode := range entry.ModelsThinking {
+				m.modelThinkingModes[cfg.Provider+":"+strings.ToLower(model)] = mode
+			}
+		}
 	}
 
 	if cfg.Provider == "" && cfg.Llm.URL != "" {
@@ -341,6 +395,8 @@ func newProviderTUI(cfg *Config, configPath string) providerTUIModel {
 		} else {
 			m.manualProtocolIdx = 1 // openai
 		}
+		m.manualExtraBodyInput.SetValue(formatExtraBodyJSON(cfg.Llm.ExtraBody))
+		m.manualExtraHeadersInput.SetValue(formatExtraHeadersJSON(cfg.Llm.ExtraHeaders))
 	}
 
 	return m
@@ -406,6 +462,7 @@ func applyModelDeleteToEntry(entry ProviderEntry, name string) ProviderEntry {
 	if entry.Model == name {
 		entry.Model = ""
 	}
+	entry.ModelsThinking = llm.RemoveModelsThinkingKey(entry.ModelsThinking, name)
 	return entry
 }
 
@@ -648,6 +705,9 @@ func (m providerTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "tab":
+			if m.step == stepModel && m.tryToggleModelThinkingOnTab() {
+				return m, nil
+			}
 			if m.step == stepProvider {
 				m.activeTab = (m.activeTab + 1) % tabCount
 				m.formError = ""
@@ -944,6 +1004,9 @@ func (m providerTUIModel) updateCustomProviderForm(key string, msg tea.KeyPressM
 			m.cpNameInput.SetValue("")
 			m.cpURLInput.SetValue("")
 			m.cpAuthInput.SetValue("")
+			m.cpExtraBodyInput.SetValue("")
+			m.cpExtraHeadersInput.SetValue("")
+			m.cpExtraBody = nil
 			m.apiKeyInput.SetValue("")
 			m.apiKeyMasked = false
 			m.apiKeyOriginal = ""
@@ -1011,6 +1074,13 @@ func (m *providerTUIModel) enterEditCustomProvider() {
 		m.apiKeyMasked = false
 		m.apiKeyOriginal = ""
 	}
+	m.cpExtraBodyInput.SetValue(formatExtraBodyJSON(entry.ExtraBody))
+	m.cpExtraHeadersInput.SetValue(formatExtraHeadersJSON(entry.ExtraHeaders))
+	if entry.ExtraBody != nil {
+		m.cpExtraBody = deepCloneMap(entry.ExtraBody)
+	} else {
+		m.cpExtraBody = nil
+	}
 }
 
 func authHeaderFormError(raw string) string {
@@ -1066,9 +1136,41 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.cpAuthInput.Blur()
+		m.cpStep = cpStepExtraBody
+		return m, m.cpExtraBodyInput.Focus()
+	case cpStepExtraBody:
+		extraBody, err := parseExtraBodyInput(m.cpExtraBodyInput.Value())
+		if err != nil {
+			m.formError = ""
+			return m, nil
+		}
+		m.cpExtraBody = extraBody
+		m.cpExtraBodyInput.Blur()
+		m.formError = ""
+		m.cpStep = cpStepExtraHeaders
+		return m, m.cpExtraHeadersInput.Focus()
+	case cpStepExtraHeaders:
+		// Re-parse from input so saved Extra Body matches what the user sees if they
+		// edited the field after advancing from cpStepExtraBody (inline draft hints
+		// surface parse errors; formError stays empty to avoid duplicate messages).
+		extraBody, err := parseExtraBodyInput(m.cpExtraBodyInput.Value())
+		if err != nil {
+			m.formError = ""
+			m.cpExtraHeadersInput.Blur()
+			m.cpStep = cpStepExtraBody
+			return m, m.cpExtraBodyInput.Focus()
+		}
+		m.cpExtraBody = extraBody
+		extraHeaders, err := parseExtraHeadersInput(m.cpExtraHeadersInput.Value())
+		if err != nil {
+			m.formError = ""
+			return m, nil
+		}
+		m.cpExtraHeadersInput.Blur()
+		m.formError = ""
 		if m.editingCustom {
 			r := m.result()
-			if err := m.applyEditCustomProviderSave(); err != nil {
+			if err := m.applyEditCustomProviderSaveWithExtras(r, extraBody, extraHeaders, true); err != nil {
 				return m, nil
 			}
 			// Edit succeeded — drop the user into the model list for this provider.
@@ -1085,7 +1187,7 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.creatingCustom {
-			return m.applyCreateCustomProvider()
+			return m.applyCreateCustomProvider(extraBody, extraHeaders)
 		}
 		m.confirmed = true
 		return m, tea.Quit
@@ -1093,7 +1195,7 @@ func (m providerTUIModel) handleCustomFormEnter() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
+func (m providerTUIModel) applyCreateCustomProvider(extraBody map[string]any, extraHeaders map[string]string) (tea.Model, tea.Cmd) {
 	if m.existingCfg == nil {
 		m.formError = "failed to save: config not loaded"
 		return m, nil
@@ -1119,10 +1221,24 @@ func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
 	}
 
 	entry := ProviderEntry{
-		URL:        r.url,
-		Protocol:   r.protocol,
-		AuthHeader: r.authHeader,
-		APIKey:     strings.TrimSpace(m.apiKeyInput.Value()),
+		URL:          r.url,
+		Protocol:     r.protocol,
+		AuthHeader:   r.authHeader,
+		APIKey:       strings.TrimSpace(m.apiKeyInput.Value()),
+		ExtraBody:    extraBody,
+		ExtraHeaders: extraHeaders,
+	}
+	if entry.ExtraBody != nil {
+		if err := llm.ValidateExtraBody(entry.ExtraBody); err != nil {
+			m.formError = err.Error()
+			return m, nil
+		}
+	}
+	if len(entry.ExtraHeaders) > 0 {
+		if err := llm.ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
+			m.formError = err.Error()
+			return m, nil
+		}
 	}
 	m.existingCfg.CustomProviders[r.provider] = entry
 
@@ -1139,6 +1255,9 @@ func (m providerTUIModel) applyCreateCustomProvider() (tea.Model, tea.Cmd) {
 	m.cpNameInput.SetValue("")
 	m.cpURLInput.SetValue("")
 	m.cpAuthInput.SetValue("")
+	m.cpExtraBodyInput.SetValue("")
+	m.cpExtraHeadersInput.SetValue("")
+	m.cpExtraBody = nil
 	m.apiKeyInput.SetValue("")
 	m.apiKeyMasked = false
 	m.apiKeyOriginal = ""
@@ -1164,11 +1283,18 @@ func cloneProviderEntry(v ProviderEntry) ProviderEntry {
 		Models:     append([]string(nil), v.Models...),
 		AuthHeader: v.AuthHeader,
 	}
+	// ExtraBody needs deep clone because json.Unmarshal shares nested maps/slices.
 	if v.ExtraBody != nil {
-		out.ExtraBody = make(map[string]any, len(v.ExtraBody))
-		for k, val := range v.ExtraBody {
-			// Shallow copy only: nested maps/slices inside val are not cloned.
-			out.ExtraBody[k] = val
+		out.ExtraBody = deepCloneMap(v.ExtraBody)
+	}
+	// ExtraHeaders and ModelsThinking are flat scalar maps; shallow copy is sufficient.
+	if len(v.ExtraHeaders) > 0 {
+		out.ExtraHeaders = cloneExtraHeadersMap(v.ExtraHeaders)
+	}
+	if len(v.ModelsThinking) > 0 {
+		out.ModelsThinking = make(map[string]string, len(v.ModelsThinking))
+		for k, val := range v.ModelsThinking {
+			out.ModelsThinking[k] = val
 		}
 	}
 	return out
@@ -1193,7 +1319,12 @@ func cloneCustomProviderList(src []customProviderListItem) []customProviderListI
 	return out
 }
 
+// applyEditCustomProviderSave persists edits without touching ExtraBody/ExtraHeaders.
 func (m *providerTUIModel) applyEditCustomProviderSave() error {
+	return m.applyEditCustomProviderSaveWithExtras(m.result(), nil, nil, false)
+}
+
+func (m *providerTUIModel) applyEditCustomProviderSaveWithExtras(r providerTUIResult, extraBody map[string]any, extraHeaders map[string]string, updateExtras bool) error {
 	if m.existingCfg == nil {
 		m.formError = "failed to save: config not loaded"
 		return fmt.Errorf("config not loaded")
@@ -1202,7 +1333,6 @@ func (m *providerTUIModel) applyEditCustomProviderSave() error {
 		m.formError = "failed to save: config path not available"
 		return fmt.Errorf("config path not available")
 	}
-	r := m.result()
 	backupProviders := cloneCustomProvidersMap(m.existingCfg.CustomProviders)
 	backupActiveProvider := m.existingCfg.Provider
 	backupActiveModel := m.existingCfg.Model
@@ -1219,12 +1349,29 @@ func (m *providerTUIModel) applyEditCustomProviderSave() error {
 		entry.Models = append([]string(nil), r.models...)
 	}
 	entry.Models = ensureModelInList(entry.Models, r.model)
-	// Optional fields are always applied so users can intentionally clear them.
-	// To detect "user cleared the API key" vs "user left it masked/untouched",
-	// apiKey is only overwritten when the user actively typed something.
 	entry.URL = r.url
 	entry.Protocol = r.protocol
 	entry.AuthHeader = r.authHeader
+	if updateExtras {
+		if extraBody != nil {
+			entry.ExtraBody = deepCloneMap(extraBody)
+		} else {
+			entry.ExtraBody = nil
+		}
+		entry.ExtraHeaders = cloneExtraHeadersMap(extraHeaders)
+	}
+	if entry.ExtraBody != nil {
+		if err := llm.ValidateExtraBody(entry.ExtraBody); err != nil {
+			m.formError = err.Error()
+			return err
+		}
+	}
+	if len(entry.ExtraHeaders) > 0 {
+		if err := llm.ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
+			m.formError = err.Error()
+			return err
+		}
+	}
 	if key, edited := m.customAPIKeyForSave(); edited {
 		entry.APIKey = key
 	}
@@ -1282,6 +1429,10 @@ func (m *providerTUIModel) blurCPStep() {
 		m.apiKeyInput.Blur()
 	case cpStepAuthHeader:
 		m.cpAuthInput.Blur()
+	case cpStepExtraBody:
+		m.cpExtraBodyInput.Blur()
+	case cpStepExtraHeaders:
+		m.cpExtraHeadersInput.Blur()
 	}
 }
 
@@ -1295,6 +1446,10 @@ func (m *providerTUIModel) focusCPStep() tea.Cmd {
 		return m.apiKeyInput.Focus()
 	case cpStepAuthHeader:
 		return m.cpAuthInput.Focus()
+	case cpStepExtraBody:
+		return m.cpExtraBodyInput.Focus()
+	case cpStepExtraHeaders:
+		return m.cpExtraHeadersInput.Focus()
 	}
 	return nil
 }
@@ -1313,6 +1468,10 @@ func (m providerTUIModel) passThroughCPInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.apiKeyInput, cmd = m.apiKeyInput.Update(msg)
 	case cpStepAuthHeader:
 		m.cpAuthInput, cmd = m.cpAuthInput.Update(msg)
+	case cpStepExtraBody:
+		m.cpExtraBodyInput, cmd = m.cpExtraBodyInput.Update(msg)
+	case cpStepExtraHeaders:
+		m.cpExtraHeadersInput, cmd = m.cpExtraHeadersInput.Update(msg)
 	}
 	if _, ok := msg.(tea.KeyPressMsg); ok {
 		m.formError = ""
@@ -1333,6 +1492,14 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 				m.manualURLInput.SetValue(m.existingCfg.Llm.URL)
 				m.manualModelInput.SetValue(m.existingCfg.Llm.Model)
 				m.manualAuthHeaderInput.SetValue(m.existingCfg.Llm.AuthHeader)
+				m.manualExtraBodyInput.SetValue(formatExtraBodyJSON(m.existingCfg.Llm.ExtraBody))
+				m.manualExtraHeadersInput.SetValue(formatExtraHeadersJSON(m.existingCfg.Llm.ExtraHeaders))
+				if m.existingCfg.Llm.ExtraBody != nil {
+					m.manualExtraBody = deepCloneMap(m.existingCfg.Llm.ExtraBody)
+				} else {
+					m.manualExtraBody = nil
+				}
+				m.manualExtraHeaders = cloneExtraHeadersMap(m.existingCfg.Llm.ExtraHeaders)
 				if m.existingCfg.Llm.AuthToken != "" {
 					m.manualTokenOriginal = m.existingCfg.Llm.AuthToken
 					m.manualTokenMasked = true
@@ -1346,9 +1513,13 @@ func (m providerTUIModel) updateManualForm(key string, msg tea.KeyPressMsg) (tea
 				m.manualURLInput.SetValue("")
 				m.manualModelInput.SetValue("")
 				m.manualAuthHeaderInput.SetValue("")
+				m.manualExtraBodyInput.SetValue("")
+				m.manualExtraHeadersInput.SetValue("")
 				m.manualTokenInput.SetValue("")
 				m.manualTokenMasked = false
 				m.manualTokenOriginal = ""
+				m.manualExtraBody = nil
+				m.manualExtraHeaders = nil
 			}
 			m.formError = ""
 			return m, nil
@@ -1569,35 +1740,57 @@ func (m providerTUIModel) handleManualFormEnter() (tea.Model, tea.Cmd) {
 		if m.manualURLInput.Value() == "" {
 			return m, nil
 		}
-		m.manualURLInput.Blur()
+		m.blurManualStep()
 		m.manualStep = manualStepProtocol
-		return m, nil
+		return m, m.focusManualStep()
 	case manualStepProtocol:
 		m.manualStep = manualStepModel
-		return m, m.manualModelInput.Focus()
+		return m, m.focusManualStep()
 	case manualStepModel:
 		if m.manualModelInput.Value() == "" {
 			return m, nil
 		}
-		m.manualModelInput.Blur()
+		m.blurManualStep()
 		m.manualStep = manualStepAuthToken
-		return m, m.manualTokenInput.Focus()
+		return m, m.focusManualStep()
 	case manualStepAuthToken:
 		if strings.TrimSpace(m.manualTokenInput.Value()) == "" && m.manualTokenOriginal == "" {
 			m.formError = manualAuthTokenRequiredError
 			return m, nil
 		}
 		m.formError = ""
-		m.manualTokenInput.Blur()
+		m.blurManualStep()
 		m.manualStep = manualStepAuthHeader
-		return m, m.manualAuthHeaderInput.Focus()
+		return m, m.focusManualStep()
 	case manualStepAuthHeader:
 		raw := m.manualAuthHeaderInput.Value()
 		if _, err := llm.NormalizeAuthHeader(raw); err != nil {
 			m.formError = authHeaderFormError(raw)
 			return m, nil
 		}
-		m.manualAuthHeaderInput.Blur()
+		m.blurManualStep()
+		m.manualStep = manualStepExtraBody
+		return m, m.focusManualStep()
+	case manualStepExtraBody:
+		extraBody, err := parseExtraBodyInput(m.manualExtraBodyInput.Value())
+		if err != nil {
+			m.formError = ""
+			return m, nil
+		}
+		m.manualExtraBodyInput.Blur()
+		m.formError = ""
+		m.manualExtraBody = extraBody
+		m.manualStep = manualStepExtraHeaders
+		return m, m.focusManualStep()
+	case manualStepExtraHeaders:
+		extraHeaders, err := parseExtraHeadersInput(m.manualExtraHeadersInput.Value())
+		if err != nil {
+			m.formError = ""
+			return m, nil
+		}
+		m.manualExtraHeadersInput.Blur()
+		m.formError = ""
+		m.manualExtraHeaders = extraHeaders
 		m.confirmed = true
 		return m, tea.Quit
 	}
@@ -1616,10 +1809,14 @@ func (m *providerTUIModel) blurManualStep() {
 		m.manualTokenInput.Blur()
 	case manualStepAuthHeader:
 		m.manualAuthHeaderInput.Blur()
+	case manualStepExtraBody:
+		m.manualExtraBodyInput.Blur()
+	case manualStepExtraHeaders:
+		m.manualExtraHeadersInput.Blur()
 	}
 }
 
-func (m providerTUIModel) focusManualStep() tea.Cmd {
+func (m *providerTUIModel) focusManualStep() tea.Cmd {
 	switch m.manualStep {
 	case manualStepURL:
 		return m.manualURLInput.Focus()
@@ -1631,6 +1828,10 @@ func (m providerTUIModel) focusManualStep() tea.Cmd {
 		return m.manualTokenInput.Focus()
 	case manualStepAuthHeader:
 		return m.manualAuthHeaderInput.Focus()
+	case manualStepExtraBody:
+		return m.manualExtraBodyInput.Focus()
+	case manualStepExtraHeaders:
+		return m.manualExtraHeadersInput.Focus()
 	}
 	return nil
 }
@@ -1651,6 +1852,10 @@ func (m providerTUIModel) passThroughManualInput(msg tea.Msg) (tea.Model, tea.Cm
 		m.manualTokenInput, cmd = m.manualTokenInput.Update(msg)
 	case manualStepAuthHeader:
 		m.manualAuthHeaderInput, cmd = m.manualAuthHeaderInput.Update(msg)
+	case manualStepExtraBody:
+		m.manualExtraBodyInput, cmd = m.manualExtraBodyInput.Update(msg)
+	case manualStepExtraHeaders:
+		m.manualExtraHeadersInput, cmd = m.manualExtraHeadersInput.Update(msg)
 	}
 	if _, ok := msg.(tea.KeyPressMsg); ok {
 		m.formError = ""
@@ -1696,7 +1901,7 @@ func (m providerTUIModel) handleEnter() (tea.Model, tea.Cmd) {
 		case tabManual:
 			m.inManualForm = true
 			m.manualStep = manualStepURL
-			return m, m.manualURLInput.Focus()
+			return m, m.focusManualStep()
 		}
 
 	case stepModel:
@@ -1795,7 +2000,7 @@ func (m *providerTUIModel) loadExistingAPIKey() {
 
 func (m providerTUIModel) selectedModelFromState() string {
 	if m.modelInput.Value() != "" && (m.customModel || m.isCustomModelItem(m.modelIdx)) {
-		return m.modelInput.Value()
+		return strings.TrimSpace(m.modelInput.Value())
 	}
 	models := m.models()
 	if m.modelIdx < len(models) {
@@ -1821,10 +2026,11 @@ func (m providerTUIModel) result() providerTUIResult {
 		}
 
 		return providerTUIResult{
-			provider:         p.Name,
-			model:            model,
-			apiKey:           apiKey,
-			sessionModelPick: m.sessionModelPickSnapshot(),
+			provider:           p.Name,
+			model:              model,
+			apiKey:             apiKey,
+			modelThinkingModes: m.modelsThinkingSnapshotForSave(),
+			sessionModelPick:   m.sessionModelPickSnapshot(),
 		}
 
 	case tabCustom:
@@ -1879,6 +2085,8 @@ func (m providerTUIModel) result() providerTUIResult {
 				url:              cp.entry.URL,
 				protocol:         cp.entry.Protocol,
 				authHeader:       cp.entry.AuthHeader,
+				extraBody:        cp.entry.ExtraBody,
+				extraHeaders:     cp.entry.ExtraHeaders,
 				sessionModelPick: m.sessionModelPickSnapshot(),
 			}
 		}
@@ -1891,16 +2099,451 @@ func (m providerTUIModel) result() providerTUIResult {
 		}
 		authHeader, _ := llm.NormalizeAuthHeader(m.manualAuthHeaderInput.Value())
 		return providerTUIResult{
-			isManual:   true,
-			url:        m.manualURLInput.Value(),
-			model:      m.manualModelInput.Value(),
-			apiKey:     apiKey,
-			protocol:   cpProtocols[m.manualProtocolIdx],
-			authHeader: authHeader,
+			isManual:     true,
+			url:          strings.TrimSpace(m.manualURLInput.Value()),
+			model:        strings.TrimSpace(m.manualModelInput.Value()),
+			apiKey:       apiKey,
+			protocol:     cpProtocols[m.manualProtocolIdx],
+			authHeader:   authHeader,
+			extraBody:    m.manualExtraBody,
+			extraHeaders: m.manualExtraHeaders,
 		}
 	}
 
 	return providerTUIResult{}
+}
+
+func formatExtraBodyJSON(m map[string]any) string {
+	if len(m) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func deepCloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCloneAny(v)
+	}
+	return out
+}
+
+// deepCloneAny recursively clones JSON-shaped values from json.Unmarshal.
+// Scalars are immutable and returned as-is; other types would be shared.
+func deepCloneAny(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		return deepCloneMap(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = deepCloneAny(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func parseExtraBodyInput(raw string) (map[string]any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if len(raw) > maxExtraBodyBytes {
+		return nil, fmt.Errorf("extra body too large (max %d bytes)", maxExtraBodyBytes)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if err := llm.ValidateExtraBody(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func formatExtraHeadersJSON(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func cloneExtraHeadersMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func parseExtraHeadersInput(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if len(raw) > maxExtraHeadersBytes {
+		return nil, fmt.Errorf("extra headers too large (max %d bytes)", maxExtraHeadersBytes)
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if err := llm.ValidateExtraHeadersMap(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func extraHeadersErrorFromDraft(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	if _, err := parseExtraHeadersInput(raw); err != nil {
+		return tuiErrorStyle.Render("  " + err.Error())
+	}
+	return ""
+}
+
+func (m providerTUIModel) currentModelName() string {
+	return m.selectedModelFromState()
+}
+
+func (m providerTUIModel) modelForThinkingSnapshot() string {
+	if model := m.selectedModelFromState(); model != "" {
+		return model
+	}
+	return m.sessionModelPickFor(m.providerNameForModelStep())
+}
+
+type modelThinkingState struct {
+	providerName  string
+	modes         map[string]string
+	loadPersisted func(model string) (string, bool)
+	allowToggle   func() bool
+}
+
+func (s modelThinkingState) currentMode(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return llm.ModelsThinkingOn
+	}
+	key := s.providerName + ":" + strings.ToLower(model)
+	if s.modes != nil {
+		if mode, ok := s.modes[key]; ok {
+			if normalized, ok := validatedThinkingMode(mode); ok {
+				return normalized
+			}
+		}
+	}
+	if s.loadPersisted != nil {
+		if mode, ok := s.loadPersisted(model); ok {
+			if normalized, ok := validatedThinkingMode(mode); ok {
+				return normalized
+			}
+		}
+	}
+	return llm.ModelsThinkingOn
+}
+
+func validatedThinkingMode(mode string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	if err := llm.ValidateModelsThinkingMode(normalized); err != nil {
+		return "", false
+	}
+	return normalized, true
+}
+
+func (s modelThinkingState) canDisable(model string) bool {
+	if s.allowToggle != nil && !s.allowToggle() {
+		return false
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	return llm.CanDisableThinking(s.providerName, model)
+}
+
+func toggleModelThinkingMode(modes *map[string]string, providerName, model, currentMode string) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" || modes == nil {
+		return
+	}
+	key := providerName + ":" + model
+	if *modes == nil {
+		*modes = make(map[string]string)
+	}
+	if currentMode == llm.ModelsThinkingOff {
+		(*modes)[key] = llm.ModelsThinkingOn
+	} else {
+		(*modes)[key] = llm.ModelsThinkingOff
+	}
+}
+
+func tryToggleModelThinking(state modelThinkingState, model string, modes *map[string]string) bool {
+	if !state.canDisable(model) {
+		return false
+	}
+	toggleModelThinkingMode(modes, state.providerName, model, state.currentMode(model))
+	return true
+}
+
+func modelThinkingModesSnapshot(modes map[string]string, providerName string) map[string]string {
+	if len(modes) == 0 {
+		return nil
+	}
+	prefix := providerName + ":"
+	out := make(map[string]string)
+	for k, v := range modes {
+		if after, ok := strings.CutPrefix(k, prefix); ok {
+			out[after] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func modelsThinkingSnapshotForSave(modes map[string]string, state modelThinkingState, currentModel string) map[string]string {
+	out := modelThinkingModesSnapshot(modes, state.providerName)
+	currentModel = strings.TrimSpace(currentModel)
+	if currentModel == "" {
+		return normalizeModelsThinkingSnapshotKeys(out)
+	}
+	if state.allowToggle != nil && !state.allowToggle() {
+		return normalizeModelsThinkingSnapshotKeys(out)
+	}
+	if !llm.IsThinkingSupported(state.providerName, currentModel) {
+		return normalizeModelsThinkingSnapshotKeys(out)
+	}
+	mode := state.currentMode(currentModel)
+	key := strings.ToLower(currentModel)
+	out = normalizeModelsThinkingSnapshotKeys(out)
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out[key] = mode
+	return out
+}
+
+func normalizeModelsThinkingSnapshotKeys(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make(map[string]string, len(m))
+	for _, k := range keys {
+		lower := strings.ToLower(strings.TrimSpace(k))
+		if lower == "" {
+			continue
+		}
+		if _, exists := out[lower]; exists {
+			continue
+		}
+		out[lower] = m[k]
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (m providerTUIModel) modelThinkingState() modelThinkingState {
+	p := m.currentProvider()
+	var loadPersisted func(string) (string, bool)
+	if m.existingCfg != nil && m.activeTab == tabOfficial {
+		loadPersisted = func(model string) (string, bool) {
+			if entry, ok := m.existingCfg.Providers[p.Name]; ok {
+				return llm.LookupModelsThinkingMode(entry.ModelsThinking, model)
+			}
+			return "", false
+		}
+	}
+	return modelThinkingState{
+		providerName:  p.Name,
+		modes:         m.modelThinkingModes,
+		loadPersisted: loadPersisted,
+		allowToggle:   func() bool { return m.activeTab == tabOfficial },
+	}
+}
+
+func (m modelTUIModel) modelThinkingState() modelThinkingState {
+	var loadPersisted func(string) (string, bool)
+	if !m.isCustomProvider && m.existingCfg != nil {
+		loadPersisted = func(model string) (string, bool) {
+			if entry, ok := m.existingCfg.Providers[m.providerName]; ok {
+				return llm.LookupModelsThinkingMode(entry.ModelsThinking, model)
+			}
+			return "", false
+		}
+	}
+	return modelThinkingState{
+		providerName:  m.providerName,
+		modes:         m.modelThinkingModes,
+		loadPersisted: loadPersisted,
+		allowToggle:   func() bool { return !m.isCustomProvider },
+	}
+}
+
+func thinkingLabelFor(providerName, modelName, mode string) string {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return ""
+	}
+	if !llm.IsThinkingSupported(providerName, modelName) {
+		return ""
+	}
+	if llm.IsThinkingOnly(providerName, modelName) {
+		return tuiItemStyle.Render("[Thinking: thinking only]")
+	}
+	if llm.IsThinkingAlwaysOn(providerName, modelName) {
+		return tuiItemStyle.Render("[Thinking: always on]")
+	}
+	if mode == llm.ModelsThinkingOff {
+		return tuiDimStyle.Render("[Thinking: off]")
+	}
+	return tuiItemStyle.Render("[Thinking: on]")
+}
+
+func (m providerTUIModel) currentModelThinkingMode() string {
+	return m.modelThinkingState().currentMode(m.currentModelName())
+}
+
+func (m providerTUIModel) currentModelCanDisable() bool {
+	return m.modelThinkingState().canDisable(m.currentModelName())
+}
+
+func (m providerTUIModel) currentThinkingLabel() string {
+	p := m.currentProvider()
+	return thinkingLabelFor(p.Name, m.currentModelName(), m.currentModelThinkingMode())
+}
+
+func (m *providerTUIModel) tryToggleModelThinkingOnTab() bool {
+	return tryToggleModelThinking(m.modelThinkingState(), m.currentModelName(), &m.modelThinkingModes)
+}
+
+func (m *providerTUIModel) toggleModelThinking(model string) {
+	state := m.modelThinkingState()
+	toggleModelThinkingMode(&m.modelThinkingModes, state.providerName, model, state.currentMode(model))
+}
+
+func (m providerTUIModel) modelThinkingModesSnapshot() map[string]string {
+	return modelThinkingModesSnapshot(m.modelThinkingModes, m.currentProvider().Name)
+}
+
+func (m providerTUIModel) modelsThinkingSnapshotForSave() map[string]string {
+	return modelsThinkingSnapshotForSave(m.modelThinkingModes, m.modelThinkingState(), m.modelForThinkingSnapshot())
+}
+
+func (m modelTUIModel) currentModelThinkingMode() string {
+	return m.modelThinkingState().currentMode(m.currentModelName())
+}
+
+func (m modelTUIModel) currentModelCanDisable() bool {
+	return m.modelThinkingState().canDisable(m.currentModelName())
+}
+
+func (m *modelTUIModel) tryToggleModelThinkingOnTab() bool {
+	return tryToggleModelThinking(m.modelThinkingState(), m.currentModelName(), &m.modelThinkingModes)
+}
+
+func (m *modelTUIModel) toggleModelThinking(model string) {
+	state := m.modelThinkingState()
+	toggleModelThinkingMode(&m.modelThinkingModes, state.providerName, model, state.currentMode(model))
+}
+
+func (m modelTUIModel) modelThinkingModesSnapshot() map[string]string {
+	return modelThinkingModesSnapshot(m.modelThinkingModes, m.providerName)
+}
+
+func (m modelTUIModel) modelsThinkingSnapshotForSave() map[string]string {
+	return modelsThinkingSnapshotForSave(m.modelThinkingModes, m.modelThinkingState(), m.currentModelName())
+}
+
+func (m providerTUIModel) customProviderExtraBodyConfigured() bool {
+	return len(m.customProviderExtraBody()) > 0
+}
+
+func (m providerTUIModel) customProviderExtraBody() map[string]any {
+	if m.activeTab != tabCustom {
+		return nil
+	}
+	cp, ok := m.selectedCustomProvider()
+	if !ok {
+		return nil
+	}
+	entry := m.customProviderEntry(cp.name, cp.entry)
+	return entry.ExtraBody
+}
+
+func (m providerTUIModel) customProviderExtraBodyHint() string {
+	if m.activeTab != tabCustom {
+		return ""
+	}
+	return extraBodyHintLine(m.customProviderExtraBody())
+}
+
+func extraBodyHintLine(extraBody map[string]any) string {
+	if len(extraBody) == 0 {
+		return ""
+	}
+	return tuiDimStyle.Render("  Extra body: " + formatExtraBodyJSON(extraBody))
+}
+
+func extraBodyHintFromDraft(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	body, err := parseExtraBodyInput(raw)
+	if err != nil {
+		return tuiErrorStyle.Render("  " + err.Error())
+	}
+	if len(body) == 0 {
+		return ""
+	}
+	return extraBodyHintLine(body)
+}
+
+// extraBodyErrorFromDraft returns a validation error for invalid draft JSON only.
+// Valid JSON is omitted because the active form field already shows the input.
+func extraBodyErrorFromDraft(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	if _, err := parseExtraBodyInput(raw); err != nil {
+		return tuiErrorStyle.Render("  " + err.Error())
+	}
+	return ""
 }
 
 func listCursorPrefix(isCursor bool) string {
@@ -2085,6 +2728,8 @@ func (m providerTUIModel) viewCustomProviderForm(s *strings.Builder) {
 		{"Base URL", m.cpURLInput.Value(), m.cpStep == cpStepBaseURL},
 		{"API Key", strings.Repeat("*", len(m.apiKeyInput.Value())), m.cpStep == cpStepAPIKey},
 		{"Auth Header", m.cpAuthInput.Value(), m.cpStep == cpStepAuthHeader},
+		{"Extra Body", m.cpExtraBodyInput.Value(), m.cpStep == cpStepExtraBody},
+		{"Extra Headers", m.cpExtraHeadersInput.Value(), m.cpStep == cpStepExtraHeaders},
 	}
 
 	for _, f := range fields {
@@ -2112,6 +2757,16 @@ func (m providerTUIModel) viewCustomProviderForm(s *strings.Builder) {
 				}
 			case cpStepAuthHeader:
 				s.WriteString("    " + m.cpAuthInput.View() + "\n")
+			case cpStepExtraBody:
+				s.WriteString("    " + m.cpExtraBodyInput.View() + "\n")
+				if errHint := extraBodyErrorFromDraft(m.cpExtraBodyInput.Value()); errHint != "" {
+					s.WriteString(errHint + "\n")
+				}
+			case cpStepExtraHeaders:
+				s.WriteString("    " + m.cpExtraHeadersInput.View() + "\n")
+				if errHint := extraHeadersErrorFromDraft(m.cpExtraHeadersInput.Value()); errHint != "" {
+					s.WriteString(errHint + "\n")
+				}
 			}
 		} else {
 			display := f.value
@@ -2165,6 +2820,8 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 		{"Model", m.manualModelInput.Value(), m.manualStep == manualStepModel},
 		{"Auth Token", strings.Repeat("*", len(m.manualTokenInput.Value())), m.manualStep == manualStepAuthToken},
 		{"Auth Header", m.manualAuthHeaderInput.Value(), m.manualStep == manualStepAuthHeader},
+		{"Extra Body", m.manualExtraBodyInput.Value(), m.manualStep == manualStepExtraBody},
+		{"Extra Headers", m.manualExtraHeadersInput.Value(), m.manualStep == manualStepExtraHeaders},
 	}
 
 	for _, f := range fields {
@@ -2192,6 +2849,16 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 				}
 			case manualStepAuthHeader:
 				s.WriteString("    " + m.manualAuthHeaderInput.View() + "\n")
+			case manualStepExtraBody:
+				s.WriteString("    " + m.manualExtraBodyInput.View() + "\n")
+				if errHint := extraBodyErrorFromDraft(m.manualExtraBodyInput.Value()); errHint != "" {
+					s.WriteString(errHint + "\n")
+				}
+			case manualStepExtraHeaders:
+				s.WriteString("    " + m.manualExtraHeadersInput.View() + "\n")
+				if errHint := extraHeadersErrorFromDraft(m.manualExtraHeadersInput.Value()); errHint != "" {
+					s.WriteString(errHint + "\n")
+				}
 			}
 		} else {
 			display := f.value
@@ -2214,7 +2881,14 @@ func (m providerTUIModel) viewManualTab(s *strings.Builder) {
 }
 
 func (m providerTUIModel) viewModel(s *strings.Builder) {
-	s.WriteString(tuiTitleStyle.Render(fmt.Sprintf("  Select a model (%s)", m.modelProviderName())))
+	title := fmt.Sprintf("  Select a model (%s)", m.modelProviderName())
+	s.WriteString(tuiTitleStyle.Render(title))
+	if m.activeTab == tabOfficial {
+		if label := m.currentThinkingLabel(); label != "" {
+			s.WriteString("    ")
+			s.WriteString(label)
+		}
+	}
 	s.WriteString("\n\n")
 
 	models := m.models()
@@ -2256,12 +2930,24 @@ func (m providerTUIModel) viewModel(s *strings.Builder) {
 
 	s.WriteString("\n")
 
+	if hint := m.customProviderExtraBodyHint(); hint != "" && m.activeTab == tabCustom {
+		s.WriteString(hint)
+		s.WriteString("\n")
+		s.WriteString("\n")
+	}
+
 	if m.confirmingDeleteModel {
 		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))
 		s.WriteString("\n")
 		s.WriteString(tuiHelpStyle.Render("  y Confirm · n/Esc Cancel"))
 	} else if m.cursorOnDeletableModel() {
-		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  d Delete  Esc Back"))
+		if m.activeTab == tabOfficial && m.currentModelCanDisable() {
+			s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Tab Thinking  Enter Confirm  d Delete  Esc Back"))
+		} else {
+			s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  d Delete  Esc Back"))
+		}
+	} else if m.activeTab == tabOfficial && m.currentModelCanDisable() {
+		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Tab Thinking  Enter Confirm  Esc Back"))
 	} else {
 		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  Esc Back"))
 	}
@@ -2450,6 +3136,8 @@ type modelTUIModel struct {
 
 	// savedInSession is true after a model add/delete was persisted during the session.
 	savedInSession bool
+
+	modelThinkingModes map[string]string
 }
 
 // newModelTUI builds a model-only TUI for tests. It has no config path or existing
@@ -2506,6 +3194,15 @@ func newModelTUIConfig(cfg modelTUIConfig) modelTUIModel {
 		if !found {
 			m.modelIdx = len(models)
 			m.modelInput.SetValue(cfg.CurrentModel)
+		}
+	}
+
+	if !cfg.IsCustom && cfg.ExistingCfg != nil && cfg.ProviderName != "" {
+		if entry, ok := cfg.ExistingCfg.Providers[cfg.ProviderName]; ok && len(entry.ModelsThinking) > 0 {
+			m.modelThinkingModes = make(map[string]string, len(entry.ModelsThinking))
+			for model, mode := range entry.ModelsThinking {
+				m.modelThinkingModes[cfg.ProviderName+":"+strings.ToLower(model)] = mode
+			}
 		}
 	}
 
@@ -2735,6 +3432,11 @@ func (m modelTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.modelIdx = 0
 			}
 			return m, nil
+		case "tab":
+			if m.tryToggleModelThinkingOnTab() {
+				return m, nil
+			}
+			return m, nil
 		case "d":
 			if m.cursorOnUserAddedModel() {
 				models := m.displayModels()
@@ -2859,7 +3561,7 @@ func (m *modelTUIModel) resetCustomModelInput() {
 
 func (m modelTUIModel) selectedModel() string {
 	if m.customModel || m.isCustomItem(m.modelIdx) {
-		return m.modelInput.Value()
+		return strings.TrimSpace(m.modelInput.Value())
 	}
 	models := m.displayModels()
 	if m.modelIdx < len(models) {
@@ -2868,10 +3570,32 @@ func (m modelTUIModel) selectedModel() string {
 	return ""
 }
 
+func (m modelTUIModel) currentModelName() string {
+	return m.selectedModel()
+}
+
+func (m modelTUIModel) customProviderExtraBody() map[string]any {
+	if !m.isCustomProvider || m.existingCfg == nil {
+		return nil
+	}
+	if entry, ok := m.existingCfg.CustomProviders[m.providerName]; ok {
+		return entry.ExtraBody
+	}
+	return nil
+}
+
 func (m modelTUIModel) View() tea.View {
 	var s strings.Builder
 	s.WriteString("\n")
-	s.WriteString(tuiTitleStyle.Render(fmt.Sprintf("  Select a model (%s)", m.provider.DisplayName)))
+
+	title := fmt.Sprintf("  Select a model (%s)", m.provider.DisplayName)
+	s.WriteString(tuiTitleStyle.Render(title))
+	if !m.isCustomProvider {
+		if label := thinkingLabelFor(m.providerName, m.currentModelName(), m.currentModelThinkingMode()); label != "" {
+			s.WriteString("    ")
+			s.WriteString(label)
+		}
+	}
 	s.WriteString("\n\n")
 
 	models := m.displayModels()
@@ -2913,12 +3637,20 @@ func (m modelTUIModel) View() tea.View {
 
 	s.WriteString("\n")
 
+	if hint := extraBodyHintLine(m.customProviderExtraBody()); hint != "" && m.isCustomProvider {
+		s.WriteString(hint)
+		s.WriteString("\n")
+		s.WriteString("\n")
+	}
+
 	if m.confirmingDeleteModel {
 		s.WriteString("  " + tuiSelectedItemStyle.Render(fmt.Sprintf("Delete %q? (y/n)", m.deleteModelName)))
 		s.WriteString("\n")
 		s.WriteString(tuiHelpStyle.Render("  y Confirm · n/Esc Cancel"))
 	} else if m.cursorOnUserAddedModel() {
 		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  d Delete  Esc Cancel"))
+	} else if !m.isCustomProvider && m.currentModelCanDisable() {
+		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Tab Thinking  Enter Confirm  Esc Cancel"))
 	} else {
 		s.WriteString(tuiHelpStyle.Render("  ↑/↓ Select  Enter Confirm  Esc Cancel"))
 	}

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -485,7 +485,7 @@ func TestWindowSizeMsg(t *testing.T) {
 
 func TestBlurManualStep_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
-	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader, manualStepExtraBody, manualStepExtraHeaders} {
+	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader} {
 		m.manualStep = step
 		m.blurManualStep()
 	}
@@ -494,12 +494,10 @@ func TestBlurManualStep_AllSteps(t *testing.T) {
 func TestFocusManualStep_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	textSteps := map[manualStep]func(providerTUIModel) bool{
-		manualStepURL:          func(m providerTUIModel) bool { return m.manualURLInput.Focused() },
-		manualStepModel:        func(m providerTUIModel) bool { return m.manualModelInput.Focused() },
-		manualStepAuthToken:    func(m providerTUIModel) bool { return m.manualTokenInput.Focused() },
-		manualStepAuthHeader:   func(m providerTUIModel) bool { return m.manualAuthHeaderInput.Focused() },
-		manualStepExtraBody:    func(m providerTUIModel) bool { return m.manualExtraBodyInput.Focused() },
-		manualStepExtraHeaders: func(m providerTUIModel) bool { return m.manualExtraHeadersInput.Focused() },
+		manualStepURL:        func(m providerTUIModel) bool { return m.manualURLInput.Focused() },
+		manualStepModel:      func(m providerTUIModel) bool { return m.manualModelInput.Focused() },
+		manualStepAuthToken:  func(m providerTUIModel) bool { return m.manualTokenInput.Focused() },
+		manualStepAuthHeader: func(m providerTUIModel) bool { return m.manualAuthHeaderInput.Focused() },
 	}
 	for step, focused := range textSteps {
 		m.manualStep = step
@@ -1906,7 +1904,7 @@ func TestProviderTUIView_CustomForm_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	m.activeTab = tabCustom
 	m.creatingCustom = true
-	for _, step := range []customProviderStep{cpStepName, cpStepBaseURL, cpStepAPIKey, cpStepAuthHeader, cpStepProtocol, cpStepExtraBody, cpStepExtraHeaders} {
+	for _, step := range []customProviderStep{cpStepName, cpStepBaseURL, cpStepAPIKey, cpStepAuthHeader, cpStepProtocol} {
 		m.cpStep = step
 		v := m.View()
 		if v.Content == "" {
@@ -1932,7 +1930,7 @@ func TestProviderTUIView_ManualForm_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	m.activeTab = tabManual
 	m.inManualForm = true
-	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader, manualStepExtraBody, manualStepExtraHeaders} {
+	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader} {
 		m.manualStep = step
 		v := m.View()
 		if v.Content == "" {

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -242,6 +242,35 @@ func TestCloneProviderEntry_NilExtraBody(t *testing.T) {
 	}
 }
 
+func TestCloneProviderEntry_PreservesModelsThinking(t *testing.T) {
+	orig := ProviderEntry{
+		Model:          "claude-sonnet-4-6",
+		ModelsThinking: map[string]string{"claude-sonnet-4-6": "off"},
+	}
+	clone := cloneProviderEntry(orig)
+	if clone.ModelsThinking["claude-sonnet-4-6"] != "off" {
+		t.Fatalf("ModelsThinking not cloned: %#v", clone.ModelsThinking)
+	}
+	clone.ModelsThinking["claude-sonnet-4-6"] = "on"
+	if orig.ModelsThinking["claude-sonnet-4-6"] != "off" {
+		t.Fatal("modifying clone should not affect original ModelsThinking")
+	}
+}
+
+func TestApplyModelDeleteToEntry_RemovesModelsThinking(t *testing.T) {
+	entry := ProviderEntry{
+		Models:         []string{"model-a", "model-b"},
+		ModelsThinking: map[string]string{"model-a": "off", "model-b": "off"},
+	}
+	got := applyModelDeleteToEntry(entry, "model-a")
+	if len(got.Models) != 1 || got.Models[0] != "model-b" {
+		t.Fatalf("Models = %#v", got.Models)
+	}
+	if len(got.ModelsThinking) != 1 || got.ModelsThinking["model-b"] != "off" {
+		t.Fatalf("ModelsThinking = %#v", got.ModelsThinking)
+	}
+}
+
 func TestCustomListCount(t *testing.T) {
 	cfg := &Config{
 		CustomProviders: map[string]ProviderEntry{
@@ -456,7 +485,7 @@ func TestWindowSizeMsg(t *testing.T) {
 
 func TestBlurManualStep_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
-	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader} {
+	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader, manualStepExtraBody, manualStepExtraHeaders} {
 		m.manualStep = step
 		m.blurManualStep()
 	}
@@ -464,9 +493,24 @@ func TestBlurManualStep_AllSteps(t *testing.T) {
 
 func TestFocusManualStep_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
-	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader} {
+	textSteps := map[manualStep]func(providerTUIModel) bool{
+		manualStepURL:          func(m providerTUIModel) bool { return m.manualURLInput.Focused() },
+		manualStepModel:        func(m providerTUIModel) bool { return m.manualModelInput.Focused() },
+		manualStepAuthToken:    func(m providerTUIModel) bool { return m.manualTokenInput.Focused() },
+		manualStepAuthHeader:   func(m providerTUIModel) bool { return m.manualAuthHeaderInput.Focused() },
+		manualStepExtraBody:    func(m providerTUIModel) bool { return m.manualExtraBodyInput.Focused() },
+		manualStepExtraHeaders: func(m providerTUIModel) bool { return m.manualExtraHeadersInput.Focused() },
+	}
+	for step, focused := range textSteps {
 		m.manualStep = step
 		m.focusManualStep()
+		if !focused(m) {
+			t.Errorf("step %d should focus its input", step)
+		}
+	}
+	m.manualStep = manualStepProtocol
+	if cmd := m.focusManualStep(); cmd != nil {
+		t.Error("protocol step should not return a focus command")
 	}
 }
 
@@ -1862,7 +1906,7 @@ func TestProviderTUIView_CustomForm_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	m.activeTab = tabCustom
 	m.creatingCustom = true
-	for _, step := range []customProviderStep{cpStepName, cpStepBaseURL, cpStepAPIKey, cpStepAuthHeader, cpStepProtocol} {
+	for _, step := range []customProviderStep{cpStepName, cpStepBaseURL, cpStepAPIKey, cpStepAuthHeader, cpStepProtocol, cpStepExtraBody, cpStepExtraHeaders} {
 		m.cpStep = step
 		v := m.View()
 		if v.Content == "" {
@@ -1888,7 +1932,7 @@ func TestProviderTUIView_ManualForm_AllSteps(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	m.activeTab = tabManual
 	m.inManualForm = true
-	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader} {
+	for _, step := range []manualStep{manualStepURL, manualStepProtocol, manualStepModel, manualStepAuthToken, manualStepAuthHeader, manualStepExtraBody, manualStepExtraHeaders} {
 		m.manualStep = step
 		v := m.View()
 		if v.Content == "" {
@@ -1943,5 +1987,251 @@ func TestProviderTUIView_StepModel_CustomTabDeleteHelp(t *testing.T) {
 	got = stripANSI(m.View().Content)
 	if !strings.Contains(got, "d Delete") {
 		t.Errorf("custom model row should show d Delete hint; got:\n%s", got)
+	}
+}
+
+func TestModelThinkingState_CurrentMode_InMemoryNormalized(t *testing.T) {
+	state := modelThinkingState{
+		providerName: "anthropic",
+		modes: map[string]string{
+			"anthropic:claude-sonnet-4-6": " OFF ",
+		},
+	}
+	if got := state.currentMode("claude-sonnet-4-6"); got != llm.ModelsThinkingOff {
+		t.Fatalf("currentMode = %q", got)
+	}
+}
+
+func TestModelThinkingState_CurrentMode_InMemoryCaseInsensitive(t *testing.T) {
+	state := modelThinkingState{
+		providerName: "anthropic",
+		modes: map[string]string{
+			"anthropic:claude-sonnet-4-6": llm.ModelsThinkingOff,
+		},
+	}
+	if got := state.currentMode("Claude-Sonnet-4-6"); got != llm.ModelsThinkingOff {
+		t.Fatalf("currentMode = %q", got)
+	}
+}
+
+func TestModelThinkingState_CurrentMode_InvalidFallsBackToPersisted(t *testing.T) {
+	state := modelThinkingState{
+		providerName: "anthropic",
+		modes: map[string]string{
+			"anthropic:claude-sonnet-4-6": "maybe",
+		},
+		loadPersisted: func(model string) (string, bool) {
+			return llm.ModelsThinkingOff, true
+		},
+	}
+	if got := state.currentMode("claude-sonnet-4-6"); got != llm.ModelsThinkingOff {
+		t.Fatalf("currentMode = %q", got)
+	}
+}
+
+func TestModelThinkingState_CurrentMode_EmptyModelDefaultsOn(t *testing.T) {
+	state := modelThinkingState{providerName: "anthropic"}
+	if got := state.currentMode("  "); got != llm.ModelsThinkingOn {
+		t.Fatalf("currentMode = %q", got)
+	}
+}
+
+func TestModelThinkingState_CurrentMode_ProviderIsolation(t *testing.T) {
+	// Same model name, different providers, should have different thinking modes.
+	state := modelThinkingState{
+		providerName: "dashscope",
+		modes: map[string]string{
+			"dashscope:deepseek-v4-pro": llm.ModelsThinkingOff,
+			"deepseek:deepseek-v4-pro":  llm.ModelsThinkingOn,
+		},
+	}
+	if got := state.currentMode("deepseek-v4-pro"); got != llm.ModelsThinkingOff {
+		t.Fatalf("dashscope deepseek-v4-pro currentMode = %q, want off", got)
+	}
+	stateDeepseek := modelThinkingState{
+		providerName: "deepseek",
+		modes: map[string]string{
+			"dashscope:deepseek-v4-pro": llm.ModelsThinkingOff,
+			"deepseek:deepseek-v4-pro":  llm.ModelsThinkingOn,
+		},
+	}
+	if got := stateDeepseek.currentMode("deepseek-v4-pro"); got != llm.ModelsThinkingOn {
+		t.Fatalf("deepseek deepseek-v4-pro currentMode = %q, want on", got)
+	}
+}
+
+func TestToggleModelThinkingMode_NormalizesModelKey(t *testing.T) {
+	modes := map[string]string{}
+	toggleModelThinkingMode(&modes, "anthropic", " Claude-Sonnet-4-6 ", llm.ModelsThinkingOn)
+	if modes["anthropic:claude-sonnet-4-6"] != llm.ModelsThinkingOff {
+		t.Fatalf("modes = %#v", modes)
+	}
+}
+
+func TestToggleModelThinkingMode_NilModesPointerNoPanic(t *testing.T) {
+	var modes map[string]string
+	toggleModelThinkingMode(nil, "anthropic", "claude-sonnet-4-6", llm.ModelsThinkingOn)
+	if modes != nil {
+		t.Fatalf("expected nil modes, got %#v", modes)
+	}
+}
+
+func TestTryToggleModelThinking_TogglesWhenSupported(t *testing.T) {
+	modes := map[string]string{}
+	state := modelThinkingState{
+		providerName: "deepseek",
+		allowToggle:  func() bool { return true },
+	}
+	if !tryToggleModelThinking(state, "deepseek-v4-pro", &modes) {
+		t.Fatal("expected toggle to succeed")
+	}
+	if modes["deepseek:deepseek-v4-pro"] != llm.ModelsThinkingOff {
+		t.Fatalf("modes = %#v", modes)
+	}
+}
+
+func TestTryToggleModelThinking_RejectsUnsupportedModel(t *testing.T) {
+	modes := map[string]string{}
+	state := modelThinkingState{
+		providerName: "dashscope",
+		allowToggle:  func() bool { return true },
+	}
+	if tryToggleModelThinking(state, "kimi-k2.7-code", &modes) {
+		t.Fatal("expected toggle to fail for thinking-only model")
+	}
+}
+
+func TestModelsThinkingSnapshotForSave_IncludesCurrentModelOn(t *testing.T) {
+	state := modelThinkingState{
+		providerName: "baidu-qianfan",
+		allowToggle:  func() bool { return true },
+	}
+	got := modelsThinkingSnapshotForSave(nil, state, "glm-5")
+	if got["glm-5"] != llm.ModelsThinkingOn {
+		t.Fatalf("snapshot = %#v, want glm-5:on", got)
+	}
+
+	got = modelsThinkingSnapshotForSave(map[string]string{
+		"baidu-qianfan:glm-5": llm.ModelsThinkingOff,
+	}, modelThinkingState{
+		providerName: "baidu-qianfan",
+		modes: map[string]string{
+			"baidu-qianfan:glm-5": llm.ModelsThinkingOff,
+		},
+		allowToggle: func() bool { return true },
+	}, "glm-5")
+	if got["glm-5"] != llm.ModelsThinkingOff {
+		t.Fatalf("snapshot = %#v, want glm-5:off", got)
+	}
+}
+
+func TestModelsThinkingSnapshotForSave_CollapsesMixedCaseKeys(t *testing.T) {
+	state := modelThinkingState{
+		providerName: "dashscope",
+		modes: map[string]string{
+			"dashscope:qwen3.7-max": llm.ModelsThinkingOff,
+		},
+		allowToggle: func() bool { return true },
+	}
+	got := modelsThinkingSnapshotForSave(map[string]string{
+		"dashscope:Qwen3.7-Max": llm.ModelsThinkingOff,
+	}, state, "qwen3.7-max")
+	if len(got) != 1 {
+		t.Fatalf("snapshot = %#v, want single normalized key", got)
+	}
+	if got["qwen3.7-max"] != llm.ModelsThinkingOff {
+		t.Fatalf("snapshot = %#v, want qwen3.7-max:off", got)
+	}
+	if _, dup := got["Qwen3.7-Max"]; dup {
+		t.Fatalf("snapshot should not keep mixed-case duplicate: %#v", got)
+	}
+}
+
+func TestProviderTUI_ModelsThinkingSnapshotUsesSessionModelPick(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope-tokenplan",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"dashscope-tokenplan": {
+				Model: "deepseek-v4-flash",
+				ModelsThinking: map[string]string{
+					"glm-5":       "on",
+					"glm-5.1":     "off",
+					"qwen3.7-max": "on",
+				},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope-tokenplan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	m.sessionModelPick = map[string]string{"dashscope-tokenplan": "deepseek-v4-flash"}
+	m.modelIdx = 9999 // stale cursor; result() still resolves model via sessionModelPick
+
+	r := m.result()
+	if r.model != "deepseek-v4-flash" {
+		t.Fatalf("result.model = %q, want deepseek-v4-flash", r.model)
+	}
+	if r.modelThinkingModes["deepseek-v4-flash"] != llm.ModelsThinkingOn {
+		t.Fatalf("modelThinkingModes = %#v, want deepseek-v4-flash:on", r.modelThinkingModes)
+	}
+}
+
+func TestProviderTUI_ModelsThinkingSnapshotUsesCustomModelRow(t *testing.T) {
+	cfg := &Config{
+		Provider: "dashscope-tokenplan",
+		Model:    "deepseek-v4-flash",
+		Providers: map[string]ProviderEntry{
+			"dashscope-tokenplan": {
+				Model: "deepseek-v4-flash",
+				ModelsThinking: map[string]string{
+					"glm-5": "on",
+				},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabOfficial
+	for i, p := range m.providers {
+		if p.Name == "dashscope-tokenplan" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.step = stepAPIKey
+	models := m.models()
+	m.modelIdx = len(models)
+	m.modelInput.SetValue("deepseek-v4-flash")
+
+	r := m.result()
+	if r.modelThinkingModes["deepseek-v4-flash"] != llm.ModelsThinkingOn {
+		t.Fatalf("modelThinkingModes = %#v, want deepseek-v4-flash:on", r.modelThinkingModes)
+	}
+}
+
+func TestModelThinkingModesSnapshot(t *testing.T) {
+	if got := modelThinkingModesSnapshot(nil, "anthropic"); got != nil {
+		t.Fatalf("snapshot = %#v", got)
+	}
+	src := map[string]string{
+		"anthropic:model-a": llm.ModelsThinkingOff,
+		"deepseek:model-b":  llm.ModelsThinkingOff,
+	}
+	got := modelThinkingModesSnapshot(src, "anthropic")
+	if got["model-a"] != llm.ModelsThinkingOff {
+		t.Fatalf("expected model-a in snapshot, got %#v", got)
+	}
+	if _, ok := got["model-b"]; ok {
+		t.Fatal("model-b should not be in anthropic snapshot")
+	}
+	got["model-a"] = llm.ModelsThinkingOn
+	if src["anthropic:model-a"] != llm.ModelsThinkingOff {
+		t.Fatal("snapshot should be a copy")
 	}
 }

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -92,10 +92,6 @@ func assertManualInputFocused(t *testing.T, m providerTUIModel, step manualStep,
 		got = m.manualTokenInput.Focused()
 	case manualStepAuthHeader:
 		got = m.manualAuthHeaderInput.Focused()
-	case manualStepExtraBody:
-		got = m.manualExtraBodyInput.Focused()
-	case manualStepExtraHeaders:
-		got = m.manualExtraHeadersInput.Focused()
 	default:
 		return
 	}
@@ -390,14 +386,6 @@ func TestProviderTUI_ManualFormEscBackThroughAllTextSteps(t *testing.T) {
 			step: manualStepAuthHeader, name: "Auth Header", edit: "-h",
 			valueFn: func(m providerTUIModel) string { return m.manualAuthHeaderInput.Value() },
 		},
-		{
-			step: manualStepExtraBody, name: "Extra Body", edit: " ",
-			valueFn: func(m providerTUIModel) string { return m.manualExtraBodyInput.Value() },
-		},
-		{
-			step: manualStepExtraHeaders, name: "Extra Headers", edit: "x",
-			valueFn: func(m providerTUIModel) string { return m.manualExtraHeadersInput.Value() },
-		},
 	}
 
 	for _, spec := range specs {
@@ -415,9 +403,9 @@ func TestProviderTUI_ManualFormEscBackThroughAllTextSteps(t *testing.T) {
 			for m.manualStep != spec.step {
 				m = advanceManualForm(m, 1)
 			}
-			if spec.step == manualStepExtraHeaders {
+			if spec.step == manualStepAuthHeader {
 				m = escManualForm(m)
-				assertManualInputFocused(t, m, manualStepExtraBody, true, "Extra Body")
+				assertManualInputFocused(t, m, manualStepAuthToken, true, "Auth Token")
 				m = advanceManualForm(m, 1)
 			} else {
 				m = advanceManualForm(m, 1)
@@ -435,25 +423,12 @@ func TestProviderTUI_ManualFormEscBackThroughAllTextSteps(t *testing.T) {
 	}
 }
 
-func TestProviderTUI_ManualFormEscFromURLClearsExtraMaps(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabManual
-	m = enterManualForm(m)
-	m.manualExtraBody = map[string]any{"stale": true}
-	m.manualExtraHeaders = map[string]string{"X-Stale": "yes"}
-
-	m2 := escManualForm(m)
-	if m2.inManualForm {
-		t.Fatal("expected to exit manual form")
-	}
-	if m2.manualExtraBody != nil || m2.manualExtraHeaders != nil {
-		t.Fatalf("stale extra maps should be cleared: body=%#v headers=%#v", m2.manualExtraBody, m2.manualExtraHeaders)
-	}
-}
-
-func TestProviderTUI_ManualFormEscFromURLResetsExtraMapsFromConfig(t *testing.T) {
+func TestProviderTUI_ManualFormEscFromURLResetsFieldsFromConfig(t *testing.T) {
 	cfg := &Config{
 		Llm: LlmConfig{
+			URL:          "https://example.com/v1",
+			Model:        "test-model",
+			AuthToken:    "token",
 			ExtraBody:    map[string]any{"enable_thinking": false},
 			ExtraHeaders: map[string]string{"X-Org": "org"},
 		},
@@ -461,15 +436,11 @@ func TestProviderTUI_ManualFormEscFromURLResetsExtraMapsFromConfig(t *testing.T)
 	m := newProviderTUI(cfg, "")
 	m.activeTab = tabManual
 	m = enterManualForm(m)
-	m.manualExtraBody = map[string]any{"stale": true}
-	m.manualExtraHeaders = map[string]string{"X-Stale": "yes"}
+	m.manualURLInput.SetValue("https://stale.example.com")
 
 	m2 := escManualForm(m)
-	if m2.manualExtraBody["enable_thinking"] != false {
-		t.Fatalf("manualExtraBody = %#v, want config value", m2.manualExtraBody)
-	}
-	if m2.manualExtraHeaders["X-Org"] != "org" {
-		t.Fatalf("manualExtraHeaders = %#v, want config value", m2.manualExtraHeaders)
+	if m2.manualURLInput.Value() != cfg.Llm.URL {
+		t.Fatalf("manualURLInput = %q, want config URL", m2.manualURLInput.Value())
 	}
 }
 
@@ -1092,27 +1063,23 @@ func TestProviderTUI_EditCustomClearKey_NoMaskedOnStepAPIKey(t *testing.T) {
 
 	result, _ := m.Update(enterKey())
 	m2 := result.(providerTUIModel)
-	result, _ = m2.Update(enterKey()) // extra body (skip)
-	m3 := result.(providerTUIModel)
-	result, _ = m3.Update(enterKey()) // extra headers (skip)
-	m4 := result.(providerTUIModel)
-	if m4.step != stepModel {
-		t.Fatalf("step = %d, want stepModel", m4.step)
+	if m2.step != stepModel {
+		t.Fatalf("step = %d, want stepModel", m2.step)
 	}
-	if got := m4.customProviders[m4.customIdx].entry.APIKey; got != "" {
+	if got := m2.customProviders[m2.customIdx].entry.APIKey; got != "" {
 		t.Errorf("saved APIKey = %q, want empty", got)
 	}
 
-	m4.modelIdx = modelIdxForName(t, m4, "test")
-	result, _ = m4.Update(enterKey())
-	m5 := result.(providerTUIModel)
-	if m5.step != stepAPIKey {
-		t.Fatalf("step = %d, want stepAPIKey", m5.step)
+	m2.modelIdx = modelIdxForName(t, m2, "test")
+	result, _ = m2.Update(enterKey())
+	m3 := result.(providerTUIModel)
+	if m3.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m3.step)
 	}
-	if m5.apiKeyMasked {
+	if m3.apiKeyMasked {
 		t.Error("apiKeyMasked should be false after clearing key in edit")
 	}
-	got := stripANSI(m5.View().Content)
+	got := stripANSI(m3.View().Content)
 	if strings.Contains(got, "Type or paste to replace the saved key") {
 		t.Errorf("view should not show replace hint; got:\n%s", got)
 	}
@@ -1198,34 +1165,27 @@ func TestProviderTUI_CustomFormCreateReturnsToModelList(t *testing.T) {
 	m6.apiKeyInput.SetValue("key-123")
 	result, _ = m6.Update(enterKey()) // API key -> auth header
 	m7 := result.(providerTUIModel)
-	result, _ = m7.Update(enterKey()) // auth header -> extra body
+	result, _ = m7.Update(enterKey()) // auth header -> save
 	m8 := result.(providerTUIModel)
-	result, _ = m8.Update(enterKey()) // extra body -> extra headers
-	m9 := result.(providerTUIModel)
-	result, cmd := m9.Update(enterKey()) // extra headers -> save
-	m10 := result.(providerTUIModel)
 
-	if cmd != nil {
-		t.Error("create should not quit TUI")
-	}
-	if m10.creatingCustom {
+	if m8.creatingCustom {
 		t.Error("creatingCustom should be false after create")
 	}
 	// Create should drop the user into the model selection step for the new
 	// provider so they can pick/add a model right away.
-	if m10.step != stepModel {
-		t.Errorf("step = %d, want stepModel", m10.step)
+	if m8.step != stepModel {
+		t.Errorf("step = %d, want stepModel", m8.step)
 	}
-	if len(m10.customProviders) != 1 {
-		t.Fatalf("expected 1 custom provider, got %d", len(m10.customProviders))
+	if len(m8.customProviders) != 1 {
+		t.Fatalf("expected 1 custom provider, got %d", len(m8.customProviders))
 	}
-	if m10.customProviders[0].name != "my-new" {
-		t.Errorf("provider name = %q, want %q", m10.customProviders[0].name, "my-new")
+	if m8.customProviders[0].name != "my-new" {
+		t.Errorf("provider name = %q, want %q", m8.customProviders[0].name, "my-new")
 	}
 	if cfg.Provider != "" {
 		t.Error("active provider should not be set when only creating")
 	}
-	if !m10.savedInSession {
+	if !m8.savedInSession {
 		t.Error("savedInSession should be true after create")
 	}
 	if _, err := os.Stat(configPath); err != nil {
@@ -2925,189 +2885,31 @@ func TestApplyManualConfigNormalizesAuthHeader(t *testing.T) {
 	}
 }
 
-func TestProviderTUI_CustomFormExtraHeadersReparsesExtraBodyFromInput(t *testing.T) {
+func TestApplyManualConfig_PreservesExistingExtraFields(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 	cfg := &Config{
-		CustomProviders: map[string]ProviderEntry{
-			"aaa": {
-				URL:       "https://example.com/v1",
-				Protocol:  "openai",
-				Model:     "test",
-				Models:    []string{"test"},
-				ExtraBody: map[string]any{"stale": true},
-			},
+		Llm: LlmConfig{
+			ExtraBody:    map[string]any{"enable_thinking": false},
+			ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
 		},
 	}
-	m := newProviderTUI(cfg, configPath)
-	m.activeTab = tabCustom
-	m.editingCustom = true
-	m.editTargetName = "aaa"
-	m.cpProtocolIdx = 1
-	m.cpNameInput.SetValue("aaa")
-	m.cpURLInput.SetValue("https://example.com/v1")
-	m.cpStep = cpStepExtraHeaders
-	m.cpExtraBody = map[string]any{"stale": true}
-	m.cpExtraBodyInput.SetValue(`{"enable_thinking":false}`)
-	m.cpExtraHeadersInput.SetValue(`{}`)
-	m.cpExtraHeadersInput.Focus()
 
-	result, _ := m.Update(enterKey())
-	m2 := result.(providerTUIModel)
-	if m2.formError != "" {
-		t.Fatalf("unexpected formError: %q", m2.formError)
-	}
-	got := cfg.CustomProviders["aaa"].ExtraBody
-	if got["enable_thinking"] != false {
-		t.Fatalf("ExtraBody should come from input field, not stale cache: %#v", got)
-	}
-	if _, ok := got["stale"]; ok {
-		t.Fatal("stale cached extra body should not be persisted")
-	}
-}
-
-func TestProviderTUI_ManualFormExtraHeadersReparsesExtraBodyFromInput(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabManual
-	m = enterManualForm(m)
-	m.manualStep = manualStepExtraHeaders
-	m.manualExtraBody = map[string]any{"stale": true}
-	m.manualExtraBodyInput.SetValue(`{"enable_thinking":false}`)
-	m.manualExtraHeadersInput.SetValue(`{}`)
-	m.manualExtraHeadersInput.Focus()
-
-	result, _ := m.Update(enterKey())
-	m2 := result.(providerTUIModel)
-	if m2.formError != "" {
-		t.Fatalf("unexpected formError: %q", m2.formError)
-	}
-	if !m2.confirmed {
-		t.Fatal("expected manual form confirmed")
-	}
-	got := m2.result().extraBody
-	if got["enable_thinking"] != false {
-		t.Fatalf("ExtraBody should come from input field, not stale cache: %#v", got)
-	}
-	if _, ok := got["stale"]; ok {
-		t.Fatal("stale cached extra body should not be persisted")
-	}
-}
-
-func TestProviderTUI_ManualFormExtraHeadersFallsBackToExtraBodyOnParseError(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabManual
-	m = enterManualForm(m)
-	m.manualStep = manualStepExtraHeaders
-	m.manualExtraBody = nil
-	m.manualExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
-	m.manualExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
-	m.manualExtraHeadersInput.Focus()
-
-	result, _ := m.Update(enterKey())
-	m2 := result.(providerTUIModel)
-	if m2.manualStep != manualStepExtraBody {
-		t.Fatalf("manualStep = %d, want extra body after invalid extra body input", m2.manualStep)
-	}
-	if m2.formError != "" {
-		t.Fatalf("formError = %q, want empty (inline draft error only)", m2.formError)
-	}
-	if hint := extraBodyErrorFromDraft(m2.manualExtraBodyInput.Value()); hint == "" {
-		t.Fatal("expected inline extra body error hint")
-	}
-}
-
-func TestProviderTUI_CustomFormExtraHeadersFallsBackToExtraBodyOnParseError(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabCustom
-	m.creatingCustom = true
-	m.cpStep = cpStepExtraHeaders
-	m.cpExtraBody = nil
-	m.cpExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
-	m.cpExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
-	m.cpExtraHeadersInput.Focus()
-
-	result, _ := m.Update(enterKey())
-	m2 := result.(providerTUIModel)
-	if m2.cpStep != cpStepExtraBody {
-		t.Fatalf("cpStep = %d, want extra body after invalid extra body input", m2.cpStep)
-	}
-	if m2.formError != "" {
-		t.Fatalf("formError = %q, want empty (inline draft error only)", m2.formError)
-	}
-	if hint := extraBodyErrorFromDraft(m2.cpExtraBodyInput.Value()); hint == "" {
-		t.Fatal("expected inline extra body error hint")
-	}
-}
-
-func TestApplyManualConfigExtraHeaders(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	cfg := &Config{}
-
-	withHeaders := providerTUIResult{
-		isManual:     true,
-		url:          "https://example.com/v1",
-		model:        "test-model",
-		apiKey:       "token",
-		protocol:     "openai",
-		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
-	}
-	if err := applyManualConfig(configPath, cfg, withHeaders); err != nil {
-		t.Fatalf("applyManualConfig: %v", err)
-	}
-	if cfg.Llm.ExtraHeaders["X-Org-ID"] != "org-123" {
-		t.Fatalf("ExtraHeaders = %#v", cfg.Llm.ExtraHeaders)
-	}
-}
-
-func TestApplyManualConfigRejectsReservedExtraHeaders(t *testing.T) {
-	cfg := &Config{}
 	result := providerTUIResult{
-		isManual:     true,
-		url:          "https://example.com/v1",
-		model:        "test-model",
-		apiKey:       "token",
-		protocol:     "openai",
-		extraHeaders: map[string]string{"Authorization": "bad"},
-	}
-	if err := applyManualConfig("", cfg, result); err == nil {
-		t.Fatal("expected error for reserved extra header")
-	}
-}
-
-func TestApplyManualConfigExtraBody(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	cfg := &Config{}
-
-	withBody := providerTUIResult{
-		isManual:  true,
-		url:       "https://example.com/v1",
-		model:     "test-model",
-		apiKey:    "token",
-		protocol:  "openai",
-		extraBody: map[string]any{"enable_thinking": false},
-	}
-	if err := applyManualConfig(configPath, cfg, withBody); err != nil {
-		t.Fatalf("applyManualConfig: %v", err)
-	}
-	if cfg.Llm.ExtraBody["enable_thinking"] != false {
-		t.Fatalf("ExtraBody = %#v", cfg.Llm.ExtraBody)
-	}
-
-	cfg = &Config{}
-	cleared := providerTUIResult{
 		isManual: true,
 		url:      "https://example.com/v1",
 		model:    "test-model",
 		apiKey:   "token",
 		protocol: "openai",
 	}
-	if err := applyManualConfig(configPath, cfg, cleared); err != nil {
-		t.Fatalf("applyManualConfig cleared: %v", err)
+	if err := applyManualConfig(configPath, cfg, result); err != nil {
+		t.Fatalf("applyManualConfig: %v", err)
 	}
-	if cfg.Llm.ExtraBody != nil {
-		t.Fatalf("ExtraBody should be nil when unset, got %#v", cfg.Llm.ExtraBody)
+	if cfg.Llm.ExtraBody["enable_thinking"] != false {
+		t.Fatalf("ExtraBody = %#v, want preserved", cfg.Llm.ExtraBody)
+	}
+	if cfg.Llm.ExtraHeaders["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v, want preserved", cfg.Llm.ExtraHeaders)
 	}
 }
 
@@ -3137,80 +2939,42 @@ func TestApplyCustomProviderConfigNormalizesAuthHeader(t *testing.T) {
 	}
 }
 
-func TestApplyCustomProviderConfigAppliesExtraBodyAndHeaders(t *testing.T) {
+func TestApplyCustomProviderConfigPreservesExistingExtraFields(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 	cfg := &Config{
 		CustomProviders: map[string]ProviderEntry{
 			"test-provider": {
-				URL:      "https://example.com/v1",
-				Protocol: "openai",
-				Model:    "m",
-				Models:   []string{"m"},
-			},
-		},
-	}
-
-	result := providerTUIResult{
-		provider:     "test-provider",
-		model:        "m",
-		models:       []string{"m"},
-		isCustom:     true,
-		url:          "https://example.com/v1",
-		protocol:     "openai",
-		extraBody:    map[string]any{"enable_thinking": false},
-		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
-	}
-	if err := applyCustomProviderConfig(configPath, cfg, result); err != nil {
-		t.Fatalf("applyCustomProviderConfig: %v", err)
-	}
-	entry := cfg.CustomProviders["test-provider"]
-	if entry.ExtraBody["enable_thinking"] != false {
-		t.Fatalf("ExtraBody = %#v", entry.ExtraBody)
-	}
-	if entry.ExtraHeaders["X-Org-ID"] != "org-123" {
-		t.Fatalf("ExtraHeaders = %#v", entry.ExtraHeaders)
-	}
-}
-
-func TestApplyCustomProviderConfigPreservesSessionSavedExtras(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-
-	// Simulate applyCreateCustomProvider saving extras while initial cfg was empty.
-	sessionCfg := &Config{
-		CustomProviders: map[string]ProviderEntry{
-			"new-provider": {
 				URL:          "https://example.com/v1",
 				Protocol:     "openai",
+				Model:        "m",
+				Models:       []string{"m"},
 				ExtraBody:    map[string]any{"enable_thinking": false},
 				ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
 			},
 		},
 	}
-	if err := saveConfig(configPath, sessionCfg); err != nil {
-		t.Fatalf("saveConfig: %v", err)
-	}
 
 	result := providerTUIResult{
-		provider:     "new-provider",
-		model:        "test-model",
-		models:       []string{"test-model"},
-		isCustom:     true,
-		url:          "https://example.com/v1",
-		protocol:     "openai",
-		extraBody:    map[string]any{"enable_thinking": false},
-		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
+		provider: "test-provider",
+		model:    "m2",
+		models:   []string{"m", "m2"},
+		isCustom: true,
+		url:      "https://example.com/v1",
+		protocol: "openai",
 	}
-	if err := applyCustomProviderConfig(configPath, sessionCfg, result); err != nil {
+	if err := applyCustomProviderConfig(configPath, cfg, result); err != nil {
 		t.Fatalf("applyCustomProviderConfig: %v", err)
 	}
-	entry := sessionCfg.CustomProviders["new-provider"]
+	entry := cfg.CustomProviders["test-provider"]
+	if entry.Model != "m2" {
+		t.Fatalf("Model = %q, want m2", entry.Model)
+	}
 	if entry.ExtraBody["enable_thinking"] != false {
-		t.Fatalf("ExtraBody = %#v, want session-saved value preserved", entry.ExtraBody)
+		t.Fatalf("ExtraBody = %#v, want preserved", entry.ExtraBody)
 	}
 	if entry.ExtraHeaders["X-Org-ID"] != "org-123" {
-		t.Fatalf("ExtraHeaders = %#v, want session-saved value preserved", entry.ExtraHeaders)
+		t.Fatalf("ExtraHeaders = %#v, want preserved", entry.ExtraHeaders)
 	}
 }
 
@@ -3239,33 +3003,6 @@ func TestProviderTUI_TabTogglesThinkingOnOfficialModelStep(t *testing.T) {
 	}
 }
 
-func TestProviderTUI_CustomModelViewShowsExtraBodyHint(t *testing.T) {
-	cfg := &Config{
-		CustomProviders: map[string]ProviderEntry{
-			"my-proxy": {
-				URL:       "https://example.com/v1",
-				Protocol:  "openai",
-				Model:     "qwen3.7-max",
-				ExtraBody: map[string]any{"enable_thinking": false},
-			},
-		},
-	}
-	m := newProviderTUI(cfg, "")
-	m.activeTab = tabCustom
-	m.customIdx = 0
-	m.step = stepModel
-
-	got := stripANSI(m.View().Content)
-	if !strings.Contains(got, `Extra body: {"enable_thinking":false}`) {
-		t.Errorf("view should show extra body JSON, got:\n%s", got)
-	}
-	helpIdx := strings.Index(got, "↑/↓ Select")
-	hintIdx := strings.Index(got, "Extra body:")
-	if helpIdx < 0 || hintIdx < 0 || hintIdx >= helpIdx {
-		t.Errorf("extra body hint should appear above help line, got:\n%s", got)
-	}
-}
-
 func TestModelTUI_TabTogglesThinking(t *testing.T) {
 	m := officialConfigModelTUI(t, "", nil)
 	result, _ := m.Update(tabKeyMsg())
@@ -3279,44 +3016,6 @@ func TestModelTUI_TabTogglesThinking(t *testing.T) {
 	}
 	if !strings.Contains(got, "Tab Thinking") {
 		t.Errorf("help should mention Tab Thinking, got:\n%s", got)
-	}
-}
-
-func TestModelTUI_CustomShowsExtraBodyHint(t *testing.T) {
-	m := customConfigModelTUI(t, "", []string{"qwen3.7-max"})
-	if entry, ok := m.existingCfg.CustomProviders[m.providerName]; ok {
-		entry.ExtraBody = map[string]any{"enable_thinking": false}
-		m.existingCfg.CustomProviders[m.providerName] = entry
-	}
-	got := stripANSI(m.View().Content)
-	if !strings.Contains(got, `Extra body: {"enable_thinking":false}`) {
-		t.Errorf("view should show extra body JSON, got:\n%s", got)
-	}
-}
-
-func TestParseExtraBodyInput(t *testing.T) {
-	body, err := parseExtraBodyInput(`{"enable_thinking": false}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if body["enable_thinking"] != false {
-		t.Fatalf("body = %#v", body)
-	}
-	if _, err := parseExtraBodyInput("{bad"); err == nil {
-		t.Fatal("expected error for invalid JSON")
-	}
-	if body, err := parseExtraBodyInput(""); err != nil || body != nil {
-		t.Fatalf("empty input = %#v, %v", body, err)
-	}
-	if body, err := parseExtraBodyInput("{}"); err != nil || body != nil {
-		t.Fatalf("empty object should normalize to nil: %#v, %v", body, err)
-	}
-	large := strings.Repeat("a", maxExtraBodyBytes+1)
-	if _, err := parseExtraBodyInput(`{"x":"` + large + `"}`); err == nil {
-		t.Fatal("expected error for oversized extra body")
-	}
-	if _, err := parseExtraBodyInput(`{"model":"gpt-4"}`); err == nil {
-		t.Fatal("expected error for reserved extra_body key")
 	}
 }
 
@@ -3340,88 +3039,6 @@ func TestValidateExtraBody(t *testing.T) {
 	}
 }
 
-func TestExtraBodyHintFromDraft(t *testing.T) {
-	if hint := extraBodyHintFromDraft(`{"enable_thinking":false}`); !strings.Contains(hint, "enable_thinking") {
-		t.Fatalf("hint = %q", hint)
-	}
-	if hint := extraBodyHintFromDraft("{bad"); hint == "" {
-		t.Fatal("invalid JSON should show an error hint")
-	}
-	if hint := extraBodyHintFromDraft(""); hint != "" {
-		t.Fatalf("empty input should not produce hint, got %q", hint)
-	}
-}
-
-func TestExtraBodyErrorFromDraft(t *testing.T) {
-	if hint := extraBodyErrorFromDraft(`{"enable_thinking":false}`); hint != "" {
-		t.Fatalf("valid JSON should not produce error hint, got %q", hint)
-	}
-	if hint := extraBodyErrorFromDraft("{bad"); hint == "" {
-		t.Fatal("invalid JSON should show an error hint")
-	}
-	if hint := extraBodyErrorFromDraft(""); hint != "" {
-		t.Fatalf("empty input should not produce hint, got %q", hint)
-	}
-}
-
-func TestProviderTUIView_CustomForm_ExtraBodyNoDuplicateHint(t *testing.T) {
-	cfg := &Config{
-		CustomProviders: map[string]ProviderEntry{
-			"stepfun-openai": {
-				URL:       "https://api.stepfun.com/v1",
-				Protocol:  "openai",
-				ExtraBody: map[string]any{"enable_thinking": true},
-			},
-		},
-	}
-	m := newProviderTUI(cfg, "")
-	m.activeTab = tabCustom
-	m.editingCustom = true
-	m.editTargetName = "stepfun-openai"
-	m.cpStep = cpStepExtraBody
-	m.cpExtraBodyInput.SetValue(`{"enable_thinking":true}`)
-
-	got := stripANSI(m.View().Content)
-	if strings.Count(got, "Extra body:") != 0 {
-		t.Errorf("active extra body step should not show duplicate hint line, got:\n%s", got)
-	}
-	if !strings.Contains(got, "Extra Body:") {
-		t.Errorf("expected active Extra Body field label, got:\n%s", got)
-	}
-	if !strings.Contains(got, `{"enable_thinking":true}`) {
-		t.Errorf("expected extra body JSON in input, got:\n%s", got)
-	}
-}
-
-func TestProviderTUIView_CustomForm_ExtraBodyShowsParseError(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabCustom
-	m.creatingCustom = true
-	m.cpStep = cpStepExtraBody
-	m.cpExtraBodyInput.SetValue("{bad")
-
-	got := stripANSI(m.View().Content)
-	if strings.Count(got, "invalid JSON") != 1 {
-		t.Errorf("expected exactly one parse error while typing, got:\n%s", got)
-	}
-}
-
-func TestProviderTUIView_CustomForm_ExtraBodyConfirmParseErrorOnce(t *testing.T) {
-	m := newProviderTUI(&Config{}, "")
-	m.activeTab = tabCustom
-	m.creatingCustom = true
-	m.cpStep = cpStepExtraBody
-	m.cpExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
-
-	result, _ := m.Update(enterKey())
-	m2 := result.(providerTUIModel)
-
-	got := stripANSI(m2.View().Content)
-	if strings.Count(got, "invalid JSON") != 1 {
-		t.Errorf("expected exactly one parse error after confirm, got:\n%s", got)
-	}
-}
-
 func TestCloneProviderEntry_DeepClonesExtraBody(t *testing.T) {
 	orig := ProviderEntry{
 		ExtraBody: map[string]any{
@@ -3434,91 +3051,6 @@ func TestCloneProviderEntry_DeepClonesExtraBody(t *testing.T) {
 	origThinking := orig.ExtraBody["thinking"].(map[string]any)
 	if origThinking["budget_tokens"] != 100 {
 		t.Fatal("nested ExtraBody values should be deep-cloned")
-	}
-}
-
-func TestFormatParseExtraBodyRoundTrip(t *testing.T) {
-	orig := map[string]any{"enable_thinking": false, "temperature": 0.2}
-	formatted := formatExtraBodyJSON(orig)
-	parsed, err := parseExtraBodyInput(formatted)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if parsed["enable_thinking"] != false || parsed["temperature"] != 0.2 {
-		t.Fatalf("round trip = %#v", parsed)
-	}
-	body, err := parseExtraBodyInput("  " + formatted + "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if body["enable_thinking"] != false {
-		t.Fatalf("whitespace trim failed: %#v", body)
-	}
-}
-
-func TestFormatExtraBodyJSON_Deterministic(t *testing.T) {
-	m := map[string]any{"b": 2, "a": 1}
-	got1 := formatExtraBodyJSON(m)
-	got2 := formatExtraBodyJSON(m)
-	if got1 != got2 || got1 != `{"a":1,"b":2}` {
-		t.Fatalf("deterministic JSON = %q", got1)
-	}
-}
-
-func TestParseExtraHeadersInput(t *testing.T) {
-	body, err := parseExtraHeadersInput(`{"X-Org-ID":"org-123","X-Forwarded-For":"1.2.3.4,5.6.7.8"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if body["X-Org-ID"] != "org-123" {
-		t.Fatalf("body = %#v", body)
-	}
-	if _, err := parseExtraHeadersInput("{bad"); err == nil {
-		t.Fatal("expected error for invalid JSON")
-	}
-	if body, err := parseExtraHeadersInput(""); err != nil || body != nil {
-		t.Fatalf("empty input = %#v, %v", body, err)
-	}
-	if _, err := parseExtraHeadersInput(`{"Authorization":"bad"}`); err == nil {
-		t.Fatal("expected error for reserved header")
-	}
-}
-
-func TestProviderTUI_CustomFormCreatePersistsExtraHeaders(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.json")
-	cfg := &Config{}
-	m := newProviderTUI(cfg, configPath)
-
-	result, _ := m.Update(rightKey())
-	m2 := result.(providerTUIModel)
-	result, _ = m2.Update(enterKey())
-	m3 := result.(providerTUIModel)
-	m3.cpNameInput.SetValue("hdr-provider")
-	result, _ = m3.Update(enterKey())
-	m4 := result.(providerTUIModel)
-	result, _ = m4.Update(enterKey())
-	m5 := result.(providerTUIModel)
-	m5.cpURLInput.SetValue("https://api.example.com")
-	result, _ = m5.Update(enterKey())
-	m6 := result.(providerTUIModel)
-	m6.apiKeyInput.SetValue("key-123")
-	result, _ = m6.Update(enterKey())
-	m7 := result.(providerTUIModel)
-	result, _ = m7.Update(enterKey())
-	m8 := result.(providerTUIModel)
-	m8.cpExtraBodyInput.SetValue(`{"enable_thinking":false}`)
-	result, _ = m8.Update(enterKey())
-	m9 := result.(providerTUIModel)
-	m9.cpExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
-	result, _ = m9.Update(enterKey())
-	m10 := result.(providerTUIModel)
-	if m10.step != stepModel {
-		t.Fatalf("step = %d, want stepModel", m10.step)
-	}
-	got := cfg.CustomProviders["hdr-provider"].ExtraHeaders
-	if got["X-Org-ID"] != "org-123" {
-		t.Fatalf("ExtraHeaders = %#v", got)
 	}
 }
 

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -40,6 +40,70 @@ func charKey(c rune) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: c, Text: string(c)}
 }
 
+func manualFormPrefilledTUI() providerTUIModel {
+	cfg := &Config{
+		Llm: LlmConfig{
+			URL:       "https://api.stepfun.com/v1",
+			Model:     "step-3.5-flash",
+			AuthToken: "token-123",
+		},
+	}
+	return newProviderTUI(cfg, "")
+}
+
+func enterManualForm(m providerTUIModel) providerTUIModel {
+	result, _ := m.Update(enterKey())
+	return result.(providerTUIModel)
+}
+
+func advanceManualForm(m providerTUIModel, steps int) providerTUIModel {
+	for range steps {
+		result, _ := m.Update(enterKey())
+		m = result.(providerTUIModel)
+	}
+	return m
+}
+
+func escManualForm(m providerTUIModel) providerTUIModel {
+	result, _ := m.Update(escKey())
+	return result.(providerTUIModel)
+}
+
+func typeChars(m providerTUIModel, chars string) providerTUIModel {
+	for _, c := range chars {
+		result, _ := m.Update(charKey(c))
+		m = result.(providerTUIModel)
+	}
+	return m
+}
+
+func assertManualInputFocused(t *testing.T, m providerTUIModel, step manualStep, focused bool, stepName string) {
+	t.Helper()
+	if m.manualStep != step {
+		t.Fatalf("manualStep = %d, want %s", m.manualStep, stepName)
+	}
+	var got bool
+	switch step {
+	case manualStepURL:
+		got = m.manualURLInput.Focused()
+	case manualStepModel:
+		got = m.manualModelInput.Focused()
+	case manualStepAuthToken:
+		got = m.manualTokenInput.Focused()
+	case manualStepAuthHeader:
+		got = m.manualAuthHeaderInput.Focused()
+	case manualStepExtraBody:
+		got = m.manualExtraBodyInput.Focused()
+	case manualStepExtraHeaders:
+		got = m.manualExtraHeadersInput.Focused()
+	default:
+		return
+	}
+	if got != focused {
+		t.Fatalf("%s input focused = %v, want %v", stepName, got, focused)
+	}
+}
+
 // --- Tab switching tests ---
 
 func TestProviderTUI_TabSwitchRight(t *testing.T) {
@@ -237,6 +301,192 @@ func TestProviderTUI_ManualTabEnterStartsForm(t *testing.T) {
 	}
 	if m4.manualStep != manualStepURL {
 		t.Errorf("manualStep = %d, want %d", m4.manualStep, manualStepURL)
+	}
+}
+
+func TestProviderTUI_ManualFormEscBackToURLAllowsEditing(t *testing.T) {
+	m := manualFormPrefilledTUI()
+
+	m2 := enterManualForm(m)
+	assertManualInputFocused(t, m2, manualStepURL, true, "URL")
+
+	m3 := advanceManualForm(m2, 1)
+	assertManualInputFocused(t, m3, manualStepProtocol, false, "URL")
+
+	m4 := escManualForm(m3)
+	assertManualInputFocused(t, m4, manualStepURL, true, "URL")
+
+	m6 := typeChars(m4, "-x")
+	want := "https://api.stepfun.com/v1-x"
+	if got := m6.manualURLInput.Value(); got != want {
+		t.Errorf("URL after editing = %q, want %q", got, want)
+	}
+}
+
+func TestProviderTUI_ManualFormForwardToModelAllowsEditing(t *testing.T) {
+	m := enterManualForm(manualFormPrefilledTUI())
+	m2 := advanceManualForm(m, 2) // URL -> Protocol -> Model
+	assertManualInputFocused(t, m2, manualStepModel, true, "Model")
+
+	m3 := typeChars(m2, "-x")
+	want := "step-3.5-flash-x"
+	if got := m3.manualModelInput.Value(); got != want {
+		t.Errorf("Model after editing = %q, want %q", got, want)
+	}
+}
+
+func TestProviderTUI_ManualFormEscBackToModelAllowsEditing(t *testing.T) {
+	m := enterManualForm(manualFormPrefilledTUI())
+	m2 := advanceManualForm(m, 3) // through Auth Token
+	assertManualInputFocused(t, m2, manualStepAuthToken, true, "Auth Token")
+
+	m3 := escManualForm(m2)
+	assertManualInputFocused(t, m3, manualStepModel, true, "Model")
+
+	m4 := typeChars(m3, "-x")
+	want := "step-3.5-flash-x"
+	if got := m4.manualModelInput.Value(); got != want {
+		t.Errorf("Model after esc back = %q, want %q", got, want)
+	}
+}
+
+func TestProviderTUI_ManualFormProtocolRoundTripRefocusesModel(t *testing.T) {
+	m := enterManualForm(manualFormPrefilledTUI())
+	m2 := advanceManualForm(m, 2) // Model step
+	assertManualInputFocused(t, m2, manualStepModel, true, "Model")
+
+	m3 := escManualForm(m2) // back to Protocol
+	if m3.manualStep != manualStepProtocol {
+		t.Fatalf("manualStep = %d, want protocol", m3.manualStep)
+	}
+
+	m4 := advanceManualForm(m3, 1) // forward to Model again
+	assertManualInputFocused(t, m4, manualStepModel, true, "Model")
+
+	m5 := typeChars(m4, "-r")
+	if got := m5.manualModelInput.Value(); got != "step-3.5-flash-r" {
+		t.Errorf("Model after protocol round trip = %q", got)
+	}
+}
+
+func TestProviderTUI_ManualFormEscBackThroughAllTextSteps(t *testing.T) {
+	type stepSpec struct {
+		step    manualStep
+		name    string
+		edit    string
+		valueFn func(providerTUIModel) string
+	}
+
+	specs := []stepSpec{
+		{
+			step: manualStepURL, name: "URL", edit: "-u",
+			valueFn: func(m providerTUIModel) string { return m.manualURLInput.Value() },
+		},
+		{
+			step: manualStepModel, name: "Model", edit: "-m",
+			valueFn: func(m providerTUIModel) string { return m.manualModelInput.Value() },
+		},
+		{
+			step: manualStepAuthHeader, name: "Auth Header", edit: "-h",
+			valueFn: func(m providerTUIModel) string { return m.manualAuthHeaderInput.Value() },
+		},
+		{
+			step: manualStepExtraBody, name: "Extra Body", edit: " ",
+			valueFn: func(m providerTUIModel) string { return m.manualExtraBodyInput.Value() },
+		},
+		{
+			step: manualStepExtraHeaders, name: "Extra Headers", edit: "x",
+			valueFn: func(m providerTUIModel) string { return m.manualExtraHeadersInput.Value() },
+		},
+	}
+
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			cfg := &Config{
+				Llm: LlmConfig{
+					URL:          "https://api.stepfun.com/v1",
+					Model:        "step-3.5-flash",
+					AuthToken:    "token-123",
+					ExtraBody:    map[string]any{"enable_thinking": false},
+					ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
+				},
+			}
+			m := enterManualForm(newProviderTUI(cfg, ""))
+			for m.manualStep != spec.step {
+				m = advanceManualForm(m, 1)
+			}
+			if spec.step == manualStepExtraHeaders {
+				m = escManualForm(m)
+				assertManualInputFocused(t, m, manualStepExtraBody, true, "Extra Body")
+				m = advanceManualForm(m, 1)
+			} else {
+				m = advanceManualForm(m, 1)
+				m = escManualForm(m)
+			}
+			assertManualInputFocused(t, m, spec.step, true, spec.name)
+
+			before := spec.valueFn(m)
+			m = typeChars(m, spec.edit)
+			after := spec.valueFn(m)
+			if after == before {
+				t.Fatalf("%s input did not change after esc back; before=%q after=%q", spec.name, before, after)
+			}
+		})
+	}
+}
+
+func TestProviderTUI_ManualFormEscFromURLClearsExtraMaps(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabManual
+	m = enterManualForm(m)
+	m.manualExtraBody = map[string]any{"stale": true}
+	m.manualExtraHeaders = map[string]string{"X-Stale": "yes"}
+
+	m2 := escManualForm(m)
+	if m2.inManualForm {
+		t.Fatal("expected to exit manual form")
+	}
+	if m2.manualExtraBody != nil || m2.manualExtraHeaders != nil {
+		t.Fatalf("stale extra maps should be cleared: body=%#v headers=%#v", m2.manualExtraBody, m2.manualExtraHeaders)
+	}
+}
+
+func TestProviderTUI_ManualFormEscFromURLResetsExtraMapsFromConfig(t *testing.T) {
+	cfg := &Config{
+		Llm: LlmConfig{
+			ExtraBody:    map[string]any{"enable_thinking": false},
+			ExtraHeaders: map[string]string{"X-Org": "org"},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabManual
+	m = enterManualForm(m)
+	m.manualExtraBody = map[string]any{"stale": true}
+	m.manualExtraHeaders = map[string]string{"X-Stale": "yes"}
+
+	m2 := escManualForm(m)
+	if m2.manualExtraBody["enable_thinking"] != false {
+		t.Fatalf("manualExtraBody = %#v, want config value", m2.manualExtraBody)
+	}
+	if m2.manualExtraHeaders["X-Org"] != "org" {
+		t.Fatalf("manualExtraHeaders = %#v, want config value", m2.manualExtraHeaders)
+	}
+}
+
+func TestProviderTUI_ManualFormEscBackToAuthTokenAllowsEditing(t *testing.T) {
+	m := enterManualForm(manualFormPrefilledTUI())
+	m2 := advanceManualForm(m, 4) // through Auth Header
+	assertManualInputFocused(t, m2, manualStepAuthHeader, true, "Auth Header")
+
+	m3 := escManualForm(m2)
+	assertManualInputFocused(t, m3, manualStepAuthToken, true, "Auth Token")
+
+	m4 := typeChars(m3, "z")
+	if m4.manualTokenMasked {
+		t.Fatal("masked token should clear on edit after esc back")
+	}
+	if got := m4.manualTokenInput.Value(); got != "z" {
+		t.Errorf("Auth token after esc back = %q, want %q", got, "z")
 	}
 }
 
@@ -842,23 +1092,27 @@ func TestProviderTUI_EditCustomClearKey_NoMaskedOnStepAPIKey(t *testing.T) {
 
 	result, _ := m.Update(enterKey())
 	m2 := result.(providerTUIModel)
-	if m2.step != stepModel {
-		t.Fatalf("step = %d, want stepModel", m2.step)
+	result, _ = m2.Update(enterKey()) // extra body (skip)
+	m3 := result.(providerTUIModel)
+	result, _ = m3.Update(enterKey()) // extra headers (skip)
+	m4 := result.(providerTUIModel)
+	if m4.step != stepModel {
+		t.Fatalf("step = %d, want stepModel", m4.step)
 	}
-	if got := m2.customProviders[m2.customIdx].entry.APIKey; got != "" {
+	if got := m4.customProviders[m4.customIdx].entry.APIKey; got != "" {
 		t.Errorf("saved APIKey = %q, want empty", got)
 	}
 
-	m2.modelIdx = modelIdxForName(t, m2, "test")
-	result, _ = m2.Update(enterKey())
-	m3 := result.(providerTUIModel)
-	if m3.step != stepAPIKey {
-		t.Fatalf("step = %d, want stepAPIKey", m3.step)
+	m4.modelIdx = modelIdxForName(t, m4, "test")
+	result, _ = m4.Update(enterKey())
+	m5 := result.(providerTUIModel)
+	if m5.step != stepAPIKey {
+		t.Fatalf("step = %d, want stepAPIKey", m5.step)
 	}
-	if m3.apiKeyMasked {
+	if m5.apiKeyMasked {
 		t.Error("apiKeyMasked should be false after clearing key in edit")
 	}
-	got := stripANSI(m3.View().Content)
+	got := stripANSI(m5.View().Content)
 	if strings.Contains(got, "Type or paste to replace the saved key") {
 		t.Errorf("view should not show replace hint; got:\n%s", got)
 	}
@@ -944,30 +1198,34 @@ func TestProviderTUI_CustomFormCreateReturnsToModelList(t *testing.T) {
 	m6.apiKeyInput.SetValue("key-123")
 	result, _ = m6.Update(enterKey()) // API key -> auth header
 	m7 := result.(providerTUIModel)
-	result, cmd := m7.Update(enterKey()) // auth header -> save
+	result, _ = m7.Update(enterKey()) // auth header -> extra body
 	m8 := result.(providerTUIModel)
+	result, _ = m8.Update(enterKey()) // extra body -> extra headers
+	m9 := result.(providerTUIModel)
+	result, cmd := m9.Update(enterKey()) // extra headers -> save
+	m10 := result.(providerTUIModel)
 
 	if cmd != nil {
 		t.Error("create should not quit TUI")
 	}
-	if m8.creatingCustom {
+	if m10.creatingCustom {
 		t.Error("creatingCustom should be false after create")
 	}
 	// Create should drop the user into the model selection step for the new
 	// provider so they can pick/add a model right away.
-	if m8.step != stepModel {
-		t.Errorf("step = %d, want stepModel", m8.step)
+	if m10.step != stepModel {
+		t.Errorf("step = %d, want stepModel", m10.step)
 	}
-	if len(m8.customProviders) != 1 {
-		t.Fatalf("expected 1 custom provider, got %d", len(m8.customProviders))
+	if len(m10.customProviders) != 1 {
+		t.Fatalf("expected 1 custom provider, got %d", len(m10.customProviders))
 	}
-	if m8.customProviders[0].name != "my-new" {
-		t.Errorf("provider name = %q, want %q", m8.customProviders[0].name, "my-new")
+	if m10.customProviders[0].name != "my-new" {
+		t.Errorf("provider name = %q, want %q", m10.customProviders[0].name, "my-new")
 	}
 	if cfg.Provider != "" {
 		t.Error("active provider should not be set when only creating")
 	}
-	if !m8.savedInSession {
+	if !m10.savedInSession {
 		t.Error("savedInSession should be true after create")
 	}
 	if _, err := os.Stat(configPath); err != nil {
@@ -2667,6 +2925,142 @@ func TestApplyManualConfigNormalizesAuthHeader(t *testing.T) {
 	}
 }
 
+func TestProviderTUI_CustomFormExtraHeadersReparsesExtraBodyFromInput(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:       "https://example.com/v1",
+				Protocol:  "openai",
+				Model:     "test",
+				Models:    []string{"test"},
+				ExtraBody: map[string]any{"stale": true},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.editingCustom = true
+	m.editTargetName = "aaa"
+	m.cpProtocolIdx = 1
+	m.cpNameInput.SetValue("aaa")
+	m.cpURLInput.SetValue("https://example.com/v1")
+	m.cpStep = cpStepExtraHeaders
+	m.cpExtraBody = map[string]any{"stale": true}
+	m.cpExtraBodyInput.SetValue(`{"enable_thinking":false}`)
+	m.cpExtraHeadersInput.SetValue(`{}`)
+	m.cpExtraHeadersInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.formError != "" {
+		t.Fatalf("unexpected formError: %q", m2.formError)
+	}
+	got := cfg.CustomProviders["aaa"].ExtraBody
+	if got["enable_thinking"] != false {
+		t.Fatalf("ExtraBody should come from input field, not stale cache: %#v", got)
+	}
+	if _, ok := got["stale"]; ok {
+		t.Fatal("stale cached extra body should not be persisted")
+	}
+}
+
+func TestProviderTUI_CustomFormExtraHeadersFallsBackToExtraBodyOnParseError(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabCustom
+	m.creatingCustom = true
+	m.cpStep = cpStepExtraHeaders
+	m.cpExtraBody = nil
+	m.cpExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
+	m.cpExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
+	m.cpExtraHeadersInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.cpStep != cpStepExtraBody {
+		t.Fatalf("cpStep = %d, want extra body after invalid extra body input", m2.cpStep)
+	}
+	if m2.formError != "" {
+		t.Fatalf("formError = %q, want empty (inline draft error only)", m2.formError)
+	}
+	if hint := extraBodyErrorFromDraft(m2.cpExtraBodyInput.Value()); hint == "" {
+		t.Fatal("expected inline extra body error hint")
+	}
+}
+
+func TestApplyManualConfigExtraHeaders(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{}
+
+	withHeaders := providerTUIResult{
+		isManual:     true,
+		url:          "https://example.com/v1",
+		model:        "test-model",
+		apiKey:       "token",
+		protocol:     "openai",
+		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
+	}
+	if err := applyManualConfig(configPath, cfg, withHeaders); err != nil {
+		t.Fatalf("applyManualConfig: %v", err)
+	}
+	if cfg.Llm.ExtraHeaders["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v", cfg.Llm.ExtraHeaders)
+	}
+}
+
+func TestApplyManualConfigRejectsReservedExtraHeaders(t *testing.T) {
+	cfg := &Config{}
+	result := providerTUIResult{
+		isManual:     true,
+		url:          "https://example.com/v1",
+		model:        "test-model",
+		apiKey:       "token",
+		protocol:     "openai",
+		extraHeaders: map[string]string{"Authorization": "bad"},
+	}
+	if err := applyManualConfig("", cfg, result); err == nil {
+		t.Fatal("expected error for reserved extra header")
+	}
+}
+
+func TestApplyManualConfigExtraBody(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{}
+
+	withBody := providerTUIResult{
+		isManual:  true,
+		url:       "https://example.com/v1",
+		model:     "test-model",
+		apiKey:    "token",
+		protocol:  "openai",
+		extraBody: map[string]any{"enable_thinking": false},
+	}
+	if err := applyManualConfig(configPath, cfg, withBody); err != nil {
+		t.Fatalf("applyManualConfig: %v", err)
+	}
+	if cfg.Llm.ExtraBody["enable_thinking"] != false {
+		t.Fatalf("ExtraBody = %#v", cfg.Llm.ExtraBody)
+	}
+
+	cfg = &Config{}
+	cleared := providerTUIResult{
+		isManual: true,
+		url:      "https://example.com/v1",
+		model:    "test-model",
+		apiKey:   "token",
+		protocol: "openai",
+	}
+	if err := applyManualConfig(configPath, cfg, cleared); err != nil {
+		t.Fatalf("applyManualConfig cleared: %v", err)
+	}
+	if cfg.Llm.ExtraBody != nil {
+		t.Fatalf("ExtraBody should be nil when unset, got %#v", cfg.Llm.ExtraBody)
+	}
+}
+
 func TestApplyCustomProviderConfigNormalizesAuthHeader(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
@@ -2690,5 +3084,478 @@ func TestApplyCustomProviderConfigNormalizesAuthHeader(t *testing.T) {
 	}
 	if got := cfg.CustomProviders["test-provider"].AuthHeader; got != "authorization" {
 		t.Errorf("AuthHeader = %q, want %q", got, "authorization")
+	}
+}
+
+func TestApplyCustomProviderConfigAppliesExtraBodyAndHeaders(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"test-provider": {
+				URL:      "https://example.com/v1",
+				Protocol: "openai",
+				Model:    "m",
+				Models:   []string{"m"},
+			},
+		},
+	}
+
+	result := providerTUIResult{
+		provider:     "test-provider",
+		model:        "m",
+		models:       []string{"m"},
+		isCustom:     true,
+		url:          "https://example.com/v1",
+		protocol:     "openai",
+		extraBody:    map[string]any{"enable_thinking": false},
+		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
+	}
+	if err := applyCustomProviderConfig(configPath, cfg, result); err != nil {
+		t.Fatalf("applyCustomProviderConfig: %v", err)
+	}
+	entry := cfg.CustomProviders["test-provider"]
+	if entry.ExtraBody["enable_thinking"] != false {
+		t.Fatalf("ExtraBody = %#v", entry.ExtraBody)
+	}
+	if entry.ExtraHeaders["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v", entry.ExtraHeaders)
+	}
+}
+
+func TestApplyCustomProviderConfigPreservesSessionSavedExtras(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+
+	// Simulate applyCreateCustomProvider saving extras while initial cfg was empty.
+	sessionCfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"new-provider": {
+				URL:          "https://example.com/v1",
+				Protocol:     "openai",
+				ExtraBody:    map[string]any{"enable_thinking": false},
+				ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
+			},
+		},
+	}
+	if err := saveConfig(configPath, sessionCfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	result := providerTUIResult{
+		provider:     "new-provider",
+		model:        "test-model",
+		models:       []string{"test-model"},
+		isCustom:     true,
+		url:          "https://example.com/v1",
+		protocol:     "openai",
+		extraBody:    map[string]any{"enable_thinking": false},
+		extraHeaders: map[string]string{"X-Org-ID": "org-123"},
+	}
+	if err := applyCustomProviderConfig(configPath, sessionCfg, result); err != nil {
+		t.Fatalf("applyCustomProviderConfig: %v", err)
+	}
+	entry := sessionCfg.CustomProviders["new-provider"]
+	if entry.ExtraBody["enable_thinking"] != false {
+		t.Fatalf("ExtraBody = %#v, want session-saved value preserved", entry.ExtraBody)
+	}
+	if entry.ExtraHeaders["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v, want session-saved value preserved", entry.ExtraHeaders)
+	}
+}
+
+func TestProviderTUI_TabTogglesThinkingOnOfficialModelStep(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabOfficial
+	m.step = stepModel
+	m.modelIdx = 0
+
+	result, _ := m.Update(tabKeyMsg())
+	m2 := result.(providerTUIModel)
+	model := m2.models()[0]
+	if m2.currentModelThinkingMode() != "off" {
+		t.Fatalf("mode = %q, want off after Tab", m2.currentModelThinkingMode())
+	}
+	if got := m2.modelThinkingModes[m2.currentProvider().Name+":"+strings.ToLower(model)]; got != "off" {
+		t.Errorf("modelThinkingModes[%q] = %q, want off", model, got)
+	}
+
+	got := stripANSI(m2.View().Content)
+	if !strings.Contains(got, "Thinking: off") {
+		t.Errorf("view should show Thinking: off, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Tab Thinking") {
+		t.Errorf("help should mention Tab Thinking, got:\n%s", got)
+	}
+}
+
+func TestProviderTUI_CustomModelViewShowsExtraBodyHint(t *testing.T) {
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"my-proxy": {
+				URL:       "https://example.com/v1",
+				Protocol:  "openai",
+				Model:     "qwen3.7-max",
+				ExtraBody: map[string]any{"enable_thinking": false},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.customIdx = 0
+	m.step = stepModel
+
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, `Extra body: {"enable_thinking":false}`) {
+		t.Errorf("view should show extra body JSON, got:\n%s", got)
+	}
+	helpIdx := strings.Index(got, "↑/↓ Select")
+	hintIdx := strings.Index(got, "Extra body:")
+	if helpIdx < 0 || hintIdx < 0 || hintIdx >= helpIdx {
+		t.Errorf("extra body hint should appear above help line, got:\n%s", got)
+	}
+}
+
+func TestModelTUI_TabTogglesThinking(t *testing.T) {
+	m := officialConfigModelTUI(t, "", nil)
+	result, _ := m.Update(tabKeyMsg())
+	m2 := asModelTUIModel(t, result)
+	if m2.currentModelThinkingMode() != "off" {
+		t.Fatalf("mode = %q, want off after Tab", m2.currentModelThinkingMode())
+	}
+	got := stripANSI(m2.View().Content)
+	if !strings.Contains(got, "Thinking: off") {
+		t.Errorf("view should show Thinking: off, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Tab Thinking") {
+		t.Errorf("help should mention Tab Thinking, got:\n%s", got)
+	}
+}
+
+func TestModelTUI_CustomShowsExtraBodyHint(t *testing.T) {
+	m := customConfigModelTUI(t, "", []string{"qwen3.7-max"})
+	if entry, ok := m.existingCfg.CustomProviders[m.providerName]; ok {
+		entry.ExtraBody = map[string]any{"enable_thinking": false}
+		m.existingCfg.CustomProviders[m.providerName] = entry
+	}
+	got := stripANSI(m.View().Content)
+	if !strings.Contains(got, `Extra body: {"enable_thinking":false}`) {
+		t.Errorf("view should show extra body JSON, got:\n%s", got)
+	}
+}
+
+func TestParseExtraBodyInput(t *testing.T) {
+	body, err := parseExtraBodyInput(`{"enable_thinking": false}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("body = %#v", body)
+	}
+	if _, err := parseExtraBodyInput("{bad"); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if body, err := parseExtraBodyInput(""); err != nil || body != nil {
+		t.Fatalf("empty input = %#v, %v", body, err)
+	}
+	if body, err := parseExtraBodyInput("{}"); err != nil || body != nil {
+		t.Fatalf("empty object should normalize to nil: %#v, %v", body, err)
+	}
+	large := strings.Repeat("a", maxExtraBodyBytes+1)
+	if _, err := parseExtraBodyInput(`{"x":"` + large + `"}`); err == nil {
+		t.Fatal("expected error for oversized extra body")
+	}
+	if _, err := parseExtraBodyInput(`{"model":"gpt-4"}`); err == nil {
+		t.Fatal("expected error for reserved extra_body key")
+	}
+}
+
+func TestValidateExtraBody(t *testing.T) {
+	if err := llm.ValidateExtraBody(map[string]any{"enable_thinking": false}); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"model", "messages", "stream", "max_tokens", "max_completion_tokens", "system", "tools", "tool_choice", "stop"} {
+		if err := llm.ValidateExtraBody(map[string]any{key: "x"}); err == nil {
+			t.Fatalf("expected error for reserved key %q", key)
+		}
+	}
+	if err := llm.ValidateExtraBody(map[string]any{"Model": "x"}); err == nil {
+		t.Fatal("expected case-insensitive reserved key rejection")
+	}
+	if err := llm.ValidateExtraBody(map[string]any{"thinking": map[string]any{"type": "disabled"}}); err != nil {
+		t.Fatalf("nested maps should be allowed: %v", err)
+	}
+	if err := llm.ValidateExtraBody(map[string]any{"nested": map[string]any{"model": "override"}}); err != nil {
+		t.Fatalf("nested reserved keys should be allowed: %v", err)
+	}
+}
+
+func TestExtraBodyHintFromDraft(t *testing.T) {
+	if hint := extraBodyHintFromDraft(`{"enable_thinking":false}`); !strings.Contains(hint, "enable_thinking") {
+		t.Fatalf("hint = %q", hint)
+	}
+	if hint := extraBodyHintFromDraft("{bad"); hint == "" {
+		t.Fatal("invalid JSON should show an error hint")
+	}
+	if hint := extraBodyHintFromDraft(""); hint != "" {
+		t.Fatalf("empty input should not produce hint, got %q", hint)
+	}
+}
+
+func TestExtraBodyErrorFromDraft(t *testing.T) {
+	if hint := extraBodyErrorFromDraft(`{"enable_thinking":false}`); hint != "" {
+		t.Fatalf("valid JSON should not produce error hint, got %q", hint)
+	}
+	if hint := extraBodyErrorFromDraft("{bad"); hint == "" {
+		t.Fatal("invalid JSON should show an error hint")
+	}
+	if hint := extraBodyErrorFromDraft(""); hint != "" {
+		t.Fatalf("empty input should not produce hint, got %q", hint)
+	}
+}
+
+func TestProviderTUIView_CustomForm_ExtraBodyNoDuplicateHint(t *testing.T) {
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"stepfun-openai": {
+				URL:       "https://api.stepfun.com/v1",
+				Protocol:  "openai",
+				ExtraBody: map[string]any{"enable_thinking": true},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, "")
+	m.activeTab = tabCustom
+	m.editingCustom = true
+	m.editTargetName = "stepfun-openai"
+	m.cpStep = cpStepExtraBody
+	m.cpExtraBodyInput.SetValue(`{"enable_thinking":true}`)
+
+	got := stripANSI(m.View().Content)
+	if strings.Count(got, "Extra body:") != 0 {
+		t.Errorf("active extra body step should not show duplicate hint line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Extra Body:") {
+		t.Errorf("expected active Extra Body field label, got:\n%s", got)
+	}
+	if !strings.Contains(got, `{"enable_thinking":true}`) {
+		t.Errorf("expected extra body JSON in input, got:\n%s", got)
+	}
+}
+
+func TestProviderTUIView_CustomForm_ExtraBodyShowsParseError(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabCustom
+	m.creatingCustom = true
+	m.cpStep = cpStepExtraBody
+	m.cpExtraBodyInput.SetValue("{bad")
+
+	got := stripANSI(m.View().Content)
+	if strings.Count(got, "invalid JSON") != 1 {
+		t.Errorf("expected exactly one parse error while typing, got:\n%s", got)
+	}
+}
+
+func TestProviderTUIView_CustomForm_ExtraBodyConfirmParseErrorOnce(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabCustom
+	m.creatingCustom = true
+	m.cpStep = cpStepExtraBody
+	m.cpExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+
+	got := stripANSI(m2.View().Content)
+	if strings.Count(got, "invalid JSON") != 1 {
+		t.Errorf("expected exactly one parse error after confirm, got:\n%s", got)
+	}
+}
+
+func TestCloneProviderEntry_DeepClonesExtraBody(t *testing.T) {
+	orig := ProviderEntry{
+		ExtraBody: map[string]any{
+			"thinking": map[string]any{"type": "disabled", "budget_tokens": 100},
+		},
+	}
+	clone := cloneProviderEntry(orig)
+	thinking := clone.ExtraBody["thinking"].(map[string]any)
+	thinking["budget_tokens"] = 200
+	origThinking := orig.ExtraBody["thinking"].(map[string]any)
+	if origThinking["budget_tokens"] != 100 {
+		t.Fatal("nested ExtraBody values should be deep-cloned")
+	}
+}
+
+func TestFormatParseExtraBodyRoundTrip(t *testing.T) {
+	orig := map[string]any{"enable_thinking": false, "temperature": 0.2}
+	formatted := formatExtraBodyJSON(orig)
+	parsed, err := parseExtraBodyInput(formatted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed["enable_thinking"] != false || parsed["temperature"] != 0.2 {
+		t.Fatalf("round trip = %#v", parsed)
+	}
+	body, err := parseExtraBodyInput("  " + formatted + "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("whitespace trim failed: %#v", body)
+	}
+}
+
+func TestFormatExtraBodyJSON_Deterministic(t *testing.T) {
+	m := map[string]any{"b": 2, "a": 1}
+	got1 := formatExtraBodyJSON(m)
+	got2 := formatExtraBodyJSON(m)
+	if got1 != got2 || got1 != `{"a":1,"b":2}` {
+		t.Fatalf("deterministic JSON = %q", got1)
+	}
+}
+
+func TestParseExtraHeadersInput(t *testing.T) {
+	body, err := parseExtraHeadersInput(`{"X-Org-ID":"org-123","X-Forwarded-For":"1.2.3.4,5.6.7.8"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["X-Org-ID"] != "org-123" {
+		t.Fatalf("body = %#v", body)
+	}
+	if _, err := parseExtraHeadersInput("{bad"); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if body, err := parseExtraHeadersInput(""); err != nil || body != nil {
+		t.Fatalf("empty input = %#v, %v", body, err)
+	}
+	if _, err := parseExtraHeadersInput(`{"Authorization":"bad"}`); err == nil {
+		t.Fatal("expected error for reserved header")
+	}
+}
+
+func TestProviderTUI_CustomFormCreatePersistsExtraHeaders(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{}
+	m := newProviderTUI(cfg, configPath)
+
+	result, _ := m.Update(rightKey())
+	m2 := result.(providerTUIModel)
+	result, _ = m2.Update(enterKey())
+	m3 := result.(providerTUIModel)
+	m3.cpNameInput.SetValue("hdr-provider")
+	result, _ = m3.Update(enterKey())
+	m4 := result.(providerTUIModel)
+	result, _ = m4.Update(enterKey())
+	m5 := result.(providerTUIModel)
+	m5.cpURLInput.SetValue("https://api.example.com")
+	result, _ = m5.Update(enterKey())
+	m6 := result.(providerTUIModel)
+	m6.apiKeyInput.SetValue("key-123")
+	result, _ = m6.Update(enterKey())
+	m7 := result.(providerTUIModel)
+	result, _ = m7.Update(enterKey())
+	m8 := result.(providerTUIModel)
+	m8.cpExtraBodyInput.SetValue(`{"enable_thinking":false}`)
+	result, _ = m8.Update(enterKey())
+	m9 := result.(providerTUIModel)
+	m9.cpExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
+	result, _ = m9.Update(enterKey())
+	m10 := result.(providerTUIModel)
+	if m10.step != stepModel {
+		t.Fatalf("step = %d, want stepModel", m10.step)
+	}
+	got := cfg.CustomProviders["hdr-provider"].ExtraHeaders
+	if got["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v", got)
+	}
+}
+
+func TestApplyEditCustomProviderSave_PreservesExtraBody(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:          "https://example.com/v1",
+				Protocol:     "anthropic",
+				Model:        "test",
+				Models:       []string{"test"},
+				ExtraBody:    map[string]any{"thinking": map[string]any{"type": "disabled"}},
+				ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.editingCustom = true
+	m.editTargetName = "aaa"
+	m.cpProtocolIdx = 0
+	m.cpNameInput.SetValue("aaa")
+	m.cpURLInput.SetValue("https://example.com/v1")
+
+	if err := m.applyEditCustomProviderSave(); err != nil {
+		t.Fatalf("applyEditCustomProviderSave: %v", err)
+	}
+	if cfg.CustomProviders["aaa"].ExtraBody == nil {
+		t.Fatal("ExtraBody should be preserved when not editing extra body step")
+	}
+	if cfg.CustomProviders["aaa"].ExtraHeaders["X-Org-ID"] != "org-123" {
+		t.Fatalf("ExtraHeaders = %#v", cfg.CustomProviders["aaa"].ExtraHeaders)
+	}
+}
+
+func TestApplyEditCustomProviderSave_RejectsInvalidExistingExtraBody(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	cfg := &Config{
+		CustomProviders: map[string]ProviderEntry{
+			"aaa": {
+				URL:       "https://example.com/v1",
+				Protocol:  "anthropic",
+				Model:     "test",
+				Models:    []string{"test"},
+				ExtraBody: map[string]any{"model": "override"},
+			},
+		},
+	}
+	m := newProviderTUI(cfg, configPath)
+	m.activeTab = tabCustom
+	m.editingCustom = true
+	m.editTargetName = "aaa"
+	m.cpProtocolIdx = 0
+	m.cpNameInput.SetValue("aaa")
+	m.cpURLInput.SetValue("https://example.com/v1")
+
+	if err := m.applyEditCustomProviderSave(); err == nil {
+		t.Fatal("expected error for manually edited invalid extra_body")
+	}
+	if !strings.Contains(m.formError, "model") {
+		t.Errorf("formError = %q, want reserved key error", m.formError)
+	}
+}
+
+func TestThinkingLabelFor_EmptyModelName(t *testing.T) {
+	if got := thinkingLabelFor("kimi", "", "on"); got != "" {
+		t.Errorf("empty model name should hide label, got %q", got)
+	}
+}
+
+func TestProviderTUI_CustomModelRowHidesThinkingLabel(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabOfficial
+	m.step = stepModel
+	for i, p := range m.providers {
+		if p.Name == "kimi" {
+			m.officialIdx = i
+			break
+		}
+	}
+	m.modelIdx = len(m.models()) // "Enter custom model name..." row
+
+	got := stripANSI(m.View().Content)
+	if strings.Contains(got, "[Thinking:") {
+		t.Errorf("thinking label should be hidden on custom model row, got:\n%s", got)
 	}
 }

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -3019,26 +3019,6 @@ func TestModelTUI_TabTogglesThinking(t *testing.T) {
 	}
 }
 
-func TestValidateExtraBody(t *testing.T) {
-	if err := llm.ValidateExtraBody(map[string]any{"enable_thinking": false}); err != nil {
-		t.Fatal(err)
-	}
-	for _, key := range []string{"model", "messages", "stream", "max_tokens", "max_completion_tokens", "system", "tools", "tool_choice", "stop"} {
-		if err := llm.ValidateExtraBody(map[string]any{key: "x"}); err == nil {
-			t.Fatalf("expected error for reserved key %q", key)
-		}
-	}
-	if err := llm.ValidateExtraBody(map[string]any{"Model": "x"}); err == nil {
-		t.Fatal("expected case-insensitive reserved key rejection")
-	}
-	if err := llm.ValidateExtraBody(map[string]any{"thinking": map[string]any{"type": "disabled"}}); err != nil {
-		t.Fatalf("nested maps should be allowed: %v", err)
-	}
-	if err := llm.ValidateExtraBody(map[string]any{"nested": map[string]any{"model": "override"}}); err != nil {
-		t.Fatalf("nested reserved keys should be allowed: %v", err)
-	}
-}
-
 func TestCloneProviderEntry_DeepClonesExtraBody(t *testing.T) {
 	orig := ProviderEntry{
 		ExtraBody: map[string]any{
@@ -3088,7 +3068,7 @@ func TestApplyEditCustomProviderSave_PreservesExtraBody(t *testing.T) {
 	}
 }
 
-func TestApplyEditCustomProviderSave_RejectsInvalidExistingExtraBody(t *testing.T) {
+func TestApplyEditCustomProviderSave_PreservesInvalidExistingExtraBody(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 	cfg := &Config{
@@ -3110,11 +3090,11 @@ func TestApplyEditCustomProviderSave_RejectsInvalidExistingExtraBody(t *testing.
 	m.cpNameInput.SetValue("aaa")
 	m.cpURLInput.SetValue("https://example.com/v1")
 
-	if err := m.applyEditCustomProviderSave(); err == nil {
-		t.Fatal("expected error for manually edited invalid extra_body")
+	if err := m.applyEditCustomProviderSave(); err != nil {
+		t.Fatalf("applyEditCustomProviderSave: %v", err)
 	}
-	if !strings.Contains(m.formError, "model") {
-		t.Errorf("formError = %q, want reserved key error", m.formError)
+	if cfg.CustomProviders["aaa"].ExtraBody["model"] != "override" {
+		t.Fatalf("ExtraBody = %#v, want preserved", cfg.CustomProviders["aaa"].ExtraBody)
 	}
 }
 

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -2966,6 +2966,56 @@ func TestProviderTUI_CustomFormExtraHeadersReparsesExtraBodyFromInput(t *testing
 	}
 }
 
+func TestProviderTUI_ManualFormExtraHeadersReparsesExtraBodyFromInput(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabManual
+	m = enterManualForm(m)
+	m.manualStep = manualStepExtraHeaders
+	m.manualExtraBody = map[string]any{"stale": true}
+	m.manualExtraBodyInput.SetValue(`{"enable_thinking":false}`)
+	m.manualExtraHeadersInput.SetValue(`{}`)
+	m.manualExtraHeadersInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.formError != "" {
+		t.Fatalf("unexpected formError: %q", m2.formError)
+	}
+	if !m2.confirmed {
+		t.Fatal("expected manual form confirmed")
+	}
+	got := m2.result().extraBody
+	if got["enable_thinking"] != false {
+		t.Fatalf("ExtraBody should come from input field, not stale cache: %#v", got)
+	}
+	if _, ok := got["stale"]; ok {
+		t.Fatal("stale cached extra body should not be persisted")
+	}
+}
+
+func TestProviderTUI_ManualFormExtraHeadersFallsBackToExtraBodyOnParseError(t *testing.T) {
+	m := newProviderTUI(&Config{}, "")
+	m.activeTab = tabManual
+	m = enterManualForm(m)
+	m.manualStep = manualStepExtraHeaders
+	m.manualExtraBody = nil
+	m.manualExtraBodyInput.SetValue(`{"enable_thinking": tru}`)
+	m.manualExtraHeadersInput.SetValue(`{"X-Org-ID":"org-123"}`)
+	m.manualExtraHeadersInput.Focus()
+
+	result, _ := m.Update(enterKey())
+	m2 := result.(providerTUIModel)
+	if m2.manualStep != manualStepExtraBody {
+		t.Fatalf("manualStep = %d, want extra body after invalid extra body input", m2.manualStep)
+	}
+	if m2.formError != "" {
+		t.Fatalf("formError = %q, want empty (inline draft error only)", m2.formError)
+	}
+	if hint := extraBodyErrorFromDraft(m2.manualExtraBodyInput.Value()); hint == "" {
+		t.Fatal("expected inline extra body error hint")
+	}
+}
+
 func TestProviderTUI_CustomFormExtraHeadersFallsBackToExtraBodyOnParseError(t *testing.T) {
 	m := newProviderTUI(&Config{}, "")
 	m.activeTab = tabCustom

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -1,9 +1,26 @@
 package llm
 
 import (
+	"maps"
 	"sort"
 	"strings"
 )
+
+// ModelThinkingConfig describes per-model thinking behavior for a provider.
+// A zero value means "use the provider's default ThinkingStyle, toggleable".
+// All fields are value types (strings/enums), so shallow-copying this struct is safe.
+type ModelThinkingConfig struct {
+	// Style overrides the provider's default ThinkingStyle for this model.
+	// Zero value means no override.
+	Style ThinkingStyle
+	// Policy overrides the default toggleable behavior for this model.
+	// Zero value means "no override: fall back to the provider's default policy".
+	// The only meaningful explicit values are AlwaysOn, ThinkingOnly, and NotSupported.
+	Policy ThinkingPolicy
+	// ObjectOn sets thinking.type when mode is "on" (ThinkingStyleObject only).
+	// Zero value means "enabled". Use "adaptive" for models that reject "enabled".
+	ObjectOn string
+}
 
 // Provider holds the preset configuration for a known LLM provider.
 type Provider struct {
@@ -14,7 +31,21 @@ type Provider struct {
 	AuthHeader  string // Anthropic-only; empty for OpenAI-compatible
 	EnvVar      string // environment variable name for API key fallback
 	Models      []string
+	// ThinkingStyle is the default encoding style for this provider's models.
+	// Use ThinkingStyleNotSupported to hide the thinking toggle entirely.
+	ThinkingStyle ThinkingStyle
+	// ModelThinking overrides default thinking behavior per model (case-insensitive key).
+	// Override keys are lowercase; Models entries may use provider-canonical casing.
+	ModelThinking map[string]ModelThinkingConfig
 }
+
+// thinkingProviderMeta is the runtime index built from registry thinking fields.
+type thinkingProviderMeta struct {
+	defaultStyle   ThinkingStyle
+	modelOverrides map[string]ModelThinkingConfig
+}
+
+var thinkingProviderIndex map[string]thinkingProviderMeta
 
 var registry = []Provider{
 	{
@@ -24,6 +55,8 @@ var registry = []Provider{
 		BaseURL:     "https://api.anthropic.com",
 		AuthHeader:  "x-api-key",
 		EnvVar:      "ANTHROPIC_API_KEY",
+		// Thinking auto-inject is off; users may pass thinking via extra_body.
+		ThinkingStyle: ThinkingStyleNotSupported,
 		Models: []string{
 			"claude-opus-4-8",
 			"claude-opus-4-7",
@@ -32,11 +65,12 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "openai",
-		DisplayName: "OpenAI API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.openai.com/v1",
-		EnvVar:      "OPENAI_API_KEY",
+		Name:          "openai",
+		DisplayName:   "OpenAI API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.openai.com/v1",
+		EnvVar:        "OPENAI_API_KEY",
+		ThinkingStyle: ThinkingStyleNotSupported,
 		Models: []string{
 			"gpt-5.5",
 			"gpt-5.4",
@@ -44,11 +78,19 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "dashscope",
-		DisplayName: "Alibaba DashScope API",
-		Protocol:    "openai",
-		BaseURL:     "https://dashscope.aliyuncs.com/compatible-mode/v1",
-		EnvVar:      "DASHSCOPE_API_KEY",
+		Name:          "dashscope",
+		DisplayName:   "Alibaba DashScope API",
+		Protocol:      "openai",
+		BaseURL:       "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		EnvVar:        "DASHSCOPE_API_KEY",
+		ThinkingStyle: ThinkingStyleEnableBool,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"deepseek-v4-pro":   {Style: ThinkingStyleObject},
+			"deepseek-v4-flash": {Style: ThinkingStyleObject},
+			// MiniMax on DashScope uses thinking.type, not enable_thinking (see supplier report).
+			"minimax-m2.5":   {Style: ThinkingStyleObject, Policy: ThinkingPolicyAlwaysOn},
+			"kimi-k2.7-code": {Policy: ThinkingPolicyAlwaysOn},
+		},
 		Models: []string{
 			"qwen3.7-max",
 			"qwen3.7-plus",
@@ -62,11 +104,19 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "dashscope-tokenplan",
-		DisplayName: "Alibaba DashScope Token Plan API",
-		Protocol:    "openai",
-		BaseURL:     "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
-		EnvVar:      "DASHSCOPE_TOKENPLAN_KEY",
+		Name:          "dashscope-tokenplan",
+		DisplayName:   "Alibaba DashScope Token Plan API",
+		Protocol:      "openai",
+		BaseURL:       "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+		EnvVar:        "DASHSCOPE_TOKENPLAN_KEY",
+		ThinkingStyle: ThinkingStyleEnableBool,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"deepseek-v4-pro":   {Style: ThinkingStyleObject},
+			"deepseek-v4-flash": {Style: ThinkingStyleObject},
+			// MiniMax on DashScope uses thinking.type, not enable_thinking (see supplier report).
+			"minimax-m2.5":   {Style: ThinkingStyleObject, Policy: ThinkingPolicyAlwaysOn},
+			"kimi-k2.7-code": {Policy: ThinkingPolicyAlwaysOn},
+		},
 		Models: []string{
 			"qwen3.7-max",
 			"qwen3.7-plus",
@@ -89,6 +139,8 @@ var registry = []Provider{
 		Protocol:    "openai",
 		BaseURL:     "https://ark.cn-beijing.volces.com/api/v3",
 		EnvVar:      "ARK_API_KEY",
+		// All doubao-seed models use thinking.type encoding (ThinkingStyleObject).
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
 			"doubao-seed-evolving",
 			"doubao-seed-2-1-pro-260628",
@@ -99,23 +151,32 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "deepseek",
-		DisplayName: "DeepSeek API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.deepseek.com",
-		EnvVar:      "DEEPSEEK_API_KEY",
+		Name:          "deepseek",
+		DisplayName:   "DeepSeek API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.deepseek.com",
+		EnvVar:        "DEEPSEEK_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
 			"deepseek-v4-pro",
 			"deepseek-v4-flash",
 		},
 	},
 	{
-		Name:        "tencent-tokenhub",
-		DisplayName: "Tencent TokenHub API",
-		Protocol:    "openai",
-		BaseURL:     "https://tokenhub.tencentmaas.com/v1",
-		EnvVar:      "TENCENT_TOKENHUB_API_KEY",
+		Name:          "tencent-tokenhub",
+		DisplayName:   "Tencent TokenHub API",
+		Protocol:      "openai",
+		BaseURL:       "https://tokenhub.tencentmaas.com/v1",
+		EnvVar:        "TENCENT_TOKENHUB_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"kimi-k2.7-code": {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m2.7":   {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m2.5":   {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m3":     {ObjectOn: "adaptive"},
+		},
 		Models: []string{
+			"hy3",
 			"hy3-preview",
 			"deepseek-v4-pro",
 			"deepseek-v4-flash",
@@ -132,21 +193,28 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "hy-tokenplan",
-		DisplayName: "Tencent Hunyuan Token Plan API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.lkeap.cloud.tencent.com/plan/v3",
-		EnvVar:      "TENCENT_HUNYUAN_TOKENPLAN_KEY",
+		Name:          "hy-tokenplan",
+		DisplayName:   "Tencent Hunyuan Token Plan API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.lkeap.cloud.tencent.com/plan/v3",
+		EnvVar:        "TENCENT_HUNYUAN_TOKENPLAN_KEY",
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
+			"hy3",
 			"hy3-preview",
 		},
 	},
 	{
-		Name:        "kimi",
-		DisplayName: "Kimi Moonshot API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.moonshot.cn/v1",
-		EnvVar:      "MOONSHOT_API_KEY",
+		Name:          "kimi",
+		DisplayName:   "Kimi Moonshot API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.moonshot.cn/v1",
+		EnvVar:        "MOONSHOT_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"kimi-k2.7-code":           {Policy: ThinkingPolicyAlwaysOn},
+			"kimi-k2.7-code-highspeed": {Policy: ThinkingPolicyAlwaysOn},
+		},
 		Models: []string{
 			"kimi-k2.7-code",
 			"kimi-k2.7-code-highspeed",
@@ -155,11 +223,12 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "z-ai",
-		DisplayName: "Z.AI API",
-		Protocol:    "openai",
-		BaseURL:     "https://open.bigmodel.cn/api/paas/v4",
-		EnvVar:      "Z_AI_API_KEY",
+		Name:          "z-ai",
+		DisplayName:   "Z.AI API",
+		Protocol:      "openai",
+		BaseURL:       "https://open.bigmodel.cn/api/paas/v4",
+		EnvVar:        "Z_AI_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
 			"glm-5.2",
 			"glm-5.1",
@@ -169,11 +238,12 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "z-ai-coding",
-		DisplayName: "Z.AI Coding Plan API",
-		Protocol:    "openai",
-		BaseURL:     "https://open.bigmodel.cn/api/coding/paas/v4",
-		EnvVar:      "Z_AI_CODING_API_KEY",
+		Name:          "z-ai-coding",
+		DisplayName:   "Z.AI Coding Plan API",
+		Protocol:      "openai",
+		BaseURL:       "https://open.bigmodel.cn/api/coding/paas/v4",
+		EnvVar:        "Z_AI_CODING_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
 			"glm-5.2",
 			"glm-5.1",
@@ -182,22 +252,31 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "mimo",
-		DisplayName: "Xiaomi MiMo API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.xiaomimimo.com/v1",
-		EnvVar:      "MIMO_API_KEY",
+		Name:          "mimo",
+		DisplayName:   "Xiaomi MiMo API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.xiaomimimo.com/v1",
+		EnvVar:        "MIMO_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
 		Models: []string{
 			"mimo-v2.5-pro",
 			"mimo-v2.5",
 		},
 	},
 	{
-		Name:        "minimax",
-		DisplayName: "MiniMax API",
-		Protocol:    "openai",
-		BaseURL:     "https://api.minimaxi.com/v1",
-		EnvVar:      "MINIMAX_API_KEY",
+		Name:          "minimax",
+		DisplayName:   "MiniMax API",
+		Protocol:      "openai",
+		BaseURL:       "https://api.minimaxi.com/v1",
+		EnvVar:        "MINIMAX_API_KEY",
+		ThinkingStyle: ThinkingStyleObject,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"minimax-m3":             {ObjectOn: "adaptive"},
+			"minimax-m2.7":           {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m2.7-highspeed": {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m2.5":           {Policy: ThinkingPolicyAlwaysOn},
+			"minimax-m2.5-highspeed": {Policy: ThinkingPolicyAlwaysOn},
+		},
 		Models: []string{
 			"MiniMax-M3",
 			"MiniMax-M2.7",
@@ -207,11 +286,20 @@ var registry = []Provider{
 		},
 	},
 	{
-		Name:        "baidu-qianfan",
-		DisplayName: "Baidu Qianfan API",
-		Protocol:    "openai",
-		BaseURL:     "https://qianfan.baidubce.com/v2",
-		EnvVar:      "QIANFAN_API_KEY",
+		Name:          "baidu-qianfan",
+		DisplayName:   "Baidu Qianfan API",
+		Protocol:      "openai",
+		BaseURL:       "https://qianfan.baidubce.com/v2",
+		EnvVar:        "QIANFAN_API_KEY",
+		ThinkingStyle: ThinkingStyleEnableBool,
+		ModelThinking: map[string]ModelThinkingConfig{
+			"deepseek-v4-pro":   {Style: ThinkingStyleObject},
+			"deepseek-v4-flash": {Style: ThinkingStyleObject},
+			"glm-5.2":           {Style: ThinkingStyleObject},
+			"glm-5.1":           {Style: ThinkingStyleObject},
+			"glm-5":             {Style: ThinkingStyleObject},
+			"kimi-k2.6":         {Style: ThinkingStyleObject},
+		},
 		Models: []string{
 			"ernie-5.1",
 			"ernie-5.0",
@@ -231,8 +319,20 @@ var registryMap map[string]Provider
 
 func init() {
 	registryMap = make(map[string]Provider, len(registry))
+	thinkingProviderIndex = make(map[string]thinkingProviderMeta, len(registry))
 	for _, p := range registry {
-		registryMap[strings.ToLower(p.Name)] = p
+		key := strings.ToLower(p.Name)
+		registryMap[key] = p
+		meta := thinkingProviderMeta{
+			defaultStyle: p.ThinkingStyle,
+		}
+		if len(p.ModelThinking) > 0 {
+			meta.modelOverrides = make(map[string]ModelThinkingConfig, len(p.ModelThinking))
+			for model, cfg := range p.ModelThinking {
+				meta.modelOverrides[strings.ToLower(model)] = cfg
+			}
+		}
+		thinkingProviderIndex[key] = meta
 	}
 }
 
@@ -264,6 +364,10 @@ func copyProvider(p Provider) Provider {
 		models := make([]string, len(p.Models))
 		copy(models, p.Models)
 		p.Models = models
+	}
+	if p.ModelThinking != nil {
+		// Isolated copy for registry introspection; runtime resolution uses thinkingProviderIndex.
+		p.ModelThinking = maps.Clone(p.ModelThinking)
 	}
 	return p
 }

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -71,6 +71,41 @@ func TestLookupProvider_ReturnsCopyOfModels(t *testing.T) {
 	}
 }
 
+func TestLookupProvider_ReturnsCopyOfThinkingFields(t *testing.T) {
+	q1, ok := LookupProvider("baidu-qianfan")
+	if !ok {
+		t.Fatal("baidu-qianfan not found")
+	}
+	q1.ModelThinking["deepseek-v4-pro"] = ModelThinkingConfig{Style: ThinkingStyleEnableBool}
+
+	q2, _ := LookupProvider("baidu-qianfan")
+	if q2.ModelThinking["deepseek-v4-pro"].Style != ThinkingStyleObject {
+		t.Error("ModelThinking mutation leaked into registry")
+	}
+}
+
+func TestLookupProvider_ReturnsIsolatedModelThinkingMap(t *testing.T) {
+	original := registryMap["baidu-qianfan"]
+	defer func() { registryMap["baidu-qianfan"] = original }()
+
+	mutated := original
+	mutated.ModelThinking = map[string]ModelThinkingConfig{
+		"deepseek-v4-pro": {Style: ThinkingStyleObject},
+	}
+	registryMap["baidu-qianfan"] = mutated
+
+	p, ok := LookupProvider("baidu-qianfan")
+	if !ok {
+		t.Fatal("baidu-qianfan not found")
+	}
+	p.ModelThinking["deepseek-v4-pro"] = ModelThinkingConfig{Style: ThinkingStyleEnableBool}
+
+	got, _ := LookupProvider("baidu-qianfan")
+	if got.ModelThinking["deepseek-v4-pro"].Style != ThinkingStyleObject {
+		t.Fatal("ModelThinking mutation leaked into registry")
+	}
+}
+
 func TestLookupProvider_PreservesModelOrder(t *testing.T) {
 	p, ok := LookupProvider("anthropic")
 	if !ok {
@@ -124,5 +159,40 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 	}
 	if p.AuthHeader != "" {
 		t.Errorf("AuthHeader = %q, want empty", p.AuthHeader)
+	}
+}
+
+func TestProviderThinkingMeta_BuiltFromRegistry(t *testing.T) {
+	meta, ok := thinkingProviderIndex["dashscope"]
+	if !ok {
+		t.Fatal("dashscope thinking meta missing")
+	}
+	if meta.defaultStyle != ThinkingStyleEnableBool {
+		t.Fatalf("defaultStyle = %q", meta.defaultStyle)
+	}
+
+	qianfan, ok := thinkingProviderIndex["baidu-qianfan"]
+	if !ok {
+		t.Fatal("baidu-qianfan thinking meta missing")
+	}
+	if qianfan.modelOverrides["deepseek-v4-pro"].Style != ThinkingStyleObject {
+		t.Fatalf("deepseek override = %q", qianfan.modelOverrides["deepseek-v4-pro"].Style)
+	}
+	if qianfan.modelOverrides["glm-5.2"].Style != ThinkingStyleObject {
+		t.Fatalf("glm override = %q", qianfan.modelOverrides["glm-5.2"].Style)
+	}
+	if qianfan.modelOverrides["kimi-k2.6"].Style != ThinkingStyleObject {
+		t.Fatalf("kimi-k2.6 style = %q", qianfan.modelOverrides["kimi-k2.6"].Style)
+	}
+	if meta.modelOverrides["kimi-k2.7-code"].Policy != ThinkingPolicyAlwaysOn {
+		t.Fatalf("dashscope kimi-k2.7-code policy = %q", meta.modelOverrides["kimi-k2.7-code"].Policy)
+	}
+
+	mimo, ok := thinkingProviderIndex["mimo"]
+	if !ok {
+		t.Fatal("mimo thinking meta missing")
+	}
+	if mimo.defaultStyle != ThinkingStyleObject {
+		t.Fatalf("mimo defaultStyle = %q", mimo.defaultStyle)
 	}
 }

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -208,6 +209,10 @@ type providerEntryConfig struct {
 	TimeoutSec   int               `json:"timeout_sec,omitempty"` // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	// ModelsThinking maps model names (case-insensitive) to thinking mode overrides.
+	// Valid values: "on" (enable thinking) or "off" (disable thinking).
+	// Only the active model's entry is applied at runtime; other keys are ignored.
+	ModelsThinking map[string]string `json:"models_thinking,omitempty"`
 }
 
 type configFile struct {
@@ -327,8 +332,8 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q has no model configured; run 'ocr config model' to select one or pass --model", cfg.Provider)
 	}
 
+	var err error
 	if protocol == "anthropic" {
-		var err error
 		ah := "authorization"
 		if isPreset && authHeader != "" {
 			ah = authHeader
@@ -347,7 +352,19 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		authHeader = ""
 	}
 
-	extraBody = entry.ExtraBody
+	if err = ValidateModelsThinking(entry.ModelsThinking); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q models_thinking: %w", cfg.Provider, err)
+	}
+	if err = ValidateExtraBody(entry.ExtraBody); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q extra_body: %w", cfg.Provider, err)
+	}
+	extraBody, err = ApplyModelsThinking(entry.ExtraBody, entry.ModelsThinking, cfg.Provider, model)
+	if err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q models_thinking: %w", cfg.Provider, err)
+	}
+	if err = ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q extra_headers: %w", cfg.Provider, err)
+	}
 	extraHeaders := entry.ExtraHeaders
 
 	timeout, err := validateTimeoutSec(entry.TimeoutSec)
@@ -407,6 +424,13 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 	timeout, err := validateTimeoutSec(cfg.Llm.TimeoutSec)
 	if err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
+	}
+
+	if err = ValidateExtraBody(cfg.Llm.ExtraBody); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file llm.extra_body: %w", err)
+	}
+	if err = ValidateExtraHeadersMap(cfg.Llm.ExtraHeaders); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file llm.extra_headers: %w", err)
 	}
 
 	return ResolvedEndpoint{URL: cfg.Llm.URL, Token: cfg.Llm.AuthToken, Model: model, Protocol: protocol, AuthHeader: authHeader, Source: "OCR config file", ExtraBody: cfg.Llm.ExtraBody, ExtraHeaders: cfg.Llm.ExtraHeaders, Timeout: timeout}, true, nil
@@ -552,6 +576,29 @@ func NormalizeAuthHeader(header string) (string, error) {
 	}
 }
 
+func isReservedExtraBodyKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "model", "messages", "stream", "max_tokens", "max_completion_tokens", "system", "tools", "tool_choice", "stop":
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateExtraBody rejects top-level keys that would override core request payload fields.
+// Nested keys are allowed; only top-level reserved names are blocked.
+func ValidateExtraBody(m map[string]any) error {
+	if len(m) == 0 {
+		return nil
+	}
+	for k := range m {
+		if isReservedExtraBodyKey(strings.ToLower(k)) {
+			return fmt.Errorf("extra_body must not set %q (case-insensitive; reserved for request payload)", k)
+		}
+	}
+	return nil
+}
+
 // reservedHeaders are HTTP headers that extra_headers must not override.
 // They are managed by dedicated config fields (auth_header, auth_token) or set automatically by the SDK.
 // Letting extra_headers clobber them would cause confusing auth/content-type failures with no clear error.
@@ -600,6 +647,25 @@ func ParseExtraHeaders(raw string) (map[string]string, error) {
 		result[key] = value
 	}
 	return result, nil
+}
+
+// ValidateExtraHeadersMap rejects reserved header names in a parsed extra_headers map.
+// This is defense-in-depth for manually edited config.json; ParseExtraHeaders applies the same rules.
+func ValidateExtraHeadersMap(m map[string]string) error {
+	if len(m) == 0 {
+		return nil
+	}
+	var conflicts []string
+	for k := range m {
+		if reservedHeaders[strings.ToLower(k)] {
+			conflicts = append(conflicts, k)
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return fmt.Errorf("extra header(s) %s conflict with reserved headers; use the dedicated config field instead", strings.Join(conflicts, ", "))
+	}
+	return nil
 }
 
 // splitHeaderPairs splits a comma-separated string while respecting double-quoted segments.

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -355,15 +354,9 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 	if err = ValidateModelsThinking(entry.ModelsThinking); err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q models_thinking: %w", cfg.Provider, err)
 	}
-	if err = ValidateExtraBody(entry.ExtraBody); err != nil {
-		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q extra_body: %w", cfg.Provider, err)
-	}
 	extraBody, err = ApplyModelsThinking(entry.ExtraBody, entry.ModelsThinking, cfg.Provider, model)
 	if err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q models_thinking: %w", cfg.Provider, err)
-	}
-	if err = ValidateExtraHeadersMap(entry.ExtraHeaders); err != nil {
-		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q extra_headers: %w", cfg.Provider, err)
 	}
 	extraHeaders := entry.ExtraHeaders
 
@@ -424,13 +417,6 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 	timeout, err := validateTimeoutSec(cfg.Llm.TimeoutSec)
 	if err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
-	}
-
-	if err = ValidateExtraBody(cfg.Llm.ExtraBody); err != nil {
-		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file llm.extra_body: %w", err)
-	}
-	if err = ValidateExtraHeadersMap(cfg.Llm.ExtraHeaders); err != nil {
-		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file llm.extra_headers: %w", err)
 	}
 
 	return ResolvedEndpoint{URL: cfg.Llm.URL, Token: cfg.Llm.AuthToken, Model: model, Protocol: protocol, AuthHeader: authHeader, Source: "OCR config file", ExtraBody: cfg.Llm.ExtraBody, ExtraHeaders: cfg.Llm.ExtraHeaders, Timeout: timeout}, true, nil
@@ -576,29 +562,6 @@ func NormalizeAuthHeader(header string) (string, error) {
 	}
 }
 
-func isReservedExtraBodyKey(key string) bool {
-	switch strings.ToLower(key) {
-	case "model", "messages", "stream", "max_tokens", "max_completion_tokens", "system", "tools", "tool_choice", "stop":
-		return true
-	default:
-		return false
-	}
-}
-
-// ValidateExtraBody rejects top-level keys that would override core request payload fields.
-// Nested keys are allowed; only top-level reserved names are blocked.
-func ValidateExtraBody(m map[string]any) error {
-	if len(m) == 0 {
-		return nil
-	}
-	for k := range m {
-		if isReservedExtraBodyKey(k) {
-			return fmt.Errorf("extra_body must not set %q (case-insensitive; reserved for request payload)", k)
-		}
-	}
-	return nil
-}
-
 // reservedHeaders are HTTP headers that extra_headers must not override.
 // They are managed by dedicated config fields (auth_header, auth_token) or set automatically by the SDK.
 // Letting extra_headers clobber them would cause confusing auth/content-type failures with no clear error.
@@ -647,25 +610,6 @@ func ParseExtraHeaders(raw string) (map[string]string, error) {
 		result[key] = value
 	}
 	return result, nil
-}
-
-// ValidateExtraHeadersMap rejects reserved header names in a parsed extra_headers map.
-// This is defense-in-depth for manually edited config.json; ParseExtraHeaders applies the same rules.
-func ValidateExtraHeadersMap(m map[string]string) error {
-	if len(m) == 0 {
-		return nil
-	}
-	var conflicts []string
-	for k := range m {
-		if reservedHeaders[strings.ToLower(k)] {
-			conflicts = append(conflicts, k)
-		}
-	}
-	if len(conflicts) > 0 {
-		sort.Strings(conflicts)
-		return fmt.Errorf("extra header(s) %s conflict with reserved headers; use the dedicated config field instead", strings.Join(conflicts, ", "))
-	}
-	return nil
 }
 
 // splitHeaderPairs splits a comma-separated string while respecting double-quoted segments.

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -592,7 +592,7 @@ func ValidateExtraBody(m map[string]any) error {
 		return nil
 	}
 	for k := range m {
-		if isReservedExtraBodyKey(strings.ToLower(k)) {
+		if isReservedExtraBodyKey(k) {
 			return fmt.Errorf("extra_body must not set %q (case-insensitive; reserved for request payload)", k)
 		}
 	}

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -643,6 +643,89 @@ func TestResolveEndpoint_ProviderExtraBody(t *testing.T) {
 	}
 }
 
+func TestResolveEndpoint_ModelsThinking(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "deepseek",
+		Providers: map[string]providerEntryConfig{
+			"deepseek": {
+				APIKey: "sk-test",
+				Model:  "deepseek-v4-pro",
+				ModelsThinking: map[string]string{
+					"deepseek-v4-pro": "off",
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(cfgPath, data, 0644)
+
+	ep, err := ResolveEndpoint(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	thinking, ok := ep.ExtraBody["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("ExtraBody thinking = %#v, want disabled", ep.ExtraBody["thinking"])
+	}
+}
+
+func TestResolveEndpoint_InvalidModelsThinking(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "deepseek",
+		Providers: map[string]providerEntryConfig{
+			"deepseek": {
+				APIKey: "sk-test",
+				Model:  "deepseek-v4-pro",
+				ModelsThinking: map[string]string{
+					"deepseek-v4-pro": "bogus",
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(cfgPath, data, 0644)
+
+	_, err := ResolveEndpoint(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for invalid models_thinking")
+	}
+}
+
+func TestResolveEndpoint_ModelsThinking_OverridesExtraBody(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "dashscope",
+		Providers: map[string]providerEntryConfig{
+			"dashscope": {
+				APIKey: "sk-test",
+				Model:  "qwen3.7-max",
+				ModelsThinking: map[string]string{
+					"qwen3.7-max": "off",
+				},
+				ExtraBody: map[string]any{"enable_thinking": true},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(cfgPath, data, 0644)
+
+	ep, err := ResolveEndpoint(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.ExtraBody["enable_thinking"] != false {
+		t.Fatalf("ExtraBody = %#v, want models_thinking off to override extra_body", ep.ExtraBody)
+	}
+}
+
 func TestResolveEndpointWithModelOverride_ValidModelInPresetList(t *testing.T) {
 	clearAllEnv(t)
 
@@ -1069,6 +1152,76 @@ func TestResolveEndpoint_OCREnvExtraHeadersReservedRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reserved") {
 		t.Errorf("error should mention reserved header, got: %v", err)
+	}
+}
+
+func TestValidateExtraHeadersMap(t *testing.T) {
+	if err := ValidateExtraHeadersMap(map[string]string{"X-Org-ID": "org-123"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateExtraHeadersMap(map[string]string{"Authorization": "bad"}); err == nil {
+		t.Fatal("expected reserved header error")
+	}
+}
+
+func TestValidateExtraBody(t *testing.T) {
+	if err := ValidateExtraBody(map[string]any{"enable_thinking": false}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateExtraBody(map[string]any{"model": "x"}); err == nil {
+		t.Fatal("expected reserved key error")
+	}
+}
+
+func TestResolveEndpoint_ProviderExtraBodyReservedRejected(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "anthropic",
+		Providers: map[string]providerEntryConfig{
+			"anthropic": {
+				APIKey:    "sk-ant-test",
+				Model:     "claude-sonnet-4-6",
+				ExtraBody: map[string]any{"model": "override"},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(cfgPath, data, 0644)
+
+	_, err := ResolveEndpoint(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for reserved extra_body key in JSON config")
+	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestResolveEndpoint_ProviderExtraHeadersReservedRejected(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "anthropic",
+		Providers: map[string]providerEntryConfig{
+			"anthropic": {
+				APIKey:       "sk-ant-test",
+				Model:        "claude-sonnet-4-6",
+				ExtraHeaders: map[string]string{"Authorization": "bad"},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(cfgPath, data, 0644)
+
+	_, err := ResolveEndpoint(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for reserved extra header in JSON config")
+	}
+	if !strings.Contains(err.Error(), "Authorization") {
+		t.Errorf("error = %v", err)
 	}
 }
 

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -1155,25 +1155,7 @@ func TestResolveEndpoint_OCREnvExtraHeadersReservedRejected(t *testing.T) {
 	}
 }
 
-func TestValidateExtraHeadersMap(t *testing.T) {
-	if err := ValidateExtraHeadersMap(map[string]string{"X-Org-ID": "org-123"}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := ValidateExtraHeadersMap(map[string]string{"Authorization": "bad"}); err == nil {
-		t.Fatal("expected reserved header error")
-	}
-}
-
-func TestValidateExtraBody(t *testing.T) {
-	if err := ValidateExtraBody(map[string]any{"enable_thinking": false}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := ValidateExtraBody(map[string]any{"model": "x"}); err == nil {
-		t.Fatal("expected reserved key error")
-	}
-}
-
-func TestResolveEndpoint_ProviderExtraBodyReservedRejected(t *testing.T) {
+func TestResolveEndpoint_ProviderExtraBodyLoadsReservedKeys(t *testing.T) {
 	clearAllEnv(t)
 
 	cfg := configFile{
@@ -1190,16 +1172,16 @@ func TestResolveEndpoint_ProviderExtraBodyReservedRejected(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.json")
 	os.WriteFile(cfgPath, data, 0644)
 
-	_, err := ResolveEndpoint(cfgPath)
-	if err == nil {
-		t.Fatal("expected error for reserved extra_body key in JSON config")
+	ep, err := ResolveEndpoint(cfgPath)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
 	}
-	if !strings.Contains(err.Error(), "model") {
-		t.Errorf("error = %v", err)
+	if ep.ExtraBody["model"] != "override" {
+		t.Fatalf("ExtraBody = %#v", ep.ExtraBody)
 	}
 }
 
-func TestResolveEndpoint_ProviderExtraHeadersReservedRejected(t *testing.T) {
+func TestResolveEndpoint_ProviderExtraHeadersLoadsReservedKeys(t *testing.T) {
 	clearAllEnv(t)
 
 	cfg := configFile{
@@ -1216,12 +1198,12 @@ func TestResolveEndpoint_ProviderExtraHeadersReservedRejected(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.json")
 	os.WriteFile(cfgPath, data, 0644)
 
-	_, err := ResolveEndpoint(cfgPath)
-	if err == nil {
-		t.Fatal("expected error for reserved extra header in JSON config")
+	ep, err := ResolveEndpoint(cfgPath)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
 	}
-	if !strings.Contains(err.Error(), "Authorization") {
-		t.Errorf("error = %v", err)
+	if ep.ExtraHeaders["Authorization"] != "bad" {
+		t.Fatalf("ExtraHeaders = %#v", ep.ExtraHeaders)
 	}
 }
 

--- a/internal/llm/thinking.go
+++ b/internal/llm/thinking.go
@@ -267,8 +267,11 @@ func ApplyModelsThinking(extraBody map[string]any, modelsThinking map[string]str
 }
 
 func cloneExtraBodyMap(m map[string]any) map[string]any {
-	if m == nil || len(m) == 0 {
+	if m == nil {
 		return nil
+	}
+	if len(m) == 0 {
+		return map[string]any{}
 	}
 	out := make(map[string]any, len(m))
 	for k, v := range m {

--- a/internal/llm/thinking.go
+++ b/internal/llm/thinking.go
@@ -51,10 +51,16 @@ func ValidateModelsThinkingMode(mode string) error {
 
 // ValidateModelsThinking validates every entry in a models_thinking map.
 func ValidateModelsThinking(m map[string]string) error {
+	seen := make(map[string]string, len(m))
 	for model, mode := range m {
 		if strings.TrimSpace(model) == "" {
 			return fmt.Errorf("models_thinking keys must be non-empty model names")
 		}
+		key := strings.ToLower(strings.TrimSpace(model))
+		if prev, dup := seen[key]; dup {
+			return fmt.Errorf("models_thinking has ambiguous keys %q and %q (case-insensitive duplicate)", prev, model)
+		}
+		seen[key] = model
 		if err := ValidateModelsThinkingMode(mode); err != nil {
 			return fmt.Errorf("models_thinking[%q]: %w", model, err)
 		}

--- a/internal/llm/thinking.go
+++ b/internal/llm/thinking.go
@@ -1,0 +1,457 @@
+package llm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ThinkingStyle describes how a provider encodes thinking on/off in extra_body.
+type ThinkingStyle string
+
+const (
+	ThinkingStyleObject       ThinkingStyle = "thinking_object"
+	ThinkingStyleEnableBool   ThinkingStyle = "enable_thinking_bool"
+	ThinkingStyleNotSupported ThinkingStyle = "not_supported"
+)
+
+// ThinkingPolicy describes per-model thinking toggle behavior.
+type ThinkingPolicy string
+
+const (
+	// ThinkingPolicyToggle is the zero value: the model is toggleable (on/off).
+	ThinkingPolicyToggle ThinkingPolicy = ""
+	// ThinkingPolicyAlwaysOn marks models that always run with thinking enabled.
+	ThinkingPolicyAlwaysOn ThinkingPolicy = "always_on"
+	// ThinkingPolicyThinkingOnly marks thinking-only models that reject enable_thinking: false.
+	ThinkingPolicyThinkingOnly ThinkingPolicy = "thinking_only"
+	// ThinkingPolicyNotSupported hides the thinking toggle for the model.
+	ThinkingPolicyNotSupported ThinkingPolicy = "not_supported"
+)
+
+const (
+	// ModelsThinkingOn enables thinking for a model (persisted in config).
+	ModelsThinkingOn = "on"
+	// ModelsThinkingOff disables thinking for a model (persisted in config).
+	ModelsThinkingOff = "off"
+
+	thinkingObjectOnEnabled  = "enabled"
+	thinkingObjectOnAdaptive = "adaptive"
+	thinkingObjectOff        = "disabled"
+)
+
+// ValidateModelsThinkingMode reports whether mode is a supported models_thinking value.
+func ValidateModelsThinkingMode(mode string) error {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode != ModelsThinkingOn && mode != ModelsThinkingOff {
+		return fmt.Errorf("must be %q or %q, got %q", ModelsThinkingOn, ModelsThinkingOff, mode)
+	}
+	return nil
+}
+
+// ValidateModelsThinking validates every entry in a models_thinking map.
+func ValidateModelsThinking(m map[string]string) error {
+	for model, mode := range m {
+		if strings.TrimSpace(model) == "" {
+			return fmt.Errorf("models_thinking keys must be non-empty model names")
+		}
+		if err := ValidateModelsThinkingMode(mode); err != nil {
+			return fmt.Errorf("models_thinking[%q]: %w", model, err)
+		}
+	}
+	return nil
+}
+
+func translateThinking(mode, providerName, modelName string) map[string]any {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		return nil
+	}
+	policy := lookupModelThinkingPolicy(providerName, modelName)
+	if policy == ThinkingPolicyAlwaysOn || policy == ThinkingPolicyThinkingOnly {
+		return nil
+	}
+	if policy == ThinkingPolicyNotSupported {
+		return nil
+	}
+	style := lookupThinkingStyle(providerName, modelName)
+	switch style {
+	case ThinkingStyleObject:
+		switch mode {
+		case ModelsThinkingOn:
+			onType := lookupObjectOnType(providerName, modelName)
+			return map[string]any{"thinking": map[string]any{"type": onType}}
+		case ModelsThinkingOff:
+			return map[string]any{"thinking": map[string]any{"type": thinkingObjectOff}}
+		default:
+			return nil
+		}
+	case ThinkingStyleEnableBool:
+		switch mode {
+		case ModelsThinkingOn:
+			return map[string]any{"enable_thinking": true}
+		case ModelsThinkingOff:
+			return map[string]any{"enable_thinking": false}
+		default:
+			return nil
+		}
+	default:
+		return nil
+	}
+}
+
+func hasToggleStyle(providerName, modelName string) bool {
+	style := lookupThinkingStyle(providerName, modelName)
+	return style == ThinkingStyleObject || style == ThinkingStyleEnableBool
+}
+
+// IsThinkingSupported reports whether the provider exposes a thinking toggle.
+func IsThinkingSupported(providerName, modelName string) bool {
+	policy := lookupModelThinkingPolicy(providerName, modelName)
+	switch policy {
+	case ThinkingPolicyAlwaysOn, ThinkingPolicyThinkingOnly:
+		return true
+	case ThinkingPolicyNotSupported:
+		return false
+	default:
+		return hasToggleStyle(providerName, modelName)
+	}
+}
+
+// CanDisableThinking reports whether the user can turn thinking off for a model.
+func CanDisableThinking(providerName, modelName string) bool {
+	policy := lookupModelThinkingPolicy(providerName, modelName)
+	if policy == ThinkingPolicyAlwaysOn || policy == ThinkingPolicyThinkingOnly || policy == ThinkingPolicyNotSupported {
+		return false
+	}
+	return hasToggleStyle(providerName, modelName)
+}
+
+// IsThinkingAlwaysOn reports models that always run with thinking enabled.
+func IsThinkingAlwaysOn(providerName, modelName string) bool {
+	return lookupModelThinkingPolicy(providerName, modelName) == ThinkingPolicyAlwaysOn
+}
+
+// IsThinkingOnly reports models that only support thinking mode.
+func IsThinkingOnly(providerName, modelName string) bool {
+	return lookupModelThinkingPolicy(providerName, modelName) == ThinkingPolicyThinkingOnly
+}
+
+func lookupModelThinkingPolicy(providerName, modelName string) ThinkingPolicy {
+	providerName = strings.ToLower(strings.TrimSpace(providerName))
+	modelLower := strings.ToLower(strings.TrimSpace(modelName))
+	if modelLower == "" {
+		return ThinkingPolicyNotSupported
+	}
+	meta, ok := thinkingProviderIndex[providerName]
+	if !ok {
+		return ThinkingPolicyNotSupported
+	}
+	if cfg, ok := meta.modelOverrides[modelLower]; ok {
+		// NOTE: The zero value of Policy ("") doubles as "unset", so an explicit
+		// ThinkingPolicyToggle override is indistinguishable from no override.
+		// Do not set Policy to ThinkingPolicyToggle in ModelThinkingConfig;
+		// omit the field instead.
+		if cfg.Policy != "" {
+			return cfg.Policy
+		}
+	}
+	if lookupThinkingStyleFromMeta(meta, modelLower) == ThinkingStyleNotSupported {
+		return ThinkingPolicyNotSupported
+	}
+	return ThinkingPolicyToggle
+}
+
+func lookupThinkingStyle(providerName, modelName string) ThinkingStyle {
+	providerName = strings.ToLower(strings.TrimSpace(providerName))
+	modelLower := strings.ToLower(strings.TrimSpace(modelName))
+	if modelLower == "" {
+		return ThinkingStyleNotSupported
+	}
+
+	meta, ok := thinkingProviderIndex[providerName]
+	if !ok {
+		return ThinkingStyleNotSupported
+	}
+	return lookupThinkingStyleFromMeta(meta, modelLower)
+}
+
+func lookupObjectOnType(providerName, modelName string) string {
+	providerName = strings.ToLower(strings.TrimSpace(providerName))
+	modelLower := strings.ToLower(strings.TrimSpace(modelName))
+	if modelLower == "" {
+		return thinkingObjectOnEnabled
+	}
+	meta, ok := thinkingProviderIndex[providerName]
+	if !ok {
+		return thinkingObjectOnEnabled
+	}
+	if cfg, ok := meta.modelOverrides[modelLower]; ok && cfg.ObjectOn != "" {
+		return cfg.ObjectOn
+	}
+	return thinkingObjectOnEnabled
+}
+
+func lookupThinkingStyleFromMeta(meta thinkingProviderMeta, modelLower string) ThinkingStyle {
+	if modelLower != "" {
+		if cfg, ok := meta.modelOverrides[modelLower]; ok && cfg.Style != "" {
+			return cfg.Style
+		}
+	}
+	if meta.defaultStyle != "" {
+		return meta.defaultStyle
+	}
+	return ThinkingStyleNotSupported
+}
+
+func thinkingProviderKnown(providerName string) bool {
+	_, ok := thinkingProviderIndex[strings.ToLower(strings.TrimSpace(providerName))]
+	return ok
+}
+
+// ApplyModelsThinking merges models_thinking for the current model into extraBody.
+// When the model has a config entry, "on"/"off" inject fields via mergeExtraBody and
+// take precedence over conflicting extraBody keys. When there is no entry for the
+// model (or models_thinking is empty), extraBody is passed through unchanged.
+// The returned map is always a new value; the input extraBody is never mutated.
+// extraBody must be JSON-shaped (from json.Unmarshal): only map[string]any and []any
+// are deep-cloned; other types are shared by reference.
+// For mode "on", translateThinking returns explicit thinking fields (enabled or
+// adaptive per model ObjectOn); those are merged into extraBody the same way as "off".
+// Intentional asymmetry: "on" silently no-ops when thinking cannot be injected;
+// "off" returns an error on preset providers when disable is unsupported, so users
+// can detect stale models_thinking entries. Custom (non-registry) providers ignore
+// models_thinking on both paths via thinkingProviderKnown.
+func ApplyModelsThinking(extraBody map[string]any, modelsThinking map[string]string, providerName, model string) (map[string]any, error) {
+	if len(modelsThinking) == 0 {
+		return cloneExtraBodyMap(extraBody), nil
+	}
+	mode, ok := LookupModelsThinkingMode(modelsThinking, model)
+	if !ok {
+		return cloneExtraBodyMap(extraBody), nil
+	}
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	switch mode {
+	case ModelsThinkingOn:
+		if !IsThinkingSupported(providerName, model) {
+			return cloneExtraBodyMap(extraBody), nil
+		}
+		translated := translateThinking(ModelsThinkingOn, providerName, model)
+		if translated == nil {
+			// always_on / thinking_only models need no injection; "on" is a no-op.
+			return cloneExtraBodyMap(extraBody), nil
+		}
+		return mergeExtraBody(extraBody, translated), nil
+	case ModelsThinkingOff:
+		// Custom providers are not in thinkingProviderIndex; ignore models_thinking.
+		if !thinkingProviderKnown(providerName) {
+			return cloneExtraBodyMap(extraBody), nil
+		}
+		if !CanDisableThinking(providerName, model) {
+			return nil, fmt.Errorf("provider %q does not support disabling thinking for model %q; remove models_thinking entry or change provider", providerName, model)
+		}
+		translated := translateThinking(ModelsThinkingOff, providerName, model)
+		if translated == nil {
+			return nil, fmt.Errorf("internal error: provider %q model %q passed CanDisableThinking but translateThinking returned nil", providerName, model)
+		}
+		return mergeExtraBody(extraBody, translated), nil
+	default:
+		return nil, fmt.Errorf("provider %q model %q: invalid models_thinking mode %q", providerName, model, mode)
+	}
+}
+
+func cloneExtraBodyMap(m map[string]any) map[string]any {
+	if m == nil || len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCloneValue(v)
+	}
+	return out
+}
+
+// deepCloneValue clones JSON-shaped extra_body values. Callers must populate extraBody
+// from json.Unmarshal, which only produces map[string]any and []any. Non-JSON types
+// are shared by reference, so the "input never mutated" guarantee requires JSON-shaped input.
+func deepCloneValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, v := range val {
+			out[k] = deepCloneValue(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, v := range val {
+			out[i] = deepCloneValue(v)
+		}
+		return out
+	default:
+		// JSON scalars (string/number/bool/null) are immutable; shared by reference is safe.
+		return v
+	}
+}
+
+// LookupModelsThinkingMode returns the thinking mode for model using case-insensitive key matching.
+func LookupModelsThinkingMode(modelsThinking map[string]string, model string) (string, bool) {
+	key := strings.ToLower(strings.TrimSpace(model))
+	if key == "" {
+		return "", false
+	}
+	if mode, ok := modelsThinking[key]; ok {
+		return mode, true
+	}
+	// Fallback for hand-edited config that may not have normalized keys.
+	var candidates []string
+	for k := range modelsThinking {
+		if strings.EqualFold(strings.TrimSpace(k), key) {
+			candidates = append(candidates, k)
+		}
+	}
+	switch len(candidates) {
+	case 0:
+		return "", false
+	case 1:
+		return modelsThinking[candidates[0]], true
+	default:
+		// Multiple case-insensitive matches: ambiguous config.
+		// Deterministic first-wins fallback; callers should normalize keys on save.
+		sort.Strings(candidates)
+		return modelsThinking[candidates[0]], true
+	}
+}
+
+// NormalizeModelsThinking lowercases keys and normalizes mode values to "on" or "off".
+func NormalizeModelsThinking(m map[string]string) (map[string]string, error) {
+	if err := ValidateModelsThinking(m); err != nil {
+		return nil, err
+	}
+	return MergeModelsThinking(nil, m), nil
+}
+
+// MergeModelsThinking merges override into base. Both "on" and "off" are stored.
+// Model keys are normalized to lowercase trimmed form.
+// Callers must run ValidateModelsThinking on the result before persisting.
+func MergeModelsThinking(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(override))
+	applyThinkingMapLayer(merged, base, false)
+	applyThinkingMapLayer(merged, override, true)
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func applyThinkingMapLayer(dest map[string]string, src map[string]string, overwrite bool) {
+	if len(src) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(src))
+	for k := range src {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	seen := make(map[string]struct{}, len(src))
+	for _, k := range keys {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		if !overwrite {
+			if _, exists := dest[key]; exists {
+				continue
+			}
+		}
+		switch strings.ToLower(strings.TrimSpace(src[k])) {
+		case ModelsThinkingOff:
+			dest[key] = ModelsThinkingOff
+		case ModelsThinkingOn:
+			dest[key] = ModelsThinkingOn
+		default:
+			// Callers must validate before merging; any other value is unsupported.
+			dest[key] = src[k]
+		}
+	}
+}
+
+// PruneModelsThinking removes entries whose model keys are not in models (case-insensitive).
+func PruneModelsThinking(thinking map[string]string, models []string) map[string]string {
+	if len(thinking) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		key := strings.ToLower(strings.TrimSpace(model))
+		if key != "" {
+			allowed[key] = struct{}{}
+		}
+	}
+	out := make(map[string]string, len(thinking))
+	for k, v := range thinking {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; ok {
+			out[key] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// RemoveModelsThinkingKey drops one model's entry from the map (case-insensitive).
+// Remaining keys are always normalized to lowercase trimmed form.
+func RemoveModelsThinkingKey(thinking map[string]string, model string) map[string]string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if len(thinking) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(thinking))
+	for k, v := range thinking {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		if model != "" && key == model {
+			continue
+		}
+		out[key] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mergeExtraBody(base, override map[string]any) map[string]any {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(base)+len(override))
+	// Copy all base entries; override loop below replaces or deep-merges as needed.
+	for k, v := range base {
+		out[k] = deepCloneValue(v)
+	}
+	for k, v := range override {
+		if baseMap, ok := base[k].(map[string]any); ok {
+			if overrideMap, ok := v.(map[string]any); ok {
+				out[k] = mergeExtraBody(baseMap, overrideMap)
+				continue
+			}
+		}
+		out[k] = deepCloneValue(v)
+	}
+	return out
+}

--- a/internal/llm/thinking_test.go
+++ b/internal/llm/thinking_test.go
@@ -1,6 +1,9 @@
 package llm
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTranslateThinking_Object_Off(t *testing.T) {
 	body := translateThinking("off", "deepseek", "deepseek-v4-pro")
@@ -203,6 +206,16 @@ func TestValidateModelsThinking_RejectsEmptyModelKey(t *testing.T) {
 	}
 	if err := ValidateModelsThinking(map[string]string{"   ": "off"}); err == nil {
 		t.Fatal("expected error for whitespace model key")
+	}
+}
+
+func TestValidateModelsThinking_RejectsCaseInsensitiveDuplicateKeys(t *testing.T) {
+	err := ValidateModelsThinking(map[string]string{"Model-A": "on", "model-a": "off"})
+	if err == nil {
+		t.Fatal("expected error for case-insensitive duplicate keys")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguous duplicate message", err)
 	}
 }
 

--- a/internal/llm/thinking_test.go
+++ b/internal/llm/thinking_test.go
@@ -1,0 +1,638 @@
+package llm
+
+import "testing"
+
+func TestTranslateThinking_Object_Off(t *testing.T) {
+	body := translateThinking("off", "deepseek", "deepseek-v4-pro")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("body = %#v, want thinking.type disabled", body)
+	}
+}
+
+func TestTranslateThinking_Object_On(t *testing.T) {
+	body := translateThinking("on", "deepseek", "deepseek-v4-pro")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "enabled" {
+		t.Fatalf("body = %#v, want thinking.type enabled", body)
+	}
+}
+
+func TestTranslateThinking_Bool_Off(t *testing.T) {
+	body := translateThinking("off", "dashscope", "qwen3.7-max")
+	if body["enable_thinking"] != false {
+		t.Fatalf("body = %#v, want enable_thinking false", body)
+	}
+}
+
+func TestTranslateThinking_Bool_On(t *testing.T) {
+	body := translateThinking("on", "dashscope", "qwen3.7-max")
+	if body["enable_thinking"] != true {
+		t.Fatalf("body = %#v, want enable_thinking true", body)
+	}
+}
+
+func TestTranslateThinking_NotSupported(t *testing.T) {
+	if body := translateThinking("off", "openai", "gpt-5.5"); body != nil {
+		t.Fatalf("body = %#v, want nil", body)
+	}
+}
+
+func TestTranslateThinking_AlwaysOn(t *testing.T) {
+	if body := translateThinking("off", "kimi", "kimi-k2.7-code"); body != nil {
+		t.Fatalf("body = %#v, want nil for always-on model", body)
+	}
+}
+
+func TestCanDisableThinking(t *testing.T) {
+	if CanDisableThinking("anthropic", "claude-opus-4-6") {
+		t.Error("anthropic claude should not allow disable (not_supported)")
+	}
+	if CanDisableThinking("kimi", "kimi-k2.7-code") {
+		t.Error("kimi-k2.7-code should not allow disable")
+	}
+	if CanDisableThinking("dashscope", "kimi-k2.7-code") {
+		t.Error("dashscope kimi-k2.7-code passthrough should not allow disable")
+	}
+	if CanDisableThinking("dashscope", "MiniMax-M2.5") {
+		t.Error("dashscope MiniMax-M2.5 passthrough should not allow disable")
+	}
+	if CanDisableThinking("openai", "gpt-5.5") {
+		t.Error("openai should not allow disable")
+	}
+	if !CanDisableThinking("mimo", "mimo-v2.5-pro") {
+		t.Error("mimo should allow disable")
+	}
+	if !CanDisableThinking("baidu-qianfan", "kimi-k2.6") {
+		t.Error("qianfan kimi-k2.6 should allow disable (thinking_object)")
+	}
+	if !CanDisableThinking("baidu-qianfan", "glm-5.2") {
+		t.Error("qianfan glm-5.2 should allow disable")
+	}
+}
+
+func TestIsThinkingSupported_EmptyModelName(t *testing.T) {
+	if IsThinkingSupported("deepseek", "") {
+		t.Fatal("empty model name should not be thinking-supported")
+	}
+	if IsThinkingSupported("dashscope", "  ") {
+		t.Fatal("whitespace model name should not be thinking-supported")
+	}
+}
+
+func TestLookupThinkingStyle_EmptyModelName(t *testing.T) {
+	if got := lookupThinkingStyle("deepseek", ""); got != ThinkingStyleNotSupported {
+		t.Fatalf("empty model = %q, want NotSupported", got)
+	}
+	if got := lookupThinkingStyle("deepseek", "  "); got != ThinkingStyleNotSupported {
+		t.Fatalf("whitespace model = %q, want NotSupported", got)
+	}
+}
+
+func TestMergeExtraBody_EmptyMaps(t *testing.T) {
+	if got := mergeExtraBody(map[string]any{}, nil); got != nil {
+		t.Fatalf("empty map + nil = %#v, want nil", got)
+	}
+	if got := mergeExtraBody(nil, map[string]any{}); got != nil {
+		t.Fatalf("nil + empty map = %#v, want nil", got)
+	}
+	if got := mergeExtraBody(nil, nil); got != nil {
+		t.Fatalf("nil + nil = %#v, want nil", got)
+	}
+}
+
+func TestCloneExtraBodyMap_EmptyMap(t *testing.T) {
+	if got := cloneExtraBodyMap(map[string]any{}); got != nil {
+		t.Fatalf("empty map should clone to nil, got %#v", got)
+	}
+}
+
+func TestMergeExtraBody_OverrideWins(t *testing.T) {
+	base := map[string]any{"thinking": map[string]any{"type": "disabled"}}
+	override := map[string]any{"temperature": 0.2}
+	merged := mergeExtraBody(base, override)
+	if merged["temperature"] != 0.2 {
+		t.Fatalf("merged = %#v", merged)
+	}
+	thinking, ok := merged["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("thinking not preserved: %#v", merged)
+	}
+
+	override2 := map[string]any{"thinking": map[string]any{"type": "enabled"}}
+	merged2 := mergeExtraBody(base, override2)
+	thinking2 := merged2["thinking"].(map[string]any)
+	if thinking2["type"] != "enabled" {
+		t.Fatalf("override should win: %#v", merged2)
+	}
+}
+
+func TestMergeExtraBody_DeepMergePreservesSiblingKeys(t *testing.T) {
+	base := map[string]any{
+		"thinking": map[string]any{
+			"type":          "enabled",
+			"budget_tokens": 5000,
+		},
+	}
+	override := map[string]any{
+		"thinking": map[string]any{"type": "disabled"},
+	}
+	merged := mergeExtraBody(base, override)
+	thinking := merged["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Fatalf("type = %#v", thinking["type"])
+	}
+	if thinking["budget_tokens"] != 5000 {
+		t.Fatalf("budget_tokens should be preserved: %#v", thinking)
+	}
+}
+
+func TestApplyModelsThinking_DeepMergePreservesThinkingBudget(t *testing.T) {
+	base := map[string]any{
+		"thinking": map[string]any{
+			"type":          "enabled",
+			"budget_tokens": 5000,
+		},
+	}
+	body, err := ApplyModelsThinking(base, map[string]string{"deepseek-v4-pro": "off"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := body["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" || thinking["budget_tokens"] != 5000 {
+		t.Fatalf("body = %#v", body)
+	}
+}
+
+func TestTranslateThinking_UnknownMode(t *testing.T) {
+	if body := translateThinking("enabled", "deepseek", "deepseek-v4-pro"); body != nil {
+		t.Fatalf("unknown mode on object style = %#v, want nil", body)
+	}
+	if body := translateThinking("enabled", "dashscope", "qwen3.7-max"); body != nil {
+		t.Fatalf("unknown mode on bool style = %#v, want nil", body)
+	}
+}
+
+func TestLookupModelsThinkingMode_DuplicateCaseInsensitiveKeys(t *testing.T) {
+	m := map[string]string{
+		"Claude-3": "off",
+		"CLAUDE-3": "on",
+	}
+	mode, ok := LookupModelsThinkingMode(m, "claude-3")
+	if !ok {
+		t.Fatal("expected match")
+	}
+	// Deterministic: sort picks "CLAUDE-3" before "Claude-3".
+	if mode != "on" {
+		t.Fatalf("mode = %q, want on (alphabetically first key)", mode)
+	}
+}
+
+func TestValidateModelsThinking(t *testing.T) {
+	if err := ValidateModelsThinking(map[string]string{"m": "off"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateModelsThinking(map[string]string{"m": "bogus"}); err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}
+
+func TestValidateModelsThinking_RejectsEmptyModelKey(t *testing.T) {
+	if err := ValidateModelsThinking(map[string]string{"": "off"}); err == nil {
+		t.Fatal("expected error for empty model key")
+	}
+	if err := ValidateModelsThinking(map[string]string{"   ": "off"}); err == nil {
+		t.Fatal("expected error for whitespace model key")
+	}
+}
+
+func TestMergeModelsThinking(t *testing.T) {
+	got := MergeModelsThinking(map[string]string{"a": "off"}, map[string]string{"a": "on", "b": "off"})
+	if got["a"] != ModelsThinkingOn {
+		t.Fatalf("on should override off for key a: %#v", got)
+	}
+	if got["b"] != "off" {
+		t.Fatalf("off should be stored: %#v", got)
+	}
+
+	got = MergeModelsThinking(map[string]string{"a": "off"}, map[string]string{"a": " ON ", "b": " OFF "})
+	if got["a"] != ModelsThinkingOn {
+		t.Fatalf("normalized on should be stored: %#v", got)
+	}
+	if got["b"] != "off" {
+		t.Fatalf("normalized OFF should be stored as off: %#v", got)
+	}
+
+	baseOnly := MergeModelsThinking(map[string]string{"x": "off"}, nil)
+	if baseOnly["x"] != "off" {
+		t.Fatalf("base copy = %#v", baseOnly)
+	}
+	baseOnly["x"] = "on"
+	orig := MergeModelsThinking(map[string]string{"x": "off"}, nil)
+	if orig["x"] != "off" {
+		t.Fatal("MergeModelsThinking should return a copy")
+	}
+	if got := MergeModelsThinking(nil, nil); got != nil {
+		t.Fatalf("nil/nil should return nil, got %#v", got)
+	}
+	if got := MergeModelsThinking(nil, map[string]string{"a": "off"}); got["a"] != "off" {
+		t.Fatalf("nil base with override should store off, got %#v", got)
+	}
+
+	got = MergeModelsThinking(map[string]string{"Model-A": "off"}, map[string]string{"Model-B": " OFF "})
+	if got["model-a"] != "off" || got["model-b"] != "off" {
+		t.Fatalf("keys should be normalized: %#v", got)
+	}
+
+	got = MergeModelsThinking(nil, map[string]string{"bad-model": "disabled"})
+	if got["bad-model"] != "disabled" {
+		t.Fatalf("invalid override should be preserved: %#v", got)
+	}
+
+	got = MergeModelsThinking(map[string]string{"Model-A": "off", "model-a": "on"}, nil)
+	if got["model-a"] != "off" {
+		t.Fatalf("case-variant duplicates should keep first sorted key, got %#v", got)
+	}
+}
+
+func TestApplyModelsThinking_UnknownProviderIgnoresModelsThinking(t *testing.T) {
+	base := map[string]any{"enable_thinking": true}
+	body, err := ApplyModelsThinking(base, map[string]string{"m": "off"}, "my-custom-provider", "some-model")
+	if err != nil {
+		t.Fatalf("custom provider should ignore models_thinking: %v", err)
+	}
+	if body["enable_thinking"] != true {
+		t.Fatalf("extra_body should pass through, got %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_Off(t *testing.T) {
+	body, err := ApplyModelsThinking(nil, map[string]string{"deepseek-v4-pro": "off"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := body["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Fatalf("body = %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_InvalidMode(t *testing.T) {
+	_, err := ApplyModelsThinking(nil, map[string]string{"m": "enabled"}, "anthropic", "m")
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}
+
+func TestApplyModelsThinking_AlwaysOnError(t *testing.T) {
+	_, err := ApplyModelsThinking(nil, map[string]string{"kimi-k2.7-code": "off"}, "kimi", "kimi-k2.7-code")
+	if err == nil {
+		t.Fatal("expected error for always-on model")
+	}
+}
+
+func TestApplyModelsThinking_NotSupportedError(t *testing.T) {
+	// anthropic is now not_supported; trying to disable thinking on any model should error.
+	_, err := ApplyModelsThinking(nil, map[string]string{"claude-opus-4-6": "off"}, "anthropic", "claude-opus-4-6")
+	if err == nil {
+		t.Fatal("expected error for not-supported provider")
+	}
+}
+
+func TestApplyModelsThinking_NoEntryExtraBodyWins(t *testing.T) {
+	base := map[string]any{
+		"temperature":     0.5,
+		"enable_thinking": false,
+	}
+	body, err := ApplyModelsThinking(base, nil, "dashscope", "qwen3.7-max")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("without models_thinking entry extra_body should win: %#v", body)
+	}
+	if body["temperature"] != 0.5 {
+		t.Fatalf("other extra_body fields should be preserved: %#v", body)
+	}
+
+	// Other models in map should not affect current model.
+	body, err = ApplyModelsThinking(base, map[string]string{"glm-5.1": "off"}, "baidu-qianfan", "glm-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("missing model entry should leave extra_body unchanged: %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_ConfigOnOverridesExtraBodyDisable(t *testing.T) {
+	base := map[string]any{
+		"enable_thinking": false,
+	}
+	body, err := ApplyModelsThinking(base, map[string]string{"qwen3.7-max": "on"}, "dashscope", "qwen3.7-max")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != true {
+		t.Fatalf("models_thinking on should override extra_body disable: %#v", body)
+	}
+
+	base = map[string]any{
+		"thinking": map[string]any{"type": "disabled", "budget_tokens": 5000},
+	}
+	body, err = ApplyModelsThinking(base, map[string]string{"deepseek-v4-pro": "on"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := body["thinking"].(map[string]any)
+	if thinking["type"] != "enabled" {
+		t.Fatalf("models_thinking on should override extra_body thinking disable: %#v", body)
+	}
+	if thinking["budget_tokens"] != 5000 {
+		t.Fatalf("deep merge should preserve sibling keys: %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_NoEntryPreservesExtraBodyForUnsupportedProvider(t *testing.T) {
+	base := map[string]any{"enable_thinking": false}
+	body, err := ApplyModelsThinking(base, nil, "openai", "gpt-5.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("unsupported provider should pass extra_body unchanged: %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_OverridesExtraBody(t *testing.T) {
+	base := map[string]any{"enable_thinking": true}
+	body, err := ApplyModelsThinking(base, map[string]string{"qwen3.7-max": "off"}, "dashscope", "qwen3.7-max")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["enable_thinking"] != false {
+		t.Fatalf("models_thinking off should override extra_body: %#v", body)
+	}
+
+	base = map[string]any{"thinking": map[string]any{"type": "enabled"}}
+	body, err = ApplyModelsThinking(base, map[string]string{"deepseek-v4-pro": "off"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := body["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Fatalf("models_thinking off should override extra_body thinking: %#v", body)
+	}
+}
+
+func TestApplyModelsThinking_CaseInsensitiveModelKey(t *testing.T) {
+	body, err := ApplyModelsThinking(nil, map[string]string{"DeepSeek-V4-Pro": "off"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := body["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Fatalf("case-insensitive models_thinking lookup failed: %#v", body)
+	}
+}
+
+func TestNormalizeModelsThinking(t *testing.T) {
+	got, err := NormalizeModelsThinking(map[string]string{"Model-A": " OFF "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["model-a"] != ModelsThinkingOff {
+		t.Fatalf("got = %#v", got)
+	}
+	got, err = NormalizeModelsThinking(map[string]string{"m": "on"})
+	if err != nil {
+		t.Fatal("all-on input should be stored")
+	}
+	if got["m"] != ModelsThinkingOn {
+		t.Fatalf("got = %#v", got)
+	}
+	if _, err := NormalizeModelsThinking(map[string]string{"m": "enabled"}); err == nil {
+		t.Fatal("expected error for invalid models_thinking value")
+	}
+}
+
+func TestPruneModelsThinking(t *testing.T) {
+	got := PruneModelsThinking(map[string]string{
+		"model-a": ModelsThinkingOff,
+		"model-b": ModelsThinkingOff,
+	}, []string{"Model-A", "other"})
+	if len(got) != 1 || got["model-a"] != ModelsThinkingOff {
+		t.Fatalf("PruneModelsThinking = %#v", got)
+	}
+}
+
+func TestRemoveModelsThinkingKey(t *testing.T) {
+	got := RemoveModelsThinkingKey(map[string]string{"Claude-Sonnet-4-6": ModelsThinkingOff}, "claude-sonnet-4-6")
+	if got != nil {
+		t.Fatalf("RemoveModelsThinkingKey should clear last entry, got %#v", got)
+	}
+}
+
+func TestApplyModelsThinking_ReturnsCopy(t *testing.T) {
+	orig := map[string]any{"temperature": 0.5}
+	got, err := ApplyModelsThinking(orig, nil, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got["temperature"] = 1.0
+	if orig["temperature"] != 0.5 {
+		t.Fatal("mutating result should not affect input extraBody")
+	}
+
+	nested := map[string]any{
+		"thinking": map[string]any{
+			"type":          "enabled",
+			"budget_tokens": 5000,
+		},
+	}
+	got, err = ApplyModelsThinking(nested, map[string]string{"deepseek-v4-pro": "off"}, "deepseek", "deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking := got["thinking"].(map[string]any)
+	thinking["budget_tokens"] = 1
+	origThinking := nested["thinking"].(map[string]any)
+	if origThinking["budget_tokens"] != 5000 {
+		t.Fatal("mutating nested result should not affect input extraBody")
+	}
+}
+
+func TestRemoveModelsThinkingKey_NormalizesKeys(t *testing.T) {
+	got := RemoveModelsThinkingKey(map[string]string{"Model-A": ModelsThinkingOff}, "other")
+	if got["model-a"] != ModelsThinkingOff {
+		t.Fatalf("keys should be normalized even without removal: %#v", got)
+	}
+	got = RemoveModelsThinkingKey(map[string]string{"Model-A": ModelsThinkingOff}, "")
+	if got["model-a"] != ModelsThinkingOff {
+		t.Fatalf("empty model should still normalize keys: %#v", got)
+	}
+}
+
+func TestApplyModelsThinking_ConfigOnUnsupportedProviderPassesExtraBody(t *testing.T) {
+	base := map[string]any{"temperature": 0.5}
+	body, err := ApplyModelsThinking(base, map[string]string{"m": "on"}, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["temperature"] != 0.5 || len(body) != 1 {
+		t.Fatalf("unsupported provider should pass extra_body through even with models_thinking on: %#v", body)
+	}
+
+	body, err = ApplyModelsThinking(base, map[string]string{"m": " ON "}, "anthropic", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("normalized on on unsupported provider should not inject: %#v", body)
+	}
+}
+
+func TestTranslateThinking_QianfanDeepSeekUsesObject(t *testing.T) {
+	body := translateThinking("off", "baidu-qianfan", "deepseek-v4-pro")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("deepseek on qianfan should use thinking object: %#v", body)
+	}
+
+	boolBody := translateThinking("off", "baidu-qianfan", "ernie-5.1")
+	if boolBody["enable_thinking"] != false {
+		t.Fatalf("ernie on qianfan should use enable_thinking: %#v", boolBody)
+	}
+
+	glmBody := translateThinking("off", "baidu-qianfan", "glm-5.2")
+	glmThinking, ok := glmBody["thinking"].(map[string]any)
+	if !ok || glmThinking["type"] != "disabled" {
+		t.Fatalf("glm on qianfan should use thinking object: %#v", glmBody)
+	}
+}
+
+func TestTranslateThinking_QianfanKimiK26NotSupported(t *testing.T) {
+	// kimi-k2.6 is now thinking_object on qianfan (verified by testing).
+	body := translateThinking("off", "baidu-qianfan", "kimi-k2.6")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("qianfan kimi-k2.6 should use thinking object: %#v", body)
+	}
+	if !IsThinkingSupported("baidu-qianfan", "kimi-k2.6") {
+		t.Fatal("qianfan kimi-k2.6 should expose thinking toggle")
+	}
+}
+
+func TestThinkingPolicy_ThinkingOnly(t *testing.T) {
+	original, had := thinkingProviderIndex["thinking-only-fixture"]
+	defer func() {
+		if had {
+			thinkingProviderIndex["thinking-only-fixture"] = original
+		} else {
+			delete(thinkingProviderIndex, "thinking-only-fixture")
+		}
+	}()
+	thinkingProviderIndex["thinking-only-fixture"] = thinkingProviderMeta{
+		defaultStyle: ThinkingStyleEnableBool,
+		modelOverrides: map[string]ModelThinkingConfig{
+			"fixture-model": {Policy: ThinkingPolicyThinkingOnly},
+		},
+	}
+
+	if !IsThinkingOnly("thinking-only-fixture", "fixture-model") {
+		t.Fatal("fixture model should be thinking only")
+	}
+	if !IsThinkingSupported("thinking-only-fixture", "fixture-model") {
+		t.Fatal("thinking only models should report thinking supported")
+	}
+	if CanDisableThinking("thinking-only-fixture", "fixture-model") {
+		t.Fatal("thinking only models cannot be disabled via toggle")
+	}
+	body, err := ApplyModelsThinking(nil, map[string]string{"fixture-model": "off"}, "thinking-only-fixture", "fixture-model")
+	if err == nil {
+		t.Fatal("expected error when disabling thinking on thinking_only model")
+	}
+	if body != nil {
+		t.Fatalf("body = %#v, want nil on error", body)
+	}
+	onBody, err := ApplyModelsThinking(nil, map[string]string{"fixture-model": "on"}, "thinking-only-fixture", "fixture-model")
+	if err != nil {
+		t.Fatalf("on path should pass through: %v", err)
+	}
+	if onBody != nil {
+		t.Fatalf("on path should not inject for thinking_only: %#v", onBody)
+	}
+}
+
+func TestThinkingPolicy_DashScopeAlwaysOn(t *testing.T) {
+	// kimi-k2.7-code and MiniMax-M2.5 are now always_on on dashscope (not thinking_only).
+	if !IsThinkingAlwaysOn("dashscope", "kimi-k2.7-code") {
+		t.Fatal("dashscope kimi-k2.7-code should be always on")
+	}
+	if IsThinkingOnly("dashscope", "kimi-k2.7-code") {
+		t.Fatal("dashscope kimi-k2.7-code should not be thinking only")
+	}
+	if !IsThinkingAlwaysOn("dashscope", "MiniMax-M2.5") {
+		t.Fatal("dashscope MiniMax-M2.5 should be always on")
+	}
+	if IsThinkingOnly("dashscope", "MiniMax-M2.5") {
+		t.Fatal("dashscope MiniMax-M2.5 should not be thinking only")
+	}
+	if !CanDisableThinking("dashscope", "qwen3.7-max") {
+		t.Fatal("mixed qwen models should remain toggleable on dashscope")
+	}
+}
+
+func TestIsThinkingAlwaysOn_ProviderSpecificPrefixes(t *testing.T) {
+	if !IsThinkingAlwaysOn("minimax", "MiniMax-M2.7-highspeed") {
+		t.Fatal("minimax M2.7 should be always on")
+	}
+	if IsThinkingAlwaysOn("deepseek", "deepseek-v4-pro") {
+		t.Fatal("deepseek should not inherit minimax always-on prefixes")
+	}
+	if !IsThinkingAlwaysOn("tencent-tokenhub", "kimi-k2.7-code") {
+		t.Fatal("tokenhub kimi-k2.7 passthrough should be always on")
+	}
+	if IsThinkingAlwaysOn("kimi", "kimi-k2.6") {
+		t.Fatal("kimi-k2.6 should not be always on")
+	}
+	if IsThinkingAlwaysOn("kimi", "kimi-k2.5") {
+		t.Fatal("kimi-k2.5 should not be always on")
+	}
+	if IsThinkingAlwaysOn("minimax", "MiniMax-M3") {
+		t.Fatal("MiniMax-M3 should not be always on")
+	}
+}
+
+func TestTranslateThinking_MiniMaxM3UsesAdaptive(t *testing.T) {
+	body := translateThinking(ModelsThinkingOn, "minimax", "MiniMax-M3")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != thinkingObjectOnAdaptive {
+		t.Fatalf("on = %#v, want thinking.type adaptive", body)
+	}
+
+	body = translateThinking(ModelsThinkingOff, "minimax", "MiniMax-M3")
+	thinking, ok = body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("off = %#v, want thinking.type disabled", body)
+	}
+}
+
+func TestTranslateThinking_TencentTokenhubMiniMaxM3UsesAdaptive(t *testing.T) {
+	body := translateThinking(ModelsThinkingOn, "tencent-tokenhub", "minimax-m3")
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok || thinking["type"] != thinkingObjectOnAdaptive {
+		t.Fatalf("on = %#v, want thinking.type adaptive", body)
+	}
+}
+
+func TestApplyModelsThinking_MiniMaxM3OnInjectsAdaptive(t *testing.T) {
+	got, err := ApplyModelsThinking(nil, map[string]string{"minimax-m3": ModelsThinkingOn}, "minimax", "MiniMax-M3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	thinking, ok := got["thinking"].(map[string]any)
+	if !ok || thinking["type"] != thinkingObjectOnAdaptive {
+		t.Fatalf("got = %#v, want thinking.type adaptive", got)
+	}
+}

--- a/internal/llm/thinking_test.go
+++ b/internal/llm/thinking_test.go
@@ -105,8 +105,12 @@ func TestMergeExtraBody_EmptyMaps(t *testing.T) {
 }
 
 func TestCloneExtraBodyMap_EmptyMap(t *testing.T) {
-	if got := cloneExtraBodyMap(map[string]any{}); got != nil {
-		t.Fatalf("empty map should clone to nil, got %#v", got)
+	got := cloneExtraBodyMap(map[string]any{})
+	if got == nil {
+		t.Fatal("empty map should clone to non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty map should clone to {}, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->

Support per-model thinking overrides with registry-aware injection, TUI/CLI persistence, and defense-in-depth validation for extra_body and extra_headers.

1. model thinking switch in official mode

1.1 thinking: on
<img width="686" height="292" alt="image" src="https://github.com/user-attachments/assets/6a60b540-33e9-497a-9781-2f85746c5749" />

1.2 thinking: off
<img width="691" height="290" alt="image" src="https://github.com/user-attachments/assets/c5508730-e305-40f9-9306-3c5f3ee006f7" />

1.3 thinking: always on (e.g., kimi-k2.7-code)
<img width="695" height="214" alt="image" src="https://github.com/user-attachments/assets/fcec4d80-9f3e-455d-9c20-7a943b670d90" />


2. add extra_body and extra_headers configuration in custom and manual mode

2.1 extra_body
<img width="706" height="224" alt="image" src="https://github.com/user-attachments/assets/883a7c8d-5cbe-4318-892b-a09bf11536eb" />

2.2 extra_headers
<img width="699" height="243" alt="image" src="https://github.com/user-attachments/assets/cc264168-54b4-41a2-91e1-0ebe10c824c0" />
 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
