### PR TITLE
fix(scan): check user include patterns before the extension allowlist

### DIFF
--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -349,12 +349,15 @@ func (a *Agent) whyExcluded(it model.ScanItem) model.ExcludeReason {
 	if a.args.FileFilter != nil && a.args.FileFilter.IsUserExcluded(path) {
 		return model.ExcludeUserRule
 	}
+	// User-include is checked before the extension allowlist (matching the
+	// preview/diff path in internal/agent) so an explicit include glob can
+	// admit otherwise-unsupported extensions (e.g. .ftl). See #371.
+	if a.args.FileFilter != nil && a.args.FileFilter.HasInclude() && a.args.FileFilter.IsUserIncluded(path) {
+		return model.ExcludeNone
+	}
 	ext := extFromPath(path)
 	if ext != "" && !allowedext.IsAllowedExt(ext) {
 		return model.ExcludeExtension
-	}
-	if a.args.FileFilter != nil && a.args.FileFilter.HasInclude() && a.args.FileFilter.IsUserIncluded(path) {
-		return model.ExcludeNone
 	}
 	if allowedext.IsExcludedPath(path) {
 		return model.ExcludeDefaultPath

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -156,6 +156,16 @@ func TestWhyExcluded_AllBranches(t *testing.T) {
 			want:   model.ExcludeNone,
 		},
 		{
+			// #371: a user-include glob must override the built-in extension
+			// allowlist (as it already does on the preview/diff path). A
+			// non-allowlisted extension (.ftl) with a matching include glob
+			// must be included, not rejected as ExcludeExtension.
+			name:   "user include overrides extension allowlist",
+			item:   model.ScanItem{Path: "templates/email.ftl", Content: "x"},
+			filter: &rules.FileFilter{Include: []string{"**/*.ftl"}},
+			want:   model.ExcludeNone,
+		},
+		{
 			name: "default excluded path",
 			item: model.ScanItem{Path: "pkg/handler_test.go", Content: "x"},
 			want: model.ExcludeDefaultPath,


### PR DESCRIPTION
## Description

In the full-scan path, user `--include` patterns were evaluated **after** the built-in extension allowlist, so a file with a non-allowlisted extension could never be force-included into a scan — even when the user explicitly asked for it. The preview path already evaluates user includes first, so `ocr preview` and the actual scan disagreed about which files a given `--include` selects.

This change moves the user-include check ahead of the extension-allowlist check in the scan path (`internal/scan/agent.go`), matching the preview path's decision order. Explicit user intent now wins over the built-in default in both places.

This also provides the "let users extend the allowlist themselves" escape hatch discussed in #371: `--include "**/*.ftl"` (or any other extension) now works for scans without a code change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Coverage tests extended: a non-allowlisted extension matched by a user `--include` is now included in the scan (this case fails on the previous ordering), and existing exclusion behavior without `--include` is unchanged. `make check` (tidy + fmt + vet) passes.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Related to #371 (complements the FreeMarker rules PR; makes the allowlist user-extensible via `--include`)
