### PR TITLE
fix(llm): make OCR_LLM_EXTRA_HEADERS apply to all resolver strategies

### DIFF
--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -94,6 +94,22 @@ func ResolveEndpointWithModelOverride(configPath, modelOverride string) (Resolve
 			if ok {
 				ep.Timeout = envTimeout
 			}
+			// OCR_LLM_EXTRA_HEADERS is a global override: merges into
+			// extra headers regardless of which strategy resolved the
+			// endpoint. Env values take precedence over config-file values.
+			if raw := os.Getenv(envOCRLLMExtraHeaders); raw != "" {
+				envHeaders, err := ParseExtraHeaders(raw)
+				if err != nil {
+					return ResolvedEndpoint{}, fmt.Errorf("resolve %s: %w", s.name, err)
+				}
+				if ep.ExtraHeaders == nil {
+					ep.ExtraHeaders = envHeaders
+				} else {
+					for k, v := range envHeaders {
+						ep.ExtraHeaders[k] = v
+					}
+				}
+			}
 			return ep, nil
 		}
 	}
@@ -173,16 +189,7 @@ func tryOCREnv(modelOverride string) (ResolvedEndpoint, bool, error) {
 		}
 	}
 
-	var extraHeaders map[string]string
-	if extraHeadersRaw := os.Getenv(envOCRLLMExtraHeaders); extraHeadersRaw != "" {
-		var err error
-		extraHeaders, err = ParseExtraHeaders(extraHeadersRaw)
-		if err != nil {
-			return ResolvedEndpoint{}, false, fmt.Errorf("OCR environment: %w", err)
-		}
-	}
-
-	return ResolvedEndpoint{URL: url, Token: token, Model: model, Protocol: protocol, AuthHeader: authHeader, Source: "OCR environment", ExtraHeaders: extraHeaders}, true, nil
+	return ResolvedEndpoint{URL: url, Token: token, Model: model, Protocol: protocol, AuthHeader: authHeader, Source: "OCR environment"}, true, nil
 }
 
 // llmFileConfig represents the llm section in config.json.

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -1155,6 +1155,41 @@ func TestResolveEndpoint_ProviderExtraHeaders(t *testing.T) {
 	}
 }
 
+func TestResolveEndpoint_EnvExtraHeadersMergedWithConfigFile(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv("OCR_LLM_EXTRA_HEADERS", "EagleEye-TraceId=trace-from-env,X-New=from-env")
+
+	cfg := configFile{
+		Provider: "anthropic",
+		Providers: map[string]providerEntryConfig{
+			"anthropic": {
+				APIKey:       "sk-ant-test",
+				Model:        "claude-sonnet-4-6",
+				ExtraHeaders: map[string]string{"X-Org-ID": "org-123"},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ep, err := ResolveEndpoint(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := ep.ExtraHeaders["X-Org-ID"]; !ok || v != "org-123" {
+		t.Errorf("config file header preserved: ExtraHeaders[\"X-Org-ID\"] = %q, want %q", v, "org-123")
+	}
+	if v, ok := ep.ExtraHeaders["EagleEye-TraceId"]; !ok || v != "trace-from-env" {
+		t.Errorf("env header merged: ExtraHeaders[\"EagleEye-TraceId\"] = %q, want %q", v, "trace-from-env")
+	}
+	if v, ok := ep.ExtraHeaders["X-New"]; !ok || v != "from-env" {
+		t.Errorf("env header merged: ExtraHeaders[\"X-New\"] = %q, want %q", v, "from-env")
+	}
+}
+
 func TestResolveEndpoint_LegacyLlmExtraHeaders(t *testing.T) {
 	clearAllEnv(t)
 


### PR DESCRIPTION
## Summary

- **Move `OCR_LLM_EXTRA_HEADERS` parsing** from `tryOCREnv` into the global resolution loop so it applies to every resolver strategy (config-file providers, OCR env, legacy env, etc.), not just OCR environment variables.
- **Merge semantics**: environment headers are merged into whatever extra headers the winning strategy already provides; on key conflict the env value wins.
- **Add test** `TestResolveEndpoint_EnvExtraHeadersMergedWithConfigFile` to verify that config-file headers are preserved while env headers are merged on top.

## Test plan

- [x] `make check` passes (fmt + vet)
- [x] `make test` passes (all unit tests including the new merge test)