### PR TITLE
fix(pages): widen blog detail content area with percentage-based max-width

### DIFF
--- a/pages/src/content/blog/en/introducing-ocr-blog.md
+++ b/pages/src/content/blog/en/introducing-ocr-blog.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing the Open Code Review Blog System
-date: 2026-07-01
+date: 2026-07-10
 tags: [announcement, guide]
 summary: Learn how the Open Code Review blog system works and how you can contribute articles using simple Markdown files managed in GitHub.
 author: lizhengfeng101

--- a/pages/src/content/blog/ja/introducing-ocr-blog.md
+++ b/pages/src/content/blog/ja/introducing-ocr-blog.md
@@ -1,6 +1,6 @@
 ---
 title: Open Code Review ブログシステムの紹介
-date: 2026-07-01
+date: 2026-07-10
 tags: [アナウンス, ガイド]
 summary: Open Code Review ブログシステムの仕組みと、GitHub の Markdown ファイルを使って記事を書く方法を紹介します。
 author: lizhengfeng101

--- a/pages/src/content/blog/zh/introducing-ocr-blog.md
+++ b/pages/src/content/blog/zh/introducing-ocr-blog.md
@@ -1,6 +1,6 @@
 ---
 title: Open Code Review 博客系统介绍
-date: 2026-07-01
+date: 2026-07-10
 tags: [公告, 指南]
 summary: 了解 Open Code Review 博客系统的工作原理，以及如何通过 GitHub 中的 Markdown 文件来撰写和发布文章。
 author: lizhengfeng101

--- a/pages/src/pages/BlogPage.tsx
+++ b/pages/src/pages/BlogPage.tsx
@@ -188,7 +188,7 @@ const BlogPage: React.FC = () => {
         <Navbar />
         <div style={{ display: 'flex', justifyContent: 'center', maxWidth: 1440, margin: '0 auto', flex: 1, width: '100%' }}>
           {/* Main content */}
-          <div style={{ flex: 1, minWidth: 0, padding: isMobile ? '32px 20px 80px' : '40px 48px 80px', maxWidth: 820 }}>
+          <div style={{ flex: 1, minWidth: 0, padding: isMobile ? '32px 20px 80px' : '40px 48px 80px', maxWidth: isMobile ? undefined : '65%' }}>
             {/* Back link */}
             <button
               onClick={() => navigate('/blog')}


### PR DESCRIPTION
## Summary

- Replace the fixed `maxWidth: 820` on the blog detail content column with a responsive `maxWidth: '65%'` (desktop only; mobile remains uncapped).
- This lets the article body fill more of the available horizontal space, reducing the visual asymmetry where the right-side TOC occupies room but the left margin is empty.

## Test plan

- [ ] Open a blog post on a wide desktop viewport (≥1440px) and confirm the content area is noticeably wider than before.
- [ ] Resize the browser to ~1024px and verify the layout still looks balanced.
- [ ] Check on mobile (< 768px) that the content stretches full-width with no unexpected cap.
- [ ] Verify the right-side TOC still renders correctly and doesn't overlap the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)