### PR TITLE
fix(llm): support opt-in OpenAI streaming

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -333,6 +333,9 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 	for k, v := range c.cfg.ExtraBody {
 		opts = append(opts, openaiopt.WithJSONSet(k, v))
 	}
+	if stream, ok := c.cfg.ExtraBody["stream"].(bool); ok && stream {
+		return c.completionsStreaming(ctx, params, opts...)
+	}
 
 	sdkResp, err := c.sdk.Chat.Completions.New(ctx, params, opts...)
 	if err != nil {
@@ -340,6 +343,78 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 	}
 
 	return c.mapOpenAIResponse(sdkResp), nil
+}
+
+func (c *OpenAIClient) completionsStreaming(ctx context.Context, params openai.ChatCompletionNewParams, opts ...openaiopt.RequestOption) (*ChatResponse, error) {
+	stream := c.sdk.Chat.Completions.NewStreaming(ctx, params, opts...)
+	defer stream.Close()
+
+	accumulator := openai.ChatCompletionAccumulator{}
+	reasoningByChoice := make(map[int64]*strings.Builder)
+	seenChoices := make(map[int64]bool)
+	finishedChoices := make(map[int64]bool)
+	var choiceOrder []int64
+	var usage *UsageInfo
+	for stream.Next() {
+		chunk := stream.Current()
+		if chunk.JSON.Usage.Valid() {
+			if chunkUsage := resolveUsage([]byte(chunk.RawJSON())); chunkUsage != nil {
+				usage = chunkUsage
+			}
+		}
+		for _, choice := range chunk.Choices {
+			if !seenChoices[choice.Index] {
+				seenChoices[choice.Index] = true
+				choiceOrder = append(choiceOrder, choice.Index)
+			}
+			if choice.FinishReason != "" {
+				finishedChoices[choice.Index] = true
+			}
+
+			extra, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]
+			if !ok {
+				continue
+			}
+
+			var reasoningContent string
+			if err := json.Unmarshal([]byte(extra.Raw()), &reasoningContent); err != nil {
+				reasoningContent = extra.Raw()
+			}
+			builder := reasoningByChoice[choice.Index]
+			if builder == nil {
+				builder = &strings.Builder{}
+				reasoningByChoice[choice.Index] = builder
+			}
+			builder.WriteString(reasoningContent)
+		}
+		if !accumulator.AddChunk(chunk) {
+			return nil, fmt.Errorf("OpenAI streaming response contained inconsistent chunks")
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+	if len(choiceOrder) == 0 {
+		return nil, fmt.Errorf("OpenAI streaming response contained no choices")
+	}
+	for _, index := range choiceOrder {
+		if !finishedChoices[index] {
+			return nil, fmt.Errorf("OpenAI streaming response ended before choice %d finished", index)
+		}
+	}
+
+	resp := c.mapOpenAIResponse(&accumulator.ChatCompletion)
+	if usage != nil {
+		resp.Usage = usage
+	}
+	for i := range resp.Choices {
+		builder := reasoningByChoice[accumulator.Choices[i].Index]
+		if builder != nil {
+			resp.Choices[i].Message.ReasoningContent = builder.String()
+		}
+	}
+
+	return resp, nil
 }
 
 // buildOpenAIParams converts the shared ChatRequest into OpenAI SDK parameters.

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -2,9 +2,14 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 )
@@ -438,6 +443,500 @@ func TestOpenAIClient_ExtraHeadersSent(t *testing.T) {
 	}
 	if gotOrgID != "org-abc" {
 		t.Errorf("X-Org-ID = %q, want %q", gotOrgID, "org-abc")
+	}
+}
+
+func writeOpenAISSE(t *testing.T, w http.ResponseWriter, events ...string) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Error("response writer does not support flushing")
+		return
+	}
+
+	for _, event := range events {
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", event); err != nil {
+			t.Errorf("write SSE event: %v", err)
+			return
+		}
+		flusher.Flush()
+	}
+
+	if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+		t.Errorf("write SSE done event: %v", err)
+		return
+	}
+	flusher.Flush()
+}
+
+func TestOpenAIClient_StreamOnlyGateway(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		stream, ok := body["stream"].(bool)
+		if !ok || !stream {
+			t.Errorf("stream = %#v, want boolean true", body["stream"])
+			http.Error(w, "streaming required", http.StatusBadRequest)
+			return
+		}
+		if body["vendor_flag"] != "keep-me" {
+			t.Errorf("vendor_flag = %#v, want %q", body["vendor_flag"], "keep-me")
+			http.Error(w, "vendor flag required", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("X-Test-Header"); got != "streaming" {
+			t.Errorf("X-Test-Header = %q, want %q", got, "streaming")
+			http.Error(w, "test header required", http.StatusBadRequest)
+			return
+		}
+
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"role":"assistant","content":"hel"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-stream",
+		ExtraBody: map[string]any{
+			"stream":      true,
+			"vendor_flag": "keep-me",
+		},
+		ExtraHeaders: map[string]string{
+			"X-Test-Header": "streaming",
+		},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if resp.ID != "chatcmpl-stream" {
+		t.Errorf("ID = %q, want %q", resp.ID, "chatcmpl-stream")
+	}
+	if resp.Model != "gpt-stream" {
+		t.Errorf("Model = %q, want %q", resp.Model, "gpt-stream")
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content == nil || *resp.Choices[0].Message.Content != "hello" {
+		t.Errorf("content = %#v, want %q", resp.Choices[0].Message.Content, "hello")
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish reason = %q, want %q", resp.Choices[0].FinishReason, "stop")
+	}
+}
+
+func TestOpenAIClient_StreamingRequiresBooleanTrue(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured bool
+		value      any
+	}{
+		{name: "missing"},
+		{name: "boolean false", configured: true, value: false},
+		{name: "string true", configured: true, value: "true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+					http.Error(w, "invalid request body", http.StatusBadRequest)
+					return
+				}
+
+				got, exists := body["stream"]
+				if exists != tt.configured {
+					t.Errorf("stream presence = %t, want %t", exists, tt.configured)
+				}
+				if tt.configured {
+					switch want := tt.value.(type) {
+					case bool:
+						gotBool, ok := got.(bool)
+						if !ok || gotBool != want {
+							t.Errorf("stream = %#v, want boolean %t", got, want)
+						}
+					case string:
+						gotString, ok := got.(string)
+						if !ok || gotString != want {
+							t.Errorf("stream = %#v, want string %q", got, want)
+						}
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{
+					"id":"chatcmpl-json",
+					"object":"chat.completion",
+					"model":"gpt-json",
+					"choices":[{"index":0,"message":{"role":"assistant","content":"json"},"finish_reason":"stop"}]
+				}`)
+			}))
+			defer server.Close()
+
+			var extraBody map[string]any
+			if tt.configured {
+				extraBody = map[string]any{"stream": tt.value}
+			}
+			client := NewOpenAIClient(ClientConfig{
+				URL:       server.URL + "/v1",
+				APIKey:    "test-key",
+				Model:     "gpt-json",
+				ExtraBody: extraBody,
+			})
+
+			resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+				Messages: []Message{{Role: "user", Content: "ping"}},
+			})
+			if err != nil {
+				t.Fatalf("CompletionsWithCtx: %v", err)
+			}
+			if got := resp.Content(); got != "json" {
+				t.Errorf("content = %q, want %q", got, "json")
+			}
+		})
+	}
+}
+
+func TestOpenAIClient_StreamingToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-tools","object":"chat.completion.chunk","created":1,"model":"gpt-tools","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_weather","type":"function","function":{"name":"get_","arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-tools","object":"chat.completion.chunk","created":1,"model":"gpt-tools","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"weather","arguments":"\"Paris\"}"}}]},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-tools","object":"chat.completion.chunk","created":1,"model":"gpt-tools","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-tools",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "weather"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	toolCalls := resp.ToolCalls()
+	if len(toolCalls) != 1 {
+		t.Fatalf("ToolCalls length = %d, want 1", len(toolCalls))
+	}
+	toolCall := toolCalls[0]
+	if toolCall.ID != "call_weather" {
+		t.Errorf("ToolCall ID = %q, want %q", toolCall.ID, "call_weather")
+	}
+	if toolCall.Type != "function" {
+		t.Errorf("ToolCall type = %q, want %q", toolCall.Type, "function")
+	}
+	if toolCall.Function.Name != "get_weather" {
+		t.Errorf("ToolCall function name = %q, want %q", toolCall.Function.Name, "get_weather")
+	}
+	if toolCall.Function.Arguments != `{"city":"Paris"}` {
+		t.Errorf("ToolCall arguments = %q, want %q", toolCall.Function.Arguments, `{"city":"Paris"}`)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish reason = %q, want %q", resp.Choices[0].FinishReason, "tool_calls")
+	}
+}
+
+func TestOpenAIClient_StreamingError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w, `{"error":{"message":"upstream stream failed","type":"server_error"}}`)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if err == nil || !strings.Contains(err.Error(), "upstream stream failed") {
+		t.Fatalf("error = %v, want error containing %q", err, "upstream stream failed")
+	}
+}
+
+func TestOpenAIClient_StreamingCancellation(t *testing.T) {
+	chunkWritten := make(chan struct{}, 1)
+	handlerErr := make(chan error, 1)
+	reportHandlerError := func(err error) {
+		select {
+		case handlerErr <- err:
+		default:
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			reportHandlerError(errors.New("response writer does not support flushing"))
+			return
+		}
+		if _, err := fmt.Fprint(w, `data: {"id":"chatcmpl-cancel","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}
+
+`); err != nil {
+			reportHandlerError(fmt.Errorf("write SSE event: %w", err))
+			return
+		}
+		flusher.Flush()
+		select {
+		case chunkWritten <- struct{}{}:
+		default:
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type result struct {
+		resp *ChatResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		resp, err := client.CompletionsWithCtx(ctx, ChatRequest{
+			Messages: []Message{{Role: "user", Content: "ping"}},
+		})
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	select {
+	case <-chunkWritten:
+		cancel()
+	case err := <-handlerErr:
+		cancel()
+		t.Fatalf("stream handler: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for streamed chunk")
+	}
+
+	select {
+	case got := <-resultCh:
+		if got.resp != nil {
+			t.Fatalf("response = %#v, want nil", got.resp)
+		}
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streaming cancellation deadlocked")
+	}
+}
+
+func TestOpenAIClient_StreamingInconsistentChunks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-one","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"role":"assistant","content":"one"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-two","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"content":"two"},"finish_reason":"stop"}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if err == nil || !strings.Contains(err.Error(), "inconsistent chunks") {
+		t.Fatalf("error = %v, want error containing %q", err, "inconsistent chunks")
+	}
+}
+
+func TestOpenAIClient_StreamingUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		streamOptions, ok := body["stream_options"].(map[string]any)
+		if !ok {
+			t.Errorf("stream_options = %#v, want object", body["stream_options"])
+			http.Error(w, "stream options required", http.StatusBadRequest)
+			return
+		}
+		includeUsage, ok := streamOptions["include_usage"].(bool)
+		if !ok || !includeUsage {
+			t.Errorf("stream_options.include_usage = %#v, want boolean true", streamOptions["include_usage"])
+			http.Error(w, "streaming usage required", http.StatusBadRequest)
+			return
+		}
+
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-usage","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}],"usage":null}`,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-usage","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}`,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-usage","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13,"prompt_tokens_details":{"cached_tokens":4}}}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-usage",
+		ExtraBody: map[string]any{
+			"stream": true,
+			"stream_options": map[string]any{
+				"include_usage": true,
+			},
+		},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if resp.Usage == nil {
+		t.Fatal("Usage = nil, want token usage")
+	}
+	if resp.Usage.PromptTokens != 10 {
+		t.Errorf("PromptTokens = %d, want 10", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.CompletionTokens != 3 {
+		t.Errorf("CompletionTokens = %d, want 3", resp.Usage.CompletionTokens)
+	}
+	if resp.Usage.TotalTokens != 13 {
+		t.Errorf("TotalTokens = %d, want 13", resp.Usage.TotalTokens)
+	}
+	if resp.Usage.CacheReadTokens != 4 {
+		t.Errorf("CacheReadTokens = %d, want 4", resp.Usage.CacheReadTokens)
+	}
+}
+
+func TestOpenAIClient_StreamingReasoningContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-reasoning","object":"chat.completion.chunk","created":1,"model":"gpt-reasoning","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"first "},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-reasoning","object":"chat.completion.chunk","created":1,"model":"gpt-reasoning","choices":[{"index":0,"delta":{"reasoning_content":"second","content":"answer"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-reasoning","object":"chat.completion.chunk","created":1,"model":"gpt-reasoning","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-reasoning",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if got := resp.Choices[0].Message.ReasoningContent; got != "first second" {
+		t.Errorf("ReasoningContent = %q, want %q", got, "first second")
+	}
+	if resp.Choices[0].Message.Content == nil || *resp.Choices[0].Message.Content != "answer" {
+		t.Errorf("Content = %#v, want %q", resp.Choices[0].Message.Content, "answer")
+	}
+}
+
+func TestOpenAIClient_StreamingIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-incomplete","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if err == nil || !strings.Contains(err.Error(), "ended before choice 0 finished") {
+		t.Fatalf("error = %v, want error containing %q", err, "ended before choice 0 finished")
+	}
+}
+
+func TestOpenAIClient_StreamingNoChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-empty","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1}}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if err == nil || !strings.Contains(err.Error(), "contained no choices") {
+		t.Fatalf("error = %v, want error containing %q", err, "contained no choices")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds an opt-in streamed Chat Completions path for OpenAI-compatible providers whose gateways require SSE responses.

Fixes #358.

## Changes

- select the SDK streaming API only when `extra_body.stream` is the JSON boolean `true`
- accumulate streamed text, fragmented tool calls, finish reasons, usage, and vendor `reasoning_content` into the existing `ChatResponse`
- preserve cached-token usage from raw usage chunks without injecting `stream_options`
- propagate stream errors and cancellation without returning partial responses or retrying the logical completion
- reject inconsistent, empty, and cleanly truncated streams
- add real `httptest.Server` coverage for the streaming request and response contracts

## Configuration

Streaming remains opt-in through the existing provider configuration:

```bash
ocr config set custom_providers.<name>.extra_body '{"stream":true}'
```

The value must be a JSON boolean. A missing value, `false`, or the string `"true"` keeps the existing non-streaming path.

## Non-goals

- This does not enable streaming by default or print tokens incrementally in the CLI.
- This does not add automatic fallback between streaming and non-streaming requests.
- This does not change Anthropic behavior, public LLM interfaces, or provider schemas.

## Validation

- `go test ./internal/llm -run 'TestOpenAIClient_(StreamOnlyGateway|Streaming.*)$' -count=1`
- `go test ./internal/llm -count=1`
- `go test ./cmd/opencodereview ./internal/llm -count=1`
- `go vet ./...`
- `go build -o /tmp/ocr-issue-358 ./cmd/opencodereview`
- `git diff --check origin/main...HEAD`

`go test ./... -count=1` and `make test` also pass all changed and dependent packages, including `internal/llm`. On this machine they still report the clean-`origin/main` `internal/tool` failures because Apple Git 2.39.3 does not support `git grep --end-of-options` (`fatal: unable to resolve revision: --end-of-options`).
