### PR TITLE
fix(diff): preserve non-ASCII paths

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -310,7 +310,7 @@ func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {
 }
 
 func (p *Provider) untrackedFilesList(ctx context.Context) ([]string, error) {
-	out, err := p.runGit(ctx, "ls-files", "--others", "--exclude-standard")
+	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard")
 	if err != nil || out == "" {
 		return nil, nil
 	}

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -116,14 +116,14 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		if base == "" {
 			return nil, fmt.Errorf("cannot find merge-base between %s and %s", p.from, p.to)
 		}
-		out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
+		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
 		if err != nil {
 			return nil, fmt.Errorf("git diff failed: %w", err)
 		}
 		combined.WriteString(out)
 
 	case ModeCommit:
-		out, err := p.runGit(ctx, "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
+		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
 		if err != nil {
 			return nil, fmt.Errorf("git show failed: %w", err)
 		}
@@ -261,14 +261,14 @@ func (p *Provider) computeMergeBase(ctx context.Context, from, to string) string
 }
 
 func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, error) {
-	out, err := p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
 	if err == nil && out != "" {
 		return out, nil
 	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
-	return p.runGit(ctx, "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--staged", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	return p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--staged", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
 }
 
 func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -65,6 +65,87 @@ func initRepoWithChange(t *testing.T) string {
 	return repo
 }
 
+// initRepoWithNonASCIIChange creates a repository whose changed file path
+// contains both non-ASCII characters and Next.js-style route groups. It forces
+// Git's default path quoting so tests do not depend on the user's global config.
+func initRepoWithNonASCIIChange(t *testing.T) (string, string) {
+	t.Helper()
+	repo := t.TempDir()
+
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+	runGitTest(t, repo, "config", "commit.gpgsign", "false")
+	runGitTest(t, repo, "config", "core.quotepath", "true")
+
+	relPath := "src/café/(authenticated)/文件.ts"
+	file := filepath.Join(repo, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("create non-ASCII path: %v", err)
+	}
+	if err := os.WriteFile(file, []byte("before\n"), 0o644); err != nil {
+		t.Fatalf("write non-ASCII file: %v", err)
+	}
+	runGitTest(t, repo, "add", "--", relPath)
+	runGitTest(t, repo, "commit", "-q", "-m", "initial commit")
+
+	if err := os.WriteFile(file, []byte("after\n"), 0o644); err != nil {
+		t.Fatalf("modify non-ASCII file: %v", err)
+	}
+	return repo, relPath
+}
+
+func TestDiffModesPreserveNonASCIIPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider func(t *testing.T, repo string, runner *gitcmd.Runner) *Provider
+	}{
+		{
+			name: "workspace",
+			provider: func(_ *testing.T, repo string, runner *gitcmd.Runner) *Provider {
+				return NewWorkspaceProvider(repo, runner)
+			},
+		},
+		{
+			name: "commit",
+			provider: func(t *testing.T, repo string, runner *gitcmd.Runner) *Provider {
+				runGitTest(t, repo, "add", "-A")
+				runGitTest(t, repo, "commit", "-q", "-m", "update non-ASCII file")
+				return NewCommitProvider(repo, "HEAD", runner)
+			},
+		},
+		{
+			name: "range",
+			provider: func(t *testing.T, repo string, runner *gitcmd.Runner) *Provider {
+				runGitTest(t, repo, "add", "-A")
+				runGitTest(t, repo, "commit", "-q", "-m", "update non-ASCII file")
+				return NewProvider(repo, "HEAD~1", "HEAD", runner)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, relPath := initRepoWithNonASCIIChange(t)
+			provider := tt.provider(t, repo, gitcmd.New(0))
+
+			diffs, err := provider.GetDiff(context.Background())
+			if err != nil {
+				t.Fatalf("GetDiff returned error: %v", err)
+			}
+			if len(diffs) != 1 {
+				t.Fatalf("got %d diffs, want 1: %+v", len(diffs), diffs)
+			}
+			if diffs[0].NewPath != relPath {
+				t.Errorf("NewPath = %q, want %q", diffs[0].NewPath, relPath)
+			}
+			if diffs[0].NewFileContent != "after\n" {
+				t.Errorf("NewFileContent = %q, want %q", diffs[0].NewFileContent, "after\n")
+			}
+		})
+	}
+}
+
 // TestWorkspaceDiffSurvivesExternalDiffTool guards against issue #82: when a
 // user has configured an external diff tool (GIT_EXTERNAL_DIFF or
 // diff.external), git diff/show emit the tool's output instead of unified diff

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -146,6 +146,31 @@ func TestDiffModesPreserveNonASCIIPaths(t *testing.T) {
 	}
 }
 
+func TestWorkspaceDiffPreservesNonASCIIUntrackedPath(t *testing.T) {
+	repo, trackedPath := initRepoWithNonASCIIChange(t)
+	runGitTest(t, repo, "checkout", "--", trackedPath)
+
+	untrackedPath := "src/café/(authenticated)/新增.ts"
+	if err := os.WriteFile(filepath.Join(repo, filepath.FromSlash(untrackedPath)), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatalf("write non-ASCII untracked file: %v", err)
+	}
+
+	provider := NewWorkspaceProvider(repo, gitcmd.New(0))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff returned error: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("got %d diffs, want 1: %+v", len(diffs), diffs)
+	}
+	if diffs[0].NewPath != untrackedPath {
+		t.Errorf("NewPath = %q, want %q", diffs[0].NewPath, untrackedPath)
+	}
+	if diffs[0].NewFileContent != "untracked\n" {
+		t.Errorf("NewFileContent = %q, want %q", diffs[0].NewFileContent, "untracked\n")
+	}
+}
+
 // TestWorkspaceDiffSurvivesExternalDiffTool guards against issue #82: when a
 // user has configured an external diff tool (GIT_EXTERNAL_DIFF or
 // diff.external), git diff/show emit the tool's output instead of unified diff


### PR DESCRIPTION
## Description

Git quotes non-ASCII path bytes by default when `core.quotepath` is enabled. The diff parser then receives escaped, quoted paths instead of the literal repository paths, so the generated diff may not be parsed and the file cannot be read back at the selected ref.

This change:

- passes `-c core.quotepath=false` to the range, commit, and workspace diff-generation commands, matching the existing file-read behavior;
- applies the same configuration when listing untracked files;
- adds regression tests with paths containing non-ASCII characters and a Next.js-style route group;
- verifies workspace (tracked and untracked), single-commit, and range review modes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `go test -race -count=1 ./internal/diff`
- [x] `go vet ./...`
- [x] `make build`
- [x] `make coverage` (82.3% total; 91.9% for `internal/diff`)
- [x] `git diff --check upstream/main...HEAD`
- [x] `make test` passes locally (Git 2.49.0)
- [ ] Manual testing (describe below)

The regression tests create real temporary Git repositories with `core.quotepath=true`, covering both tracked and untracked non-ASCII paths. They fail before the corresponding fix and pass after it.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal bug fix
- [x] I have signed the CLA

## Related Issues

Closes #361
