### PR TITLE
docs(pages): split install and version commands into separate code blocks

### DIFF
--- a/pages/src/content/docs/en/quickstart.md
+++ b/pages/src/content/docs/en/quickstart.md
@@ -16,6 +16,9 @@ Get your first code review running in a few minutes.
 
 ```bash
 npm install -g @alibaba-group/open-code-review
+```
+
+```bash
 ocr version
 ```
 

--- a/pages/src/content/docs/ja/quickstart.md
+++ b/pages/src/content/docs/ja/quickstart.md
@@ -16,6 +16,9 @@ sidebar:
 
 ```bash
 npm install -g @alibaba-group/open-code-review
+```
+
+```bash
 ocr version
 ```
 

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -16,6 +16,9 @@ sidebar:
 
 ```bash
 npm install -g @alibaba-group/open-code-review
+```
+
+```bash
 ocr version
 ```
 


### PR DESCRIPTION
## Summary
- Split `npm install` and `ocr version` into separate code blocks in the quickstart guide so each command can be copied independently.
- Applied the same change across all three language versions (en, ja, zh).

## Test plan
- [ ] Verify the quickstart page renders correctly with two separate code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)