### PR TITLE
feat(telemetry): propagate W3C traceparent from parent process

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -115,7 +115,7 @@ func runReview(args []string) error {
 	q := newQuietHandle(opts.outputFormat, opts.audience)
 	defer q.Restore()
 
-	ctx, span := telemetry.StartSpan(context.Background(), "review.run")
+	ctx, span := telemetry.StartSpan(telemetry.ContextWithTraceParentFromEnv(context.Background()), "review.run")
 	defer span.End()
 	telemetry.SetAttr(span, "review.repo", cc.RepoDir)
 	telemetry.SetAttr(span, "review.from", opts.from)

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -208,7 +208,7 @@ func runScan(args []string) error {
 	q := newQuietHandle(opts.outputFormat, opts.audience)
 	defer q.Restore()
 
-	ctx, span := telemetry.StartSpan(context.Background(), "scan.run")
+	ctx, span := telemetry.StartSpan(telemetry.ContextWithTraceParentFromEnv(context.Background()), "scan.run")
 	defer span.End()
 	var traceID string
 	if telemetry.IsEnabled() {

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -57,6 +58,10 @@ func Init(ctx context.Context) bool {
 
 	otel.SetTracerProvider(tracerProvider)
 	otel.SetMeterProvider(meterProvider)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
 
 	return len(shutdownFuncs) > 0
 }

--- a/internal/telemetry/span.go
+++ b/internal/telemetry/span.go
@@ -3,11 +3,13 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,6 +24,20 @@ func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) 
 		return ctx, trace.SpanFromContext(ctx)
 	}
 	return getTracer().Start(ctx, name, opts...)
+}
+
+// ContextWithTraceParentFromEnv extracts W3C traceparent from the TRACEPARENT
+// environment variable and returns a context carrying the upstream span context.
+// Returns ctx unchanged when telemetry is disabled or the variable is unset.
+func ContextWithTraceParentFromEnv(ctx context.Context) context.Context {
+	if !IsEnabled() {
+		return ctx
+	}
+	tp := os.Getenv("TRACEPARENT")
+	if tp == "" {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier{"traceparent": tp})
 }
 
 // TraceIDFromContext returns the hex-encoded trace ID of the span carried by

--- a/internal/telemetry/span_test.go
+++ b/internal/telemetry/span_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -169,4 +171,74 @@ func TestRecordLLMResult_Error(t *testing.T) {
 func TestRecordLLMResult_NilSpan(t *testing.T) {
 	RecordLLMResult(nil, 100*time.Millisecond, 0, nil)
 	RecordLLMResult(nil, 100*time.Millisecond, 0, fmt.Errorf("err"))
+}
+
+// A well-formed W3C traceparent: version-traceID-spanID-flags.
+const validTraceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+const wantExtractedTraceID = "0af7651916cd43dd8448eb211c80319c"
+
+func TestContextWithTraceParentFromEnv_Extracts(t *testing.T) {
+	setupEnabledTelemetry(t)
+	// Init registers TraceContext+Baggage at the global propagator; mirror
+	// that here so Extract works without going through the full Init path.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+
+	t.Setenv("TRACEPARENT", validTraceParent)
+	ctx := ContextWithTraceParentFromEnv(context.Background())
+
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		t.Fatal("expected a valid SpanContext after extracting TRACEPARENT")
+	}
+	if got := sc.TraceID().String(); got != wantExtractedTraceID {
+		t.Errorf("extracted TraceID = %q, want %q", got, wantExtractedTraceID)
+	}
+
+	// A span started on this ctx must inherit the upstream trace (child, not root).
+	_, span := StartSpan(ctx, "test.child")
+	defer span.End()
+	if got := span.SpanContext().TraceID().String(); got != wantExtractedTraceID {
+		t.Errorf("child span TraceID = %q, want %q (must inherit upstream)", got, wantExtractedTraceID)
+	}
+}
+
+func TestContextWithTraceParentFromEnv_AbsentOrDisabled(t *testing.T) {
+	// Telemetry disabled: must short-circuit and leave ctx with no span context.
+	initialized = false
+	shutdownFuncs = nil
+	t.Setenv("TRACEPARENT", validTraceParent)
+	ctx := ContextWithTraceParentFromEnv(context.Background())
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		t.Error("expected no valid SpanContext when telemetry is disabled")
+	}
+
+	// Telemetry enabled but TRACEPARENT unset: ctx unchanged (no upstream parent).
+	setupEnabledTelemetry(t)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+	t.Setenv("TRACEPARENT", "")
+	ctx = ContextWithTraceParentFromEnv(context.Background())
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		t.Error("expected no valid SpanContext when TRACEPARENT is unset")
+	}
+}
+
+func TestContextWithTraceParentFromEnv_Malformed(t *testing.T) {
+	setupEnabledTelemetry(t)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+
+	for _, bad := range []string{
+		"not-a-traceparent",
+		"00-invalidtraceid-invalidspanid-01",
+	} {
+		t.Run(bad, func(t *testing.T) {
+			t.Setenv("TRACEPARENT", bad)
+			ctx := ContextWithTraceParentFromEnv(context.Background())
+			if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+				t.Errorf("expected no valid SpanContext for malformed TRACEPARENT %q", bad)
+			}
+		})
+	}
 }


### PR DESCRIPTION
- Add ContextWithTraceParentFromEnv to extract TRACEPARENT env var and inject upstream span context via OTel TextMapPropagator.
- Register TraceContext+Baggage composite propagator in Init().
- Wire trace parent propagation into review and scan entry points.
- Add tests for valid, absent, disabled, and malformed TRACEPARENT.

## Description

When OCR is invoked by a parent process (e.g. Claude Code), the parent sets a `TRACEPARENT` environment variable following the W3C Trace Context specification. Previously, OCR always started a new root trace, making it impossible to correlate OCR spans with the caller's trace.

This PR adds `ContextWithTraceParentFromEnv()` which reads the `TRACEPARENT` env var and injects the upstream span context into the Go context via the OTel `TextMapPropagator`. Both the `review` and `scan` commands now use this function so their spans become children of the upstream trace. A `TraceContext + Baggage` composite propagator is registered during `Init()` to support extraction.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Added `TestContextWithTraceParentFromEnv_Extracts` — verifies a valid TRACEPARENT is extracted and child spans inherit the upstream trace ID.  
Added `TestContextWithTraceParentFromEnv_AbsentOrDisabled` — verifies no span context is injected when telemetry is disabled or TRACEPARENT is unset.  
Added `TestContextWithTraceParentFromEnv_Malformed` — verifies malformed TRACEPARENT values are gracefully ignored (no panic, no invalid span context).  
All tests pass with `go test -shuffle=on`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

N/A
