### PR TITLE
fix(diff): add --end-of-options guard and no-commit regression test for workspace diff

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -261,13 +261,18 @@ func (p *Provider) computeMergeBase(ctx context.Context, from, to string) string
 }
 
 func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, error) {
-	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "HEAD", "--")
+	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", "HEAD", "--")
 	if err == nil && out != "" {
 		return out, nil
 	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
+	// Fall back to the staged diff when `git diff HEAD` errored or was empty. This is
+	// not redundant with the call above: in a repository with no commits yet there is no
+	// HEAD, so `git diff HEAD` fails with "bad revision 'HEAD'", but `git diff --staged`
+	// still surfaces staged changes by diffing the index against the empty tree — the only
+	// way to review a workspace before its first commit.
 	return p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--staged", "--")
 }
 

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -205,6 +205,36 @@ func TestWorkspaceDiffSurvivesExternalDiffTool(t *testing.T) {
 	}
 }
 
+// TestWorkspaceDiffNoCommitsUsesStagedFallback pins the second runGit call in
+// workspaceTrackedDiff: in a repository with no commits there is no HEAD, so
+// `git diff HEAD` fails, and the staged diff is the only way to review the
+// workspace. Removing the `--staged` fallback (as an over-eager "simplification"
+// might) makes this return zero diffs.
+func TestWorkspaceDiffNoCommitsUsesStagedFallback(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+
+	// Staged file, no commit yet -> no HEAD. No commit also means no need for
+	// the user.email/user.name/commit.gpgsign config the committing tests set.
+	file := filepath.Join(repo, "staged.txt")
+	if err := os.WriteFile(file, []byte("alpha\nbeta\n"), 0o644); err != nil {
+		t.Fatalf("write staged.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "staged.txt")
+
+	runner := gitcmd.New(0)
+	provider := NewWorkspaceProvider(repo, runner)
+
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff returned error: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatalf("expected staged changes to be surfaced in a repo with no commits " +
+			"(the --staged fallback in workspaceTrackedDiff), got 0 diffs")
+	}
+}
+
 // TestCommitDiffSurvivesExternalDiffTool covers the ModeCommit call site
 // (git show <commit>), which likewise must pass --no-ext-diff so that a
 // user's external diff tool does not break single-commit analysis.


### PR DESCRIPTION
## Description

Follow-up to #381, which normalized the git argument ordering in `workspaceTrackedDiff` (`internal/diff/git.go`) but stopped short of the `--end-of-options` guard. This PR adds the remaining pieces:

- **`--end-of-options` before `HEAD`** in the first `runGit` call, bringing workspace mode fully in line with the canonical range/commit/merge-base call sites in the same file, which already use the guard. After this change, every call site that takes a positional ref carries it; the `--staged` fallback and `ls-files` calls have no positional ref, so they correctly omit it. `--end-of-options` requires git ≥ 2.24 (Nov 2019), well within the project's documented Git ≥ 2.41 floor.
- **A clarifying comment** on why the `--staged` fallback is load-bearing: in a repository with no commits there is no `HEAD`, so `git diff HEAD` fails, but `git diff --staged` still surfaces staged changes by diffing the index against the empty tree.
- **`TestWorkspaceDiffNoCommitsUsesStagedFallback`**, a regression test that stages a file in a commit-less repository and asserts the workspace diff surfaces it — pinning the fallback so it can't be "simplified" away. The test sets no commit-related git config (`user.email`/`user.name`/`commit.gpgsign`), since it never commits.

## Type of Change

- [x] Refactoring (no functional changes)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

`go test -race ./...` — 2001 tests across 23 packages pass. The new regression test fails if the `--staged` fallback is removed and passes with the `--end-of-options` guard in place. `make check` (tidy + fmt + vet) passes.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Follow-up to #381. Closes #374
