### PR TITLE
feat(delegate): add delegate mode for host-agent code review

### DIFF
--- a/cmd/opencodereview/bundle_helpers.go
+++ b/cmd/opencodereview/bundle_helpers.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/open-code-review/open-code-review/internal/reviewbundle"
+)
+
+func writePrivateFile(path string, content []byte) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("open output %s: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write output %s: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close output %s: %w", path, err)
+	}
+	return nil
+}
+
+func loadBundleByID(path, bundleID string) (*reviewbundle.Bundle, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle: %w", err)
+	}
+	bundle, bundleErr := reviewbundle.LoadBundle(bytes.NewReader(content))
+	if bundleErr == nil {
+		if bundle.BundleID != bundleID {
+			return nil, fmt.Errorf(
+				"bundle at %q has bundle_id %q, comments require %q",
+				path, bundle.BundleID, bundleID,
+			)
+		}
+		return bundle, nil
+	}
+	manifest, manifestErr := reviewbundle.LoadScanManifest(bytes.NewReader(content))
+	if manifestErr != nil {
+		return nil, bundleErr
+	}
+	for index := range manifest.Bundles {
+		if manifest.Bundles[index].BundleID == bundleID {
+			return &manifest.Bundles[index], nil
+		}
+	}
+	return nil, fmt.Errorf("bundle_id %q is not present in scan manifest", bundleID)
+}
+
+func loadBundleAndComments(bundlePath, commentsPath string) (*reviewbundle.Bundle, *reviewbundle.Comments, error) {
+	commentsFile, err := os.Open(commentsPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open comments: %w", err)
+	}
+	comments, loadErr := reviewbundle.LoadComments(commentsFile)
+	closeErr := commentsFile.Close()
+	if loadErr != nil {
+		return nil, nil, loadErr
+	}
+	if closeErr != nil {
+		return nil, nil, fmt.Errorf("close comments: %w", closeErr)
+	}
+	bundle, err := loadBundleByID(bundlePath, comments.BundleID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bundle, comments, nil
+}
+
+func loadValidationResult(path string) (*reviewbundle.ValidationResult, error) {
+	if path == "" {
+		return nil, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open validation result: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	var result reviewbundle.ValidationResult
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode validation result: %w", err)
+	}
+	return &result, nil
+}

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/reviewbundle"
+	"github.com/open-code-review/open-code-review/internal/stdout"
+)
+
+type delegatePrepareOptions struct {
+	repoDir        string
+	rulePath       string
+	from           string
+	to             string
+	commit         string
+	excludes       string
+	includes       string
+	outputPath     string
+	maxBundleBytes int
+	maxGitProcs    int
+	showHelp       bool
+}
+
+func runDelegate(args []string) error {
+	return runDelegateWithWriter(args, stdout.Writer())
+}
+
+func runDelegateWithWriter(args []string, writer io.Writer) error {
+	if len(args) == 0 {
+		return executeDelegateMain(nil, writer)
+	}
+	switch args[0] {
+	case "validate":
+		return runDelegateValidate(context.Background(), args[1:], writer)
+	case "report":
+		return runDelegateReport(args[1:], writer)
+	case "-h", "--help":
+		printDelegateUsage(writer)
+		return nil
+	default:
+		if strings.HasPrefix(args[0], "-") {
+			return executeDelegateMain(args, writer)
+		}
+		return fmt.Errorf("unknown delegate command: %s", args[0])
+	}
+}
+
+func executeDelegateMain(args []string, writer io.Writer) error {
+	options, err := parseDelegatePrepareFlags(args)
+	if err != nil {
+		return err
+	}
+	if options.showHelp {
+		printDelegatePrepareUsage(writer)
+		return nil
+	}
+	return executeDelegatePrepare(context.Background(), options, writer)
+}
+
+func parseDelegatePrepareFlags(args []string) (delegatePrepareOptions, error) {
+	flags := newOcrFlagSet("ocr delegate")
+	options := delegatePrepareOptions{}
+	flags.StringVar(&options.repoDir, "repo", "", "root directory of the git repository")
+	flags.StringVar(&options.rulePath, "rule", "", "path to a custom review rule file")
+	flags.StringVar(&options.from, "from", "", "source ref for a range review")
+	flags.StringVar(&options.to, "to", "", "target ref for a range review")
+	flags.StringVarP(&options.commit, "commit", "c", "", "single commit to review")
+	flags.StringVar(&options.excludes, "exclude", "", "comma-separated path patterns to exclude")
+	flags.StringVar(&options.includes, "include", "", "comma-separated path patterns to include")
+	flags.StringVar(&options.outputPath, "output", "", "explicit bundle output path")
+	flags.IntVar(
+		&options.maxBundleBytes,
+		"max-bundle-bytes",
+		int(reviewbundle.DefaultMaxBundleBytes),
+		"maximum encoded bundle size",
+	)
+	flags.IntVar(&options.maxGitProcs, "max-git-procs", 16, "maximum concurrent git subprocesses")
+	if err := flags.Parse(args); err != nil {
+		return options, fmt.Errorf("parse flags: %w", err)
+	}
+	options.showHelp = flags.showHelp
+	if options.showHelp {
+		return options, nil
+	}
+	if err := validateDelegatePrepareOptions(options); err != nil {
+		return options, err
+	}
+	return options, nil
+}
+
+func validateDelegatePrepareOptions(options delegatePrepareOptions) error {
+	modeCount := 0
+	if options.from != "" || options.to != "" {
+		modeCount++
+	}
+	if options.commit != "" {
+		modeCount++
+	}
+	if modeCount > 1 {
+		return fmt.Errorf("only one review mode allowed (--from/--to or --commit)")
+	}
+	if options.from != "" && options.to == "" {
+		return fmt.Errorf("--to is required when --from is specified")
+	}
+	if options.to != "" && options.from == "" {
+		return fmt.Errorf("--from is required when --to is specified")
+	}
+	if options.maxBundleBytes <= 0 {
+		return fmt.Errorf("--max-bundle-bytes must be greater than zero")
+	}
+	if options.maxGitProcs <= 0 {
+		return fmt.Errorf("--max-git-procs must be greater than zero")
+	}
+	return nil
+}
+
+func executeDelegatePrepare(
+	ctx context.Context,
+	options delegatePrepareOptions,
+	writer io.Writer,
+) error {
+	repoDir, _, err := resolveWorkingDir(options.repoDir, true)
+	if err != nil {
+		return err
+	}
+	resolver, fileFilter, err := rules.NewResolver(repoDir, options.rulePath)
+	if err != nil {
+		return fmt.Errorf("load rules: %w", err)
+	}
+	excludePatterns := splitPaths(options.excludes)
+	if len(excludePatterns) > 0 {
+		if fileFilter == nil {
+			fileFilter = &rules.FileFilter{}
+		}
+		fileFilter.Exclude = append(fileFilter.Exclude, excludePatterns...)
+	}
+	includePatterns := splitPaths(options.includes)
+	if len(includePatterns) > 0 {
+		if fileFilter == nil {
+			fileFilter = &rules.FileFilter{}
+		}
+		fileFilter.Include = append(fileFilter.Include, includePatterns...)
+	}
+
+	bundle, encoded, err := reviewbundle.Prepare(ctx, reviewbundle.PrepareOptions{
+		RepoDir: repoDir,
+		Target: reviewbundle.TargetSpec{
+			From: options.from, To: options.to, Commit: options.commit,
+		},
+		Resolver:      resolver,
+		FileFilter:    fileFilter,
+		GitRunner:     gitcmd.New(options.maxGitProcs),
+		MaxBundleSize: int64(options.maxBundleBytes),
+	})
+	if err != nil {
+		return fmt.Errorf("prepare review bundle: %w", err)
+	}
+
+	bundlePath := options.outputPath
+	if bundlePath == "" {
+		tmpFile, tmpErr := os.CreateTemp("", "ocr-bundle-*.json")
+		if tmpErr != nil {
+			return fmt.Errorf("create temp file: %w", tmpErr)
+		}
+		bundlePath = tmpFile.Name()
+		_ = tmpFile.Close()
+	}
+	if err := writePrivateFile(bundlePath, encoded); err != nil {
+		return err
+	}
+
+	absBundlePath, err := filepath.Abs(bundlePath)
+	if err != nil {
+		return fmt.Errorf("resolve bundle path: %w", err)
+	}
+	workflow := renderDelegateWorkflow(bundle, absBundlePath)
+	_, err = fmt.Fprint(writer, workflow)
+	return err
+}
+
+func renderDelegateWorkflow(bundle *reviewbundle.Bundle, bundlePath string) string {
+	var sb strings.Builder
+
+	sb.WriteString("# OCR Delegate Review Workflow\n\n")
+	sb.WriteString("## Review Target\n\n")
+	sb.WriteString(fmt.Sprintf("- **Mode**: %s\n", bundle.Target.Mode))
+	sb.WriteString(fmt.Sprintf("- **Files**: %d total, %d reviewable\n",
+		bundle.Summary.TotalFiles, bundle.Summary.ReviewableFiles))
+	sb.WriteString(fmt.Sprintf("- **Changes**: +%d -%d\n",
+		bundle.Summary.Insertions, bundle.Summary.Deletions))
+	sb.WriteString(fmt.Sprintf("- **Bundle**: `%s`\n", bundlePath))
+	sb.WriteString(fmt.Sprintf("- **Bundle ID**: `%s`\n\n", bundle.BundleID))
+
+	sb.WriteString("## Step 1: Read the Bundle and Produce Review Comments\n\n")
+	sb.WriteString("Read the bundle file above. It contains the full review evidence:\n")
+	sb.WriteString("file patches, hunks, content hashes, and review rules.\n\n")
+	sb.WriteString("Your task: review the code changes and produce a JSON comments file\n")
+	sb.WriteString("conforming to the contract below.\n\n")
+
+	sb.WriteString("### Contract\n\n")
+	contractJSON, _ := json.MarshalIndent(bundle.Contract, "", "  ")
+	sb.WriteString("```json\n")
+	sb.WriteString(string(contractJSON))
+	sb.WriteString("\n```\n\n")
+
+	sb.WriteString("### Output Schema (review-comments/v1)\n\n")
+	sb.WriteString("```json\n")
+	sb.WriteString(`{
+  "schema_version": "review-comments/v1",
+  "bundle_id": "` + bundle.BundleID + `",
+  "summary": {
+    "files_reviewed": <number of files you reviewed>,
+    "issues_found": <number of comments>
+  },
+  "comments": [
+    {
+      "path": "<file path from bundle>",
+      "start_line": <1-based line in new file>,
+      "end_line": <1-based line in new file>,
+      "priority": "high|medium|low",
+      "category": "bug|security|performance|concurrency|maintainability|test",
+      "title": "<short title>",
+      "content": "<detailed explanation>",
+      "recommendation": "<how to fix>",
+      "existing_code": "<optional: current code snippet>",
+      "suggestion_code": "<optional: suggested replacement>",
+      "confidence": <0.0-1.0>
+    }
+  ]
+}`)
+	sb.WriteString("\n```\n\n")
+
+	sb.WriteString("### Rules\n\n")
+	if len(bundle.Rules) == 0 {
+		sb.WriteString("No custom rules configured. Apply standard review best practices.\n\n")
+	} else {
+		sb.WriteString("Apply these review rules when analyzing the code:\n\n")
+		ruleIDs := make([]string, 0, len(bundle.Rules))
+		for id := range bundle.Rules {
+			ruleIDs = append(ruleIDs, id)
+		}
+		sort.Strings(ruleIDs)
+		for _, id := range ruleIDs {
+			rule := bundle.Rules[id]
+			sb.WriteString(fmt.Sprintf("- **%s** (pattern: `%s`): %s\n", id, rule.Pattern, rule.Content))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Step 2: Save Comments\n\n")
+	commentsPath := strings.TrimSuffix(bundlePath, ".json") + "-comments.json"
+	sb.WriteString(fmt.Sprintf("Save your review comments JSON to:\n`%s`\n\n", commentsPath))
+
+	sb.WriteString("## Step 3: Validate\n\n")
+	sb.WriteString("Run the following command to validate your comments against the bundle:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString(fmt.Sprintf("ocr delegate validate --bundle %q --comments %q\n",
+		bundlePath, commentsPath))
+	sb.WriteString("```\n\n")
+	sb.WriteString("If validation returns `\"valid\": false`, fix the errors and re-run.\n\n")
+
+	sb.WriteString("## Step 4: Generate Report\n\n")
+	sb.WriteString("Once validation passes, generate the final report:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString(fmt.Sprintf("ocr delegate report --bundle %q --comments %q\n",
+		bundlePath, commentsPath))
+	sb.WriteString("```\n\n")
+
+	return sb.String()
+}
+
+func printDelegateUsage(writer io.Writer) {
+	fmt.Fprintln(writer, `Usage:
+  ocr delegate [options]                 Prepare bundle and emit review workflow
+  ocr delegate validate [options]        Validate comments against bundle
+  ocr delegate report [options]          Render validated comments as report
+
+Run "ocr delegate -h" for prepare options.
+Run "ocr delegate validate -h" for validate options.
+Run "ocr delegate report -h" for report options.`)
+}
+
+func printDelegatePrepareUsage(writer io.Writer) {
+	fmt.Fprintln(writer, `Usage:
+  ocr delegate [--repo PATH] [--from REF --to REF | --commit REF]
+               [--rule PATH] [--exclude PATTERNS] [--include PATTERNS]
+               [--output PATH] [--max-bundle-bytes N] [--max-git-procs N]
+
+Prepares a deterministic review bundle and emits a Markdown workflow
+for the host agent to follow. No LLM API key required.`)
+}

--- a/cmd/opencodereview/delegate_cmd_test.go
+++ b/cmd/opencodereview/delegate_cmd_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/reviewbundle"
+)
+
+func initDelegateRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+repo)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init", "-q")
+	git("config", "user.email", "test@example.com")
+	git("config", "user.name", "Test")
+	git("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-m", "initial")
+	return repo
+}
+
+func TestDelegateWorkspaceMode(t *testing.T) {
+	repo := initDelegateRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"hi\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo}, &buf); err != nil {
+		t.Fatalf("runDelegateWithWriter: %v", err)
+	}
+
+	output := buf.String()
+	assertContains(t, output, "# OCR Delegate Review Workflow")
+	assertContains(t, output, "bundle_id")
+	assertContains(t, output, "ocr delegate validate")
+	assertContains(t, output, "ocr delegate report")
+	assertContains(t, output, "review-comments/v1")
+	assertNotContains(t, output, "codex-")
+}
+
+func TestDelegateRangeMode(t *testing.T) {
+	repo := initDelegateRepo(t)
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+repo)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	base := git("rev-parse", "HEAD")
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"range\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-m", "range change")
+	head := git("rev-parse", "HEAD")
+
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "--from", base, "--to", head}, &buf); err != nil {
+		t.Fatalf("runDelegateWithWriter: %v", err)
+	}
+
+	output := buf.String()
+	assertContains(t, output, "range")
+	assertContains(t, output, "Bundle ID")
+}
+
+func TestDelegateCommitMode(t *testing.T) {
+	repo := initDelegateRepo(t)
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+repo)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"commit\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-m", "commit change")
+	head := git("rev-parse", "HEAD")
+
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "-c", head}, &buf); err != nil {
+		t.Fatalf("runDelegateWithWriter: %v", err)
+	}
+
+	output := buf.String()
+	assertContains(t, output, "commit")
+	assertContains(t, output, "Bundle ID")
+}
+
+func TestDelegateOutputFlag(t *testing.T) {
+	repo := initDelegateRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"output\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "bundle.json")
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "--output", outputPath}, &buf); err != nil {
+		t.Fatalf("runDelegateWithWriter: %v", err)
+	}
+
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundle reviewbundle.Bundle
+	if err := json.Unmarshal(content, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	if bundle.BundleID == "" {
+		t.Fatal("bundle_id is empty")
+	}
+	if bundle.SchemaVersion != "review-bundle/v1" {
+		t.Errorf("schema_version = %q, want review-bundle/v1", bundle.SchemaVersion)
+	}
+}
+
+func TestDelegateRejectsConflictingTargets(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"--from", "main", "--to", "dev", "--commit", "abc"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for conflicting --from/--to and --commit")
+	}
+	if !strings.Contains(err.Error(), "only one review mode") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDelegateRejectsFromWithoutTo(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"--from", "main"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for --from without --to")
+	}
+}
+
+func TestDelegateRejectsToWithoutFrom(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"--to", "dev"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for --to without --from")
+	}
+}
+
+func TestDelegateValidateRoundtrip(t *testing.T) {
+	repo := initDelegateRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"validate\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "--output", bundlePath}, &buf); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	bundleContent, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundle reviewbundle.Bundle
+	if err := json.Unmarshal(bundleContent, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+
+	comments := reviewbundle.Comments{
+		SchemaVersion: "review-comments/v1",
+		BundleID:      bundle.BundleID,
+		Summary:       reviewbundle.CommentsSummary{FilesReviewed: 1, IssuesFound: 1},
+		Comments: []reviewbundle.ReviewComment{
+			{
+				Path:           "hello.go",
+				StartLine:      3,
+				EndLine:        3,
+				Priority:       "medium",
+				Category:       "maintainability",
+				Title:          "Use fmt.Println",
+				Content:        "Consider using fmt.Println instead of println.",
+				Recommendation: "Replace println with fmt.Println.",
+				Confidence:     0.8,
+			},
+		},
+	}
+	commentsJSON, err := json.MarshalIndent(comments, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commentsPath := filepath.Join(t.TempDir(), "comments.json")
+	if err := os.WriteFile(commentsPath, commentsJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var validateBuf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"validate", "--repo", repo, "--bundle", bundlePath, "--comments", commentsPath}, &validateBuf); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	var result reviewbundle.ValidationResult
+	if err := json.Unmarshal(validateBuf.Bytes(), &result); err != nil {
+		t.Fatalf("decode validation: %v\noutput: %s", err, validateBuf.String())
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid=true, got errors: %+v", result.Errors)
+	}
+	if result.BundleID != bundle.BundleID {
+		t.Errorf("validation bundle_id = %q, want %q", result.BundleID, bundle.BundleID)
+	}
+}
+
+func TestDelegateReportRoundtrip(t *testing.T) {
+	repo := initDelegateRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"report\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "--output", bundlePath}, &buf); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	bundleContent, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundle reviewbundle.Bundle
+	if err := json.Unmarshal(bundleContent, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+
+	comments := reviewbundle.Comments{
+		SchemaVersion: "review-comments/v1",
+		BundleID:      bundle.BundleID,
+		Summary:       reviewbundle.CommentsSummary{FilesReviewed: 1, IssuesFound: 1},
+		Comments: []reviewbundle.ReviewComment{
+			{
+				Path:           "hello.go",
+				StartLine:      3,
+				EndLine:        3,
+				Priority:       "high",
+				Category:       "bug",
+				Title:          "Unreachable code",
+				Content:        "This is a test comment.",
+				Recommendation: "Fix the bug.",
+				Confidence:     0.9,
+			},
+		},
+	}
+	commentsJSON, err := json.MarshalIndent(comments, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commentsPath := filepath.Join(t.TempDir(), "comments.json")
+	if err := os.WriteFile(commentsPath, commentsJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var reportBuf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"report", "--bundle", bundlePath, "--comments", commentsPath}, &reportBuf); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+
+	output := reportBuf.String()
+	if output == "" {
+		t.Fatal("report output is empty")
+	}
+	assertContains(t, output, "hello.go")
+	assertContains(t, output, "Unreachable code")
+}
+
+func TestDelegateWorkflowNeutralSchema(t *testing.T) {
+	repo := initDelegateRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "hello.go"), []byte("package main\n\nfunc main() { println(\"neutral\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.json")
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"--repo", repo, "--output", bundlePath}, &buf); err != nil {
+		t.Fatalf("runDelegateWithWriter: %v", err)
+	}
+
+	output := buf.String()
+	assertNotContains(t, output, "codex-")
+	assertContains(t, output, "review-comments/v1")
+
+	content, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundle reviewbundle.Bundle
+	if err := json.Unmarshal(content, &bundle); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	if bundle.SchemaVersion != "review-bundle/v1" {
+		t.Errorf("bundle schema_version = %q, want review-bundle/v1", bundle.SchemaVersion)
+	}
+	if bundle.Contract.CommentSchema != "review-comments/v1" {
+		t.Errorf("contract comment_schema = %q, want review-comments/v1", bundle.Contract.CommentSchema)
+	}
+}
+
+func TestDelegateHelp(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"-h"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, buf.String(), "Usage:")
+}
+
+func TestDelegateValidateHelp(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"validate", "-h"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, buf.String(), "Usage:")
+}
+
+func TestDelegateReportHelp(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runDelegateWithWriter([]string{"report", "-h"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, buf.String(), "Usage:")
+}
+
+func TestDelegateValidateMissingFlags(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"validate", "--bundle", "/tmp/x.json"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for missing --comments")
+	}
+}
+
+func TestDelegateReportMissingFlags(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"report", "--bundle", "/tmp/x.json"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for missing --comments")
+	}
+}
+
+func TestDelegateReportInvalidFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"report", "--bundle", "/tmp/x.json", "--comments", "/tmp/c.json", "--format", "xml"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+}
+
+func TestDelegateUnknownSubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	err := runDelegateWithWriter([]string{"unknown"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), "unknown delegate command") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected output to contain %q, got:\n%s", needle, clipString(haystack, 500))
+	}
+}
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("expected output NOT to contain %q, got:\n%s", needle, clipString(haystack, 500))
+	}
+}
+
+func clipString(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/cmd/opencodereview/delegate_report_cmd.go
+++ b/cmd/opencodereview/delegate_report_cmd.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/open-code-review/open-code-review/internal/reviewbundle"
+)
+
+type delegateReportOptions struct {
+	bundlePath     string
+	commentsPath   string
+	validationPath string
+	outputPath     string
+	format         string
+	showHelp       bool
+}
+
+func runDelegateReport(args []string, writer io.Writer) error {
+	options, err := parseDelegateReportFlags(args)
+	if err != nil {
+		return err
+	}
+	if options.showHelp {
+		printDelegateReportUsage(writer)
+		return nil
+	}
+	bundle, comments, err := loadBundleAndComments(options.bundlePath, options.commentsPath)
+	if err != nil {
+		return err
+	}
+	validation, err := loadValidationResult(options.validationPath)
+	if err != nil {
+		return err
+	}
+	report, err := reviewbundle.RenderReport(bundle, comments, reviewbundle.ReportOptions{
+		Format:     options.format,
+		Validation: validation,
+	})
+	if err != nil {
+		return err
+	}
+	if options.outputPath != "" {
+		return writePrivateFile(options.outputPath, report)
+	}
+	_, err = writer.Write(report)
+	return err
+}
+
+func parseDelegateReportFlags(args []string) (delegateReportOptions, error) {
+	flags := newOcrFlagSet("ocr delegate report")
+	options := delegateReportOptions{}
+	flags.StringVar(&options.bundlePath, "bundle", "", "review bundle JSON path")
+	flags.StringVar(&options.commentsPath, "comments", "", "review comments JSON path")
+	flags.StringVar(&options.validationPath, "validation", "", "optional validation result JSON path")
+	flags.StringVar(&options.outputPath, "output", "", "explicit report output path")
+	flags.StringVarP(&options.format, "format", "f", "markdown", "markdown, text, or json")
+	if err := flags.Parse(args); err != nil {
+		return options, fmt.Errorf("parse flags: %w", err)
+	}
+	options.showHelp = flags.showHelp
+	if options.showHelp {
+		return options, nil
+	}
+	if options.bundlePath == "" || options.commentsPath == "" {
+		return options, fmt.Errorf("--bundle and --comments are required")
+	}
+	switch options.format {
+	case "markdown", "text", "json":
+	default:
+		return options, fmt.Errorf("--format must be markdown, text, or json")
+	}
+	return options, nil
+}
+
+func printDelegateReportUsage(writer io.Writer) {
+	fmt.Fprintln(writer, `Usage:
+  ocr delegate report --bundle FILE --comments FILE
+                      [--validation FILE] [--format markdown|text|json]
+                      [--output FILE]
+
+Renders validated review comments as a formatted report.`)
+}

--- a/cmd/opencodereview/delegate_validate_cmd.go
+++ b/cmd/opencodereview/delegate_validate_cmd.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/reviewbundle"
+)
+
+type delegateValidateOptions struct {
+	repoDir      string
+	bundlePath   string
+	commentsPath string
+	outputPath   string
+	maxGitProcs  int
+	showHelp     bool
+}
+
+func runDelegateValidate(
+	ctx context.Context,
+	args []string,
+	writer io.Writer,
+) error {
+	options, err := parseDelegateValidateFlags(args)
+	if err != nil {
+		return err
+	}
+	if options.showHelp {
+		printDelegateValidateUsage(writer)
+		return nil
+	}
+	bundle, comments, err := loadBundleAndComments(options.bundlePath, options.commentsPath)
+	if err != nil {
+		return err
+	}
+	repoDir, _, err := resolveWorkingDir(
+		options.repoDir,
+		bundle.Target.Mode != reviewbundle.TargetScan,
+	)
+	if err != nil {
+		return err
+	}
+	result := reviewbundle.ValidateComments(
+		ctx,
+		bundle,
+		comments,
+		repoDir,
+		gitcmd.New(options.maxGitProcs),
+	)
+	encoded, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode validation result: %w", err)
+	}
+	if options.outputPath != "" {
+		return writePrivateFile(options.outputPath, append(encoded, '\n'))
+	}
+	_, err = writer.Write(append(encoded, '\n'))
+	return err
+}
+
+func parseDelegateValidateFlags(args []string) (delegateValidateOptions, error) {
+	flags := newOcrFlagSet("ocr delegate validate")
+	options := delegateValidateOptions{}
+	flags.StringVar(&options.repoDir, "repo", "", "root directory of the git repository")
+	flags.StringVar(&options.bundlePath, "bundle", "", "review bundle JSON path")
+	flags.StringVar(&options.commentsPath, "comments", "", "review comments JSON path")
+	flags.StringVar(&options.outputPath, "output", "", "explicit validation output path")
+	flags.IntVar(&options.maxGitProcs, "max-git-procs", 16, "maximum concurrent git subprocesses")
+	if err := flags.Parse(args); err != nil {
+		return options, fmt.Errorf("parse flags: %w", err)
+	}
+	options.showHelp = flags.showHelp
+	if options.showHelp {
+		return options, nil
+	}
+	if options.bundlePath == "" || options.commentsPath == "" {
+		return options, fmt.Errorf("--bundle and --comments are required")
+	}
+	if options.maxGitProcs <= 0 {
+		return options, fmt.Errorf("--max-git-procs must be greater than zero")
+	}
+	return options, nil
+}
+
+func printDelegateValidateUsage(writer io.Writer) {
+	fmt.Fprintln(writer, `Usage:
+  ocr delegate validate --bundle FILE --comments FILE
+                        [--repo PATH] [--output FILE] [--max-git-procs N]
+
+Validates review comments against the immutable bundle evidence.
+Returns a JSON validation result with "valid": true/false.`)
+}

--- a/cmd/opencodereview/main.go
+++ b/cmd/opencodereview/main.go
@@ -58,6 +58,8 @@ func dispatch() error {
 		return runViewer(args[1:])
 	case "session", "sessions":
 		return runSession(args[1:])
+	case "delegate":
+		return runDelegate(args[1:])
 	case "-h", "--help":
 		printTopLevelUsage()
 		return nil
@@ -79,6 +81,7 @@ Commands:
   config       Manage configuration settings
   llm          LLM utility commands
   viewer       Start the WebUI session viewer
+  delegate     Prepare evidence and emit a host-agent review workflow
   session, sessions  List and inspect saved review sessions
   version      Show version information
 

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -126,7 +126,8 @@ func runReview(args []string) error {
 	q := newQuietHandle(opts.outputFormat, opts.audience)
 	defer q.Restore()
 
-	ctx, span := telemetry.StartSpan(context.Background(), "review.run")
+	baseCtx := telemetry.ContextFromTraceParent(context.Background())
+	ctx, span := telemetry.StartSpan(baseCtx, "review.run")
 	defer span.End()
 	telemetry.SetAttr(span, "review.repo", cc.RepoDir)
 	telemetry.SetAttr(span, "review.from", opts.from)

--- a/internal/reviewbundle/bundle.go
+++ b/internal/reviewbundle/bundle.go
@@ -1,0 +1,162 @@
+// Package reviewbundle builds versioned, deterministic review inputs for
+// external agent control planes.
+package reviewbundle
+
+import "github.com/open-code-review/open-code-review/internal/model"
+
+const (
+	// BundleSchemaVersion identifies the review bundle protocol.
+	BundleSchemaVersion = "review-bundle/v1"
+	// CommentsSchemaVersion identifies the external review comments protocol.
+	CommentsSchemaVersion = "review-comments/v1"
+)
+
+// TargetMode identifies how the reviewed Git change is selected.
+type TargetMode string
+
+const (
+	TargetWorkspace TargetMode = "workspace"
+	TargetRange     TargetMode = "range"
+	TargetCommit    TargetMode = "commit"
+	TargetScan      TargetMode = "scan"
+)
+
+// Bundle is the complete deterministic input for an external reviewer.
+type Bundle struct {
+	SchemaVersion  string           `json:"schema_version"`
+	BundleID       string           `json:"bundle_id"`
+	Target         Target           `json:"target"`
+	WorkspaceState *WorkspaceState  `json:"workspace_state,omitempty"`
+	Summary        Summary          `json:"summary"`
+	Rules          map[string]Rule  `json:"rules"`
+	Files          []File           `json:"files"`
+	Contract       Contract         `json:"contract"`
+	Warnings       []ProtocolNotice `json:"warnings,omitempty"`
+}
+
+// Target records both requested refs and their resolved immutable identities.
+type Target struct {
+	Mode         TargetMode `json:"mode"`
+	From         string     `json:"from"`
+	To           string     `json:"to"`
+	Commit       string     `json:"commit"`
+	BaseSHA      string     `json:"base_sha"`
+	HeadSHA      string     `json:"head_sha"`
+	MergeBaseSHA string     `json:"merge_base_sha"`
+	DiffSHA256   string     `json:"diff_sha256"`
+}
+
+// WorkspaceState fingerprints each component of a dirty working tree.
+type WorkspaceState struct {
+	HeadSHA         string `json:"head_sha"`
+	StagedSHA256    string `json:"staged_sha256"`
+	UnstagedSHA256  string `json:"unstaged_sha256"`
+	UntrackedSHA256 string `json:"untracked_sha256"`
+}
+
+// Summary reports the complete target size and filtering outcome.
+type Summary struct {
+	TotalFiles      int   `json:"total_files"`
+	ReviewableFiles int   `json:"reviewable_files"`
+	ExcludedFiles   int   `json:"excluded_files"`
+	Insertions      int64 `json:"insertions"`
+	Deletions       int64 `json:"deletions"`
+}
+
+// Rule is a deduplicated resolved review rule.
+type Rule struct {
+	Source  string `json:"source"`
+	Pattern string `json:"pattern"`
+	Content string `json:"content"`
+}
+
+// File is one changed file and its review evidence.
+type File struct {
+	Path          string              `json:"path"`
+	OldPath       string              `json:"old_path"`
+	Status        string              `json:"status"`
+	Reviewable    bool                `json:"reviewable"`
+	ExcludeReason model.ExcludeReason `json:"exclude_reason,omitempty"`
+	Insertions    int64               `json:"insertions"`
+	Deletions     int64               `json:"deletions"`
+	ContentSHA256 string              `json:"content_sha256"`
+	RuleID        string              `json:"rule_id"`
+	Patch         string              `json:"patch"`
+	Content       string              `json:"content,omitempty"`
+	Hunks         []Hunk              `json:"hunks"`
+}
+
+// Hunk records the old and new line bounds of one unified-diff hunk.
+type Hunk struct {
+	OldStart int `json:"old_start"`
+	OldCount int `json:"old_count"`
+	NewStart int `json:"new_start"`
+	NewCount int `json:"new_count"`
+}
+
+// Contract tells an external reviewer which output protocol is accepted.
+type Contract struct {
+	CommentSchema      string   `json:"comment_schema"`
+	LineNumbers        string   `json:"line_numbers"`
+	AllowedPriorities  []string `json:"allowed_priorities"`
+	AllowedCategories  []string `json:"allowed_categories"`
+	MaxBundleBytes     int64    `json:"max_bundle_bytes"`
+	BundleSizeBytes    int64    `json:"bundle_size_bytes"`
+	RequiresReflection bool     `json:"requires_reflection"`
+}
+
+// DefaultContract returns the mandatory Phase 1 review-output constraints.
+func DefaultContract() Contract {
+	return Contract{
+		CommentSchema:     CommentsSchemaVersion,
+		LineNumbers:       "one_based_new_file",
+		AllowedPriorities: []string{"high", "medium", "low"},
+		AllowedCategories: []string{
+			"bug",
+			"security",
+			"performance",
+			"concurrency",
+			"maintainability",
+			"test",
+		},
+		RequiresReflection: true,
+	}
+}
+
+// ProtocolNotice is a structured non-fatal protocol warning.
+type ProtocolNotice struct {
+	Code    string `json:"code"`
+	Path    string `json:"path,omitempty"`
+	Message string `json:"message"`
+}
+
+// Comments is the output protocol expected from an external reviewer.
+type Comments struct {
+	SchemaVersion string           `json:"schema_version"`
+	BundleID      string           `json:"bundle_id"`
+	Summary       CommentsSummary  `json:"summary"`
+	Comments      []ReviewComment  `json:"comments"`
+	Warnings      []ProtocolNotice `json:"warnings,omitempty"`
+}
+
+// CommentsSummary reports the external review result size.
+type CommentsSummary struct {
+	FilesReviewed int `json:"files_reviewed"`
+	IssuesFound   int `json:"issues_found"`
+}
+
+// ReviewComment is one line-level finding produced by the external reviewer.
+type ReviewComment struct {
+	Path             string  `json:"path"`
+	StartLine        int     `json:"start_line"`
+	EndLine          int     `json:"end_line"`
+	Priority         string  `json:"priority"`
+	Category         string  `json:"category"`
+	Title            string  `json:"title"`
+	Content          string  `json:"content"`
+	Recommendation   string  `json:"recommendation"`
+	ExistingCode     string  `json:"existing_code,omitempty"`
+	SuggestionCode   string  `json:"suggestion_code,omitempty"`
+	Confidence       float64 `json:"confidence"`
+	FileLevelComment bool    `json:"file_level_comment,omitempty"`
+}

--- a/internal/reviewbundle/context.go
+++ b/internal/reviewbundle/context.go
@@ -1,0 +1,411 @@
+package reviewbundle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/tool"
+)
+
+// ContextResult is the stable envelope returned by all read-only context operations.
+type ContextResult struct {
+	SchemaVersion string `json:"schema_version"`
+	BundleID      string `json:"bundle_id"`
+	Operation     string `json:"operation"`
+	Result        string `json:"result"`
+}
+
+// ContextService exposes target-aware read-only repository tools.
+type ContextService struct {
+	repoDir string
+	bundle  *Bundle
+	runner  *gitcmd.Runner
+	reader  *tool.FileReader
+}
+
+// NewContextService binds all subsequent operations to one bundle identity.
+func NewContextService(
+	repoDir string,
+	bundle *Bundle,
+	runner *gitcmd.Runner,
+) *ContextService {
+	mode := tool.ModeWorkspace
+	ref := ""
+	if bundle != nil {
+		switch bundle.Target.Mode {
+		case TargetRange:
+			mode = tool.ModeRange
+			ref = bundle.Target.HeadSHA
+		case TargetCommit:
+			mode = tool.ModeCommit
+			ref = bundle.Target.HeadSHA
+		}
+	}
+	return &ContextService{
+		repoDir: repoDir,
+		bundle:  bundle,
+		runner:  runner,
+		reader: &tool.FileReader{
+			RepoDir: repoDir,
+			Mode:    mode,
+			Ref:     ref,
+			Runner:  runner,
+		},
+	}
+}
+
+// Read returns at most 500 target-version lines through the native reader.
+func (service *ContextService) Read(
+	ctx context.Context,
+	path string,
+	startLine int,
+	maxLines int,
+) (ContextResult, error) {
+	if err := service.ready(ctx); err != nil {
+		return ContextResult{}, err
+	}
+	cleaned, safe := cleanProtocolPath(path)
+	if !safe {
+		return ContextResult{}, &ProtocolError{Code: "path_escape", Message: "path must stay inside the repository"}
+	}
+	if startLine <= 0 {
+		startLine = 1
+	}
+	if maxLines <= 0 {
+		maxLines = 200
+	}
+	if maxLines > 500 {
+		maxLines = 500
+	}
+	if service.bundle.Target.Mode == TargetScan {
+		result, err := service.readScanFile(cleaned, startLine, maxLines)
+		if err != nil {
+			return ContextResult{}, err
+		}
+		return service.result("read", result), nil
+	}
+	endLine := startLine + maxLines - 1
+	result, err := tool.NewFileRead(service.reader).Execute(ctx, map[string]any{
+		"file_path":  cleaned,
+		"start_line": float64(startLine),
+		"end_line":   float64(endLine),
+	})
+	if err != nil {
+		return ContextResult{}, err
+	}
+	return service.result("read", result), nil
+}
+
+// Find lists target-version files whose base name contains query.
+func (service *ContextService) Find(
+	ctx context.Context,
+	query string,
+	caseSensitive bool,
+) (ContextResult, error) {
+	if err := service.ready(ctx); err != nil {
+		return ContextResult{}, err
+	}
+	if service.bundle.Target.Mode == TargetScan {
+		return service.result("find", service.findScanFiles(query, caseSensitive)), nil
+	}
+	result, err := tool.NewFileFind(service.reader).Execute(ctx, map[string]any{
+		"query_name":     query,
+		"case_sensitive": caseSensitive,
+	})
+	if err != nil {
+		return ContextResult{}, err
+	}
+	return service.result("find", result), nil
+}
+
+// Diff returns exact patches stored in the immutable bundle.
+func (service *ContextService) Diff(
+	ctx context.Context,
+	paths []string,
+) (ContextResult, error) {
+	if err := service.ready(ctx); err != nil {
+		return ContextResult{}, err
+	}
+	diffMap := make(map[string]string, len(service.bundle.Files))
+	for _, file := range service.bundle.Files {
+		evidence := file.Patch
+		if service.bundle.Target.Mode == TargetScan {
+			evidence = file.Content
+		}
+		diffMap[file.Path] = evidence
+	}
+	pathArguments := make([]any, 0, len(paths))
+	for _, path := range paths {
+		cleaned, safe := cleanProtocolPath(path)
+		if !safe {
+			return ContextResult{}, &ProtocolError{Code: "path_escape", Message: "path must stay inside the repository"}
+		}
+		pathArguments = append(pathArguments, cleaned)
+	}
+	result, err := tool.NewFileReadDiff(tool.NewDiffMap(diffMap)).Execute(ctx, map[string]any{
+		"path_array": pathArguments,
+	})
+	if err != nil {
+		return ContextResult{}, err
+	}
+	return service.result("diff", result), nil
+}
+
+// Search runs the native bounded code search against the target version.
+func (service *ContextService) Search(
+	ctx context.Context,
+	query string,
+	caseSensitive bool,
+	usePerlRegexp bool,
+	patterns []string,
+) (ContextResult, error) {
+	if err := service.ready(ctx); err != nil {
+		return ContextResult{}, err
+	}
+	patternArguments := make([]any, 0, len(patterns))
+	for _, pattern := range patterns {
+		if !safeSearchPattern(pattern) {
+			return ContextResult{}, &ProtocolError{Code: "path_escape", Message: "file pattern must stay inside the repository"}
+		}
+		patternArguments = append(patternArguments, pattern)
+	}
+	if service.bundle.Target.Mode == TargetScan {
+		if usePerlRegexp {
+			return ContextResult{}, &ProtocolError{
+				Code:    "unsupported_search_regex",
+				Message: "--perl-regexp is not supported for scan bundle context search",
+			}
+		}
+		result, err := service.searchScanFiles(query, caseSensitive, usePerlRegexp, patterns)
+		if err != nil {
+			return ContextResult{}, err
+		}
+		return service.result("search", result), nil
+	}
+	result, err := tool.NewCodeSearch(service.reader).Execute(ctx, map[string]any{
+		"search_text":     query,
+		"case_sensitive":  caseSensitive,
+		"use_perl_regexp": usePerlRegexp,
+		"file_patterns":   patternArguments,
+	})
+	if err != nil {
+		return ContextResult{}, err
+	}
+	return service.result("search", result), nil
+}
+
+func safeSearchPattern(pattern string) bool {
+	if pattern == "" || filepath.IsAbs(pattern) || strings.ContainsRune(pattern, '\x00') {
+		return false
+	}
+	for _, part := range strings.Split(filepath.ToSlash(pattern), "/") {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func (service *ContextService) scanFile(path string) (File, bool) {
+	for _, file := range service.bundle.Files {
+		if file.Path == path {
+			return file, true
+		}
+	}
+	return File{}, false
+}
+
+func (service *ContextService) readScanFile(path string, startLine int, maxLines int) (string, error) {
+	file, ok := service.scanFile(path)
+	if !ok {
+		return "", fmt.Errorf("file %q is not present in the scan bundle", path)
+	}
+	lines := splitSourceLines([]byte(file.Content))
+	totalLines := len(lines)
+	if startLine-1 > totalLines || (totalLines > 0 && startLine-1 >= totalLines) {
+		return "", fmt.Errorf("file %q has only %d lines, requested range starting at %d", path, totalLines, startLine)
+	}
+	end := startLine - 1 + maxLines
+	if end > totalLines {
+		end = totalLines
+	}
+	truncated := totalLines-(startLine-1) > 500
+	displayEnd := startLine - 1
+	if end > startLine-1 {
+		displayEnd = end
+	}
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("File: %s (Total lines: %d)\n", path, totalLines))
+	output.WriteString(fmt.Sprintf("IS_TRUNCATED: %t\n", truncated))
+	output.WriteString(fmt.Sprintf("LINE_RANGE: %d-%d\n", startLine, displayEnd))
+	for index, line := range lines[startLine-1 : end] {
+		output.WriteString(fmt.Sprintf("%d|%s\n", startLine+index, line))
+	}
+	if truncated {
+		output.WriteString("\nNote: Results truncated to 500 lines. Please narrow your line range.\n")
+	}
+	return output.String(), nil
+}
+
+func (service *ContextService) findScanFiles(query string, caseSensitive bool) string {
+	if strings.TrimSpace(query) == "" {
+		return "// The file was not found"
+	}
+	needle := query
+	if !caseSensitive {
+		needle = strings.ToLower(needle)
+	}
+	var matched []string
+	for _, file := range service.bundle.Files {
+		base := file.Path
+		if index := strings.LastIndex(base, "/"); index >= 0 {
+			base = base[index+1:]
+		}
+		haystack := base
+		if !caseSensitive {
+			haystack = strings.ToLower(haystack)
+		}
+		if strings.Contains(haystack, needle) {
+			matched = append(matched, file.Path)
+		}
+	}
+	sort.Strings(matched)
+	if len(matched) == 0 {
+		return "// The file was not found"
+	}
+	if len(matched) > 100 {
+		matched = matched[:100]
+	}
+	return strings.Join(matched, "\n")
+}
+
+func (service *ContextService) searchScanFiles(
+	query string,
+	caseSensitive bool,
+	useRegexp bool,
+	patterns []string,
+) (string, error) {
+	matcher, err := scanSearchMatcher(query, caseSensitive, useRegexp)
+	if err != nil {
+		return "", err
+	}
+	type match struct {
+		line int
+		text string
+	}
+	fileMatches := make(map[string][]match)
+	var paths []string
+	count := 0
+	for _, file := range service.bundle.Files {
+		if !scanPatternMatches(file.Path, patterns) {
+			continue
+		}
+		for index, line := range splitSourceLines([]byte(file.Content)) {
+			if matcher(line) {
+				if _, ok := fileMatches[file.Path]; !ok {
+					paths = append(paths, file.Path)
+				}
+				fileMatches[file.Path] = append(fileMatches[file.Path], match{line: index + 1, text: line})
+				count++
+				if count >= 100 {
+					break
+				}
+			}
+		}
+		if count >= 100 {
+			break
+		}
+	}
+	if count == 0 {
+		return "No matches found", nil
+	}
+	sort.Strings(paths)
+	var output strings.Builder
+	if count >= 100 {
+		output.WriteString("Note: The results have been truncated. Only showing first 100 results.\n")
+	}
+	for _, path := range paths {
+		matches := fileMatches[path]
+		output.WriteString(fmt.Sprintf("File: %s\nMatch lines: %d\n", path, len(matches)))
+		for _, match := range matches {
+			output.WriteString(fmt.Sprintf("%d|%s\n", match.line, match.text))
+		}
+		output.WriteString("\n")
+	}
+	return output.String(), nil
+}
+
+func scanSearchMatcher(query string, caseSensitive bool, useRegexp bool) (func(string) bool, error) {
+	if strings.TrimSpace(query) == "" {
+		return func(string) bool { return false }, nil
+	}
+	if useRegexp {
+		expression := query
+		if !caseSensitive {
+			expression = "(?i)" + expression
+		}
+		compiled, err := regexp.Compile(expression)
+		if err != nil {
+			return nil, err
+		}
+		return compiled.MatchString, nil
+	}
+	needle := query
+	if !caseSensitive {
+		needle = strings.ToLower(needle)
+	}
+	return func(line string) bool {
+		if !caseSensitive {
+			line = strings.ToLower(line)
+		}
+		return strings.Contains(line, needle)
+	}, nil
+}
+
+func scanPatternMatches(path string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, pattern := range patterns {
+		if matched, _ := filepath.Match(pattern, path); matched {
+			return true
+		}
+		if strings.HasPrefix(path, strings.TrimSuffix(pattern, "/")+"/") {
+			return true
+		}
+		// ponytail: minimal git-pathspec compatibility; expand if scan search needs full pathspec semantics.
+		if strings.HasPrefix(pattern, "*.") && strings.HasSuffix(path, strings.TrimPrefix(pattern, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+func (service *ContextService) ready(ctx context.Context) error {
+	if service.bundle == nil {
+		return fmt.Errorf("bundle is required")
+	}
+	if service.repoDir == "" {
+		return fmt.Errorf("repository directory is required")
+	}
+	result := ValidationResult{Errors: make([]ValidationNotice, 0)}
+	validateFreshTarget(ctx, &result, service.bundle, service.repoDir, service.runner)
+	if len(result.Errors) > 0 {
+		return &ProtocolError{Code: "stale_bundle", Message: result.Errors[0].Message}
+	}
+	return nil
+}
+
+func (service *ContextService) result(operation, result string) ContextResult {
+	return ContextResult{
+		SchemaVersion: "review-context/v1",
+		BundleID:      service.bundle.BundleID,
+		Operation:     operation,
+		Result:        result,
+	}
+}

--- a/internal/reviewbundle/context_test.go
+++ b/internal/reviewbundle/context_test.go
@@ -1,0 +1,217 @@
+package reviewbundle
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+func TestContextReadAndDiffAreBoundToBundle(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changed = true\n")
+	bundle, _, err := Prepare(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		FileFilter:    &rules.FileFilter{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+
+	read, err := service.Read(context.Background(), "base.go", 1, 3)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.BundleID != bundle.BundleID || !strings.Contains(read.Result, "var changed = true") {
+		t.Fatalf("Read() = %+v", read)
+	}
+	diffResult, err := service.Diff(context.Background(), []string{"base.go"})
+	if err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if !strings.Contains(diffResult.Result, "diff --git") {
+		t.Fatalf("Diff() = %+v", diffResult)
+	}
+}
+
+func TestContextRejectsStaleWorkspaceAndPathEscape(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changed = true\n")
+	bundle, _, err := Prepare(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+	if _, err := service.Read(context.Background(), "../secret", 1, 3); err == nil {
+		t.Fatal("Read(path escape) error = nil")
+	}
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changedAgain = true\n")
+	staleService := NewContextService(repository, bundle, gitcmd.New(2))
+	_, err = staleService.Search(context.Background(), "changed", false, false, nil)
+	var protocolError *ProtocolError
+	if !errors.As(err, &protocolError) || protocolError.Code != "stale_bundle" {
+		t.Fatalf("Search(stale) error = %v, want stale_bundle", err)
+	}
+}
+
+func TestContextReadyHonorsCancelledContext(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changed = true\n")
+	bundle, _, err := Prepare(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := service.Read(cancelled, "base.go", 1, 3); err == nil {
+		t.Fatal("Read(cancelled) error = nil")
+	}
+	if _, err := service.Read(context.Background(), "base.go", 1, 3); err != nil {
+		t.Fatalf("Read(fresh context) error = %v, want success after cancelled call", err)
+	}
+}
+
+func TestContextFindAndSearchUseTargetAwareTools(t *testing.T) {
+	repository := initPrepareRepository(t)
+	base := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+	writeTargetFile(t, repository, "base.go", "package sample\n\nfunc TargetSymbol() {}\n")
+	runTargetGit(t, repository, "add", "base.go")
+	runTargetGit(t, repository, "commit", "-m", "target")
+	head := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+	bundle, _, err := Prepare(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Target:        TargetSpec{From: base, To: head},
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+	found, err := service.Find(context.Background(), "base.go", true)
+	if err != nil || !strings.Contains(found.Result, "base.go") {
+		t.Fatalf("Find() = %+v, %v", found, err)
+	}
+	searched, err := service.Search(context.Background(), "TargetSymbol", true, false, []string{"*.go"})
+	if err != nil || !strings.Contains(searched.Result, "base.go") {
+		t.Fatalf("Search() = %+v, %v", searched, err)
+	}
+}
+
+func TestScanContextStaysInsideBundle(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "only.go", "package sample\n\nfunc InBundle() {}\n")
+	writeTargetFile(t, repository, "other.go", "package sample\n\nfunc OutsideBundle() {}\n")
+	bundle := &Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		BundleID:      "sha256:scan",
+		Target:        Target{Mode: TargetScan},
+		Files: []File{{
+			Path:          "only.go",
+			Reviewable:    true,
+			Content:       "package sample\n\nfunc InBundle() {}\n",
+			ContentSHA256: hashFields([]byte("package sample\n\nfunc InBundle() {}\n")),
+		}},
+		Contract: DefaultContract(),
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+
+	read, err := service.Read(context.Background(), "only.go", 1, 5)
+	if err != nil || !strings.Contains(read.Result, "InBundle") {
+		t.Fatalf("Read(in bundle) = %+v, %v", read, err)
+	}
+	if _, err := service.Read(context.Background(), "other.go", 1, 5); err == nil {
+		t.Fatal("Read(outside scan bundle) error = nil")
+	}
+	found, err := service.Find(context.Background(), "other.go", true)
+	if err != nil || strings.Contains(found.Result, "other.go") {
+		t.Fatalf("Find(outside scan bundle) = %+v, %v", found, err)
+	}
+	searched, err := service.Search(context.Background(), "OutsideBundle", true, false, nil)
+	if err != nil || strings.Contains(searched.Result, "other.go") || strings.Contains(searched.Result, "OutsideBundle") {
+		t.Fatalf("Search(outside scan bundle) = %+v, %v", searched, err)
+	}
+}
+
+func TestScanContextSearchRejectsPerlRegexp(t *testing.T) {
+	repository := t.TempDir()
+	content := "package sample\n\nfunc InBundle() {}\n"
+	if err := os.WriteFile(filepath.Join(repository, "only.go"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle := &Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		BundleID:      "sha256:scan",
+		Target:        Target{Mode: TargetScan},
+		Files: []File{{
+			Path:          "only.go",
+			Reviewable:    true,
+			Content:       content,
+			ContentSHA256: hashFields([]byte(content)),
+		}},
+		Contract: DefaultContract(),
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+
+	_, err := service.Search(context.Background(), `func (?=InBundle)`, true, true, nil)
+	var protocolError *ProtocolError
+	if !errors.As(err, &protocolError) || protocolError.Code != "unsupported_search_regex" {
+		t.Fatalf("Search(perl regexp in scan bundle) error = %v, want unsupported_search_regex", err)
+	}
+}
+
+func TestScanContextSearchMatchesDirectoryPattern(t *testing.T) {
+	repository := t.TempDir()
+	content := "package reviewbundle\n\nfunc scanSearchMatcher() {}\n"
+	if err := os.MkdirAll(filepath.Join(repository, "internal", "reviewbundle"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, "internal", "reviewbundle", "context.go"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle := &Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		BundleID:      "sha256:scan",
+		Target:        Target{Mode: TargetScan},
+		Files: []File{{
+			Path:          "internal/reviewbundle/context.go",
+			Reviewable:    true,
+			Content:       content,
+			ContentSHA256: hashFields([]byte(content)),
+		}},
+		Contract: DefaultContract(),
+	}
+	service := NewContextService(repository, bundle, gitcmd.New(2))
+
+	searched, err := service.Search(
+		context.Background(),
+		"scanSearchMatcher",
+		true,
+		false,
+		[]string{"internal/reviewbundle"},
+	)
+	if err != nil || !strings.Contains(searched.Result, "internal/reviewbundle/context.go") {
+		t.Fatalf("Search(directory pattern in scan bundle) = %+v, %v", searched, err)
+	}
+}

--- a/internal/reviewbundle/load.go
+++ b/internal/reviewbundle/load.go
@@ -1,0 +1,150 @@
+package reviewbundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// LoadBundle strictly decodes one review bundle protocol document.
+func LoadBundle(reader io.Reader) (*Bundle, error) {
+	var bundle Bundle
+	if err := decodeStrict(reader, &bundle); err != nil {
+		return nil, fmt.Errorf("invalid bundle schema: %w", err)
+	}
+	if bundle.SchemaVersion != BundleSchemaVersion {
+		return nil, fmt.Errorf(
+			"invalid bundle schema version %q, want %q",
+			bundle.SchemaVersion,
+			BundleSchemaVersion,
+		)
+	}
+	if bundle.BundleID == "" {
+		return nil, fmt.Errorf("invalid bundle schema: bundle_id is required")
+	}
+	computedID, err := computeBundleID(&bundle)
+	if err != nil {
+		return nil, fmt.Errorf("verify bundle_id: %w", err)
+	}
+	if bundle.BundleID != computedID {
+		return nil, fmt.Errorf("invalid bundle schema: bundle_id does not match bundle content")
+	}
+	return &bundle, nil
+}
+
+// LoadComments strictly decodes one external-comments protocol document.
+func LoadComments(reader io.Reader) (*Comments, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read comments: %w", err)
+	}
+	if err := validateCommentsShape(data); err != nil {
+		return nil, err
+	}
+	var comments Comments
+	if err := decodeStrict(bytes.NewReader(data), &comments); err != nil {
+		return nil, fmt.Errorf("invalid comments schema: %w", err)
+	}
+	if comments.SchemaVersion != CommentsSchemaVersion {
+		return nil, fmt.Errorf(
+			"invalid comments schema version %q, want %q",
+			comments.SchemaVersion,
+			CommentsSchemaVersion,
+		)
+	}
+	if comments.BundleID == "" {
+		return nil, fmt.Errorf("invalid comments schema: bundle_id is required")
+	}
+	if comments.Comments == nil {
+		return nil, fmt.Errorf("invalid comments schema: comments field is required and must be an array")
+	}
+	return &comments, nil
+}
+
+func validateCommentsShape(data []byte) error {
+	var raw struct {
+		Summary  map[string]json.RawMessage   `json:"summary"`
+		Comments []map[string]json.RawMessage `json:"comments"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("invalid comments schema: %w", err)
+	}
+	if raw.Summary == nil {
+		return fmt.Errorf("invalid comments schema: summary field is required")
+	}
+	for _, field := range []string{"files_reviewed", "issues_found"} {
+		if _, ok := raw.Summary[field]; !ok {
+			return fmt.Errorf("invalid comments schema: summary.%s is required", field)
+		}
+	}
+	if raw.Comments == nil {
+		return fmt.Errorf("invalid comments schema: comments field is required and must be an array")
+	}
+	required := []string{
+		"path", "start_line", "end_line", "priority", "category",
+		"title", "content", "recommendation", "confidence",
+	}
+	for index, comment := range raw.Comments {
+		for _, field := range required {
+			if _, ok := comment[field]; !ok {
+				return fmt.Errorf("invalid comments schema: comments[%d].%s is required", index, field)
+			}
+		}
+	}
+	return nil
+}
+
+// LoadScanManifest strictly decodes one full-file scan manifest.
+func LoadScanManifest(reader io.Reader) (*ScanManifest, error) {
+	var manifest ScanManifest
+	if err := decodeStrict(reader, &manifest); err != nil {
+		return nil, fmt.Errorf("invalid scan manifest schema: %w", err)
+	}
+	if manifest.SchemaVersion != ScanManifestSchemaVersion {
+		return nil, fmt.Errorf(
+			"invalid scan manifest schema version %q, want %q",
+			manifest.SchemaVersion,
+			ScanManifestSchemaVersion,
+		)
+	}
+	if manifest.ManifestID == "" {
+		return nil, fmt.Errorf("invalid scan manifest schema: manifest_id is required")
+	}
+	if manifest.Bundles == nil {
+		return nil, fmt.Errorf("invalid scan manifest schema: bundles is required")
+	}
+	for index := range manifest.Bundles {
+		computedID, err := computeBundleID(&manifest.Bundles[index])
+		if err != nil {
+			return nil, fmt.Errorf("verify scan bundle %d: %w", index, err)
+		}
+		if manifest.Bundles[index].BundleID != computedID {
+			return nil, fmt.Errorf("invalid scan manifest schema: bundle %d bundle_id does not match bundle content", index)
+		}
+	}
+	computedID, err := computeManifestID(&manifest)
+	if err != nil {
+		return nil, fmt.Errorf("verify manifest_id: %w", err)
+	}
+	if manifest.ManifestID != computedID {
+		return nil, fmt.Errorf("invalid scan manifest schema: manifest_id does not match manifest content")
+	}
+	return &manifest, nil
+}
+
+func decodeStrict(reader io.Reader, target any) error {
+	decoder := json.NewDecoder(reader)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/reviewbundle/partition.go
+++ b/internal/reviewbundle/partition.go
@@ -1,0 +1,205 @@
+package reviewbundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// PreparePartitioned builds a deterministic diff manifest whose bundle parts
+// each obey PrepareOptions.MaxBundleSize.
+func PreparePartitioned(
+	ctx context.Context,
+	options PrepareOptions,
+) (*ScanManifest, []byte, error) {
+	maxBundleSize := options.MaxBundleSize
+	if maxBundleSize <= 0 {
+		maxBundleSize = DefaultMaxBundleBytes
+	}
+	fullOptions := options
+	fullOptions.MaxBundleSize = math.MaxInt64
+	full, _, err := Prepare(ctx, fullOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifest := &ScanManifest{
+		SchemaVersion: ScanManifestSchemaVersion,
+		Root:          options.RepoDir,
+		TargetHash:    full.Target.DiffSHA256,
+		BatchStrategy: "diff",
+		BatchSize:     1,
+		Summary:       full.Summary,
+		SkippedFiles:  make([]ScanSkippedFile, 0),
+		Bundles:       make([]Bundle, 0),
+	}
+	current := newPartitionPacker(full, maxBundleSize)
+	for _, file := range full.Files {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		default:
+		}
+		addedSize, err := current.estimateAddition(full, file)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(current.files) > 0 && current.estimatedSize+addedSize > maxBundleSize {
+			previous, encoded, buildErr := buildDiffPartition(full, current.files, maxBundleSize)
+			if buildErr != nil {
+				return nil, nil, buildErr
+			}
+			if int64(len(encoded)) > maxBundleSize {
+				return nil, nil, partitionSizeError(len(encoded), maxBundleSize)
+			}
+			manifest.Bundles = append(manifest.Bundles, *previous)
+			current = newPartitionPacker(full, maxBundleSize)
+		}
+		current.add(file, addedSize)
+		if len(current.files) == 1 && current.estimatedSize > maxBundleSize {
+			_, singleEncoded, buildErr := buildDiffPartition(full, current.files, maxBundleSize)
+			if buildErr != nil {
+				return nil, nil, buildErr
+			}
+			if int64(len(singleEncoded)) > maxBundleSize {
+				return nil, nil, singleFilePartitionError(file.Path, len(singleEncoded), maxBundleSize)
+			}
+		}
+	}
+	if len(current.files) > 0 {
+		bundle, encoded, buildErr := buildDiffPartition(full, current.files, maxBundleSize)
+		if buildErr != nil {
+			return nil, nil, buildErr
+		}
+		if int64(len(encoded)) > maxBundleSize {
+			return nil, nil, partitionSizeError(len(encoded), maxBundleSize)
+		}
+		manifest.Bundles = append(manifest.Bundles, *bundle)
+	}
+	manifestID, err := computeManifestID(manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifest.ManifestID = manifestID
+	encoded, err := marshalManifest(manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+	return manifest, encoded, nil
+}
+
+type partitionPacker struct {
+	files         []File
+	ruleIDs       map[string]struct{}
+	estimatedSize int64
+}
+
+func newPartitionPacker(full *Bundle, maxBundleSize int64) *partitionPacker {
+	_, encoded, err := buildDiffPartition(full, nil, maxBundleSize)
+	estimated := int64(4096)
+	if err == nil {
+		estimated = int64(len(encoded))
+	}
+	return &partitionPacker{
+		files:         make([]File, 0),
+		ruleIDs:       make(map[string]struct{}),
+		estimatedSize: estimated,
+	}
+}
+
+func (packer *partitionPacker) estimateAddition(full *Bundle, file File) (int64, error) {
+	encodedFile, err := json.Marshal(file)
+	if err != nil {
+		return 0, fmt.Errorf("marshal partition file estimate: %w", err)
+	}
+	estimate := int64(len(encodedFile) + 128)
+	if _, seen := packer.ruleIDs[file.RuleID]; !seen {
+		if rule, exists := full.Rules[file.RuleID]; exists {
+			encodedRule, err := json.Marshal(rule)
+			if err != nil {
+				return 0, fmt.Errorf("marshal partition rule estimate: %w", err)
+			}
+			estimate += int64(len(encodedRule) + len(file.RuleID) + 128)
+		}
+	}
+	return estimate, nil
+}
+
+func (packer *partitionPacker) add(file File, estimatedSize int64) {
+	packer.files = append(packer.files, file)
+	packer.ruleIDs[file.RuleID] = struct{}{}
+	packer.estimatedSize += estimatedSize
+}
+
+func buildDiffPartition(
+	full *Bundle,
+	files []File,
+	maxBundleSize int64,
+) (*Bundle, []byte, error) {
+	partition := &Bundle{
+		SchemaVersion:  BundleSchemaVersion,
+		Target:         full.Target,
+		WorkspaceState: full.WorkspaceState,
+		Rules:          make(map[string]Rule),
+		Files:          append([]File(nil), files...),
+		Contract:       DefaultContract(),
+		Warnings: []ProtocolNotice{{
+			Code: "diff_partition", Message: "deterministic large-diff partition",
+		}},
+	}
+	partition.Contract.MaxBundleBytes = maxBundleSize
+	for _, file := range files {
+		partition.Summary.TotalFiles++
+		partition.Summary.Insertions += file.Insertions
+		partition.Summary.Deletions += file.Deletions
+		if file.Reviewable {
+			partition.Summary.ReviewableFiles++
+		} else {
+			partition.Summary.ExcludedFiles++
+		}
+		if rule, exists := full.Rules[file.RuleID]; exists {
+			partition.Rules[file.RuleID] = rule
+		}
+	}
+	bundleID, err := computeBundleID(partition)
+	if err != nil {
+		return nil, nil, err
+	}
+	partition.BundleID = bundleID
+	encoded, err := marshalWithStableSize(partition)
+	if err != nil {
+		return nil, nil, err
+	}
+	return partition, encoded, nil
+}
+
+func singleFilePartitionError(path string, size int, maximum int64) error {
+	return &ProtocolError{
+		Code: "bundle_too_large",
+		Message: fmt.Sprintf(
+			"file %s requires a %d-byte bundle; maximum is %d",
+			path,
+			size,
+			maximum,
+		),
+	}
+}
+
+func partitionSizeError(size int, maximum int64) error {
+	return &ProtocolError{
+		Code: "bundle_too_large",
+		Message: fmt.Sprintf(
+			"estimated partition produced a %d-byte bundle; maximum is %d",
+			size,
+			maximum,
+		),
+	}
+}
+
+func marshalManifest(manifest *ScanManifest) ([]byte, error) {
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal review manifest: %w", err)
+	}
+	return encoded, nil
+}

--- a/internal/reviewbundle/prepare.go
+++ b/internal/reviewbundle/prepare.go
@@ -1,0 +1,248 @@
+package reviewbundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/diff"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/model"
+	"github.com/open-code-review/open-code-review/internal/reviewfilter"
+)
+
+// DefaultMaxBundleBytes is the default hard limit for a single JSON bundle.
+const DefaultMaxBundleBytes int64 = 4 * 1024 * 1024
+
+// PrepareOptions configures deterministic review bundle generation.
+type PrepareOptions struct {
+	RepoDir       string
+	Target        TargetSpec
+	Resolver      rules.Resolver
+	FileFilter    *rules.FileFilter
+	GitRunner     *gitcmd.Runner
+	MaxBundleSize int64
+}
+
+// ProtocolError is an error with a stable machine-readable code.
+type ProtocolError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *ProtocolError) Error() string {
+	return e.Code + ": " + e.Message
+}
+
+// Prepare builds and serializes a deterministic bundle without invoking an LLM.
+func Prepare(ctx context.Context, options PrepareOptions) (*Bundle, []byte, error) {
+	if options.RepoDir == "" {
+		return nil, nil, fmt.Errorf("repository directory is required")
+	}
+	if options.GitRunner == nil {
+		return nil, nil, fmt.Errorf("git runner is required")
+	}
+	detailResolver, ok := options.Resolver.(rules.DetailResolver)
+	if !ok {
+		return nil, nil, fmt.Errorf("rule resolver must expose source details")
+	}
+	maxBundleSize := options.MaxBundleSize
+	if maxBundleSize <= 0 {
+		maxBundleSize = DefaultMaxBundleBytes
+	}
+
+	target, workspaceState, err := ResolveTarget(
+		ctx, options.RepoDir, options.Target, options.GitRunner,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	changes, err := loadTargetDiffs(ctx, options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load target diffs: %w", err)
+	}
+
+	bundle := &Bundle{
+		SchemaVersion:  BundleSchemaVersion,
+		Target:         target,
+		WorkspaceState: workspaceState,
+		Rules:          make(map[string]Rule),
+		Files:          make([]File, 0, len(changes)),
+		Contract:       DefaultContract(),
+	}
+	bundle.Contract.MaxBundleBytes = maxBundleSize
+	buildBundleEvidence(bundle, changes, detailResolver, options.FileFilter)
+	bundle.Target.DiffSHA256 = hashDiffs(changes)
+
+	bundleID, err := computeBundleID(bundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	bundle.BundleID = bundleID
+	encoded, err := marshalWithStableSize(bundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	if int64(len(encoded)) > maxBundleSize {
+		return nil, nil, &ProtocolError{
+			Code: "bundle_too_large",
+			Message: fmt.Sprintf(
+				"encoded bundle is %d bytes; maximum is %d bytes",
+				len(encoded),
+				maxBundleSize,
+			),
+		}
+	}
+	return bundle, encoded, nil
+}
+
+func loadTargetDiffs(ctx context.Context, options PrepareOptions) ([]model.Diff, error) {
+	var provider *diff.Provider
+	switch {
+	case options.Target.Commit != "":
+		provider = diff.NewCommitProvider(
+			options.RepoDir, options.Target.Commit, options.GitRunner,
+		)
+	case options.Target.From != "":
+		provider = diff.NewProvider(
+			options.RepoDir, options.Target.From, options.Target.To, options.GitRunner,
+		)
+	default:
+		provider = diff.NewWorkspaceProvider(options.RepoDir, options.GitRunner)
+	}
+	return provider.GetDiff(ctx)
+}
+
+func buildBundleEvidence(
+	bundle *Bundle,
+	changes []model.Diff,
+	resolver rules.DetailResolver,
+	fileFilter *rules.FileFilter,
+) {
+	filter := reviewfilter.Filter{FileFilter: fileFilter}
+	ruleIDs := make(map[string]string)
+	for _, change := range changes {
+		path := reviewfilter.EffectivePath(change)
+		excludeReason := filter.ExcludeReason(change)
+		if excludeReason == model.ExcludeNone && change.IsDeleted {
+			excludeReason = model.ExcludeDeleted
+		}
+		reviewable := excludeReason == model.ExcludeNone
+		detail := resolver.ResolveDetail(path)
+		ruleID := internRule(bundle.Rules, ruleIDs, detail)
+		hunks := convertHunks(diff.ParseHunks(change.Diff))
+
+		contentSHA256 := hashFields([]byte(change.NewFileContent))
+		if change.IsDeleted {
+			contentSHA256 = ""
+		}
+
+		bundle.Files = append(bundle.Files, File{
+			Path:          path,
+			OldPath:       change.OldPath,
+			Status:        reviewfilter.Status(change),
+			Reviewable:    reviewable,
+			ExcludeReason: excludeReason,
+			Insertions:    change.Insertions,
+			Deletions:     change.Deletions,
+			ContentSHA256: contentSHA256,
+			RuleID:        ruleID,
+			Patch:         change.Diff,
+			Hunks:         hunks,
+		})
+		bundle.Summary.TotalFiles++
+		bundle.Summary.Insertions += change.Insertions
+		bundle.Summary.Deletions += change.Deletions
+		if reviewable {
+			bundle.Summary.ReviewableFiles++
+		} else {
+			bundle.Summary.ExcludedFiles++
+		}
+	}
+}
+
+func internRule(
+	ruleTable map[string]Rule,
+	ruleIDs map[string]string,
+	detail rules.RuleDetail,
+) string {
+	key := hashFields(
+		[]byte(detail.Source),
+		[]byte(detail.Pattern),
+		[]byte(detail.Rule),
+	)
+	if existing, ok := ruleIDs[key]; ok {
+		return existing
+	}
+	hashSuffix := strings.TrimPrefix(key, "sha256:")
+	ruleID := "rule-" + hashSuffix[:16]
+	if _, exists := ruleTable[ruleID]; exists {
+		ruleID = "rule-" + hashSuffix
+	}
+	ruleIDs[key] = ruleID
+	ruleTable[ruleID] = Rule{
+		Source:  detail.Source,
+		Pattern: detail.Pattern,
+		Content: detail.Rule,
+	}
+	return ruleID
+}
+
+func convertHunks(parsed []diff.Hunk) []Hunk {
+	hunks := make([]Hunk, 0, len(parsed))
+	for _, parsedHunk := range parsed {
+		hunks = append(hunks, Hunk{
+			OldStart: parsedHunk.OldStart,
+			OldCount: parsedHunk.OldCount,
+			NewStart: parsedHunk.NewStart,
+			NewCount: parsedHunk.NewCount,
+		})
+	}
+	return hunks
+}
+
+func hashDiffs(changes []model.Diff) string {
+	fields := make([][]byte, 0, len(changes)*3)
+	for _, change := range changes {
+		fields = append(
+			fields,
+			[]byte(change.OldPath),
+			[]byte(change.NewPath),
+			[]byte(change.Diff),
+		)
+	}
+	return hashFields(fields...)
+}
+
+func computeBundleID(bundle *Bundle) (string, error) {
+	// Only scalar identity fields are changed on this shallow copy.
+	canonical := *bundle
+	canonical.BundleID = ""
+	canonical.Contract.BundleSizeBytes = 0
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("marshal bundle identity: %w", err)
+	}
+	return hashFields(encoded), nil
+}
+
+func marshalWithStableSize(bundle *Bundle) ([]byte, error) {
+	var encoded []byte
+	sizes := make([]int64, 0, 8)
+	for range 8 {
+		var err error
+		encoded, err = json.Marshal(bundle)
+		if err != nil {
+			return nil, fmt.Errorf("marshal review bundle: %w", err)
+		}
+		size := int64(len(encoded))
+		sizes = append(sizes, size)
+		if bundle.Contract.BundleSizeBytes == size {
+			return encoded, nil
+		}
+		bundle.Contract.BundleSizeBytes = size
+	}
+	return nil, fmt.Errorf("stabilize encoded bundle size; observed sizes: %v", sizes)
+}

--- a/internal/reviewbundle/prepare_test.go
+++ b/internal/reviewbundle/prepare_test.go
@@ -1,0 +1,264 @@
+package reviewbundle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+type detailResolverStub struct{}
+
+func (detailResolverStub) Resolve(path string) string {
+	return detailResolverStub{}.ResolveDetail(path).Rule
+}
+
+func (detailResolverStub) ResolveDetail(path string) rules.RuleDetail {
+	if strings.HasSuffix(path, ".go") {
+		return rules.RuleDetail{
+			Rule:    "Review Go correctness.",
+			Source:  "project",
+			Pattern: "**/*.go",
+		}
+	}
+	return rules.RuleDetail{Rule: "Review correctness.", Source: "system", Pattern: "default"}
+}
+
+func TestPrepareWorkspaceBuildsDeterministicCompleteBundle(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changed = true\n")
+	writeTargetFile(t, repository, "staged.go", "package sample\n\nvar staged = true\n")
+	runTargetGit(t, repository, "add", "staged.go")
+	if err := os.Remove(filepath.Join(repository, "deleted.go")); err != nil {
+		t.Fatalf("remove deleted file: %v", err)
+	}
+	runTargetGit(t, repository, "mv", "old.go", "renamed.go")
+	writeTargetFile(t, repository, "binary.bin", "\x00\x01changed")
+	writeTargetFile(t, repository, "ignored_test.go", "package sample\n\nfunc TestIgnored() {}\n")
+	writeTargetFile(t, repository, "no-newline.go", "package sample")
+	if err := os.Symlink("../outside", filepath.Join(repository, "link.go")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	options := PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		FileFilter:    &rules.FileFilter{},
+		GitRunner:     gitcmd.New(4),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	}
+	first, encoded, err := Prepare(context.Background(), options)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	second, secondEncoded, err := Prepare(context.Background(), options)
+	if err != nil {
+		t.Fatalf("second Prepare() error = %v", err)
+	}
+
+	if first.BundleID == "" || first.BundleID != second.BundleID {
+		t.Fatalf("unstable bundle IDs: %q != %q", first.BundleID, second.BundleID)
+	}
+	if string(encoded) != string(secondEncoded) {
+		t.Fatal("Prepare() output is not deterministic")
+	}
+	if first.SchemaVersion != BundleSchemaVersion || first.Target.DiffSHA256 == "" {
+		t.Fatalf("invalid protocol identity: %+v", first.Target)
+	}
+	if first.WorkspaceState == nil {
+		t.Fatal("workspace_state is nil")
+	}
+	if first.Summary.TotalFiles != len(first.Files) ||
+		first.Summary.ReviewableFiles+first.Summary.ExcludedFiles != first.Summary.TotalFiles {
+		t.Fatalf("inconsistent summary: %+v, files=%d", first.Summary, len(first.Files))
+	}
+	if len(first.Rules) != 2 {
+		t.Fatalf("rules = %d, want 2 deduplicated entries", len(first.Rules))
+	}
+
+	files := make(map[string]File, len(first.Files))
+	for _, file := range first.Files {
+		files[file.Path] = file
+		if file.ContentSHA256 == "" && file.ExcludeReason != model.ExcludeDeleted {
+			t.Errorf("file missing hashes or rule: %+v", file)
+		}
+		if file.RuleID == "" {
+			t.Errorf("file missing rule id: %+v", file)
+		}
+	}
+	assertPreparedStatus(t, files, "base.go", "modified", true, "")
+	assertPreparedStatus(t, files, "staged.go", "modified", true, "")
+	assertPreparedStatus(t, files, "deleted.go", "deleted", false, "deleted")
+	if files["deleted.go"].ContentSHA256 != "" {
+		t.Fatalf("deleted.go content hash = %q, want empty", files["deleted.go"].ContentSHA256)
+	}
+	assertPreparedStatus(t, files, "renamed.go", "renamed", true, "")
+	assertPreparedStatus(t, files, "binary.bin", "binary", false, "binary")
+	assertPreparedStatus(t, files, "ignored_test.go", "added", false, "default_path")
+	assertPreparedStatus(t, files, "no-newline.go", "added", true, "")
+	assertPreparedStatus(t, files, "link.go", "added", true, "")
+	if len(files["base.go"].Hunks) == 0 || files["base.go"].Patch == "" {
+		t.Fatalf("base.go missing patch evidence: %+v", files["base.go"])
+	}
+
+	var decoded Bundle
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode prepared JSON: %v", err)
+	}
+	if decoded.BundleID != first.BundleID {
+		t.Fatalf("encoded bundle ID = %q, want %q", decoded.BundleID, first.BundleID)
+	}
+	if int64(len(encoded)) != first.Contract.BundleSizeBytes {
+		t.Fatalf("bundle_size_bytes = %d, actual %d", first.Contract.BundleSizeBytes, len(encoded))
+	}
+}
+
+func TestPrepareRejectsOversizedBundleWithoutTruncation(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "large.go", "package sample\n// "+strings.Repeat("x", 4096)+"\n")
+
+	_, _, err := Prepare(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: 128,
+	})
+	var protocolError *ProtocolError
+	if !errors.As(err, &protocolError) || protocolError.Code != "bundle_too_large" {
+		t.Fatalf("Prepare() error = %v, want bundle_too_large", err)
+	}
+}
+
+func TestPreparePartitionedSplitsLargeDiffWithoutDuplicates(t *testing.T) {
+	repository := initPrepareRepository(t)
+	for _, name := range []string{"one.go", "two.go", "three.go"} {
+		writeTargetFile(
+			t,
+			repository,
+			name,
+			"package sample\n// "+strings.Repeat(name, 120)+"\n",
+		)
+	}
+	manifest, encoded, err := PreparePartitioned(context.Background(), PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: 3200,
+	})
+	if err != nil {
+		t.Fatalf("PreparePartitioned() error = %v", err)
+	}
+	if len(encoded) == 0 || len(manifest.Bundles) < 2 ||
+		manifest.BatchStrategy != "diff" {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+	seen := make(map[string]bool)
+	for _, bundle := range manifest.Bundles {
+		if bundle.Contract.BundleSizeBytes > 3200 {
+			t.Errorf("bundle size = %d, want <= 3200", bundle.Contract.BundleSizeBytes)
+		}
+		for _, file := range bundle.Files {
+			if seen[file.Path] {
+				t.Errorf("duplicate file %s", file.Path)
+			}
+			seen[file.Path] = true
+		}
+	}
+	if len(seen) != manifest.Summary.TotalFiles {
+		t.Fatalf("covered files = %d, summary = %+v", len(seen), manifest.Summary)
+	}
+}
+
+func TestPrepareRangeAndCommitUseRequestedTarget(t *testing.T) {
+	repository := initPrepareRepository(t)
+	base := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar rangeChange = true\n")
+	runTargetGit(t, repository, "add", "base.go")
+	runTargetGit(t, repository, "commit", "-m", "range change")
+	head := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+
+	baseOptions := PrepareOptions{
+		RepoDir:       repository,
+		Resolver:      detailResolverStub{},
+		GitRunner:     gitcmd.New(2),
+		MaxBundleSize: DefaultMaxBundleBytes,
+	}
+	rangeOptions := baseOptions
+	rangeOptions.Target = TargetSpec{From: base, To: head}
+	rangeBundle, _, err := Prepare(context.Background(), rangeOptions)
+	if err != nil {
+		t.Fatalf("Prepare(range) error = %v", err)
+	}
+	if rangeBundle.Target.Mode != TargetRange || rangeBundle.Target.BaseSHA != base ||
+		rangeBundle.Target.HeadSHA != head || len(rangeBundle.Files) != 1 {
+		t.Fatalf("unexpected range bundle: target=%+v files=%d", rangeBundle.Target, len(rangeBundle.Files))
+	}
+
+	commitOptions := baseOptions
+	commitOptions.Target = TargetSpec{Commit: head}
+	commitBundle, _, err := Prepare(context.Background(), commitOptions)
+	if err != nil {
+		t.Fatalf("Prepare(commit) error = %v", err)
+	}
+	if commitBundle.Target.Mode != TargetCommit || commitBundle.Target.BaseSHA != base ||
+		commitBundle.Target.HeadSHA != head || len(commitBundle.Files) != 1 {
+		t.Fatalf("unexpected commit bundle: target=%+v files=%d", commitBundle.Target, len(commitBundle.Files))
+	}
+}
+
+func initPrepareRepository(t *testing.T) string {
+	t.Helper()
+	repository := t.TempDir()
+	runTargetGit(t, repository, "init", "-q")
+	runTargetGit(t, repository, "config", "user.email", "tests@example.com")
+	runTargetGit(t, repository, "config", "user.name", "OCR Tests")
+	runTargetGit(t, repository, "config", "commit.gpgsign", "false")
+	for name, content := range map[string]string{
+		"base.go":    "package sample\n\nvar base = true\n",
+		"staged.go":  "package sample\n\nvar staged = false\n",
+		"deleted.go": "package sample\n\nvar deleted = true\n",
+		"old.go":     "package sample\n\nvar renamed = true\n",
+		"binary.bin": "\x00\x01original",
+	} {
+		writeTargetFile(t, repository, name, content)
+	}
+	runTargetGit(t, repository, "add", ".")
+	runTargetGit(t, repository, "commit", "-m", "initial")
+	return repository
+}
+
+func assertPreparedStatus(
+	t *testing.T,
+	files map[string]File,
+	path string,
+	status string,
+	reviewable bool,
+	excludeReason string,
+) {
+	t.Helper()
+	file, ok := files[path]
+	if !ok {
+		t.Errorf("prepared files missing %s; got %+v", path, files)
+		return
+	}
+	if file.Status != status || file.Reviewable != reviewable ||
+		string(file.ExcludeReason) != excludeReason {
+		t.Errorf(
+			"%s = status %q, reviewable %v, reason %q; want %q, %v, %q",
+			path,
+			file.Status,
+			file.Reviewable,
+			file.ExcludeReason,
+			status,
+			reviewable,
+			excludeReason,
+		)
+	}
+}

--- a/internal/reviewbundle/report.go
+++ b/internal/reviewbundle/report.go
@@ -1,0 +1,255 @@
+package reviewbundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ReportOptions controls deterministic report rendering.
+type ReportOptions struct {
+	Format     string
+	Validation *ValidationResult
+}
+
+// RenderReport formats external findings without changing their meaning.
+func RenderReport(bundle *Bundle, comments *Comments, options ReportOptions) ([]byte, error) {
+	if bundle == nil || comments == nil {
+		return nil, fmt.Errorf("bundle and comments are required")
+	}
+	if comments.BundleID != bundle.BundleID {
+		return nil, fmt.Errorf("bundle_id mismatch")
+	}
+	if options.Validation != nil && options.Validation.BundleID != bundle.BundleID {
+		return nil, fmt.Errorf("validation bundle_id mismatch")
+	}
+	sorted := sortedComments(comments)
+	switch options.Format {
+	case "json":
+		encoded, err := json.MarshalIndent(sorted, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encode JSON report: %w", err)
+		}
+		return append(encoded, '\n'), nil
+	case "text":
+		return renderTextReport(bundle, sorted, options.Validation), nil
+	case "", "markdown":
+		return renderMarkdownReport(bundle, sorted, options.Validation), nil
+	default:
+		return nil, fmt.Errorf("unsupported report format %q", options.Format)
+	}
+}
+
+func sortedComments(comments *Comments) *Comments {
+	result := *comments
+	result.Comments = make([]ReviewComment, len(comments.Comments))
+	copy(result.Comments, comments.Comments)
+	result.Warnings = make([]ProtocolNotice, len(comments.Warnings))
+	copy(result.Warnings, comments.Warnings)
+	sort.SliceStable(result.Comments, func(i, j int) bool {
+		left, right := result.Comments[i], result.Comments[j]
+		if priorityRank(left.Priority) != priorityRank(right.Priority) {
+			return priorityRank(left.Priority) < priorityRank(right.Priority)
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.StartLine != right.StartLine {
+			return left.StartLine < right.StartLine
+		}
+		return left.Title < right.Title
+	})
+	return &result
+}
+
+func priorityRank(priority string) int {
+	switch priority {
+	case "high":
+		return 0
+	case "medium":
+		return 1
+	case "low":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func renderMarkdownReport(
+	bundle *Bundle,
+	comments *Comments,
+	validation *ValidationResult,
+) []byte {
+	var output bytes.Buffer
+	fmt.Fprintln(&output, "# Agent Code Review")
+	fmt.Fprintln(&output)
+	fmt.Fprintf(&output, "- Bundle: %s\n", markdownCode(bundle.BundleID))
+	fmt.Fprintf(
+		&output,
+		"- Scope: %d reviewable / %d total files\n",
+		bundle.Summary.ReviewableFiles,
+		bundle.Summary.TotalFiles,
+	)
+	fmt.Fprintf(&output, "- Findings: %d\n", len(comments.Comments))
+	writeMarkdownValidation(&output, validation)
+	if len(comments.Comments) == 0 {
+		fmt.Fprintln(&output)
+		fmt.Fprintln(&output, "No findings.")
+	} else {
+		for _, comment := range comments.Comments {
+			fmt.Fprintln(&output)
+			fmt.Fprintf(
+				&output,
+				"## [%s] %s\n\n",
+				strings.ToUpper(comment.Priority),
+				escapeMarkdownHeading(comment.Title),
+			)
+			fmt.Fprintf(
+				&output,
+				"%s · %s · confidence %.2f\n\n",
+				markdownCode(commentLocation(comment)),
+				comment.Category,
+				comment.Confidence,
+			)
+			fmt.Fprintln(&output, comment.Content)
+			if comment.Recommendation != "" {
+				fmt.Fprintln(&output)
+				fmt.Fprintf(&output, "Recommendation: %s\n", comment.Recommendation)
+			}
+			if comment.ExistingCode != "" {
+				fmt.Fprintln(&output)
+				fmt.Fprintln(&output, "Existing code:")
+				fmt.Fprintln(&output)
+				writeFencedCode(&output, comment.ExistingCode)
+			}
+			if comment.SuggestionCode != "" {
+				fmt.Fprintln(&output)
+				fmt.Fprintln(&output, "Suggested code:")
+				fmt.Fprintln(&output)
+				writeFencedCode(&output, comment.SuggestionCode)
+			}
+		}
+	}
+	writeMarkdownNotices(&output, "Warnings", comments.Warnings)
+	return output.Bytes()
+}
+
+func writeMarkdownValidation(output *bytes.Buffer, validation *ValidationResult) {
+	if validation == nil {
+		fmt.Fprintln(output, "- Validation: not supplied")
+		return
+	}
+	state := "INVALID"
+	if validation.Valid {
+		state = "valid"
+	}
+	fmt.Fprintf(output, "- Validation: %s\n", state)
+	if len(validation.Errors) > 0 {
+		fmt.Fprintln(output)
+		fmt.Fprintln(output, "## Validation errors")
+		for _, notice := range validation.Errors {
+			fmt.Fprintf(output, "\n- `%s`: %s\n", notice.Code, notice.Message)
+		}
+	}
+	if len(validation.Warnings) > 0 {
+		fmt.Fprintln(output)
+		fmt.Fprintln(output, "## Validation warnings")
+		for _, notice := range validation.Warnings {
+			fmt.Fprintf(output, "\n- `%s`: %s\n", notice.Code, notice.Message)
+		}
+	}
+}
+
+func writeMarkdownNotices(output *bytes.Buffer, title string, notices []ProtocolNotice) {
+	if len(notices) == 0 {
+		return
+	}
+	fmt.Fprintln(output)
+	fmt.Fprintf(output, "## %s\n", title)
+	for _, notice := range notices {
+		fmt.Fprintf(output, "\n- `%s`: %s\n", notice.Code, notice.Message)
+	}
+}
+
+func renderTextReport(
+	bundle *Bundle,
+	comments *Comments,
+	validation *ValidationResult,
+) []byte {
+	var output bytes.Buffer
+	fmt.Fprintf(&output, "Agent Code Review\nBundle: %s\nFindings: %d\n", bundle.BundleID, len(comments.Comments))
+	if validation == nil {
+		fmt.Fprintln(&output, "Validation: not supplied")
+	} else if validation.Valid {
+		fmt.Fprintln(&output, "Validation: valid")
+	} else {
+		fmt.Fprintln(&output, "Validation: INVALID")
+		for _, notice := range validation.Errors {
+			fmt.Fprintf(&output, "ERROR %s: %s\n", notice.Code, notice.Message)
+		}
+	}
+	if validation != nil && len(validation.Warnings) > 0 {
+		for _, notice := range validation.Warnings {
+			fmt.Fprintf(&output, "WARNING %s: %s\n", notice.Code, notice.Message)
+		}
+	}
+	for _, comment := range comments.Comments {
+		fmt.Fprintf(
+			&output,
+			"\n[%s] %s (%s, %s, confidence %.2f)\n%s\n",
+			strings.ToUpper(comment.Priority),
+			comment.Title,
+			commentLocation(comment),
+			comment.Category,
+			comment.Confidence,
+			comment.Content,
+		)
+		if comment.Recommendation != "" {
+			fmt.Fprintf(&output, "Recommendation: %s\n", comment.Recommendation)
+		}
+	}
+	if len(comments.Warnings) > 0 {
+		fmt.Fprintln(&output, "\nWarnings:")
+		for _, notice := range comments.Warnings {
+			fmt.Fprintf(&output, "WARNING %s: %s\n", notice.Code, notice.Message)
+		}
+	}
+	return output.Bytes()
+}
+
+func commentLocation(comment ReviewComment) string {
+	if comment.FileLevelComment {
+		return comment.Path
+	}
+	if comment.StartLine == comment.EndLine {
+		return fmt.Sprintf("%s:%d", comment.Path, comment.StartLine)
+	}
+	return fmt.Sprintf("%s:%d-%d", comment.Path, comment.StartLine, comment.EndLine)
+}
+
+func markdownCode(value string) string {
+	if !strings.Contains(value, "`") {
+		return "`" + value + "`"
+	}
+	fence := "``"
+	for strings.Contains(value, fence) {
+		fence += "`"
+	}
+	return fence + " " + value + " " + fence
+}
+
+func escapeMarkdownHeading(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "\n", " "), "#", "\\#")
+}
+
+func writeFencedCode(output *bytes.Buffer, code string) {
+	fence := "```"
+	for strings.Contains(code, fence) {
+		fence += "`"
+	}
+	fmt.Fprintln(output, fence)
+	fmt.Fprintln(output, code)
+	fmt.Fprintln(output, fence)
+}

--- a/internal/reviewbundle/report_test.go
+++ b/internal/reviewbundle/report_test.go
@@ -1,0 +1,145 @@
+package reviewbundle
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReportMarkdownIsStableAndPriorityOrdered(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{FilesReviewed: 1, IssuesFound: 2},
+		Comments: []ReviewComment{
+			{
+				Path: "main.go", StartLine: 8, EndLine: 8,
+				Priority: "low", Category: "test", Title: "Later",
+				Content: "low content", Recommendation: "add test", Confidence: 0.6,
+			},
+			{
+				Path: "main.go", StartLine: 3, EndLine: 4,
+				Priority: "high", Category: "bug", Title: "First",
+				Content: "high content", Recommendation: "fix it", Confidence: 0.95,
+			},
+		},
+	}
+
+	report, err := RenderReport(bundle, comments, ReportOptions{Format: "markdown"})
+	if err != nil {
+		t.Fatalf("RenderReport() error = %v", err)
+	}
+	text := string(report)
+	if strings.Index(text, "[HIGH]") > strings.Index(text, "[LOW]") {
+		t.Fatalf("report is not priority ordered:\n%s", text)
+	}
+	if !strings.Contains(text, "`main.go:3-4`") || !strings.Contains(text, "Validation: not supplied") {
+		t.Fatalf("report missing evidence metadata:\n%s", text)
+	}
+}
+
+func TestReportJSONPreservesCommentsProtocol(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{},
+		Comments:      []ReviewComment{},
+	}
+	report, err := RenderReport(bundle, comments, ReportOptions{Format: "json"})
+	if err != nil {
+		t.Fatalf("RenderReport() error = %v", err)
+	}
+	var decoded Comments
+	if err := json.Unmarshal(report, &decoded); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if decoded.BundleID != comments.BundleID || decoded.Comments == nil {
+		t.Fatalf("decoded report = %+v", decoded)
+	}
+}
+
+func TestReportIncludesValidationFailures(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{},
+		Comments:      []ReviewComment{},
+	}
+	validation := &ValidationResult{
+		SchemaVersion: "review-validation/v1",
+		BundleID:      bundle.BundleID,
+		Valid:         false,
+		Errors: []ValidationNotice{{
+			Code: "stale_bundle", Message: "target changed",
+		}},
+		Warnings: []ValidationNotice{{
+			Code: "outside_changed_hunk", Message: "line is outside changed hunk",
+		}},
+	}
+	report, err := RenderReport(
+		bundle,
+		comments,
+		ReportOptions{Format: "text", Validation: validation},
+	)
+	if err != nil {
+		t.Fatalf("RenderReport() error = %v", err)
+	}
+	if !strings.Contains(string(report), "INVALID") ||
+		!strings.Contains(string(report), "stale_bundle") ||
+		!strings.Contains(string(report), "outside_changed_hunk") {
+		t.Fatalf("report missing validation failure:\n%s", report)
+	}
+}
+
+func TestReportRejectsValidationBundleMismatch(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{},
+		Comments:      []ReviewComment{},
+	}
+	validation := &ValidationResult{
+		SchemaVersion: "review-validation/v1",
+		BundleID:      "sha256:other",
+		Valid:         true,
+	}
+	_, err := RenderReport(bundle, comments, ReportOptions{Format: "markdown", Validation: validation})
+	if err == nil || !strings.Contains(err.Error(), "validation bundle_id mismatch") {
+		t.Fatalf("RenderReport() error = %v, want validation bundle mismatch", err)
+	}
+}
+
+func TestReportEscapesBackticksAndTextWarnings(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{FilesReviewed: 1, IssuesFound: 1},
+		Comments: []ReviewComment{{
+			Path: "main`weird.go", StartLine: 1, EndLine: 1,
+			Priority: "high", Category: "bug", Title: "Fence",
+			Content: "content", Recommendation: "fix", Confidence: 1,
+			ExistingCode: "````\ncode",
+		}},
+		Warnings: []ProtocolNotice{{Code: "partial", Message: "some scope skipped"}},
+	}
+	markdown, err := RenderReport(bundle, comments, ReportOptions{Format: "markdown"})
+	if err != nil {
+		t.Fatalf("RenderReport(markdown) error = %v", err)
+	}
+	if !strings.Contains(string(markdown), "`` main`weird.go:1 ``") ||
+		!strings.Contains(string(markdown), "`````") {
+		t.Fatalf("markdown report did not escape code spans/fences:\n%s", markdown)
+	}
+	text, err := RenderReport(bundle, comments, ReportOptions{Format: "text"})
+	if err != nil {
+		t.Fatalf("RenderReport(text) error = %v", err)
+	}
+	if !strings.Contains(string(text), "WARNING partial") {
+		t.Fatalf("text report missing warnings:\n%s", text)
+	}
+}

--- a/internal/reviewbundle/scan.go
+++ b/internal/reviewbundle/scan.go
@@ -1,0 +1,279 @@
+package reviewbundle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+	"github.com/open-code-review/open-code-review/internal/model"
+	"github.com/open-code-review/open-code-review/internal/scan"
+)
+
+const ScanManifestSchemaVersion = "review-manifest/v1"
+
+// ScanOptions configures deterministic full-file scan preparation.
+type ScanOptions struct {
+	RepoDir          string
+	Paths            []string
+	Resolver         rules.Resolver
+	FileFilter       *rules.FileFilter
+	GitRunner        *gitcmd.Runner
+	MaxFileSizeBytes int64
+	MaxTokenBudget   int64
+	MaxBundleSize    int64
+	BatchStrategy    string
+	BatchSize        int
+}
+
+// ScanManifest links all deterministic full-file review bundles.
+type ScanManifest struct {
+	SchemaVersion   string            `json:"schema_version"`
+	ManifestID      string            `json:"manifest_id"`
+	Root            string            `json:"root"`
+	TargetHash      string            `json:"target_hash"`
+	BatchStrategy   string            `json:"batch_strategy"`
+	BatchSize       int               `json:"batch_size"`
+	EstimatedTokens int64             `json:"estimated_tokens"`
+	Summary         Summary           `json:"summary"`
+	Partial         bool              `json:"partial"`
+	SkippedFiles    []ScanSkippedFile `json:"skipped_files"`
+	Bundles         []Bundle          `json:"bundles"`
+	Warnings        []ProtocolNotice  `json:"warnings,omitempty"`
+}
+
+// ScanSkippedFile records every enumerated file not included for review.
+type ScanSkippedFile struct {
+	Path            string `json:"path"`
+	Reason          string `json:"reason"`
+	EstimatedTokens int64  `json:"estimated_tokens,omitempty"`
+}
+
+// PrepareScan enumerates, filters, budgets, groups, and serializes full files.
+func PrepareScan(ctx context.Context, options ScanOptions) (*ScanManifest, []byte, error) {
+	if options.RepoDir == "" {
+		return nil, nil, fmt.Errorf("scan root is required")
+	}
+	detailResolver, ok := options.Resolver.(rules.DetailResolver)
+	if !ok {
+		return nil, nil, fmt.Errorf("rule resolver must expose source details")
+	}
+	maxBundleSize := options.MaxBundleSize
+	if maxBundleSize <= 0 {
+		maxBundleSize = DefaultMaxBundleBytes
+	}
+	provider := scan.NewProvider(
+		options.RepoDir,
+		options.Paths,
+		options.GitRunner,
+		options.MaxFileSizeBytes,
+	)
+	items, providerSkipped, err := provider.EnumerateDetailed(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("enumerate scan target: %w", err)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Path < items[j].Path })
+
+	batchStrategy := scan.ParseBatchStrategy(options.BatchStrategy)
+	manifest := &ScanManifest{
+		SchemaVersion: ScanManifestSchemaVersion,
+		Root:          options.RepoDir,
+		BatchStrategy: string(batchStrategy),
+		BatchSize:     options.BatchSize,
+		SkippedFiles:  make([]ScanSkippedFile, 0),
+		Bundles:       make([]Bundle, 0),
+	}
+	for _, skipped := range providerSkipped {
+		manifest.SkippedFiles = append(manifest.SkippedFiles, ScanSkippedFile{
+			Path: skipped.Path, Reason: skipped.Reason,
+		})
+	}
+	manifest.Summary.TotalFiles = len(items) + len(providerSkipped)
+	included, budgetTruncated := filterAndBudgetScanItems(manifest, items, options)
+	manifest.EstimatedTokens = scan.EstimateTokens(included, true, true, true).TotalTokens
+	manifest.Summary.ReviewableFiles = len(included)
+	manifest.Summary.ExcludedFiles = manifest.Summary.TotalFiles - len(included)
+	for _, item := range included {
+		manifest.Summary.Insertions += int64(item.LineCount)
+	}
+	manifest.Partial = budgetTruncated
+	manifest.TargetHash = hashScanItems(included)
+
+	batches := scan.GroupBatches(
+		included,
+		batchStrategy,
+		options.BatchSize,
+	)
+	for batchIndex, batch := range batches {
+		if err := appendScanBundles(
+			manifest,
+			batch,
+			batchIndex,
+			manifest.TargetHash,
+			detailResolver,
+			maxBundleSize,
+		); err != nil {
+			return nil, nil, err
+		}
+	}
+	manifestID, err := computeManifestID(manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifest.ManifestID = manifestID
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal scan manifest: %w", err)
+	}
+	return manifest, encoded, nil
+}
+
+func filterAndBudgetScanItems(
+	manifest *ScanManifest,
+	items []model.ScanItem,
+	options ScanOptions,
+) ([]model.ScanItem, bool) {
+	if options.MaxTokenBudget > 0 {
+		sort.SliceStable(items, func(i, j int) bool {
+			left := scan.EstimateItemTokens(items[i], true)
+			right := scan.EstimateItemTokens(items[j], true)
+			if left != right {
+				return left < right
+			}
+			return items[i].Path < items[j].Path
+		})
+	}
+	included := make([]model.ScanItem, 0, len(items))
+	var budgetUsed int64
+	budgetTruncated := false
+	for _, item := range items {
+		reason := scan.ExcludeReason(item, options.FileFilter)
+		if reason != model.ExcludeNone {
+			manifest.SkippedFiles = append(manifest.SkippedFiles, ScanSkippedFile{
+				Path: item.Path, Reason: string(reason),
+			})
+			continue
+		}
+		estimated := scan.EstimateItemTokens(item, true)
+		if options.MaxTokenBudget > 0 && budgetUsed+estimated > options.MaxTokenBudget {
+			budgetTruncated = true
+			manifest.SkippedFiles = append(manifest.SkippedFiles, ScanSkippedFile{
+				Path: item.Path, Reason: "token_budget", EstimatedTokens: estimated,
+			})
+			continue
+		}
+		budgetUsed += estimated
+		included = append(included, item)
+	}
+	sort.Slice(included, func(i, j int) bool { return included[i].Path < included[j].Path })
+	return included, budgetTruncated
+}
+
+func appendScanBundles(
+	manifest *ScanManifest,
+	items []model.ScanItem,
+	batchIndex int,
+	targetHash string,
+	resolver rules.DetailResolver,
+	maxBundleSize int64,
+) error {
+	bundle, err := buildScanBundle(items, batchIndex, targetHash, resolver, maxBundleSize)
+	if err == nil {
+		manifest.Bundles = append(manifest.Bundles, *bundle)
+		return nil
+	}
+	var protocolError *ProtocolError
+	if !errors.As(err, &protocolError) || protocolError.Code != "bundle_too_large" || len(items) <= 1 {
+		return err
+	}
+	midpoint := len(items) / 2
+	if err := appendScanBundles(manifest, items[:midpoint], batchIndex, targetHash, resolver, maxBundleSize); err != nil {
+		return err
+	}
+	return appendScanBundles(manifest, items[midpoint:], batchIndex, targetHash, resolver, maxBundleSize)
+}
+
+func buildScanBundle(
+	items []model.ScanItem,
+	batchIndex int,
+	targetHash string,
+	resolver rules.DetailResolver,
+	maxBundleSize int64,
+) (*Bundle, error) {
+	bundle := &Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		Target: Target{
+			Mode:       TargetScan,
+			DiffSHA256: targetHash,
+		},
+		Rules:    make(map[string]Rule),
+		Files:    make([]File, 0, len(items)),
+		Contract: DefaultContract(),
+	}
+	bundle.Contract.MaxBundleBytes = maxBundleSize
+	ruleIDs := make(map[string]string)
+	for _, item := range items {
+		ruleID := internRule(bundle.Rules, ruleIDs, resolver.ResolveDetail(item.Path))
+		bundle.Files = append(bundle.Files, File{
+			Path:          item.Path,
+			OldPath:       item.Path,
+			Status:        "scan",
+			Reviewable:    true,
+			Insertions:    int64(item.LineCount),
+			ContentSHA256: hashFields([]byte(item.Content)),
+			RuleID:        ruleID,
+			Content:       item.Content,
+			Hunks:         []Hunk{},
+		})
+		bundle.Summary.TotalFiles++
+		bundle.Summary.ReviewableFiles++
+		bundle.Summary.Insertions += int64(item.LineCount)
+	}
+	bundle.Warnings = []ProtocolNotice{{
+		Code:    "scan_batch",
+		Message: fmt.Sprintf("deterministic scan batch %d", batchIndex),
+	}}
+	bundleID, err := computeBundleID(bundle)
+	if err != nil {
+		return nil, err
+	}
+	bundle.BundleID = bundleID
+	encoded, err := marshalWithStableSize(bundle)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(encoded)) > maxBundleSize {
+		return nil, &ProtocolError{
+			Code: "bundle_too_large",
+			Message: fmt.Sprintf(
+				"scan batch %d is %d bytes; maximum is %d bytes",
+				batchIndex,
+				len(encoded),
+				maxBundleSize,
+			),
+		}
+	}
+	return bundle, nil
+}
+
+func hashScanItems(items []model.ScanItem) string {
+	fields := make([][]byte, 0, len(items)*2)
+	for _, item := range items {
+		fields = append(fields, []byte(item.Path), []byte(item.Content))
+	}
+	return hashFields(fields...)
+}
+
+func computeManifestID(manifest *ScanManifest) (string, error) {
+	canonical := *manifest
+	canonical.ManifestID = ""
+	canonical.Root = ""
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("marshal scan manifest identity: %w", err)
+	}
+	return hashFields(encoded), nil
+}

--- a/internal/reviewbundle/scan_test.go
+++ b/internal/reviewbundle/scan_test.go
@@ -1,0 +1,138 @@
+package reviewbundle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+func TestPrepareScanBuildsDeterministicGroupedManifest(t *testing.T) {
+	repository := initPrepareRepository(t)
+	writeTargetFile(t, repository, "cmd/main.go", "package main\n\nfunc main() {}\n")
+	writeTargetFile(t, repository, "pkg/util.go", "package pkg\n\nfunc Util() {}\n")
+	writeTargetFile(t, repository, "web/app.ts", "export const app = true\n")
+	writeTargetFile(t, repository, "asset.bin", "\x00binary")
+
+	options := ScanOptions{
+		RepoDir:       repository,
+		Paths:         []string{"cmd", "pkg", "web", "asset.bin"},
+		Resolver:      detailResolverStub{},
+		FileFilter:    &rules.FileFilter{},
+		GitRunner:     gitcmd.New(2),
+		BatchStrategy: "by-language",
+		BatchSize:     10,
+		MaxBundleSize: DefaultMaxBundleBytes,
+	}
+	first, firstJSON, err := PrepareScan(context.Background(), options)
+	if err != nil {
+		t.Fatalf("PrepareScan() error = %v", err)
+	}
+	second, secondJSON, err := PrepareScan(context.Background(), options)
+	if err != nil {
+		t.Fatalf("second PrepareScan() error = %v", err)
+	}
+	if first.ManifestID == "" || first.ManifestID != second.ManifestID ||
+		string(firstJSON) != string(secondJSON) {
+		t.Fatal("scan manifest is not deterministic")
+	}
+	if first.Summary.TotalFiles != 4 || first.Summary.ReviewableFiles != 3 ||
+		first.Summary.ExcludedFiles != 1 {
+		t.Fatalf("summary = %+v", first.Summary)
+	}
+	if len(first.Bundles) != 2 {
+		t.Fatalf("bundles = %d, want one Go and one TypeScript batch", len(first.Bundles))
+	}
+	assertManifestFileUniqueness(t, first)
+	foundBinarySkip := false
+	for _, skipped := range first.SkippedFiles {
+		if skipped.Path == "asset.bin" && skipped.Reason == "binary" {
+			foundBinarySkip = true
+		}
+	}
+	if !foundBinarySkip {
+		t.Fatalf("skipped files = %+v, want binary reason", first.SkippedFiles)
+	}
+	for _, bundle := range first.Bundles {
+		if bundle.Target.Mode != TargetScan {
+			t.Fatalf("target mode = %q, want scan", bundle.Target.Mode)
+		}
+		for _, file := range bundle.Files {
+			if file.Content == "" || file.Patch != "" {
+				t.Fatalf("scan file evidence = %+v", file)
+			}
+		}
+	}
+}
+
+func TestPrepareScanSupportsNonGitDirectoryAndHardBudget(t *testing.T) {
+	directory := t.TempDir()
+	for index, name := range []string{"a.go", "b.go", "c.go"} {
+		content := "package sample\n\nvar Value = \"" + string(rune('a'+index)) + "\"\n"
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest, _, err := PrepareScan(context.Background(), ScanOptions{
+		RepoDir:        directory,
+		Resolver:       detailResolverStub{},
+		GitRunner:      gitcmd.New(2),
+		BatchStrategy:  "none",
+		MaxTokenBudget: 1,
+		MaxBundleSize:  DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("PrepareScan() error = %v", err)
+	}
+	if !manifest.Partial || len(manifest.Bundles) != 0 ||
+		len(manifest.SkippedFiles) != 3 {
+		t.Fatalf("budget manifest = %+v", manifest)
+	}
+	for _, skipped := range manifest.SkippedFiles {
+		if skipped.Reason != "token_budget" {
+			t.Fatalf("skipped = %+v, want token_budget", skipped)
+		}
+	}
+}
+
+func TestPrepareScanReportsOversizedFiles(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(directory, "large.go"),
+		[]byte("package sample\nvar Large = true\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	manifest, _, err := PrepareScan(context.Background(), ScanOptions{
+		RepoDir:          directory,
+		Resolver:         detailResolverStub{},
+		GitRunner:        gitcmd.New(1),
+		MaxFileSizeBytes: 8,
+		MaxBundleSize:    DefaultMaxBundleBytes,
+	})
+	if err != nil {
+		t.Fatalf("PrepareScan() error = %v", err)
+	}
+	if manifest.Summary.TotalFiles != 1 || len(manifest.SkippedFiles) != 1 ||
+		manifest.SkippedFiles[0].Path != "large.go" ||
+		manifest.SkippedFiles[0].Reason != "file_size" {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+}
+
+func assertManifestFileUniqueness(t *testing.T, manifest *ScanManifest) {
+	t.Helper()
+	seen := make(map[string]bool)
+	for _, bundle := range manifest.Bundles {
+		for _, file := range bundle.Files {
+			if seen[file.Path] {
+				t.Errorf("duplicate manifest file %s", file.Path)
+			}
+			seen[file.Path] = true
+		}
+	}
+}

--- a/internal/reviewbundle/schema.go
+++ b/internal/reviewbundle/schema.go
@@ -1,0 +1,29 @@
+package reviewbundle
+
+import _ "embed"
+
+var (
+	//go:embed schemas/review-bundle-v1.json
+	bundleSchema []byte
+
+	//go:embed schemas/review-comments-v1.json
+	commentsSchema []byte
+
+	//go:embed schemas/review-manifest-v1.json
+	manifestSchema []byte
+)
+
+// BundleSchema returns a defensive copy of the embedded bundle schema.
+func BundleSchema() []byte {
+	return append([]byte(nil), bundleSchema...)
+}
+
+// CommentsSchema returns a defensive copy of the embedded comments schema.
+func CommentsSchema() []byte {
+	return append([]byte(nil), commentsSchema...)
+}
+
+// ManifestSchema returns a defensive copy of the embedded scan manifest schema.
+func ManifestSchema() []byte {
+	return append([]byte(nil), manifestSchema...)
+}

--- a/internal/reviewbundle/schema_test.go
+++ b/internal/reviewbundle/schema_test.go
@@ -1,0 +1,80 @@
+package reviewbundle
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEmbeddedSchemasAreStrictVersionedJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		wantID  string
+	}{
+		{name: "bundle", content: BundleSchema(), wantID: BundleSchemaVersion},
+		{name: "comments", content: CommentsSchema(), wantID: CommentsSchemaVersion},
+		{name: "manifest", content: ManifestSchema(), wantID: ScanManifestSchemaVersion},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var schema map[string]any
+			if err := json.Unmarshal(test.content, &schema); err != nil {
+				t.Fatalf("decode embedded schema: %v", err)
+			}
+			if got := schema["$id"]; got != test.wantID {
+				t.Fatalf("$id = %v, want %q", got, test.wantID)
+			}
+			if got := schema["additionalProperties"]; got != false {
+				t.Fatalf("additionalProperties = %v, want false", got)
+			}
+		})
+	}
+}
+
+func TestBundleJSONUsesStableProtocolFields(t *testing.T) {
+	bundle := Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		BundleID:      "sha256:bundle",
+		Target: Target{
+			Mode:       TargetWorkspace,
+			BaseSHA:    "base",
+			HeadSHA:    "head",
+			DiffSHA256: "sha256:diff",
+		},
+		Summary: Summary{TotalFiles: 1, ReviewableFiles: 1, Insertions: 2},
+		Rules: map[string]Rule{
+			"rule-1": {Source: "system", Pattern: "**/*.go", Content: "Review Go."},
+		},
+		Files: []File{{
+			Path:          "main.go",
+			OldPath:       "main.go",
+			Status:        "modified",
+			Reviewable:    true,
+			Insertions:    2,
+			ContentSHA256: "sha256:content",
+			RuleID:        "rule-1",
+			Patch:         "@@ -1 +1,2 @@",
+			Hunks:         []Hunk{{OldStart: 1, OldCount: 1, NewStart: 1, NewCount: 2}},
+		}},
+		Contract: DefaultContract(),
+	}
+
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	text := string(encoded)
+	for _, field := range []string{
+		`"schema_version":"review-bundle/v1"`,
+		`"bundle_id":"sha256:bundle"`,
+		`"diff_sha256":"sha256:diff"`,
+		`"content_sha256":"sha256:content"`,
+		`"line_numbers":"one_based_new_file"`,
+	} {
+		if !strings.Contains(text, field) {
+			t.Errorf("encoded bundle missing %s: %s", field, text)
+		}
+	}
+}

--- a/internal/reviewbundle/schemas/review-bundle-v1.json
+++ b/internal/reviewbundle/schemas/review-bundle-v1.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "review-bundle/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "bundle_id", "target", "summary", "rules", "files", "contract"],
+  "properties": {
+    "schema_version": {"const": "review-bundle/v1"},
+    "bundle_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "target": {"$ref": "#/$defs/target"},
+    "workspace_state": {"$ref": "#/$defs/workspace_state"},
+    "summary": {"$ref": "#/$defs/summary"},
+    "rules": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/rule"}
+    },
+    "files": {"type": "array", "items": {"$ref": "#/$defs/file"}},
+    "contract": {"$ref": "#/$defs/contract"},
+    "warnings": {"type": "array", "items": {"$ref": "#/$defs/notice"}}
+  },
+  "$defs": {
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "from", "to", "commit", "base_sha", "head_sha", "merge_base_sha", "diff_sha256"],
+      "properties": {
+        "mode": {"enum": ["workspace", "range", "commit", "scan"]},
+        "from": {"type": "string"},
+        "to": {"type": "string"},
+        "commit": {"type": "string"},
+        "base_sha": {"type": "string"},
+        "head_sha": {"type": "string"},
+        "merge_base_sha": {"type": "string"},
+        "diff_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "workspace_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head_sha", "staged_sha256", "unstaged_sha256", "untracked_sha256"],
+      "properties": {
+        "head_sha": {"type": "string"},
+        "staged_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "unstaged_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "untracked_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_files", "reviewable_files", "excluded_files", "insertions", "deletions"],
+      "properties": {
+        "total_files": {"type": "integer", "minimum": 0},
+        "reviewable_files": {"type": "integer", "minimum": 0},
+        "excluded_files": {"type": "integer", "minimum": 0},
+        "insertions": {"type": "integer", "minimum": 0},
+        "deletions": {"type": "integer", "minimum": 0}
+      }
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "pattern", "content"],
+      "properties": {
+        "source": {"enum": ["custom", "project", "global", "system"]},
+        "pattern": {"type": "string"},
+        "content": {"type": "string"}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "old_path", "status", "reviewable", "insertions", "deletions", "content_sha256", "rule_id", "patch", "hunks"],
+      "properties": {
+        "path": {"type": "string"},
+        "old_path": {"type": "string"},
+        "status": {"enum": ["modified", "added", "deleted", "renamed", "binary", "scan"]},
+        "reviewable": {"type": "boolean"},
+        "exclude_reason": {"enum": ["user_exclude", "unsupported_ext", "default_path", "deleted", "binary"]},
+        "insertions": {"type": "integer", "minimum": 0},
+        "deletions": {"type": "integer", "minimum": 0},
+        "content_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "rule_id": {"type": "string"},
+        "patch": {"type": "string"},
+        "content": {"type": "string"},
+        "hunks": {"type": "array", "items": {"$ref": "#/$defs/hunk"}}
+      }
+    },
+    "hunk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["old_start", "old_count", "new_start", "new_count"],
+      "properties": {
+        "old_start": {"type": "integer", "minimum": 0},
+        "old_count": {"type": "integer", "minimum": 0},
+        "new_start": {"type": "integer", "minimum": 0},
+        "new_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comment_schema", "line_numbers", "allowed_priorities", "allowed_categories", "max_bundle_bytes", "bundle_size_bytes", "requires_reflection"],
+      "properties": {
+        "comment_schema": {"const": "review-comments/v1"},
+        "line_numbers": {"const": "one_based_new_file"},
+        "allowed_priorities": {"type": "array", "items": {"enum": ["high", "medium", "low"]}},
+        "allowed_categories": {"type": "array", "items": {"enum": ["bug", "security", "performance", "concurrency", "maintainability", "test"]}},
+        "max_bundle_bytes": {"type": "integer", "minimum": 0},
+        "bundle_size_bytes": {"type": "integer", "minimum": 0},
+        "requires_reflection": {"type": "boolean"}
+      }
+    },
+    "notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {"type": "string"},
+        "path": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    }
+  }
+}

--- a/internal/reviewbundle/schemas/review-comments-v1.json
+++ b/internal/reviewbundle/schemas/review-comments-v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "review-comments/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "bundle_id", "summary", "comments"],
+  "properties": {
+    "schema_version": {"const": "review-comments/v1"},
+    "bundle_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "summary": {"$ref": "#/$defs/summary"},
+    "comments": {"type": "array", "items": {"$ref": "#/$defs/comment"}},
+    "warnings": {"type": "array", "items": {"$ref": "#/$defs/notice"}}
+  },
+  "$defs": {
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["files_reviewed", "issues_found"],
+      "properties": {
+        "files_reviewed": {"type": "integer", "minimum": 0},
+        "issues_found": {"type": "integer", "minimum": 0}
+      }
+    },
+    "comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "start_line", "end_line", "priority", "category", "title", "content", "recommendation", "confidence"],
+      "properties": {
+        "path": {"type": "string"},
+        "start_line": {"type": "integer", "minimum": 0},
+        "end_line": {"type": "integer", "minimum": 0},
+        "priority": {"enum": ["high", "medium", "low"]},
+        "category": {"enum": ["bug", "security", "performance", "concurrency", "maintainability", "test"]},
+        "title": {"type": "string", "minLength": 1},
+        "content": {"type": "string", "minLength": 1},
+        "recommendation": {"type": "string", "minLength": 1},
+        "existing_code": {"type": "string"},
+        "suggestion_code": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "file_level_comment": {"type": "boolean"}
+      }
+    },
+    "notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {"type": "string"},
+        "path": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    }
+  }
+}

--- a/internal/reviewbundle/schemas/review-manifest-v1.json
+++ b/internal/reviewbundle/schemas/review-manifest-v1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "review-manifest/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_id",
+    "root",
+    "target_hash",
+    "batch_strategy",
+    "batch_size",
+    "estimated_tokens",
+    "summary",
+    "partial",
+    "skipped_files",
+    "bundles"
+  ],
+  "properties": {
+    "schema_version": {"const": "review-manifest/v1"},
+    "manifest_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "root": {"type": "string"},
+    "target_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "batch_strategy": {"enum": ["none", "by-language", "by-directory", "diff"]},
+    "batch_size": {"type": "integer", "minimum": 1},
+    "estimated_tokens": {"type": "integer", "minimum": 0},
+    "summary": {"type": "object"},
+    "partial": {"type": "boolean"},
+    "skipped_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "reason"],
+        "properties": {
+          "path": {"type": "string"},
+          "reason": {"type": "string"},
+          "estimated_tokens": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "bundles": {"type": "array", "items": {"type": "object"}},
+    "warnings": {"type": "array", "items": {"type": "object"}}
+  }
+}

--- a/internal/reviewbundle/target.go
+++ b/internal/reviewbundle/target.go
@@ -1,0 +1,274 @@
+package reviewbundle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+// TargetSpec is the user-selected review target. An empty spec is workspace mode.
+type TargetSpec struct {
+	From   string
+	To     string
+	Commit string
+}
+
+// ResolveTarget validates refs and resolves a target to immutable Git identities.
+func ResolveTarget(
+	ctx context.Context,
+	repoDir string,
+	spec TargetSpec,
+	runner *gitcmd.Runner,
+) (Target, *WorkspaceState, error) {
+	if err := validateTargetSpec(spec); err != nil {
+		return Target{}, nil, err
+	}
+
+	switch {
+	case spec.Commit != "":
+		return resolveCommitTarget(ctx, repoDir, spec.Commit, runner)
+	case spec.From != "":
+		return resolveRangeTarget(ctx, repoDir, spec, runner)
+	default:
+		return resolveWorkspaceTarget(ctx, repoDir, runner)
+	}
+}
+
+func validateTargetSpec(spec TargetSpec) error {
+	if (spec.From == "") != (spec.To == "") {
+		if spec.From == "" {
+			return fmt.Errorf("--from is required when --to is specified")
+		}
+		return fmt.Errorf("--to is required when --from is specified")
+	}
+	if spec.Commit != "" && spec.From != "" {
+		return fmt.Errorf("only one review mode allowed (--from/--to or --commit)")
+	}
+	for _, ref := range []struct {
+		flag      string
+		reference string
+	}{
+		{"--from", spec.From},
+		{"--to", spec.To},
+		{"--commit", spec.Commit},
+	} {
+		flag, reference := ref.flag, ref.reference
+		if strings.HasPrefix(reference, "-") {
+			return fmt.Errorf("%s value %q is not a valid git ref: refs must not start with '-'", flag, reference)
+		}
+	}
+	return nil
+}
+
+func resolveWorkspaceTarget(
+	ctx context.Context,
+	repoDir string,
+	runner *gitcmd.Runner,
+) (Target, *WorkspaceState, error) {
+	head, err := resolveCommit(ctx, repoDir, "HEAD", runner)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("resolve workspace HEAD: %w", err)
+	}
+	staged, err := gitOutput(ctx, runner, repoDir,
+		"diff", "--cached", "--no-ext-diff", "--no-textconv", "--binary", "--no-color", "--")
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("read staged diff: %w", err)
+	}
+	unstaged, err := gitOutput(ctx, runner, repoDir,
+		"diff", "--no-ext-diff", "--no-textconv", "--binary", "--no-color", "--")
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("read unstaged diff: %w", err)
+	}
+	untrackedHash, err := hashUntracked(ctx, repoDir, runner)
+	if err != nil {
+		return Target{}, nil, err
+	}
+
+	state := &WorkspaceState{
+		HeadSHA:         head,
+		StagedSHA256:    hashFields(staged),
+		UnstagedSHA256:  hashFields(unstaged),
+		UntrackedSHA256: untrackedHash,
+	}
+	return Target{
+		Mode:    TargetWorkspace,
+		BaseSHA: head,
+		HeadSHA: head,
+	}, state, nil
+}
+
+func resolveRangeTarget(
+	ctx context.Context,
+	repoDir string,
+	spec TargetSpec,
+	runner *gitcmd.Runner,
+) (Target, *WorkspaceState, error) {
+	from, err := resolveCommit(ctx, repoDir, spec.From, runner)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("--from value %q is not a valid commit ref: %w", spec.From, err)
+	}
+	head, err := resolveCommit(ctx, repoDir, spec.To, runner)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("--to value %q is not a valid commit ref: %w", spec.To, err)
+	}
+	mergeBaseBytes, err := gitOutput(
+		ctx, runner, repoDir, "merge-base", "--end-of-options", from, head,
+	)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("resolve merge-base between %s and %s: %w", spec.From, spec.To, err)
+	}
+	mergeBase := strings.TrimSpace(string(mergeBaseBytes))
+	if mergeBase == "" {
+		return Target{}, nil, fmt.Errorf("cannot find merge-base between %s and %s", spec.From, spec.To)
+	}
+	return Target{
+		Mode:         TargetRange,
+		From:         from,
+		To:           head,
+		BaseSHA:      mergeBase,
+		HeadSHA:      head,
+		MergeBaseSHA: mergeBase,
+	}, nil, nil
+}
+
+func resolveCommitTarget(
+	ctx context.Context,
+	repoDir string,
+	reference string,
+	runner *gitcmd.Runner,
+) (Target, *WorkspaceState, error) {
+	head, err := resolveCommit(ctx, repoDir, reference, runner)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("--commit value %q is not a valid commit ref: %w", reference, err)
+	}
+	parentsBytes, err := gitOutput(ctx, runner, repoDir, "rev-list", "--parents", "-n", "1", head)
+	if err != nil {
+		return Target{}, nil, fmt.Errorf("resolve parent for commit %s: %w", reference, err)
+	}
+	fields := strings.Fields(string(parentsBytes))
+	base := ""
+	if len(fields) > 1 {
+		base = fields[1]
+	}
+	return Target{
+		Mode:    TargetCommit,
+		Commit:  head,
+		BaseSHA: base,
+		HeadSHA: head,
+	}, nil, nil
+}
+
+func resolveCommit(
+	ctx context.Context,
+	repoDir string,
+	reference string,
+	runner *gitcmd.Runner,
+) (string, error) {
+	output, err := gitOutput(
+		ctx, runner, repoDir, "rev-parse", "--verify", "--end-of-options", reference+"^{commit}",
+	)
+	if err != nil {
+		return "", err
+	}
+	resolved := strings.TrimSpace(string(output))
+	if resolved == "" {
+		return "", fmt.Errorf("empty commit identity")
+	}
+	return resolved, nil
+}
+
+func hashUntracked(ctx context.Context, repoDir string, runner *gitcmd.Runner) (string, error) {
+	output, err := gitOutput(
+		ctx, runner, repoDir, "ls-files", "--others", "--exclude-standard", "-z",
+	)
+	if err != nil {
+		return "", fmt.Errorf("list untracked files: %w", err)
+	}
+	paths := splitNUL(output)
+	sort.Strings(paths)
+	hasher := sha256.New()
+	var length [8]byte
+	for _, path := range paths {
+		fullPath := filepath.Join(repoDir, filepath.FromSlash(path))
+		info, statErr := os.Lstat(fullPath)
+		if statErr != nil {
+			return "", fmt.Errorf("stat untracked file %s: %w", path, statErr)
+		}
+		fileType := "regular"
+		if info.Mode()&os.ModeSymlink != 0 {
+			fileType = "symlink"
+			target, readErr := os.Readlink(fullPath)
+			if readErr != nil {
+				return "", fmt.Errorf("read untracked symlink %s: %w", path, readErr)
+			}
+			writeHashFields(hasher, length, []byte(path), []byte(fileType), []byte(target))
+		} else if info.Mode().IsRegular() {
+			writeHashFields(hasher, length, []byte(path), []byte(fileType))
+			binary.BigEndian.PutUint64(length[:], uint64(info.Size()))
+			_, _ = hasher.Write(length[:])
+			file, openErr := os.Open(fullPath)
+			if openErr != nil {
+				return "", fmt.Errorf("read untracked file %s: %w", path, openErr)
+			}
+			if _, copyErr := io.Copy(hasher, file); copyErr != nil {
+				_ = file.Close()
+				return "", fmt.Errorf("read untracked file %s: %w", path, copyErr)
+			}
+			if closeErr := file.Close(); closeErr != nil {
+				return "", fmt.Errorf("close untracked file %s: %w", path, closeErr)
+			}
+		} else {
+			fileType = info.Mode().Type().String()
+			writeHashFields(hasher, length, []byte(path), []byte(fileType), nil)
+		}
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func splitNUL(content []byte) []string {
+	raw := strings.Split(string(content), "\x00")
+	paths := make([]string, 0, len(raw))
+	for _, path := range raw {
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func gitOutput(
+	ctx context.Context,
+	runner *gitcmd.Runner,
+	repoDir string,
+	arguments ...string,
+) ([]byte, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("git runner is required")
+	}
+	return runner.Output(ctx, repoDir, arguments...)
+}
+
+func hashFields(fields ...[]byte) string {
+	hasher := sha256.New()
+	var length [8]byte
+	writeHashFields(hasher, length, fields...)
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+func writeHashFields(hasher hash.Hash, length [8]byte, fields ...[]byte) {
+	for _, field := range fields {
+		binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+		_, _ = hasher.Write(length[:])
+		_, _ = hasher.Write(field)
+	}
+}

--- a/internal/reviewbundle/target_test.go
+++ b/internal/reviewbundle/target_test.go
@@ -1,0 +1,145 @@
+package reviewbundle
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+func TestResolveTargetWorkspaceFingerprintsDirtyState(t *testing.T) {
+	repository := initTargetRepository(t)
+	writeTargetFile(t, repository, "staged.go", "package sample\n")
+	runTargetGit(t, repository, "add", "staged.go")
+	writeTargetFile(t, repository, "base.go", "package sample\n\nvar changed = true\n")
+	writeTargetFile(t, repository, "untracked.go", "package sample\n")
+
+	target, state, err := ResolveTarget(
+		context.Background(),
+		repository,
+		TargetSpec{},
+		gitcmd.New(2),
+	)
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+	if target.Mode != TargetWorkspace || target.HeadSHA == "" || target.BaseSHA != target.HeadSHA {
+		t.Fatalf("unexpected workspace target: %+v", target)
+	}
+	if state == nil || state.HeadSHA != target.HeadSHA {
+		t.Fatalf("unexpected workspace state: %+v", state)
+	}
+	emptyHash := hashFields()
+	for name, value := range map[string]string{
+		"staged":    state.StagedSHA256,
+		"unstaged":  state.UnstagedSHA256,
+		"untracked": state.UntrackedSHA256,
+	} {
+		if value == "" || value == emptyHash {
+			t.Errorf("%s hash was not populated: %q", name, value)
+		}
+	}
+}
+
+func TestResolveTargetRangeUsesMergeBaseAndResolvedHead(t *testing.T) {
+	repository := initTargetRepository(t)
+	base := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+	writeTargetFile(t, repository, "range.go", "package sample\n")
+	runTargetGit(t, repository, "add", "range.go")
+	runTargetGit(t, repository, "commit", "-m", "range")
+	head := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+
+	target, state, err := ResolveTarget(
+		context.Background(),
+		repository,
+		TargetSpec{From: base, To: head},
+		gitcmd.New(2),
+	)
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+	if state != nil {
+		t.Fatalf("range workspace state = %+v, want nil", state)
+	}
+	if target.Mode != TargetRange || target.BaseSHA != base ||
+		target.MergeBaseSHA != base || target.HeadSHA != head {
+		t.Fatalf("unexpected range target: %+v", target)
+	}
+}
+
+func TestResolveTargetCommitUsesParentAndResolvedCommit(t *testing.T) {
+	repository := initTargetRepository(t)
+	parent := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+	writeTargetFile(t, repository, "commit.go", "package sample\n")
+	runTargetGit(t, repository, "add", "commit.go")
+	runTargetGit(t, repository, "commit", "-m", "commit target")
+	head := strings.TrimSpace(runTargetGit(t, repository, "rev-parse", "HEAD"))
+
+	target, state, err := ResolveTarget(
+		context.Background(),
+		repository,
+		TargetSpec{Commit: "HEAD"},
+		gitcmd.New(2),
+	)
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+	if state != nil {
+		t.Fatalf("commit workspace state = %+v, want nil", state)
+	}
+	if target.Mode != TargetCommit || target.BaseSHA != parent || target.HeadSHA != head {
+		t.Fatalf("unexpected commit target: %+v", target)
+	}
+}
+
+func TestResolveTargetRejectsOptionLikeRef(t *testing.T) {
+	repository := initTargetRepository(t)
+	_, _, err := ResolveTarget(
+		context.Background(),
+		repository,
+		TargetSpec{Commit: "--output=/tmp/unsafe"},
+		gitcmd.New(2),
+	)
+	if err == nil || !strings.Contains(err.Error(), "must not start with '-'") {
+		t.Fatalf("ResolveTarget() error = %v, want option-like ref rejection", err)
+	}
+}
+
+func initTargetRepository(t *testing.T) string {
+	t.Helper()
+	repository := t.TempDir()
+	runTargetGit(t, repository, "init", "-q")
+	runTargetGit(t, repository, "config", "user.email", "tests@example.com")
+	runTargetGit(t, repository, "config", "user.name", "OCR Tests")
+	runTargetGit(t, repository, "config", "commit.gpgsign", "false")
+	writeTargetFile(t, repository, "base.go", "package sample\n")
+	runTargetGit(t, repository, "add", "base.go")
+	runTargetGit(t, repository, "commit", "-m", "initial")
+	return repository
+}
+
+func writeTargetFile(t *testing.T, repository, name, content string) {
+	t.Helper()
+	path := filepath.Join(repository, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runTargetGit(t *testing.T, repository string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+	return string(output)
+}

--- a/internal/reviewbundle/validate.go
+++ b/internal/reviewbundle/validate.go
@@ -1,0 +1,333 @@
+package reviewbundle
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+// ValidationNotice is a stable machine-readable validation diagnostic.
+type ValidationNotice struct {
+	Code         string `json:"code"`
+	Path         string `json:"path,omitempty"`
+	CommentIndex *int   `json:"comment_index,omitempty"`
+	Message      string `json:"message"`
+}
+
+// ValidationResult reports whether comments are safe to publish.
+type ValidationResult struct {
+	SchemaVersion string             `json:"schema_version"`
+	BundleID      string             `json:"bundle_id"`
+	Valid         bool               `json:"valid"`
+	Errors        []ValidationNotice `json:"errors"`
+	Warnings      []ValidationNotice `json:"warnings"`
+}
+
+// ValidateComments checks comments against the bundle and current target state.
+// It is read-only and never rewrites or relocates a supplied comment.
+func ValidateComments(
+	ctx context.Context,
+	bundle *Bundle,
+	comments *Comments,
+	repoDir string,
+	runner *gitcmd.Runner,
+) ValidationResult {
+	result := ValidationResult{
+		SchemaVersion: "review-validation/v1",
+		Errors:        make([]ValidationNotice, 0),
+		Warnings:      make([]ValidationNotice, 0),
+	}
+	if bundle == nil || comments == nil {
+		addValidationError(&result, "invalid_schema", "", nil, "bundle and comments are required")
+		return result
+	}
+	result.BundleID = bundle.BundleID
+	if bundle.SchemaVersion != BundleSchemaVersion ||
+		comments.SchemaVersion != CommentsSchemaVersion {
+		addValidationError(&result, "invalid_schema", "", nil, "unsupported protocol schema version")
+	}
+	if comments.BundleID != bundle.BundleID {
+		addValidationError(
+			&result,
+			"bundle_id_mismatch",
+			"",
+			nil,
+			"comments bundle_id does not match the review bundle",
+		)
+	}
+	if repoDir != "" {
+		validateFreshTarget(ctx, &result, bundle, repoDir, runner)
+	}
+
+	files := make(map[string]File, len(bundle.Files))
+	for _, file := range bundle.Files {
+		files[file.Path] = file
+	}
+	contentCache := make(map[string][]byte)
+	for index := range comments.Comments {
+		validateOneComment(ctx, &result, bundle, files, contentCache, comments.Comments[index], index, repoDir, runner)
+	}
+	if comments.Summary.IssuesFound != len(comments.Comments) {
+		addValidationError(
+			&result,
+			"invalid_summary",
+			"",
+			nil,
+			"summary.issues_found must equal the number of comments",
+		)
+	}
+	result.Valid = len(result.Errors) == 0
+	return result
+}
+
+func validateFreshTarget(
+	ctx context.Context,
+	result *ValidationResult,
+	bundle *Bundle,
+	repoDir string,
+	runner *gitcmd.Runner,
+) {
+	if bundle.Target.Mode == TargetScan {
+		for _, file := range bundle.Files {
+			content, err := readTargetFile(ctx, bundle, repoDir, file.Path, runner)
+			if err != nil || hashFields(content) != file.ContentSHA256 {
+				addValidationError(
+					result,
+					"stale_bundle",
+					file.Path,
+					nil,
+					"scan file changed after bundle creation",
+				)
+			}
+		}
+		return
+	}
+	if runner == nil {
+		addValidationError(result, "stale_bundle", "", nil, "git runner is required to verify target state")
+		return
+	}
+	spec := TargetSpec{
+		From:   bundle.Target.From,
+		To:     bundle.Target.To,
+		Commit: bundle.Target.Commit,
+	}
+	current, state, err := ResolveTarget(ctx, repoDir, spec, runner)
+	if err != nil {
+		addValidationError(result, "stale_bundle", "", nil, fmt.Sprintf("cannot verify target: %v", err))
+		return
+	}
+	stale := current.Mode != bundle.Target.Mode ||
+		current.BaseSHA != bundle.Target.BaseSHA ||
+		current.HeadSHA != bundle.Target.HeadSHA ||
+		current.MergeBaseSHA != bundle.Target.MergeBaseSHA
+	if bundle.Target.Mode == TargetWorkspace {
+		stale = stale || state == nil || bundle.WorkspaceState == nil || *state != *bundle.WorkspaceState
+	}
+	if stale {
+		addValidationError(result, "stale_bundle", "", nil, "review target changed after bundle creation")
+	}
+}
+
+func validateOneComment(
+	ctx context.Context,
+	result *ValidationResult,
+	bundle *Bundle,
+	files map[string]File,
+	contentCache map[string][]byte,
+	comment ReviewComment,
+	index int,
+	repoDir string,
+	runner *gitcmd.Runner,
+) {
+	commentIndex := index
+	cleanPath, safe := cleanProtocolPath(comment.Path)
+	if !safe {
+		addValidationError(result, "path_escape", comment.Path, &commentIndex, "path must stay inside the repository")
+		return
+	}
+	file, exists := files[cleanPath]
+	if !exists {
+		addValidationError(result, "unknown_path", cleanPath, &commentIndex, "path is not present in the bundle")
+		return
+	}
+	if !file.Reviewable {
+		addValidationError(result, "excluded_path", cleanPath, &commentIndex, "path was excluded from review")
+		return
+	}
+	if !slices.Contains(bundle.Contract.AllowedPriorities, comment.Priority) {
+		addValidationError(result, "invalid_priority", cleanPath, &commentIndex, "priority is not allowed by the bundle contract")
+	}
+	if !slices.Contains(bundle.Contract.AllowedCategories, comment.Category) {
+		addValidationError(result, "invalid_category", cleanPath, &commentIndex, "category is not allowed by the bundle contract")
+	}
+	if comment.Confidence < 0 || comment.Confidence > 1 {
+		addValidationError(result, "invalid_confidence", cleanPath, &commentIndex, "confidence must be between 0 and 1")
+	}
+	if comment.Title == "" || comment.Content == "" || comment.Recommendation == "" {
+		addValidationError(result, "invalid_comment", cleanPath, &commentIndex, "title, content, and recommendation are required")
+	}
+	if !comment.FileLevelComment && (comment.StartLine < 1 || comment.EndLine < comment.StartLine) {
+		addValidationError(result, "invalid_line_range", cleanPath, &commentIndex, "line range must be one-based and ordered")
+		return
+	}
+	if bundle.Target.Mode != TargetScan &&
+		!comment.FileLevelComment &&
+		!rangeTouchesHunk(comment.StartLine, comment.EndLine, file.Hunks) {
+		addValidationWarning(result, "outside_changed_hunk", cleanPath, &commentIndex, "comment points outside a changed hunk")
+	}
+	if repoDir != "" {
+		validateCommentContent(ctx, result, bundle, files, contentCache, comment, cleanPath, commentIndex, repoDir, runner)
+	}
+}
+
+func validateCommentContent(
+	ctx context.Context,
+	result *ValidationResult,
+	bundle *Bundle,
+	files map[string]File,
+	contentCache map[string][]byte,
+	comment ReviewComment,
+	path string,
+	index int,
+	repoDir string,
+	runner *gitcmd.Runner,
+) {
+	content, ok := contentCache[path]
+	if !ok {
+		var err error
+		content, err = readTargetFile(ctx, bundle, repoDir, path, runner)
+		if err != nil {
+			addValidationError(result, "unknown_path", path, &index, fmt.Sprintf("cannot read target file: %v", err))
+			return
+		}
+		contentCache[path] = content
+	}
+	if hashFields(content) != files[path].ContentSHA256 {
+		addValidationError(result, "stale_bundle", path, &index, "file content changed after bundle creation")
+		return
+	}
+	lines := splitSourceLines(content)
+	if !comment.FileLevelComment && comment.EndLine > len(lines) {
+		addValidationError(result, "invalid_line_range", path, &index, "line range exceeds target file")
+		return
+	}
+	if comment.ExistingCode == "" {
+		return
+	}
+	if comment.StartLine >= 1 && comment.EndLine <= len(lines) {
+		selected := strings.Join(lines[comment.StartLine-1:comment.EndLine], "\n")
+		if selected == comment.ExistingCode {
+			return
+		}
+	}
+	if countStandaloneSnippet(content, comment.ExistingCode) > 1 {
+		addValidationError(result, "ambiguous_existing_code", path, &index, "existing_code occurs more than once")
+		return
+	}
+	addValidationError(result, "existing_code_mismatch", path, &index, "existing_code does not match the supplied line range")
+}
+
+func countStandaloneSnippet(content []byte, snippet string) int {
+	if snippet == "" {
+		return 0
+	}
+	normalizedContent := "\n" + strings.TrimSuffix(string(content), "\n") + "\n"
+	normalizedSnippet := "\n" + strings.Trim(snippet, "\n") + "\n"
+	return strings.Count(normalizedContent, normalizedSnippet)
+}
+
+func cleanProtocolPath(path string) (string, bool) {
+	if path == "" || filepath.IsAbs(path) || strings.ContainsRune(path, '\x00') {
+		return "", false
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", false
+	}
+	return cleaned, true
+}
+
+func readTargetFile(
+	ctx context.Context,
+	bundle *Bundle,
+	repoDir string,
+	path string,
+	runner *gitcmd.Runner,
+) ([]byte, error) {
+	if bundle.Target.Mode != TargetWorkspace && bundle.Target.Mode != TargetScan {
+		if runner == nil {
+			return nil, fmt.Errorf("git runner is required")
+		}
+		return runner.Output(
+			ctx,
+			repoDir,
+			"-c",
+			"core.quotepath=false",
+			"show",
+			"--end-of-options",
+			bundle.Target.HeadSHA+":"+path,
+		)
+	}
+	root, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	full := filepath.Join(root, filepath.FromSlash(path))
+	resolved, err := filepath.EvalSymlinks(full)
+	if err != nil {
+		return nil, err
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("resolved path escapes repository")
+	}
+	return os.ReadFile(resolved)
+}
+
+func splitSourceLines(content []byte) []string {
+	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+	normalized = strings.TrimSuffix(normalized, "\n")
+	if normalized == "" {
+		return nil
+	}
+	return strings.Split(normalized, "\n")
+}
+
+func rangeTouchesHunk(start, end int, hunks []Hunk) bool {
+	for _, hunk := range hunks {
+		hunkEnd := hunk.NewStart + max(hunk.NewCount, 1) - 1
+		if start <= hunkEnd && end >= hunk.NewStart {
+			return true
+		}
+	}
+	return false
+}
+
+func addValidationError(
+	result *ValidationResult,
+	code string,
+	path string,
+	index *int,
+	message string,
+) {
+	result.Errors = append(result.Errors, ValidationNotice{
+		Code: code, Path: path, CommentIndex: index, Message: message,
+	})
+}
+
+func addValidationWarning(
+	result *ValidationResult,
+	code string,
+	path string,
+	index *int,
+	message string,
+) {
+	result.Warnings = append(result.Warnings, ValidationNotice{
+		Code: code, Path: path, CommentIndex: index, Message: message,
+	})
+}

--- a/internal/reviewbundle/validate_test.go
+++ b/internal/reviewbundle/validate_test.go
@@ -1,0 +1,234 @@
+package reviewbundle
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/gitcmd"
+)
+
+func TestLoadCommentsRejectsUnknownFields(t *testing.T) {
+	input := `{
+		"schema_version":"review-comments/v1",
+		"bundle_id":"sha256:test",
+		"summary":{"files_reviewed":0,"issues_found":0},
+		"comments":[],
+		"unexpected":true
+	}`
+	_, err := LoadComments(strings.NewReader(input))
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("LoadComments() error = %v, want unknown field", err)
+	}
+}
+
+func TestLoadCommentsRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "summary files reviewed",
+			input: `{"schema_version":"review-comments/v1","bundle_id":"sha256:test","summary":{"issues_found":0},"comments":[]}`,
+			want:  "summary.files_reviewed",
+		},
+		{
+			name: "comment recommendation",
+			input: `{
+				"schema_version":"review-comments/v1",
+				"bundle_id":"sha256:test",
+				"summary":{"files_reviewed":1,"issues_found":1},
+				"comments":[{
+					"path":"main.go","start_line":1,"end_line":1,
+					"priority":"medium","category":"bug","title":"title",
+					"content":"content","confidence":0.9
+				}]
+			}`,
+			want: "comments[0].recommendation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadComments(strings.NewReader(tt.input))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("LoadComments() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadBundleRejectsTamperedBundleID(t *testing.T) {
+	bundle := validIdentifiedBundle(t)
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	var tampered map[string]any
+	if err := json.Unmarshal(encoded, &tampered); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	tampered["summary"] = map[string]any{"total_files": 999}
+	encoded, err = json.Marshal(tampered)
+	if err != nil {
+		t.Fatalf("marshal tampered bundle: %v", err)
+	}
+	_, err = LoadBundle(strings.NewReader(string(encoded)))
+	if err == nil || !strings.Contains(err.Error(), "bundle_id does not match") {
+		t.Fatalf("LoadBundle(tampered) error = %v, want bundle_id mismatch", err)
+	}
+}
+
+func TestLoadScanManifestRejectsTamperedNestedBundleID(t *testing.T) {
+	bundle := validIdentifiedBundle(t)
+	bundle.Summary.TotalFiles = 999
+	manifest := &ScanManifest{
+		SchemaVersion: ScanManifestSchemaVersion,
+		TargetHash:    "sha256:target",
+		BatchStrategy: "none",
+		BatchSize:     1,
+		Bundles:       []Bundle{*bundle},
+	}
+	manifestID, err := computeManifestID(manifest)
+	if err != nil {
+		t.Fatalf("compute manifest id: %v", err)
+	}
+	manifest.ManifestID = manifestID
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	_, err = LoadScanManifest(strings.NewReader(string(encoded)))
+	if err == nil || !strings.Contains(err.Error(), "bundle 0 bundle_id does not match") {
+		t.Fatalf("LoadScanManifest(tampered nested bundle) error = %v, want nested bundle_id mismatch", err)
+	}
+}
+
+func TestValidateCommentsRejectsProtocolAndEvidenceErrors(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{FilesReviewed: 1, IssuesFound: 4},
+		Comments: []ReviewComment{
+			{
+				Path:           "../secret.go",
+				StartLine:      1,
+				EndLine:        1,
+				Priority:       "high",
+				Category:       "bug",
+				Title:          "escape",
+				Content:        "escape",
+				Recommendation: "fix",
+				Confidence:     1,
+			},
+			{
+				Path:           "missing.go",
+				StartLine:      1,
+				EndLine:        1,
+				Priority:       "medium",
+				Category:       "test",
+				Title:          "missing",
+				Content:        "missing",
+				Recommendation: "fix",
+				Confidence:     0.5,
+			},
+			{
+				Path:           "main.go",
+				StartLine:      0,
+				EndLine:        2,
+				Priority:       "low",
+				Category:       "maintainability",
+				Title:          "range",
+				Content:        "range",
+				Recommendation: "fix",
+				Confidence:     0.5,
+			},
+			{
+				Path:           "main.go",
+				StartLine:      1,
+				EndLine:        1,
+				Priority:       "urgent",
+				Category:       "style",
+				Title:          "enum",
+				Content:        "enum",
+				Recommendation: "fix",
+				Confidence:     2,
+			},
+		},
+	}
+
+	result := ValidateComments(context.Background(), bundle, comments, "", gitcmd.New(1))
+	if result.Valid {
+		t.Fatal("ValidateComments() valid = true, want false")
+	}
+	assertValidationCode(t, result.Errors, "path_escape")
+	assertValidationCode(t, result.Errors, "unknown_path")
+	assertValidationCode(t, result.Errors, "invalid_line_range")
+	assertValidationCode(t, result.Errors, "invalid_priority")
+	assertValidationCode(t, result.Errors, "invalid_category")
+	assertValidationCode(t, result.Errors, "invalid_confidence")
+}
+
+func TestValidateCommentsWarnsOutsideChangedHunk(t *testing.T) {
+	bundle := validationBundle()
+	comments := &Comments{
+		SchemaVersion: CommentsSchemaVersion,
+		BundleID:      bundle.BundleID,
+		Summary:       CommentsSummary{FilesReviewed: 1, IssuesFound: 1},
+		Comments: []ReviewComment{{
+			Path:           "main.go",
+			StartLine:      9,
+			EndLine:        9,
+			Priority:       "medium",
+			Category:       "bug",
+			Title:          "context",
+			Content:        "context",
+			Recommendation: "fix",
+			Confidence:     0.8,
+		}},
+	}
+
+	result := ValidateComments(context.Background(), bundle, comments, "", nil)
+	if !result.Valid {
+		t.Fatalf("ValidateComments() errors = %#v", result.Errors)
+	}
+	assertValidationCode(t, result.Warnings, "outside_changed_hunk")
+}
+
+func validationBundle() *Bundle {
+	return &Bundle{
+		SchemaVersion: BundleSchemaVersion,
+		BundleID:      "sha256:bundle",
+		Target:        Target{Mode: TargetRange, HeadSHA: "0123456789abcdef"},
+		Files: []File{{
+			Path:       "main.go",
+			Reviewable: true,
+			Hunks:      []Hunk{{NewStart: 3, NewCount: 2}},
+		}},
+		Contract: DefaultContract(),
+	}
+}
+
+func validIdentifiedBundle(t *testing.T) *Bundle {
+	t.Helper()
+	bundle := validationBundle()
+	bundle.BundleID = ""
+	bundleID, err := computeBundleID(bundle)
+	if err != nil {
+		t.Fatalf("compute bundle id: %v", err)
+	}
+	bundle.BundleID = bundleID
+	return bundle
+}
+
+func assertValidationCode(t *testing.T, notices []ValidationNotice, code string) {
+	t.Helper()
+	for _, notice := range notices {
+		if notice.Code == code {
+			return
+		}
+	}
+	t.Errorf("notices = %#v, want code %q", notices, code)
+}

--- a/internal/reviewfilter/filter.go
+++ b/internal/reviewfilter/filter.go
@@ -1,0 +1,99 @@
+// Package reviewfilter classifies diff entries using OCR's deterministic
+// include, exclude, extension, and path policies.
+package reviewfilter
+
+import (
+	"strings"
+
+	allowedext "github.com/open-code-review/open-code-review/internal/config/allowlist"
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+// Filter applies the user-configured and built-in review filters.
+type Filter struct {
+	FileFilter *rules.FileFilter
+}
+
+// ExcludeReason returns why a change is excluded, or model.ExcludeNone.
+func (f Filter) ExcludeReason(change model.Diff) model.ExcludeReason {
+	if change.IsBinary {
+		return model.ExcludeBinary
+	}
+
+	path := EffectivePath(change)
+	if f.FileFilter != nil && f.FileFilter.IsUserExcluded(path) {
+		return model.ExcludeUserRule
+	}
+	if f.FileFilter != nil && f.FileFilter.HasInclude() && f.FileFilter.IsUserIncluded(path) {
+		return model.ExcludeNone
+	}
+
+	extension := extensionFromPath(path)
+	if extension != "" && !allowedext.IsAllowedExt(extension) {
+		return model.ExcludeExtension
+	}
+	if allowedext.IsExcludedPath(path) {
+		return model.ExcludeDefaultPath
+	}
+	return model.ExcludeNone
+}
+
+// ExcludeScanReason preserves the native full-scan filter ordering.
+func (f Filter) ExcludeScanReason(path string, isBinary bool) model.ExcludeReason {
+	if isBinary {
+		return model.ExcludeBinary
+	}
+	if f.FileFilter != nil && f.FileFilter.IsUserExcluded(path) {
+		return model.ExcludeUserRule
+	}
+	extension := extensionFromPath(path)
+	if extension != "" && !allowedext.IsAllowedExt(extension) {
+		return model.ExcludeExtension
+	}
+	if f.FileFilter != nil && f.FileFilter.HasInclude() && f.FileFilter.IsUserIncluded(path) {
+		return model.ExcludeNone
+	}
+	if allowedext.IsExcludedPath(path) {
+		return model.ExcludeDefaultPath
+	}
+	return model.ExcludeNone
+}
+
+// EffectivePath returns the path to display and filter for a change.
+func EffectivePath(change model.Diff) string {
+	if change.NewPath == "/dev/null" {
+		return change.OldPath
+	}
+	return change.NewPath
+}
+
+// Status returns the stable protocol status for a change.
+func Status(change model.Diff) string {
+	switch {
+	case change.IsBinary:
+		return "binary"
+	case change.IsNew:
+		return "added"
+	case change.IsDeleted:
+		return "deleted"
+	case change.IsRenamed:
+		return "renamed"
+	case change.OldPath != change.NewPath && change.OldPath != "" && change.OldPath != "/dev/null":
+		return "renamed"
+	default:
+		return "modified"
+	}
+}
+
+func extensionFromPath(path string) string {
+	basename := path
+	if index := strings.LastIndex(path, "/"); index >= 0 {
+		basename = path[index+1:]
+	}
+	dot := strings.LastIndex(basename, ".")
+	if dot <= 0 {
+		return ""
+	}
+	return strings.ToLower(basename[dot:])
+}

--- a/internal/reviewfilter/filter_test.go
+++ b/internal/reviewfilter/filter_test.go
@@ -1,0 +1,148 @@
+package reviewfilter
+
+import (
+	"testing"
+
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/model"
+)
+
+func TestExcludeReasonPreservesNativeOrdering(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileFilter *rules.FileFilter
+		change     model.Diff
+		want       model.ExcludeReason
+	}{
+		{
+			name:   "binary takes precedence",
+			change: model.Diff{NewPath: "main.go", IsBinary: true},
+			want:   model.ExcludeBinary,
+		},
+		{
+			name:       "user exclude",
+			fileFilter: &rules.FileFilter{Exclude: []string{"generated/**"}},
+			change:     model.Diff{NewPath: "generated/main.go"},
+			want:       model.ExcludeUserRule,
+		},
+		{
+			name:       "review include match bypasses extension allowlist",
+			fileFilter: &rules.FileFilter{Include: []string{"docs/**"}},
+			change:     model.Diff{NewPath: "docs/notes.unsupported"},
+			want:       model.ExcludeNone,
+		},
+		{
+			name:       "review include list does not exclude non-matching files",
+			fileFilter: &rules.FileFilter{Include: []string{"docs/**"}},
+			change:     model.Diff{NewPath: "src/main.go"},
+			want:       model.ExcludeNone,
+		},
+		{
+			name:   "unsupported extension",
+			change: model.Diff{NewPath: "notes.unsupported"},
+			want:   model.ExcludeExtension,
+		},
+		{
+			name:   "default excluded path",
+			change: model.Diff{NewPath: "internal/main_test.go"},
+			want:   model.ExcludeDefaultPath,
+		},
+		{
+			name:   "reviewable",
+			change: model.Diff{NewPath: "internal/main.go"},
+			want:   model.ExcludeNone,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := Filter{FileFilter: test.fileFilter}
+			if got := filter.ExcludeReason(test.change); got != test.want {
+				t.Fatalf("ExcludeReason() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestExcludeScanReasonPreservesNativeOrdering(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileFilter *rules.FileFilter
+		path       string
+		isBinary   bool
+		want       model.ExcludeReason
+	}{
+		{
+			name:     "binary takes precedence",
+			path:     "main.go",
+			isBinary: true,
+			want:     model.ExcludeBinary,
+		},
+		{
+			name:       "user exclude",
+			fileFilter: &rules.FileFilter{Exclude: []string{"generated/**"}},
+			path:       "generated/main.go",
+			want:       model.ExcludeUserRule,
+		},
+		{
+			name:       "scan extension check stays before include match",
+			fileFilter: &rules.FileFilter{Include: []string{"docs/**"}},
+			path:       "docs/notes.unsupported",
+			want:       model.ExcludeExtension,
+		},
+		{
+			name:       "scan include list does not exclude non-matching files",
+			fileFilter: &rules.FileFilter{Include: []string{"docs/**"}},
+			path:       "src/main.go",
+			want:       model.ExcludeNone,
+		},
+		{
+			name: "default excluded path",
+			path: "internal/main_test.go",
+			want: model.ExcludeDefaultPath,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := Filter{FileFilter: test.fileFilter}
+			if got := filter.ExcludeScanReason(test.path, test.isBinary); got != test.want {
+				t.Fatalf("ExcludeScanReason() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEffectivePathUsesOldPathForDeletion(t *testing.T) {
+	change := model.Diff{OldPath: "internal/old.go", NewPath: "/dev/null", IsDeleted: true}
+	if got := EffectivePath(change); got != "internal/old.go" {
+		t.Fatalf("EffectivePath() = %q, want internal/old.go", got)
+	}
+}
+
+func TestStatusClassifiesNativeDiffStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		change model.Diff
+		want   string
+	}{
+		{name: "binary", change: model.Diff{IsBinary: true}, want: "binary"},
+		{name: "added", change: model.Diff{IsNew: true}, want: "added"},
+		{name: "deleted", change: model.Diff{IsDeleted: true}, want: "deleted"},
+		{name: "renamed flag", change: model.Diff{IsRenamed: true}, want: "renamed"},
+		{
+			name:   "renamed paths",
+			change: model.Diff{OldPath: "old.go", NewPath: "new.go"},
+			want:   "renamed",
+		},
+		{name: "modified", change: model.Diff{OldPath: "main.go", NewPath: "main.go"}, want: "modified"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Status(test.change); got != test.want {
+				t.Fatalf("Status() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/scan/batch.go
+++ b/internal/scan/batch.go
@@ -114,3 +114,11 @@ func firstLevelDirKey(it model.ScanItem) string {
 	}
 	return it.Path[:idx]
 }
+
+// ParseBatchStrategy is the exported wrapper around parseBatchStrategy.
+func ParseBatchStrategy(value string) BatchStrategy { return parseBatchStrategy(value) }
+
+// GroupBatches is the exported wrapper around groupBatches.
+func GroupBatches(items []model.ScanItem, strategy BatchStrategy, size int) [][]model.ScanItem {
+	return groupBatches(items, strategy, size)
+}

--- a/internal/scan/classify.go
+++ b/internal/scan/classify.go
@@ -1,0 +1,12 @@
+package scan
+
+import (
+	"github.com/open-code-review/open-code-review/internal/config/rules"
+	"github.com/open-code-review/open-code-review/internal/model"
+	"github.com/open-code-review/open-code-review/internal/reviewfilter"
+)
+
+// ExcludeReason applies the native full-scan reviewability order.
+func ExcludeReason(item model.ScanItem, fileFilter *rules.FileFilter) model.ExcludeReason {
+	return reviewfilter.Filter{FileFilter: fileFilter}.ExcludeScanReason(item.Path, item.IsBinary)
+}

--- a/internal/scan/estimate.go
+++ b/internal/scan/estimate.go
@@ -118,3 +118,13 @@ func humanTokens(n int64) string {
 		return fmt.Sprintf("%d", n)
 	}
 }
+
+// EstimateItemTokens is the exported wrapper around estimateFileTokens.
+func EstimateItemTokens(item model.ScanItem, planEnabled bool) int64 {
+	return estimateFileTokens(item, planEnabled)
+}
+
+// EstimateTokens is the exported wrapper around estimateCost.
+func EstimateTokens(items []model.ScanItem, planEnabled, dedupEnabled, summaryEnabled bool) Estimate {
+	return estimateCost(items, planEnabled, dedupEnabled, summaryEnabled)
+}

--- a/internal/scan/provider.go
+++ b/internal/scan/provider.go
@@ -72,12 +72,26 @@ func NewProvider(repoDir string, paths []string, runner *gitcmd.Runner, maxFileS
 	}
 }
 
+// SkippedItem records a discovered scan path that could not be enumerated.
+type SkippedItem struct {
+	Path   string
+	Reason string
+}
+
 // Enumerate returns one ScanItem per reviewable file. Binaries are emitted
 // with empty Content + IsBinary=true so previews can show them as excluded.
 func (p *Provider) Enumerate(ctx context.Context) ([]model.ScanItem, error) {
+	items, _, err := p.EnumerateDetailed(ctx)
+	return items, err
+}
+
+// EnumerateDetailed returns review candidates and explicit provider-level skips.
+func (p *Provider) EnumerateDetailed(
+	ctx context.Context,
+) ([]model.ScanItem, []SkippedItem, error) {
 	files, err := p.listFiles(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(p.paths) > 0 {
@@ -87,12 +101,10 @@ func (p *Provider) Enumerate(ctx context.Context) ([]model.ScanItem, error) {
 	gitignorePatterns := diff.LoadGitignorePatterns(p.repoDir)
 
 	var out []model.ScanItem
+	var skipped []SkippedItem
 	for _, rel := range files {
-		// Per-iteration cancellation check: a large repo with thousands of
-		// files may take seconds to walk, and downstream Lstat / ReadFile
-		// each cost a syscall — abort early when ctx is cancelled.
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if rel == "" {
 			continue
@@ -104,24 +116,26 @@ func (p *Provider) Enumerate(ctx context.Context) ([]model.ScanItem, error) {
 		info, err := os.Lstat(full)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot stat %s: %v\n", rel, err)
+			skipped = append(skipped, SkippedItem{Path: rel, Reason: "unreadable"})
 			continue
 		}
 		if !info.Mode().IsRegular() {
+			skipped = append(skipped, SkippedItem{Path: rel, Reason: "non_regular"})
 			continue
 		}
 		if info.Size() > p.maxFileSizeBytes {
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: skipping %s (%d bytes exceeds %d-byte scan limit; raise MaxTokens if the real concern is token budget, not memory)\n",
 				rel, info.Size(), p.maxFileSizeBytes)
+			skipped = append(skipped, SkippedItem{Path: rel, Reason: "file_size"})
 			continue
 		}
 		binary, err := isBinaryFile(full)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot sniff %s: %v\n", rel, err)
+			skipped = append(skipped, SkippedItem{Path: rel, Reason: "unreadable"})
 			continue
 		}
 		if binary {
-			// Emit placeholder so preview can display [B], but do not
-			// read the file body — saves memory on large binaries.
 			out = append(out, model.ScanItem{
 				Path:     rel,
 				IsBinary: true,
@@ -131,6 +145,7 @@ func (p *Provider) Enumerate(ctx context.Context) ([]model.ScanItem, error) {
 		content, err := os.ReadFile(full)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read %s: %v\n", rel, err)
+			skipped = append(skipped, SkippedItem{Path: rel, Reason: "unreadable"})
 			continue
 		}
 		out = append(out, model.ScanItem{
@@ -140,7 +155,7 @@ func (p *Provider) Enumerate(ctx context.Context) ([]model.ScanItem, error) {
 			LineCount: countLines(content),
 		})
 	}
-	return out, nil
+	return out, skipped, nil
 }
 
 // listFiles returns all source files under repoDir. In a git repo it uses

--- a/internal/telemetry/span.go
+++ b/internal/telemetry/span.go
@@ -3,11 +3,13 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -125,4 +127,21 @@ func AnyToAttr(k string, v interface{}) attribute.KeyValue {
 	default:
 		return attribute.String(k, fmt.Sprintf("%v", v))
 	}
+}
+
+// ContextFromTraceParent reads the TRACEPARENT environment variable (W3C
+// Trace Context format: "00-{traceId}-{spanId}-{flags}") and returns a
+// context carrying the extracted remote span context. This allows OCR's
+// spans to join a caller's distributed trace regardless of the upstream
+// tracing system (EagleEye, Jaeger, Datadog, etc.).
+//
+// If TRACEPARENT is unset or malformed, returns the input ctx unchanged.
+func ContextFromTraceParent(ctx context.Context) context.Context {
+	tp := os.Getenv("TRACEPARENT")
+	if tp == "" {
+		return ctx
+	}
+	prop := propagation.TraceContext{}
+	carrier := propagation.MapCarrier{"traceparent": tp}
+	return prop.Extract(ctx, carrier)
 }

--- a/plugins/open-code-review/claude-code/commands/review.md
+++ b/plugins/open-code-review/claude-code/commands/review.md
@@ -4,20 +4,29 @@ description: Run OpenCodeReview (OCR) to review code changes and autonomously ap
 
 Invoke the professional code review Agent CLI tool OpenCodeReview (OCR) to review current code changes, and let the Agent autonomously decide whether to apply fixes.
 
-## Workflow
+## Mode Detection
+
+```bash
+ocr llm test
+```
+
+- **Exit 0 → Mode A** (OCR has its own LLM configured)
+- **Non-zero → Mode B** (delegate to host agent)
+
+---
+
+## Mode A: OCR-Owned LLM
 
 ### Step 1: Run Code Review
 
-Run the OCR command:
-
 ```bash
-ocr review --audience agent [user-args]
+ocr review --audience agent --background "<business context>" [user-args]
 ```
+
 - Default (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode).
-- If the user provides `--commit` or `--c`: pass through as-is.
+- If the user provides `--commit` or `-c`: pass through as-is.
 - If the user provides `--from` and `--to`: pass through as-is.
 - (Optional) Provide `--background "requirement context"` to review whether the requirements are correctly implemented.
-- (Optional) Provide `--background-file ./requirements.md` to load the same context from a Markdown file (sanitised and limited to 8000 characters). Combined with `--background` the inline value is given first.
 - Capture full stdout. Set a 5-minute timeout.
 - If the `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`.
 
@@ -34,3 +43,28 @@ Silently discard low-confidence comments. Display the remaining comments.
 ### Step 3: Fix
 
 Automatically fix issues and suggestions that are worth adopting.
+
+---
+
+## Mode B: Delegate to Host Agent
+
+When `ocr llm test` fails (no LLM configured), use OCR's delegate mode.
+
+### Step 1: Prepare Bundle
+
+```bash
+ocr delegate [--from <base> --to <head> | --commit <ref>] [--exclude PATTERNS]
+```
+
+This outputs a self-contained Markdown workflow. Read and follow it:
+
+1. Read the bundle JSON file referenced in the workflow
+2. Review the code changes and produce comments conforming to `review-comments/v1`
+3. Save comments to the path suggested in the workflow
+4. Validate: `ocr delegate validate --bundle <path> --comments <path>`
+5. If invalid, fix errors and re-validate
+6. Generate report: `ocr delegate report --bundle <path> --comments <path>`
+
+### Step 2: Report and Fix
+
+Present the report findings to the user, then apply fixes for high/medium priority items.

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -1,239 +1,97 @@
 ---
 name: open-code-review
 description: >
-  Performs AI-powered code review on Git changes using the `ocr` CLI from
-  alibaba/open-code-review. Use when the user asks to review code, review
-  a pull request, review staged/unstaged changes, review a commit, or
-  compare branches for code quality issues. Produces line-level review
-  comments and can automatically apply fixes when requested. With appropriate
-  review rules, can detect various types of issues including bugs, security
-  vulnerabilities, performance problems, and code quality concerns.
+  AI-powered code review using the `ocr` CLI. Reviews workspace changes,
+  commits, or branch comparisons. Detects bugs, security issues,
+  performance problems, and code quality concerns. Auto-detects whether
+  to use OCR's built-in LLM (Mode A) or delegate to the host agent (Mode B).
 license: Apache-2.0
 compatibility: >
-  Requires the `ocr` CLI installed (via `npm install -g
-  @alibaba-group/open-code-review` or GitHub release binary). Requires a
-  configured LLM (Anthropic or OpenAI-compatible) before first run.
+  Requires `ocr` CLI (npm i -g @alibaba-group/open-code-review).
 metadata:
   author: alibaba
   homepage: https://github.com/alibaba/open-code-review
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Open Code Review
 
-This Codex plugin skill intentionally mirrors the canonical skill at
-`skills/open-code-review/SKILL.md`. Keep both files synchronized when updating
-OCR agent instructions; a symlink is avoided because plugin installs may only
-materialize the plugin subtree.
-
-A skill for invoking [open-code-review](https://github.com/alibaba/open-code-review) (`ocr`) — an open-source AI code review CLI that reads Git diffs and generates structured, line-level review comments.
-
-## Prerequisites check
-
-Before starting a review, verify the environment:
+## Prerequisites
 
 ```bash
-# 1. Check the CLI is installed
 which ocr || echo "NOT INSTALLED"
+```
 
-# 2. Verify LLM connectivity
+If missing: `npm install -g @alibaba-group/open-code-review`
+
+## Mode Selection
+
+```bash
 ocr llm test
 ```
 
-If `ocr` is not installed, install it first:
+- **Success → Mode A** (OCR-owned LLM)
+- **Failure → Mode B** (delegate to host agent, zero API key required)
+
+---
+
+## Mode A: OCR-Owned LLM
+
+Run the review with OCR's configured LLM:
 
 ```bash
-npm install -g @alibaba-group/open-code-review
+ocr review --audience agent --background "<business context>" [flags]
 ```
 
-If `ocr llm test` fails, the user must configure an LLM. Guide them with one of these options:
+| User intent | Flags |
+|---|---|
+| Review working copy | _(none)_ |
+| Review a commit | `--commit <ref>` |
+| Compare branches | `--from <base> --to <head>` |
+| Dry-run | `--preview` |
 
-**Option A — Environment variables (highest priority, recommended for CI):**
+Parse the output, classify by priority (high/medium/low), report findings to the user, and optionally apply fixes.
+
+---
+
+## Mode B: Delegate to Host Agent
+
+When no LLM is configured, OCR prepares a deterministic evidence bundle and returns a Markdown workflow for the host agent to follow.
+
+### Step 1: Prepare
 
 ```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
+ocr delegate [--from <base> --to <head> | --commit <ref>] [--exclude PATTERNS]
 ```
 
-**Option B — Persistent config:**
+This outputs a Markdown workflow containing:
+- The bundle file path and bundle_id
+- The review contract (allowed priorities, categories, schema)
+- Instructions for producing, validating, and rendering the review
 
-```bash
-ocr config set llm.url https://api.anthropic.com/v1/messages
-ocr config set llm.auth_token <api-key>
-ocr config set llm.model claude-opus-4-6
-ocr config set llm.use_anthropic true
-```
+### Step 2: Follow the Workflow
 
-Stop here and ask the user to provide credentials — never invent or hardcode API keys.
+The output is self-contained. Read it and follow its steps:
 
-## Workflow
+1. Read the bundle JSON file
+2. Produce review comments conforming to `review-comments/v1`
+3. Save comments to a file
+4. Run `ocr delegate validate --bundle <path> --comments <path>`
+5. If invalid, fix and re-validate
+6. Run `ocr delegate report --bundle <path> --comments <path>`
 
-### Step 1: Gather Business Context
+The report renders as Markdown/text/JSON. Present findings to the user.
 
-Analyze the review target (commits, branch, or changes) to extract concise business context. Pass this context via `--background` to improve review quality.
-
-### Step 2: Run Code Review
-
-Run the OCR command with appropriate flags. **Always pass business context via `--background`** when available:
-
-```bash
-ocr review --audience agent --background "business context here" [user-args]
-```
-
-**Argument handling:**
-
-- **Background context** (RECOMMENDED): use `--background "context"` or `-b "context"` to provide business context for better review quality
-- **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
-- **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
-- **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
-- **Timeout**: default timeout is 10 minutes per file; adjust with `--timeout <minutes>`
-- **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
-- **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
-- **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
-
-**Common invocation patterns:**
-
-| User says | Command to run |
-|-----------|---------------|
-| "review my changes" / "review the working copy" | `ocr review --audience agent -b "context"` |
-| "review this PR" / "review feature branch" | `ocr review --audience agent -b "context" --from main --to <branch>` |
-| "review commit abc123" | `ocr review --audience agent -b "context" --commit abc123` |
-| "what would be reviewed?" (dry-run) | `ocr review --preview` |
-
-**Output mode:**
-
-- Always use `--audience agent` to suppress progress UI and emit only the final summary
-
-### Step 3: Classify and Report
-
-For each comment from the review output, classify by priority and report all issues to the user:
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Likely false positives, lacking sufficient context, nitpicks, or meaningless suggestions
-
-Report all comments grouped by priority level.
-
-### Step 4: Fix
-
-Before applying fixes, check whether the user requested automatic fixes:
-
-- If the user explicitly requested "review and fix" or similar, proceed with automatic fixes
-- If the user only requested "review" without fix intent, ask for permission before applying any changes
-
-When fixing issues and suggestions:
-
-- Focus on High and Medium priority items
-- Apply fixes directly to the code when safe and well-defined
-- For complex fixes requiring manual intervention, clearly describe what needs to be done
-- Always verify fixes with the user before committing
-
-## Output Format
-
-Each comment contains:
-
-- `path`: File path
-- `content`: Review comment text
-- `start_line` / `end_line`: Line range (both 0 means positioning failed)
-- `suggestion_code`: Optional fix suggestion
-- `existing_code`: Optional original code snippet
-- `thinking`: Optional LLM reasoning process
-
-After filtering comments by priority, present results using this template:
-
-```markdown
-## Code Review Results
-
-**Files reviewed**: N
-**Issues found**: X high priority / Y medium priority
-
-### High Priority
-
-- **`path/to/file.java:42`** — Brief description
-  > Recommendation: How to fix
-
-### Medium Priority
-
-- **`path/to/file.ts:88`** — Brief description
-  > Recommendation: How to fix (if applicable)
-```
-
-If the review found no issues after filtering, simply state: "Review complete — no issues found in N files."
-
-**Priority classification:**
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Discarded silently (likely false positives, lacking context, nitpicks, or meaningless suggestions)
-
-**Handling mispositioned comments:**
-
-When `start_line` and `end_line` are both `0`, the comment failed to locate the exact position in the file. In such cases:
-
-1. Read the comment content to understand the issue
-2. Examine the target file mentioned in the comment
-3. Identify the relevant code section based on the comment's context
-4. Apply the fix or suggestion to the correct location
-
-## Custom Review Rules
-
-If the user wants project-specific rules, OCR resolves them in this priority order:
-
-1. `--rule <path>` flag (highest)
-2. `<repo>/.opencodereview/rule.json`
-3. `~/.opencodereview/rule.json`
-4. Built-in system defaults (lowest)
-
-By default, the first matching user rule replaces the built-in system rule. Set `merge_system_rule: true` on a rule entry when the matched system rule and user rule should both be included.
-
-Rule file format:
-
-```json
-{
-  "rules": [
-    {
-      "path": "**/*.java",
-      "rule": "All new methods must validate required parameters for null",
-      "merge_system_rule": true
-    },
-    {
-      "path": "**/*mapper*.xml",
-      "rule": "Check SQL for injection risks and missing closing tags"
-    }
-  ]
-}
-```
-
-To preview which rule applies to a file before reviewing:
-
-```bash
-ocr rules check src/main/java/com/example/Foo.java
-```
+---
 
 ## Gotchas
 
-- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. Always run `ocr llm test` before the first review.
-- **Working directory matters** — `ocr review` operates on the Git repo at the current directory. Use `--repo /path/to/repo` to run from elsewhere.
-- **Untracked files are reviewed in workspace mode** — running bare `ocr review` includes staged, unstaged, *and* untracked changes. Stage selectively if you want narrower scope.
-- **Large diffs may hit token limits** — files with very large diffs may be truncated. The default `MAX_TOKENS` is 58888 per request.
-- **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
-- **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
-- **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
-
-## Validation
-
-After the review completes, verify success by checking:
-
-1. The command exited with code 0
-2. Comments were generated (or "No comments generated" message appears)
-3. Warnings (if any) are displayed in stderr
-
-If errors occurred, check the stderr warnings for details about which files failed and why.
+- Always use `--audience agent` in Mode A to suppress progress UI
+- Working directory matters — use `--repo <path>` to target another repo
+- Large diffs may hit token limits; use `--preview` to check scope first
+- In Mode B, the bundle is immutable — comments must reference paths and lines that exist in the bundle
 
 ## References
 
-- Full docs: https://github.com/alibaba/open-code-review
-- NPM package: https://www.npmjs.com/package/@alibaba-group/open-code-review
-- Issue tracker: https://github.com/alibaba/open-code-review/issues
+- Docs: https://github.com/alibaba/open-code-review
+- NPM: https://www.npmjs.com/package/@alibaba-group/open-code-review

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -1,234 +1,97 @@
 ---
 name: open-code-review
 description: >
-  Performs AI-powered code review on Git changes using the `ocr` CLI from
-  alibaba/open-code-review. Use when the user asks to review code, review
-  a pull request, review staged/unstaged changes, review a commit, or
-  compare branches for code quality issues. Produces line-level review
-  comments and can automatically apply fixes when requested. With appropriate
-  review rules, can detect various types of issues including bugs, security
-  vulnerabilities, performance problems, and code quality concerns.
+  AI-powered code review using the `ocr` CLI. Reviews workspace changes,
+  commits, or branch comparisons. Detects bugs, security issues,
+  performance problems, and code quality concerns. Auto-detects whether
+  to use OCR's built-in LLM (Mode A) or delegate to the host agent (Mode B).
 license: Apache-2.0
 compatibility: >
-  Requires the `ocr` CLI installed (via `npm install -g
-  @alibaba-group/open-code-review` or GitHub release binary). Requires a
-  configured LLM (Anthropic or OpenAI-compatible) before first run.
+  Requires `ocr` CLI (npm i -g @alibaba-group/open-code-review).
 metadata:
   author: alibaba
   homepage: https://github.com/alibaba/open-code-review
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Open Code Review
 
-A skill for invoking [open-code-review](https://github.com/alibaba/open-code-review) (`ocr`) — an open-source AI code review CLI that reads Git diffs and generates structured, line-level review comments.
-
-## Prerequisites check
-
-Before starting a review, verify the environment:
+## Prerequisites
 
 ```bash
-# 1. Check the CLI is installed
 which ocr || echo "NOT INSTALLED"
+```
 
-# 2. Verify LLM connectivity
+If missing: `npm install -g @alibaba-group/open-code-review`
+
+## Mode Selection
+
+```bash
 ocr llm test
 ```
 
-If `ocr` is not installed, install it first:
+- **Success → Mode A** (OCR-owned LLM)
+- **Failure → Mode B** (delegate to host agent, zero API key required)
+
+---
+
+## Mode A: OCR-Owned LLM
+
+Run the review with OCR's configured LLM:
 
 ```bash
-npm install -g @alibaba-group/open-code-review
+ocr review --audience agent --background "<business context>" [flags]
 ```
 
-If `ocr llm test` fails, the user must configure an LLM. Guide them with one of these options:
+| User intent | Flags |
+|---|---|
+| Review working copy | _(none)_ |
+| Review a commit | `--commit <ref>` |
+| Compare branches | `--from <base> --to <head>` |
+| Dry-run | `--preview` |
 
-**Option A — Environment variables (highest priority, recommended for CI):**
+Parse the output, classify by priority (high/medium/low), report findings to the user, and optionally apply fixes.
+
+---
+
+## Mode B: Delegate to Host Agent
+
+When no LLM is configured, OCR prepares a deterministic evidence bundle and returns a Markdown workflow for the host agent to follow.
+
+### Step 1: Prepare
 
 ```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
+ocr delegate [--from <base> --to <head> | --commit <ref>] [--exclude PATTERNS]
 ```
 
-**Option B — Persistent config:**
+This outputs a Markdown workflow containing:
+- The bundle file path and bundle_id
+- The review contract (allowed priorities, categories, schema)
+- Instructions for producing, validating, and rendering the review
 
-```bash
-ocr config set llm.url https://api.anthropic.com/v1/messages
-ocr config set llm.auth_token <api-key>
-ocr config set llm.model claude-opus-4-6
-ocr config set llm.use_anthropic true
-```
+### Step 2: Follow the Workflow
 
-Stop here and ask the user to provide credentials — never invent or hardcode API keys.
+The output is self-contained. Read it and follow its steps:
 
-## Workflow
+1. Read the bundle JSON file
+2. Produce review comments conforming to `review-comments/v1`
+3. Save comments to a file
+4. Run `ocr delegate validate --bundle <path> --comments <path>`
+5. If invalid, fix and re-validate
+6. Run `ocr delegate report --bundle <path> --comments <path>`
 
-### Step 1: Gather Business Context
+The report renders as Markdown/text/JSON. Present findings to the user.
 
-Analyze the review target (commits, branch, or changes) to extract concise business context. Pass this context via `--background` to improve review quality.
-
-### Step 2: Run Code Review
-
-Run the OCR command with appropriate flags. **Always pass business context via `--background`** when available:
-
-```bash
-ocr review --audience agent --background "business context here" [user-args]
-```
-
-**Argument handling:**
-
-- **Background context** (RECOMMENDED): use `--background "context"` or `-b "context"` to provide business context for better review quality
-- **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
-- **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
-- **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
-- **Timeout**: default timeout is 10 minutes per file; adjust with `--timeout <minutes>`
-- **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
-- **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
-- **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
-
-**Common invocation patterns:**
-
-| User says | Command to run |
-|-----------|---------------|
-| "review my changes" / "review the working copy" | `ocr review --audience agent -b "context"` |
-| "review this PR" / "review feature branch" | `ocr review --audience agent -b "context" --from main --to <branch>` |
-| "review commit abc123" | `ocr review --audience agent -b "context" --commit abc123` |
-| "what would be reviewed?" (dry-run) | `ocr review --preview` |
-
-**Output mode:**
-
-- Always use `--audience agent` to suppress progress UI and emit only the final summary
-
-### Step 3: Classify and Report
-
-For each comment from the review output, classify by priority and report all issues to the user:
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Likely false positives, lacking sufficient context, nitpicks, or meaningless suggestions
-
-Report all comments grouped by priority level.
-
-### Step 4: Fix
-
-Before applying fixes, check whether the user requested automatic fixes:
-
-- If the user explicitly requested "review and fix" or similar, proceed with automatic fixes
-- If the user only requested "review" without fix intent, ask for permission before applying any changes
-
-When fixing issues and suggestions:
-
-- Focus on High and Medium priority items
-- Apply fixes directly to the code when safe and well-defined
-- For complex fixes requiring manual intervention, clearly describe what needs to be done
-- Always verify fixes with the user before committing
-
-## Output Format
-
-Each comment contains:
-
-- `path`: File path
-- `content`: Review comment text
-- `start_line` / `end_line`: Line range (both 0 means positioning failed)
-- `suggestion_code`: Optional fix suggestion
-- `existing_code`: Optional original code snippet
-- `thinking`: Optional LLM reasoning process
-
-After filtering comments by priority, present results using this template:
-
-```markdown
-## Code Review Results
-
-**Files reviewed**: N
-**Issues found**: X high priority / Y medium priority
-
-### High Priority
-
-- **`path/to/file.java:42`** — Brief description
-  > Recommendation: How to fix
-
-### Medium Priority
-
-- **`path/to/file.ts:88`** — Brief description
-  > Recommendation: How to fix (if applicable)
-```
-
-If the review found no issues after filtering, simply state: "Review complete — no issues found in N files."
-
-**Priority classification:**
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Discarded silently (likely false positives, lacking context, nitpicks, or meaningless suggestions)
-
-**Handling mispositioned comments:**
-
-When `start_line` and `end_line` are both `0`, the comment failed to locate the exact position in the file. In such cases:
-
-1. Read the comment content to understand the issue
-2. Examine the target file mentioned in the comment
-3. Identify the relevant code section based on the comment's context
-4. Apply the fix or suggestion to the correct location
-
-## Custom Review Rules
-
-If the user wants project-specific rules, OCR resolves them in this priority order:
-
-1. `--rule <path>` flag (highest)
-2. `<repo>/.opencodereview/rule.json`
-3. `~/.opencodereview/rule.json`
-4. Built-in system defaults (lowest)
-
-By default, the first matching user rule replaces the built-in system rule. Set `merge_system_rule: true` on a rule entry when the matched system rule and user rule should both be included.
-
-Rule file format:
-
-```json
-{
-  "rules": [
-    {
-      "path": "**/*.java",
-      "rule": "All new methods must validate required parameters for null",
-      "merge_system_rule": true
-    },
-    {
-      "path": "**/*mapper*.xml",
-      "rule": "Check SQL for injection risks and missing closing tags"
-    }
-  ]
-}
-```
-
-To preview which rule applies to a file before reviewing:
-
-```bash
-ocr rules check src/main/java/com/example/Foo.java
-```
+---
 
 ## Gotchas
 
-- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. Always run `ocr llm test` before the first review.
-- **Working directory matters** — `ocr review` operates on the Git repo at the current directory. Use `--repo /path/to/repo` to run from elsewhere.
-- **Untracked files are reviewed in workspace mode** — running bare `ocr review` includes staged, unstaged, *and* untracked changes. Stage selectively if you want narrower scope.
-- **Large diffs may hit token limits** — files with very large diffs may be truncated. The default `MAX_TOKENS` is 58888 per request.
-- **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
-- **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
-- **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
-
-## Validation
-
-After the review completes, verify success by checking:
-
-1. The command exited with code 0
-2. Comments were generated (or "No comments generated" message appears)
-3. Warnings (if any) are displayed in stderr
-
-If errors occurred, check the stderr warnings for details about which files failed and why.
+- Always use `--audience agent` in Mode A to suppress progress UI
+- Working directory matters — use `--repo <path>` to target another repo
+- Large diffs may hit token limits; use `--preview` to check scope first
+- In Mode B, the bundle is immutable — comments must reference paths and lines that exist in the bundle
 
 ## References
 
-- Full docs: https://github.com/alibaba/open-code-review
-- NPM package: https://www.npmjs.com/package/@alibaba-group/open-code-review
-- Issue tracker: https://github.com/alibaba/open-code-review/issues
+- Docs: https://github.com/alibaba/open-code-review
+- NPM: https://www.npmjs.com/package/@alibaba-group/open-code-review


### PR DESCRIPTION
## Summary

Add `ocr delegate` command that enables code review without requiring an API key. The host agent (e.g. Claude Code, Cursor) uses its own reasoning to review code changes, while OCR provides the deterministic data plane — bundle preparation, anti-hallucination validation, and report rendering.

### Key changes:
- **`ocr delegate`** — prepares a review bundle and emits a Markdown workflow for the host agent to follow
- **`ocr delegate validate`** — verifies review comments against immutable bundle evidence (anti-hallucination)
- **`ocr delegate report`** — renders validated comments as a formatted report
- **`internal/reviewbundle`** — full package for bundle preparation, validation, reporting, and schema enforcement
- **`internal/reviewfilter`** — file filtering by glob patterns
- **Neutral schema naming** — `review-bundle/v1`, `review-comments/v1` (no vendor prefix)
- **Dual-mode SKILL.md** — auto-detects Mode A (OCR LLM) vs Mode B (delegate) via `ocr llm test`

### How it works:
1. Host agent runs `ocr delegate` → receives Markdown workflow + bundle file
2. Agent reads bundle, reviews code, produces `review-comments/v1` JSON
3. `ocr delegate validate` checks every comment against bundle evidence
4. `ocr delegate report` renders the final report

## Test plan
- [x] `make check` passes (fmt + vet)
- [x] `make test` passes (all unit tests green)
- [x] 17 new test cases in `delegate_cmd_test.go` covering workspace/range/commit modes, validate/report roundtrips, flag validation, help output, and schema neutrality
- [ ] Manual end-to-end test: `ocr delegate` → construct comments → validate → report