### PR TITLE
feat(diff): add --diff-file to review a validated subset of hunks

### DIFF
--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -101,6 +101,7 @@ type reviewOptions struct {
 	from           string
 	to             string
 	commit         string
+	diffFile       string // --diff-file: path to a unified patch selecting a subset of hunks
 	resume         string
 	excludes       string // --exclude: comma-separated gitignore-style patterns
 	outputFormat   string
@@ -127,6 +128,7 @@ func parseReviewFlags(args []string) (reviewOptions, error) {
 	a.StringVar(&opts.from, "from", "", "source ref to start diff from (e.g., 'main')")
 	a.StringVar(&opts.to, "to", "", "target ref to end diff at (e.g., 'feature-branch')")
 	a.StringVarP(&opts.commit, "commit", "c", "", "single commit hash or tag to review (vs its parent)")
+	a.StringVar(&opts.diffFile, "diff-file", "", "path to a unified git patch selecting a subset of complete hunks from the --from/--to (or --commit) diff; review is narrowed to those hunks")
 	a.StringVar(&opts.resume, "resume", "", "resume from a previous review session id")
 	a.StringVar(&opts.excludes, "exclude", "", "comma-separated gitignore-style patterns to exclude; merged with rule.json excludes")
 	a.StringVarP(&opts.outputFormat, "format", "f", "text", "output format: text or json")
@@ -170,6 +172,19 @@ func parseReviewFlags(args []string) (reviewOptions, error) {
 		return opts, fmt.Errorf("--preview and --resume cannot be used together")
 	}
 
+	if opts.diffFile != "" {
+		// A stable ref is required so full file reads and line mapping anchor at
+		// the true HEAD/--to tree. Workspace mode has no such ref.
+		if opts.commit == "" && (opts.from == "" || opts.to == "") {
+			return opts, fmt.Errorf("--diff-file requires --from/--to or --commit (it selects a subset of that range's hunks)")
+		}
+		// Resume replays fingerprints computed from the full-range diff; a
+		// narrowed diff would silently mismatch, so reject the combination.
+		if opts.resume != "" {
+			return opts, fmt.Errorf("--diff-file and --resume cannot be used together")
+		}
+	}
+
 	switch opts.audience {
 	case "human", "agent":
 	default:
@@ -210,6 +225,9 @@ Examples:
   ocr review --commit abc123
   ocr review -c abc123
 
+  # Review only a subset of hunks selected externally (exact subset of the range)
+  ocr review --from master --to dev-ref --diff-file selected.patch
+
   # Resume a previous range review
   ocr review --from master --to dev-ref --resume <session-id>
 
@@ -234,6 +252,7 @@ Flags:
   -b, --background string       optional requirement/business context for the review
   -B, --background-file string  path to a Markdown file used as review background (combined with --background; inline value appears first when both are set)
   -c, --commit string           single commit hash or tag to review (vs its parent)
+  --diff-file string            path to a unified git patch selecting a subset of complete hunks from the --from/--to (or --commit) diff
   -f, --format string           output format: text or json (default "text")
   --concurrency int             max concurrent file reviews (default 8)
   --max-git-procs int           max concurrent git subprocesses (default 16)

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -244,15 +244,36 @@ func validateReviewRefs(repoDir string, opts reviewOptions) error {
 	return nil
 }
 
+// maxSelectedDiffBytes caps --diff-file reads. The selection is a subset of
+// the canonical range diff, so anything past this is a mistake, not a review.
+const maxSelectedDiffBytes = 8 << 20 // 8 MB
+
 // loadSelectedDiff reads the --diff-file patch from disk. An empty path yields
-// an empty selection (default behaviour, whole-range review).
+// an empty selection (default behaviour, whole-range review). A path that is
+// set but yields no content is an error: the agent only narrows the review
+// when the selection is non-empty, so silently returning "" would fail open
+// into a full-range review.
 func loadSelectedDiff(path string) (string, error) {
 	if path == "" {
 		return "", nil
 	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("read --diff-file %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("--diff-file %q is a directory, not a file", path)
+	}
+	if info.Size() > maxSelectedDiffBytes {
+		return "", fmt.Errorf("--diff-file %q is %d bytes, exceeding the maximum of %d bytes",
+			path, info.Size(), maxSelectedDiffBytes)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("read --diff-file %q: %w", path, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", fmt.Errorf("--diff-file %q is empty; refusing to fall back to a full-range review", path)
 	}
 	return string(data), nil
 }

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -58,8 +58,13 @@ func runReview(args []string) error {
 		opts.background = mergeBackground(opts.background, fileBackground)
 	}
 
+	selectedDiff, err := loadSelectedDiff(opts.diffFile)
+	if err != nil {
+		return err
+	}
+
 	if opts.preview {
-		return runPreview(cc, opts)
+		return runPreview(cc, opts, selectedDiff)
 	}
 
 	resumeState, err := loadReviewResumeState(cc.RepoDir, opts)
@@ -116,6 +121,7 @@ func runReview(args []string) error {
 		Background:            opts.background,
 		GitRunner:             cc.GitRunner,
 		Resume:                resumeState,
+		SelectedDiff:          selectedDiff,
 	})
 
 	// Silence progress output during execution; restored before the trace
@@ -238,14 +244,28 @@ func validateReviewRefs(repoDir string, opts reviewOptions) error {
 	return nil
 }
 
-func runPreview(cc *commonContext, opts reviewOptions) error {
+// loadSelectedDiff reads the --diff-file patch from disk. An empty path yields
+// an empty selection (default behaviour, whole-range review).
+func loadSelectedDiff(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read --diff-file %q: %w", path, err)
+	}
+	return string(data), nil
+}
+
+func runPreview(cc *commonContext, opts reviewOptions, selectedDiff string) error {
 	ag := agent.New(agent.Args{
-		RepoDir:    cc.RepoDir,
-		From:       opts.from,
-		To:         opts.to,
-		Commit:     opts.commit,
-		FileFilter: cc.FileFilter,
-		GitRunner:  cc.GitRunner,
+		RepoDir:      cc.RepoDir,
+		From:         opts.from,
+		To:           opts.to,
+		Commit:       opts.commit,
+		FileFilter:   cc.FileFilter,
+		GitRunner:    cc.GitRunner,
+		SelectedDiff: selectedDiff,
 	})
 
 	preview, err := ag.Preview(context.Background())

--- a/cmd/opencodereview/selected_diff_test.go
+++ b/cmd/opencodereview/selected_diff_test.go
@@ -79,6 +79,42 @@ func TestLoadSelectedDiff(t *testing.T) {
 	}
 }
 
+// TestLoadSelectedDiff_EmptyFileRejected guards against a fail-open: an empty
+// --diff-file must be an error, not an empty selection that silently reviews
+// the full range (agent.loadDiffs only applies selection when non-empty).
+func TestLoadSelectedDiff_EmptyFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"empty.patch":      "",
+		"whitespace.patch": "  \n\t\n",
+	} {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := loadSelectedDiff(p)
+		if err == nil || !strings.Contains(err.Error(), "empty") {
+			t.Errorf("%s: got err %v, want empty-file rejection", name, err)
+		}
+	}
+}
+
+func TestLoadSelectedDiff_SizeAndDirGuards(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := loadSelectedDiff(dir); err == nil || !strings.Contains(err.Error(), "directory") {
+		t.Errorf("directory path: got err %v, want directory rejection", err)
+	}
+
+	big := filepath.Join(dir, "big.patch")
+	if err := os.WriteFile(big, make([]byte, maxSelectedDiffBytes+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadSelectedDiff(big); err == nil || !strings.Contains(err.Error(), "exceed") {
+		t.Errorf("oversized file: got err %v, want size rejection", err)
+	}
+}
+
 // --- Integration test: real git repo, subset selection ---
 
 func runGit(t *testing.T, dir string, args ...string) string {

--- a/cmd/opencodereview/selected_diff_test.go
+++ b/cmd/opencodereview/selected_diff_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/agent"
+	"github.com/open-code-review/open-code-review/internal/diff"
+	"github.com/open-code-review/open-code-review/internal/tool"
+)
+
+// --- CLI flag validation for --diff-file ---
+
+func TestParseReviewFlags_DiffFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "valid with range",
+			args: []string{"--from", "main", "--to", "dev", "--diff-file", "sel.patch"},
+		},
+		{
+			name: "valid with commit",
+			args: []string{"--commit", "abc123", "--diff-file", "sel.patch"},
+		},
+		{
+			name:    "rejects workspace mode",
+			args:    []string{"--diff-file", "sel.patch"},
+			wantErr: "requires --from/--to or --commit",
+		},
+		{
+			name:    "rejects with only from",
+			args:    []string{"--from", "main", "--diff-file", "sel.patch"},
+			wantErr: "--to is required",
+		},
+		{
+			name:    "rejects with resume",
+			args:    []string{"--from", "main", "--to", "dev", "--diff-file", "sel.patch", "--resume", "sess1"},
+			wantErr: "--diff-file and --resume cannot be used together",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseReviewFlags(tt.args)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadSelectedDiff(t *testing.T) {
+	if s, err := loadSelectedDiff(""); err != nil || s != "" {
+		t.Fatalf("empty path: got (%q,%v), want (\"\",nil)", s, err)
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "sel.patch")
+	if err := os.WriteFile(p, []byte("PATCH-BODY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if s, err := loadSelectedDiff(p); err != nil || s != "PATCH-BODY" {
+		t.Fatalf("got (%q,%v)", s, err)
+	}
+	if _, err := loadSelectedDiff(filepath.Join(dir, "nope.patch")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+// --- Integration test: real git repo, subset selection ---
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// buildMultiHunkRepo creates a repo whose HEAD changes svc.go in two separate
+// regions (two hunks) and rewrites other.go. Returns (dir, baseSHA, headSHA).
+func buildMultiHunkRepo(t *testing.T) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Base version of svc.go: 20 numbered lines.
+	var base strings.Builder
+	for i := 1; i <= 20; i++ {
+		base.WriteString("line")
+		base.WriteByte(byte('0' + i%10))
+		base.WriteString(" original\n")
+	}
+	writeFile(t, dir, "svc.go", base.String())
+	writeFile(t, dir, "other.go", "package other\n\nfunc Old() {}\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base")
+	baseSHA := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+
+	// HEAD version: insert a line near the top (hunk 1) and near the bottom
+	// (hunk 2); keep the middle unchanged so the two edits form separate hunks.
+	lines := strings.Split(strings.TrimRight(base.String(), "\n"), "\n")
+	var head strings.Builder
+	for i, l := range lines {
+		head.WriteString(l)
+		head.WriteString("\n")
+		if i == 1 { // after line index 1 → top hunk
+			head.WriteString("INSERTED-TOP\n")
+		}
+		if i == 17 { // near the bottom → separate hunk
+			head.WriteString("INSERTED-BOTTOM\n")
+		}
+	}
+	writeFile(t, dir, "svc.go", head.String())
+	writeFile(t, dir, "other.go", "package other\n\nfunc New() { println(\"changed\") }\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "head")
+	headSHA := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+
+	return dir, baseSHA, headSHA
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+var hunkStartRe = regexp.MustCompile(`(?m)^@@ `)
+
+// firstHunkOnly reconstructs a single-file patch containing only the first hunk
+// of the given canonical per-file diff (preamble + hunk 1), byte-for-byte.
+func firstHunkOnly(t *testing.T, fileDiff string) string {
+	t.Helper()
+	locs := hunkStartRe.FindAllStringIndex(fileDiff, -1)
+	if len(locs) < 2 {
+		t.Fatalf("expected >=2 hunks in svc.go diff, got %d\n%s", len(locs), fileDiff)
+	}
+	// Keep everything from start up to (not including) the second hunk header.
+	return strings.TrimRight(fileDiff[:locs[1][0]], "\n")
+}
+
+func TestIntegration_SelectedDiffScopeAndTrueHead(t *testing.T) {
+	dir, baseSHA, headSHA := buildMultiHunkRepo(t)
+	ctx := context.Background()
+
+	// 1. Canonical BASE..HEAD diff via the real provider.
+	provider := diff.NewProvider(dir, baseSHA, headSHA, nil)
+	canonical, err := provider.GetDiff(ctx)
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	var svcDiff string
+	seenOther := false
+	for _, d := range canonical {
+		if d.NewPath == "svc.go" {
+			svcDiff = d.Diff
+		}
+		if d.NewPath == "other.go" {
+			seenOther = true
+		}
+	}
+	if svcDiff == "" || !seenOther {
+		t.Fatalf("canonical missing files; got %d diffs", len(canonical))
+	}
+
+	// 2. Build a selection patch = only svc.go's first hunk.
+	selected := firstHunkOnly(t, svcDiff)
+
+	// 3. Apply selection.
+	narrowed, err := diff.ApplySelection(canonical, selected)
+	if err != nil {
+		t.Fatalf("ApplySelection: %v", err)
+	}
+
+	// Scope: only svc.go, only the top hunk.
+	if len(narrowed) != 1 || narrowed[0].NewPath != "svc.go" {
+		var paths []string
+		for _, d := range narrowed {
+			paths = append(paths, d.NewPath)
+		}
+		t.Fatalf("expected only svc.go, got %v", paths)
+	}
+	if !strings.Contains(narrowed[0].Diff, "INSERTED-TOP") {
+		t.Errorf("narrowed diff should contain top hunk")
+	}
+	if strings.Contains(narrowed[0].Diff, "INSERTED-BOTTOM") {
+		t.Errorf("narrowed diff must NOT contain the unselected bottom hunk:\n%s", narrowed[0].Diff)
+	}
+
+	// 4. Full file reads stay anchored at true HEAD: the FileReader returns the
+	// COMPLETE head file, including the region of the *unselected* bottom hunk.
+	fr := &tool.FileReader{RepoDir: dir, Mode: tool.ModeRange, Ref: headSHA}
+	content, err := fr.Read(ctx, "svc.go")
+	if err != nil {
+		t.Fatalf("FileReader.Read: %v", err)
+	}
+	if !strings.Contains(content, "INSERTED-TOP") || !strings.Contains(content, "INSERTED-BOTTOM") {
+		t.Errorf("full HEAD read must include both edits (true-head context); got:\n%s", content)
+	}
+	// And NewFileContent carried on the narrowed diff is the same true-HEAD file.
+	if !strings.Contains(narrowed[0].NewFileContent, "INSERTED-BOTTOM") {
+		t.Errorf("narrowed NewFileContent must remain the full true-HEAD file")
+	}
+
+	// 5. Preview scope reflects the narrowed selection (only svc.go reviewable).
+	ag := agent.New(agent.Args{RepoDir: dir, From: baseSHA, To: headSHA, SelectedDiff: selected})
+	preview, err := ag.Preview(ctx)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if preview.TotalFiles != 1 {
+		t.Fatalf("preview TotalFiles=%d, want 1 (other.go dropped by selection)", preview.TotalFiles)
+	}
+	if preview.Entries[0].Path != "svc.go" || !preview.Entries[0].WillReview {
+		t.Errorf("preview entry unexpected: %+v", preview.Entries[0])
+	}
+}
+
+func TestIntegration_MutatedSelectionRejected(t *testing.T) {
+	dir, baseSHA, headSHA := buildMultiHunkRepo(t)
+	ctx := context.Background()
+	provider := diff.NewProvider(dir, baseSHA, headSHA, nil)
+	canonical, err := provider.GetDiff(ctx)
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	var svcDiff string
+	for _, d := range canonical {
+		if d.NewPath == "svc.go" {
+			svcDiff = d.Diff
+		}
+	}
+	selected := firstHunkOnly(t, svcDiff)
+	// Mutate an added line body — must fail closed.
+	mutated := strings.Replace(selected, "INSERTED-TOP", "INSERTED-TOP-EVIL", 1)
+	if _, err := diff.ApplySelection(canonical, mutated); err == nil {
+		t.Fatal("expected rejection of mutated selection patch")
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -117,6 +117,12 @@ type Args struct {
 
 	// Resume is an optional read-only checkpoint index from a previous review session.
 	Resume *session.ResumeState
+
+	// SelectedDiff, when non-empty, is a unified git diff containing a subset of
+	// complete hunks from the canonical From..To / Commit diff. When set, the
+	// review is narrowed to exactly those hunks while file/tool reads still come
+	// from the true --to/HEAD tree. It is only valid in range or commit mode.
+	SelectedDiff string
 }
 
 // Agent orchestrates the AI-powered code review. LLM tool-use loop / memory
@@ -315,6 +321,13 @@ func (a *Agent) loadDiffs(ctx context.Context) error {
 	parsed, err := provider.GetDiff(ctx)
 	if err != nil {
 		return fmt.Errorf("get diffs: %w", err)
+	}
+
+	if a.args.SelectedDiff != "" {
+		parsed, err = diff.ApplySelection(parsed, a.args.SelectedDiff)
+		if err != nil {
+			return fmt.Errorf("apply selected diff: %w", err)
+		}
 	}
 
 	a.diffs = parsed

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -16,7 +16,9 @@ import (
 
 var (
 	diffHeaderRe = regexp.MustCompile(`^diff --git a/(.+?) b/(.+)$`)
-	binaryRe     = regexp.MustCompile(`Binary files `)
+	// Anchored: hunk body lines always carry a '+', '-', ' ' or '\' prefix, so
+	// content that merely mentions "Binary files " must not match.
+	binaryRe = regexp.MustCompile(`^Binary files `)
 )
 
 // ParseDiffText splits the unified diff text into per-file Diff structs.

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -129,3 +129,41 @@ index 0000000..1234567
 		t.Errorf("Insertions = %d, want 2", d.Insertions)
 	}
 }
+
+// TestParseDiffText_BinaryMentionInBody guards the binary marker detection:
+// a content line that merely contains "Binary files " (always prefixed with
+// '+', '-' or ' ' in a hunk body) must not mark the file as binary, while a
+// real line-anchored "Binary files ... differ" marker must.
+func TestParseDiffText_BinaryMentionInBody(t *testing.T) {
+	diffText := `diff --git a/doc.md b/doc.md
+index 1111111..2222222 100644
+--- a/doc.md
++++ b/doc.md
+@@ -1,2 +1,3 @@
+ docs
++Binary files are compared here
+ tail
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].IsBinary {
+		t.Errorf("IsBinary = true, want false: body mention must not trigger binary detection")
+	}
+	if diffs[0].Insertions != 1 {
+		t.Errorf("Insertions = %d, want 1", diffs[0].Insertions)
+	}
+
+	binText := "diff --git a/img.png b/img.png\nindex 111..222 100644\nBinary files a/img.png and b/img.png differ\n"
+	diffs, err = ParseDiffText(context.Background(), binText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 || !diffs[0].IsBinary {
+		t.Fatalf("real binary marker not detected: %+v", diffs)
+	}
+}

--- a/internal/diff/selection.go
+++ b/internal/diff/selection.go
@@ -1,0 +1,388 @@
+package diff
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+// rawHunk is a single @@ block captured verbatim from a unified diff.
+type rawHunk struct {
+	header                                 string   // exact "@@ -a,b +c,d @@[ ctx]" line
+	oldStart, oldCount, newStart, newCount int      // parsed header ranges
+	body                                   []string // lines after the header, verbatim
+}
+
+// text renders the hunk back to unified-diff text (header + body).
+func (h rawHunk) text() string {
+	if len(h.body) == 0 {
+		return h.header
+	}
+	return h.header + "\n" + strings.Join(h.body, "\n")
+}
+
+// selectionFile is one file section parsed from a caller-supplied selection patch.
+type selectionFile struct {
+	oldPath     string
+	newPath     string
+	isBinary    bool
+	isSubmodule bool
+	hunks       []rawHunk
+}
+
+// displayPath returns the most meaningful path for error messages.
+func (sf selectionFile) displayPath() string {
+	if sf.newPath != "" && sf.newPath != "/dev/null" {
+		return sf.newPath
+	}
+	return sf.oldPath
+}
+
+// ApplySelection narrows the canonical BASE..HEAD diff set down to only the
+// hunks present in selectionPatch, which must be a standard unified git diff
+// whose files and hunks are an exact subset of canonical.
+//
+// The returned diffs preserve each file's NewFileContent (read at the true
+// --to/HEAD ref) and the original hunk headers, so downstream line resolution
+// still yields true-HEAD line numbers. Only the per-file Diff text and the
+// insertion/deletion counts are narrowed to the selected hunks, and files with
+// no selected hunk are dropped entirely.
+//
+// It fails closed: any invented/renamed/mutated hunk, malformed patch, path
+// traversal, mismatched header/ranges, ambiguous match, duplicate selection, or
+// unsupported binary/submodule shape is rejected with an error rather than
+// silently widening or narrowing scope.
+func ApplySelection(canonical []model.Diff, selectionPatch string) ([]model.Diff, error) {
+	if strings.TrimSpace(selectionPatch) == "" {
+		return nil, fmt.Errorf("selected diff is empty")
+	}
+
+	blocks, err := splitSelectionFiles(selectionPatch)
+	if err != nil {
+		return nil, err
+	}
+
+	type canonEntry struct {
+		diff     *model.Diff
+		preamble string
+		hunks    []rawHunk
+	}
+	entries := make([]*canonEntry, len(canonical))
+	byNew := make(map[string]*canonEntry)
+	byOld := make(map[string]*canonEntry)
+	for i := range canonical {
+		d := &canonical[i]
+		pre, hunks := splitFileHunks(d.Diff)
+		e := &canonEntry{diff: d, preamble: pre, hunks: hunks}
+		entries[i] = e
+		if d.NewPath != "" && d.NewPath != "/dev/null" {
+			byNew[d.NewPath] = e
+		}
+		if d.OldPath != "" && d.OldPath != "/dev/null" {
+			byOld[d.OldPath] = e
+		}
+	}
+
+	// chosen[entry] = set of selected canonical hunk indices.
+	chosen := make(map[*canonEntry]map[int]bool)
+
+	for _, block := range blocks {
+		sf, perr := parseSelectionFile(block)
+		if perr != nil {
+			return nil, perr
+		}
+		if verr := validateSelectionPath(sf.oldPath); verr != nil {
+			return nil, verr
+		}
+		if verr := validateSelectionPath(sf.newPath); verr != nil {
+			return nil, verr
+		}
+
+		var e *canonEntry
+		if sf.newPath != "" && sf.newPath != "/dev/null" {
+			e = byNew[sf.newPath]
+		}
+		if e == nil && sf.oldPath != "" && sf.oldPath != "/dev/null" {
+			e = byOld[sf.oldPath]
+		}
+		if e == nil {
+			return nil, fmt.Errorf("selected diff references %q which is not part of the canonical diff", sf.displayPath())
+		}
+		if !pathsMatch(sf, e.diff) {
+			return nil, fmt.Errorf("selected diff path mismatch for %q: canonical change is %s -> %s",
+				sf.displayPath(), e.diff.OldPath, e.diff.NewPath)
+		}
+		if e.diff.IsBinary || sf.isBinary {
+			return nil, fmt.Errorf("selected diff includes binary file %q, which cannot be hunk-selected", sf.displayPath())
+		}
+		if sf.isSubmodule {
+			return nil, fmt.Errorf("selected diff includes submodule change %q, which cannot be hunk-selected", sf.displayPath())
+		}
+		if len(sf.hunks) == 0 {
+			return nil, fmt.Errorf("selected diff for %q contains no hunks", sf.displayPath())
+		}
+
+		set := chosen[e]
+		if set == nil {
+			set = make(map[int]bool)
+			chosen[e] = set
+		}
+		for _, sh := range sf.hunks {
+			idx, merr := matchCanonicalHunk(e.hunks, sh)
+			if merr != nil {
+				return nil, fmt.Errorf("selected diff for %q: %w", sf.displayPath(), merr)
+			}
+			if set[idx] {
+				return nil, fmt.Errorf("selected diff for %q lists the same hunk (@@ -%d,%d +%d,%d @@) more than once",
+					sf.displayPath(), sh.oldStart, sh.oldCount, sh.newStart, sh.newCount)
+			}
+			set[idx] = true
+		}
+	}
+
+	var result []model.Diff
+	for _, e := range entries {
+		set := chosen[e]
+		if len(set) == 0 {
+			continue
+		}
+		nd := *e.diff
+
+		parts := make([]string, 0, len(set)+1)
+		if e.preamble != "" {
+			parts = append(parts, e.preamble)
+		}
+		var insertions, deletions int64
+		for i := range e.hunks {
+			if !set[i] {
+				continue
+			}
+			h := e.hunks[i]
+			parts = append(parts, h.text())
+			for _, bl := range h.body {
+				if len(bl) == 0 {
+					continue
+				}
+				switch bl[0] {
+				case '+':
+					insertions++
+				case '-':
+					deletions++
+				}
+			}
+		}
+		nd.Diff = strings.Join(parts, "\n")
+		nd.Insertions = insertions
+		nd.Deletions = deletions
+		result = append(result, nd)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("selected diff matched no reviewable hunks")
+	}
+	return result, nil
+}
+
+// splitSelectionFiles splits a multi-file unified diff into per-file text
+// blocks, each beginning with a "diff --git" header.
+func splitSelectionFiles(patch string) ([]string, error) {
+	patch = strings.TrimRight(patch, "\n")
+	lines := strings.Split(patch, "\n")
+	var blocks []string
+	var cur []string
+	flush := func() {
+		if len(cur) > 0 {
+			blocks = append(blocks, strings.Join(cur, "\n"))
+			cur = nil
+		}
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			flush()
+			cur = []string{line}
+			continue
+		}
+		if len(cur) == 0 {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			return nil, fmt.Errorf("selected diff: unexpected content before first 'diff --git' header: %q", line)
+		}
+		cur = append(cur, line)
+	}
+	flush()
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("selected diff: no file sections found (expected a 'diff --git' header)")
+	}
+	return blocks, nil
+}
+
+// parseSelectionFile parses one "diff --git" file block into a selectionFile.
+func parseSelectionFile(block string) (selectionFile, error) {
+	var sf selectionFile
+	lines := strings.Split(block, "\n")
+	m := diffHeaderRe.FindStringSubmatch(lines[0])
+	if m == nil {
+		return sf, fmt.Errorf("selected diff: malformed file header: %q", lines[0])
+	}
+	sf.oldPath = m[1]
+	sf.newPath = m[2]
+
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "rename from "):
+			sf.oldPath = strings.TrimPrefix(line, "rename from ")
+		case strings.HasPrefix(line, "rename to "):
+			sf.newPath = strings.TrimPrefix(line, "rename to ")
+		case line == "--- /dev/null":
+			sf.oldPath = "/dev/null"
+		case line == "+++ /dev/null":
+			sf.newPath = "/dev/null"
+		case binaryRe.MatchString(line):
+			sf.isBinary = true
+		case strings.HasPrefix(line, "Subproject commit "):
+			sf.isSubmodule = true
+		case strings.HasPrefix(line, "index ") && strings.Contains(line, " 160000"):
+			sf.isSubmodule = true
+		}
+	}
+
+	_, hunks := splitFileHunks(block)
+	sf.hunks = hunks
+	return sf, nil
+}
+
+// splitFileHunks splits a single file's unified diff into the preamble
+// (everything before the first @@ header) and the sequence of raw hunks.
+func splitFileHunks(fileDiff string) (preamble string, hunks []rawHunk) {
+	lines := strings.Split(fileDiff, "\n")
+	var pre []string
+	var cur *rawHunk
+	seenHunk := false
+	flush := func() {
+		if cur != nil {
+			cur.body = trimTrailingEmpty(cur.body)
+			hunks = append(hunks, *cur)
+			cur = nil
+		}
+	}
+	for _, line := range lines {
+		if seenHunk && strings.HasPrefix(line, "diff --git ") {
+			break // start of the next file
+		}
+		if hm := hunkHeaderRe.FindStringSubmatch(line); hm != nil {
+			flush()
+			seenHunk = true
+			oldStart, _ := strconv.Atoi(hm[1])
+			oldCount := 1
+			if hm[2] != "" {
+				oldCount, _ = strconv.Atoi(hm[2])
+			}
+			newStart, _ := strconv.Atoi(hm[3])
+			newCount := 1
+			if hm[4] != "" {
+				newCount, _ = strconv.Atoi(hm[4])
+			}
+			cur = &rawHunk{
+				header:   line,
+				oldStart: oldStart,
+				oldCount: oldCount,
+				newStart: newStart,
+				newCount: newCount,
+			}
+			continue
+		}
+		if cur == nil {
+			pre = append(pre, line)
+			continue
+		}
+		cur.body = append(cur.body, line)
+	}
+	flush()
+	return strings.Join(pre, "\n"), hunks
+}
+
+// matchCanonicalHunk finds the unique canonical hunk that exactly equals sel
+// (same four header ranges and identical body). It fails closed on no match,
+// a header-only match (mutated/partial body), or multiple matches (ambiguous).
+func matchCanonicalHunk(canon []rawHunk, sel rawHunk) (int, error) {
+	matches := make([]int, 0, 1)
+	for i, ch := range canon {
+		if ch.oldStart == sel.oldStart && ch.oldCount == sel.oldCount &&
+			ch.newStart == sel.newStart && ch.newCount == sel.newCount &&
+			equalBody(ch.body, sel.body) {
+			matches = append(matches, i)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		for _, ch := range canon {
+			if ch.oldStart == sel.oldStart && ch.newStart == sel.newStart {
+				return -1, fmt.Errorf("hunk @@ -%d,%d +%d,%d @@ does not match the canonical hunk content (modified or partial hunk)",
+					sel.oldStart, sel.oldCount, sel.newStart, sel.newCount)
+			}
+		}
+		return -1, fmt.Errorf("hunk @@ -%d,%d +%d,%d @@ is not present in the canonical diff",
+			sel.oldStart, sel.oldCount, sel.newStart, sel.newCount)
+	default:
+		return -1, fmt.Errorf("hunk @@ -%d,%d +%d,%d @@ matches multiple canonical hunks (ambiguous)",
+			sel.oldStart, sel.oldCount, sel.newStart, sel.newCount)
+	}
+}
+
+// equalBody reports whether two hunk bodies are byte-for-byte identical.
+func equalBody(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// trimTrailingEmpty drops trailing empty strings, which only ever arise from a
+// trailing newline in the source text (never from a real diff line, which
+// always carries a leading '+', '-', ' ' or '\' marker).
+func trimTrailingEmpty(lines []string) []string {
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// validateSelectionPath rejects absolute paths and '..' traversal segments.
+func validateSelectionPath(p string) error {
+	if p == "" || p == "/dev/null" {
+		return nil
+	}
+	if strings.HasPrefix(p, "/") {
+		return fmt.Errorf("selected diff path %q must be repository-relative, not absolute", p)
+	}
+	if p == ".." || strings.HasPrefix(p, "../") || strings.Contains(p, "/../") || strings.HasSuffix(p, "/..") {
+		return fmt.Errorf("selected diff path %q contains a path traversal ('..') segment", p)
+	}
+	return nil
+}
+
+// pathsMatch verifies the selection's declared old/new paths agree with the
+// canonical change, guarding against path swapping or rename mismatch.
+func pathsMatch(sf selectionFile, d *model.Diff) bool {
+	if sf.newPath != "" && sf.newPath != "/dev/null" && d.NewPath != "/dev/null" {
+		if sf.newPath != d.NewPath {
+			return false
+		}
+	}
+	if sf.oldPath != "" && sf.oldPath != "/dev/null" && d.OldPath != "/dev/null" {
+		if sf.oldPath != d.OldPath {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/diff/selection_test.go
+++ b/internal/diff/selection_test.go
@@ -333,6 +333,24 @@ func TestApplySelection_BinaryRejected(t *testing.T) {
 	}
 }
 
+func TestApplySelection_BinaryMentionInHunkBodyNotRejected(t *testing.T) {
+	// A hunk body line whose content merely mentions "Binary files " must not
+	// mark the file as binary: only a real (line-anchored) binary marker counts.
+	hunk := "@@ -1,2 +1,3 @@\n docs\n+Binary files are compared here\n tail"
+	canonical := []model.Diff{{
+		OldPath: "doc.md", NewPath: "doc.md",
+		Diff: "diff --git a/doc.md b/doc.md\n--- a/doc.md\n+++ b/doc.md\n" + hunk,
+	}}
+	patch := "diff --git a/doc.md b/doc.md\n--- a/doc.md\n+++ b/doc.md\n" + hunk
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got[0].Diff, "Binary files are compared here") {
+		t.Errorf("selected hunk content lost: %q", got[0].Diff)
+	}
+}
+
 func TestApplySelection_SubmoduleRejected(t *testing.T) {
 	canonical := []model.Diff{{
 		OldPath: "sub", NewPath: "sub",

--- a/internal/diff/selection_test.go
+++ b/internal/diff/selection_test.go
@@ -1,0 +1,421 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+// canonAFile is a two-hunk canonical diff for "a.txt" used across cases.
+// Hunk 1 adds "added-early" near the top; hunk 2 adds "added-late" near line 11.
+const canonAPreamble = "diff --git a/a.txt b/a.txt\n" +
+	"index 1111111..2222222 100644\n" +
+	"--- a/a.txt\n" +
+	"+++ b/a.txt"
+
+const canonAHunk1 = "@@ -1,3 +1,4 @@\n" +
+	" line1\n" +
+	"+added-early\n" +
+	" line2\n" +
+	" line3"
+
+const canonAHunk2 = "@@ -10,3 +11,4 @@\n" +
+	" line10\n" +
+	" line11\n" +
+	"+added-late\n" +
+	" line12"
+
+func canonAFile() model.Diff {
+	return model.Diff{
+		OldPath:        "a.txt",
+		NewPath:        "a.txt",
+		Diff:           canonAPreamble + "\n" + canonAHunk1 + "\n" + canonAHunk2,
+		NewFileContent: "HEAD-CONTENT-A",
+		Insertions:     2,
+	}
+}
+
+// selPatch wraps hunks with a minimal file header for "a.txt".
+func selAPatch(hunks ...string) string {
+	head := "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n"
+	return head + strings.Join(hunks, "\n")
+}
+
+func TestApplySelection_Success(t *testing.T) {
+	tests := []struct {
+		name           string
+		canonical      []model.Diff
+		patch          string
+		wantFiles      int
+		wantContains   []string // substrings that must appear in result[0].Diff
+		wantExcludes   []string // substrings that must NOT appear in result[0].Diff
+		wantInsertions int64
+		wantDeletions  int64
+		wantHEAD       string
+	}{
+		{
+			name:           "single hunk",
+			canonical:      []model.Diff{canonAFile()},
+			patch:          selAPatch(canonAHunk1),
+			wantFiles:      1,
+			wantContains:   []string{"@@ -1,3 +1,4 @@", "added-early"},
+			wantExcludes:   []string{"added-late", "@@ -10,3 +11,4 @@"},
+			wantInsertions: 1,
+			wantHEAD:       "HEAD-CONTENT-A",
+		},
+		{
+			name:           "multiple selected hunks in one file",
+			canonical:      []model.Diff{canonAFile()},
+			patch:          selAPatch(canonAHunk1, canonAHunk2),
+			wantFiles:      1,
+			wantContains:   []string{"added-early", "added-late", "@@ -1,3 +1,4 @@", "@@ -10,3 +11,4 @@"},
+			wantInsertions: 2,
+		},
+		{
+			name:           "non-selected hunk excluded (only second selected)",
+			canonical:      []model.Diff{canonAFile()},
+			patch:          selAPatch(canonAHunk2),
+			wantFiles:      1,
+			wantContains:   []string{"added-late", "@@ -10,3 +11,4 @@"},
+			wantExcludes:   []string{"added-early", "@@ -1,3 +1,4 @@"},
+			wantInsertions: 1,
+		},
+		{
+			name:         "preamble preserved from canonical even if selection omits index",
+			canonical:    []model.Diff{canonAFile()},
+			patch:        selAPatch(canonAHunk1),
+			wantFiles:    1,
+			wantContains: []string{"index 1111111..2222222 100644"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ApplySelection(tt.canonical, tt.patch)
+			if err != nil {
+				t.Fatalf("ApplySelection() unexpected error: %v", err)
+			}
+			if len(got) != tt.wantFiles {
+				t.Fatalf("got %d files, want %d", len(got), tt.wantFiles)
+			}
+			d := got[0]
+			for _, s := range tt.wantContains {
+				if !strings.Contains(d.Diff, s) {
+					t.Errorf("result diff missing %q; diff=\n%s", s, d.Diff)
+				}
+			}
+			for _, s := range tt.wantExcludes {
+				if strings.Contains(d.Diff, s) {
+					t.Errorf("result diff should not contain %q; diff=\n%s", s, d.Diff)
+				}
+			}
+			if tt.wantInsertions != 0 && d.Insertions != tt.wantInsertions {
+				t.Errorf("Insertions=%d, want %d", d.Insertions, tt.wantInsertions)
+			}
+			if tt.wantHEAD != "" && d.NewFileContent != tt.wantHEAD {
+				t.Errorf("NewFileContent=%q, want %q (must stay anchored at true HEAD)", d.NewFileContent, tt.wantHEAD)
+			}
+		})
+	}
+}
+
+func TestApplySelection_MultipleFiles(t *testing.T) {
+	fileB := model.Diff{
+		OldPath:        "b.txt",
+		NewPath:        "b.txt",
+		Diff:           "diff --git a/b.txt b/b.txt\nindex aaa..bbb 100644\n--- a/b.txt\n+++ b/b.txt\n@@ -1,2 +1,3 @@\n x\n+bee\n y",
+		NewFileContent: "HEAD-CONTENT-B",
+	}
+	canonical := []model.Diff{canonAFile(), fileB}
+
+	// Select hunk1 of a.txt and the only hunk of b.txt.
+	patch := selAPatch(canonAHunk1) + "\n" +
+		"diff --git a/b.txt b/b.txt\n--- a/b.txt\n+++ b/b.txt\n@@ -1,2 +1,3 @@\n x\n+bee\n y"
+
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d files, want 2", len(got))
+	}
+	// canonical order preserved: a.txt first, b.txt second.
+	if got[0].NewPath != "a.txt" || got[1].NewPath != "b.txt" {
+		t.Fatalf("unexpected order: %s, %s", got[0].NewPath, got[1].NewPath)
+	}
+	if strings.Contains(got[0].Diff, "added-late") {
+		t.Errorf("a.txt should only contain hunk1")
+	}
+	if !strings.Contains(got[1].Diff, "bee") {
+		t.Errorf("b.txt hunk missing")
+	}
+}
+
+func TestApplySelection_SelectingOneFileDropsOthers(t *testing.T) {
+	fileB := model.Diff{
+		OldPath: "b.txt", NewPath: "b.txt",
+		Diff: "diff --git a/b.txt b/b.txt\n--- a/b.txt\n+++ b/b.txt\n@@ -1,1 +1,2 @@\n x\n+bee",
+	}
+	canonical := []model.Diff{canonAFile(), fileB}
+	got, err := ApplySelection(canonical, selAPatch(canonAHunk1))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].NewPath != "a.txt" {
+		t.Fatalf("expected only a.txt, got %+v", got)
+	}
+}
+
+func TestApplySelection_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		canonical []model.Diff
+		patch     string
+		wantErr   string
+	}{
+		{
+			name:      "empty selection",
+			canonical: []model.Diff{canonAFile()},
+			patch:     "   \n  ",
+			wantErr:   "empty",
+		},
+		{
+			name:      "no diff --git header",
+			canonical: []model.Diff{canonAFile()},
+			patch:     "this is not a patch\njust text",
+			wantErr:   "before first 'diff --git'",
+		},
+		{
+			name:      "invented path not in canonical",
+			canonical: []model.Diff{canonAFile()},
+			patch:     "diff --git a/ghost.txt b/ghost.txt\n--- a/ghost.txt\n+++ b/ghost.txt\n@@ -1,1 +1,2 @@\n x\n+y",
+			wantErr:   "not part of the canonical diff",
+		},
+		{
+			name:      "modified hunk body",
+			canonical: []model.Diff{canonAFile()},
+			patch:     selAPatch("@@ -1,3 +1,4 @@\n line1\n+MUTATED\n line2\n line3"),
+			wantErr:   "modified or partial hunk",
+		},
+		{
+			name:      "wrong ranges (no such hunk location)",
+			canonical: []model.Diff{canonAFile()},
+			patch:     selAPatch("@@ -50,3 +50,4 @@\n line1\n+added-early\n line2\n line3"),
+			wantErr:   "not present in the canonical diff",
+		},
+		{
+			name:      "truncated/partial hunk body",
+			canonical: []model.Diff{canonAFile()},
+			patch:     selAPatch("@@ -1,3 +1,4 @@\n line1\n+added-early"),
+			wantErr:   "modified or partial hunk",
+		},
+		{
+			name:      "duplicate hunk selection",
+			canonical: []model.Diff{canonAFile()},
+			patch:     selAPatch(canonAHunk1, canonAHunk1),
+			wantErr:   "more than once",
+		},
+		{
+			name:      "path traversal",
+			canonical: []model.Diff{canonAFile()},
+			patch:     "diff --git a/../etc/passwd b/../etc/passwd\n--- a/../etc/passwd\n+++ b/../etc/passwd\n@@ -1,1 +1,2 @@\n x\n+y",
+			wantErr:   "path traversal",
+		},
+		{
+			name:      "absolute path",
+			canonical: []model.Diff{canonAFile()},
+			patch:     "diff --git a//etc/passwd b//etc/passwd\n--- a//etc/passwd\n+++ b//etc/passwd\n@@ -1,1 +1,2 @@\n x\n+y",
+			wantErr:   "absolute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ApplySelection(tt.canonical, tt.patch)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplySelection_AmbiguousHunk(t *testing.T) {
+	// Craft a (pathological) canonical file with two hunks that have identical
+	// headers AND identical bodies so the selection cannot be disambiguated.
+	dupHunk := "@@ -5,2 +5,3 @@\n ctx\n+dup\n ctx2"
+	canonical := []model.Diff{{
+		OldPath: "d.txt", NewPath: "d.txt",
+		Diff: "diff --git a/d.txt b/d.txt\n--- a/d.txt\n+++ b/d.txt\n" + dupHunk + "\n" + dupHunk,
+	}}
+	patch := "diff --git a/d.txt b/d.txt\n--- a/d.txt\n+++ b/d.txt\n" + dupHunk
+	_, err := ApplySelection(canonical, patch)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous error, got %v", err)
+	}
+}
+
+func TestApplySelection_DuplicateBodyDifferentLocationDisambiguated(t *testing.T) {
+	// Two hunks with identical body but different headers must be disambiguated
+	// by header (not treated as ambiguous).
+	h1 := "@@ -1,2 +1,3 @@\n ctx\n+same\n ctx2"
+	h2 := "@@ -20,2 +21,3 @@\n ctx\n+same\n ctx2"
+	canonical := []model.Diff{{
+		OldPath: "e.txt", NewPath: "e.txt",
+		Diff: "diff --git a/e.txt b/e.txt\n--- a/e.txt\n+++ b/e.txt\n" + h1 + "\n" + h2,
+	}}
+	patch := "diff --git a/e.txt b/e.txt\n--- a/e.txt\n+++ b/e.txt\n" + h2
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got[0].Diff, "@@ -20,2 +21,3 @@") {
+		t.Errorf("expected second hunk selected; diff=\n%s", got[0].Diff)
+	}
+	if strings.Contains(got[0].Diff, "@@ -1,2 +1,3 @@") {
+		t.Errorf("first hunk should not be selected; diff=\n%s", got[0].Diff)
+	}
+}
+
+func TestApplySelection_Rename(t *testing.T) {
+	canonical := []model.Diff{{
+		OldPath:        "old.txt",
+		NewPath:        "new.txt",
+		IsRenamed:      true,
+		Diff:           "diff --git a/old.txt b/new.txt\nsimilarity index 90%\nrename from old.txt\nrename to new.txt\n--- a/old.txt\n+++ b/new.txt\n@@ -1,2 +1,3 @@\n keep\n+extra\n tail",
+		NewFileContent: "HEAD-RENAMED",
+	}}
+	patch := "diff --git a/old.txt b/new.txt\nrename from old.txt\nrename to new.txt\n--- a/old.txt\n+++ b/new.txt\n@@ -1,2 +1,3 @@\n keep\n+extra\n tail"
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].NewPath != "new.txt" || !got[0].IsRenamed {
+		t.Fatalf("rename not preserved: %+v", got)
+	}
+	if got[0].NewFileContent != "HEAD-RENAMED" {
+		t.Errorf("HEAD content not preserved")
+	}
+}
+
+func TestApplySelection_Delete(t *testing.T) {
+	canonical := []model.Diff{{
+		OldPath:   "gone.txt",
+		NewPath:   "/dev/null",
+		IsDeleted: true,
+		Diff:      "diff --git a/gone.txt b/gone.txt\ndeleted file mode 100644\n--- a/gone.txt\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-a\n-b\n-c",
+	}}
+	patch := "diff --git a/gone.txt b/gone.txt\ndeleted file mode 100644\n--- a/gone.txt\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-a\n-b\n-c"
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || !got[0].IsDeleted {
+		t.Fatalf("delete not preserved: %+v", got)
+	}
+	if got[0].Deletions != 3 {
+		t.Errorf("Deletions=%d, want 3", got[0].Deletions)
+	}
+}
+
+func TestApplySelection_BinaryRejected(t *testing.T) {
+	canonical := []model.Diff{{
+		OldPath: "img.png", NewPath: "img.png", IsBinary: true,
+		Diff: "diff --git a/img.png b/img.png\nindex 111..222 100644\nBinary files a/img.png and b/img.png differ",
+	}}
+	patch := "diff --git a/img.png b/img.png\nBinary files a/img.png and b/img.png differ"
+	_, err := ApplySelection(canonical, patch)
+	if err == nil || !strings.Contains(err.Error(), "binary") {
+		t.Fatalf("expected binary rejection, got %v", err)
+	}
+}
+
+func TestApplySelection_SubmoduleRejected(t *testing.T) {
+	canonical := []model.Diff{{
+		OldPath: "sub", NewPath: "sub",
+		Diff: "diff --git a/sub b/sub\nindex 111..222 160000\n--- a/sub\n+++ b/sub\n@@ -1 +1 @@\n-Subproject commit 1111111\n+Subproject commit 2222222",
+	}}
+	patch := "diff --git a/sub b/sub\nindex 111..222 160000\n--- a/sub\n+++ b/sub\n@@ -1 +1 @@\n-Subproject commit 1111111\n+Subproject commit 2222222"
+	_, err := ApplySelection(canonical, patch)
+	if err == nil || !strings.Contains(err.Error(), "submodule") {
+		t.Fatalf("expected submodule rejection, got %v", err)
+	}
+}
+
+func TestApplySelection_CRLFContentPreserved(t *testing.T) {
+	// A file with CRLF line endings: the CR is part of each line's content in
+	// the diff. The selection is sliced verbatim, so it matches exactly.
+	hunk := "@@ -1,2 +1,3 @@\n keep\r\n+added\r\n tail\r"
+	canonical := []model.Diff{{
+		OldPath: "crlf.txt", NewPath: "crlf.txt",
+		Diff:           "diff --git a/crlf.txt b/crlf.txt\n--- a/crlf.txt\n+++ b/crlf.txt\n" + hunk,
+		NewFileContent: "keep\r\nadded\r\ntail\r\n",
+	}}
+	patch := "diff --git a/crlf.txt b/crlf.txt\n--- a/crlf.txt\n+++ b/crlf.txt\n" + hunk
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got[0].Diff, "added\r") {
+		t.Errorf("CR content not preserved: %q", got[0].Diff)
+	}
+}
+
+func TestApplySelection_UnicodeContent(t *testing.T) {
+	hunk := "@@ -1,2 +1,3 @@\n 日本語\n+café-résumé-🚀\n مرحبا"
+	canonical := []model.Diff{{
+		OldPath: "u.txt", NewPath: "u.txt",
+		Diff: "diff --git a/u.txt b/u.txt\n--- a/u.txt\n+++ b/u.txt\n" + hunk,
+	}}
+	patch := "diff --git a/u.txt b/u.txt\n--- a/u.txt\n+++ b/u.txt\n" + hunk
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got[0].Diff, "café-résumé-🚀") {
+		t.Errorf("unicode content lost: %q", got[0].Diff)
+	}
+}
+
+func TestApplySelection_NoNewlineMarker(t *testing.T) {
+	hunk := "@@ -1,2 +1,2 @@\n keep\n-old\n+new\n\\ No newline at end of file"
+	canonical := []model.Diff{{
+		OldPath: "n.txt", NewPath: "n.txt",
+		Diff: "diff --git a/n.txt b/n.txt\n--- a/n.txt\n+++ b/n.txt\n" + hunk,
+	}}
+	// Success when marker included verbatim.
+	patch := "diff --git a/n.txt b/n.txt\n--- a/n.txt\n+++ b/n.txt\n" + hunk
+	got, err := ApplySelection(canonical, patch)
+	if err != nil {
+		t.Fatalf("unexpected error with no-newline marker: %v", err)
+	}
+	if !strings.Contains(got[0].Diff, "No newline at end of file") {
+		t.Errorf("no-newline marker dropped")
+	}
+
+	// Failure when marker omitted (body differs from canonical).
+	bad := "diff --git a/n.txt b/n.txt\n--- a/n.txt\n+++ b/n.txt\n@@ -1,2 +1,2 @@\n keep\n-old\n+new"
+	if _, err := ApplySelection(canonical, bad); err == nil {
+		t.Fatalf("expected mismatch when no-newline marker omitted")
+	}
+}
+
+// TestApplySelection_LineResolverAccuracy verifies the narrowed diff still
+// resolves comment line numbers to true-HEAD positions.
+func TestApplySelection_LineResolverAccuracy(t *testing.T) {
+	got, err := ApplySelection([]model.Diff{canonAFile()}, selAPatch(canonAHunk2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "added-late" is at new-file line 13 in canonAHunk2 (@@ -10,3 +11,4 @@:
+	// line10=11, line11=12, added-late=13).
+	comments := []model.LlmComment{{Path: "a.txt", ExistingCode: "added-late"}}
+	resolved := ResolveLineNumbers(comments, got)
+	if resolved[0].StartLine != 13 || resolved[0].EndLine != 13 {
+		t.Fatalf("line resolution wrong: got start=%d end=%d, want 13/13",
+			resolved[0].StartLine, resolved[0].EndLine)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--diff-file` input to `ocr review` so a caller can review only a
subset of the changes in a range, instead of the whole `--from..--to` (or
`--commit`) diff.

Motivation: on large changesets, teams often want to select which hunks are in
scope for review (e.g. risk-ranked or path-filtered externally) and hand OCR
just that slice. Today OCR reviews the entire range. This change lets an
external tool express that selection as a plain unified git patch while keeping
all selection *policy* outside OCR.

Usage:

```
ocr review --from BASE --to HEAD --diff-file selected.patch
```

`selected.patch` is a standard unified git diff (`git diff` output) containing
an exact subset of complete hunks from the canonical `BASE..HEAD` diff. OCR
reviews only those hunks, while still reading the complete real HEAD tree, so
full-file tool reads and GitHub comment line numbers remain anchored to the true
HEAD.

## Behavior & safety

- `internal/diff.ApplySelection` narrows the canonical per-file diffs down to the
  selected hunks. It **fails closed** on anything that isn't an exact subset:
  invented/renamed/mutated hunks, malformed or truncated patches, path traversal
  (`..`/absolute), mismatched header ranges, ambiguous or duplicate matches, and
  binary/submodule shapes.
- `NewFileContent` and the original hunk headers are preserved, so line
  resolution still yields true-HEAD line numbers.
- The flag requires an explicit `--from/--to` or `--commit` range (rejected in
  workspace mode) and cannot be combined with `--resume`, because narrowing the
  diff changes the resume fingerprint.
- Default behavior is completely unchanged when `--diff-file` is not passed.

## Tests

- `internal/diff/selection_test.go`: table-driven unit tests (single/multiple
  hunks, multiple files, dropping unselected files, mutated body, wrong ranges,
  ambiguous/duplicate, rename, delete, binary, submodule, CRLF, Unicode,
  no-newline marker, and line-resolver accuracy vs true HEAD).
- `cmd/opencodereview/selected_diff_test.go`: CLI flag/mode validation plus two
  integration tests on a real temp git repo (multi-hunk HEAD, subset selection)
  asserting review/preview scope and that full reads come from true HEAD.

Refs #313