### PR TITLE
feat: add LiteLLM AI gateway provider preset

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -279,6 +279,27 @@ var registry = []Provider{
 			"qwen3.5:397b",
 		},
 	},
+	{
+		Name:        "litellm",
+		DisplayName: "LiteLLM AI Gateway",
+		Protocol:    ProtocolOpenAIChatCompletions,
+		BaseURL:     "http://localhost:4000/v1",
+		EnvVar:      "LITELLM_API_KEY",
+		Models: []string{
+			"anthropic/claude-sonnet-4-6",
+			"anthropic/claude-opus-4-6",
+			"anthropic/claude-haiku-4-5",
+			"openai/gpt-4o",
+			"openai/gpt-5.4",
+			"openai/o3",
+			"vertex_ai/gemini-2.5-flash",
+			"vertex_ai/gemini-2.5-pro",
+			"bedrock/anthropic.claude-sonnet-4-6-v1",
+			"groq/llama-4-scout-17b-16e-instruct",
+			"mistral/mistral-large-latest",
+			"deepseek/deepseek-chat",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -40,7 +40,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "kimi", "mimo", "minimax", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "kimi", "litellm", "mimo", "minimax", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}
@@ -165,6 +165,51 @@ func TestLookupProvider_OllamaCloudDetails(t *testing.T) {
 		"nemotron-3-super",
 		"nemotron-3-ultra",
 		"qwen3.5:397b",
+	}
+	if len(p.Models) != len(expectedModels) {
+		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))
+	}
+	for i, model := range expectedModels {
+		if p.Models[i] != model {
+			t.Errorf("Models[%d] = %q, want %q", i, p.Models[i], model)
+		}
+	}
+}
+
+func TestLookupProvider_LiteLLMDetails(t *testing.T) {
+	p, ok := LookupProvider("litellm")
+	if !ok {
+		t.Fatal("litellm not found")
+	}
+	if p.DisplayName != "LiteLLM AI Gateway" {
+		t.Errorf("DisplayName = %q, want %q", p.DisplayName, "LiteLLM AI Gateway")
+	}
+	if p.Protocol != ProtocolOpenAIChatCompletions {
+		t.Errorf("Protocol = %q, want %q", p.Protocol, ProtocolOpenAIChatCompletions)
+	}
+	if p.BaseURL != "http://localhost:4000/v1" {
+		t.Errorf("BaseURL = %q, want %q", p.BaseURL, "http://localhost:4000/v1")
+	}
+	if p.EnvVar != "LITELLM_API_KEY" {
+		t.Errorf("EnvVar = %q, want %q", p.EnvVar, "LITELLM_API_KEY")
+	}
+	if p.AuthHeader != "" {
+		t.Errorf("AuthHeader = %q, want empty (OpenAI-compatible uses Bearer by default)", p.AuthHeader)
+	}
+	// LiteLLM uses provider/model format for routing to backing providers.
+	expectedModels := []string{
+		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-opus-4-6",
+		"anthropic/claude-haiku-4-5",
+		"openai/gpt-4o",
+		"openai/gpt-5.4",
+		"openai/o3",
+		"vertex_ai/gemini-2.5-flash",
+		"vertex_ai/gemini-2.5-pro",
+		"bedrock/anthropic.claude-sonnet-4-6-v1",
+		"groq/llama-4-scout-17b-16e-instruct",
+		"mistral/mistral-large-latest",
+		"deepseek/deepseek-chat",
 	}
 	if len(p.Models) != len(expectedModels) {
 		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))


### PR DESCRIPTION
## Description

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a built-in provider preset, giving users access to 100+ LLM providers (Anthropic, OpenAI, Bedrock, Vertex AI, Groq, Mistral, etc.) through a single proxy endpoint.

LiteLLM is a widely-adopted AI gateway (45k+ GitHub stars) that normalizes provider-specific auth and API formats server-side, exposing a standard OpenAI-compatible endpoint.

**Changes (2 files, 67 insertions):**
- `internal/llm/providers.go` - Added `litellm` provider entry with `ProtocolOpenAIChatCompletions`, base URL `http://localhost:4000/v1`, env var `LITELLM_API_KEY`, and 12 representative models spanning 7 backing providers (Anthropic, OpenAI, Vertex AI, Bedrock, Groq, Mistral, DeepSeek)
- `internal/llm/providers_test.go` - Updated `TestListProviders_Order` sorted list, added `TestLookupProvider_LiteLLMDetails` with full field and model list verification

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

**Unit tests (36 tests, 0 regressions):**
```
=== RUN   TestLookupProvider_LiteLLMDetails
--- PASS: TestLookupProvider_LiteLLMDetails (0.00s)
=== RUN   TestListProviders_Order
--- PASS: TestListProviders_Order (0.00s)
=== RUN   TestProviders_AllProtocolsCanonical
--- PASS: TestProviders_AllProtocolsCanonical (0.00s)
PASS
ok  	github.com/open-code-review/open-code-review/internal/llm	0.569s
```

**Format + vet:** `make check` -> `check passed`

**Live E2E (Azure Foundry Claude Sonnet 4.6 via LiteLLM proxy):**
```
=== RUN   TestLiteLLM_LiveE2E/LookupProvider
Name: litellm, Protocol: openai, BaseURL: http://localhost:4000/v1
--- PASS
=== RUN   TestLiteLLM_LiveE2E/LiveCompletion
Content: "14"
Usage: prompt=20 completion=5 total=25
--- PASS
```

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA


## Example usage

> The `model` value should match the model name configured on your LiteLLM proxy (see your proxy's `config.yaml`). The proxy handles routing to the actual backing provider.

```bash
# Set provider via CLI
ocr config set provider litellm

# Or via config file
cat > ~/.config/opencodereview/config.json << 'EOF'
{
  "provider": "litellm",
  "providers": {
    "litellm": {
      "api_key": "sk-litellm-key",
      "model": "my-model"
    }
  }
}
EOF

# Or via environment variables
export LITELLM_API_KEY=sk-litellm-key
export OCR_LLM_MODEL=my-model
ocr --staged
```
