### PR TITLE
refactor(diff): normalize git argument ordering in workspaceTrackedDiff

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -261,14 +261,14 @@ func (p *Provider) computeMergeBase(ctx context.Context, from, to string) string
 }
 
 func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, error) {
-	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "HEAD", "--")
 	if err == nil && out != "" {
 		return out, nil
 	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
-	return p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--staged", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--")
+	return p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--staged", "--")
 }
 
 func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
## Description

Normalize the two `git diff` invocations in `workspaceTrackedDiff` so that all option flags come before `HEAD` or `--staged`, with the path separator `--` remaining last.

This is a consistency-only refactor. Git accepts both argument orderings, so the behavior and generated diff output remain unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (described below)

Validation performed:

- `go test -race -count=1 ./internal/diff`
- `make check`
- `make test`
- `make build`
- `git diff --check`
- Compared the old and reordered `HEAD` and `--staged` Git command outputs; both comparisons were identical.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works (not applicable: this is a no-behavior-change refactor covered by existing workspace diff tests)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable: no user-facing behavior changes)
- [x] I have signed the CLA

## Related Issues

Closes #374
