### PR TITLE
docs(pages): add Delegation Mode documentation to website

### DIFF
--- a/pages/src/content/docs/en/integrations/delegate.md
+++ b/pages/src/content/docs/en/integrations/delegate.md
@@ -1,0 +1,165 @@
+---
+title: Delegation Mode
+sidebar:
+  order: 5
+---
+
+OCR handles deterministic engineering (file selection, rule resolution)
+while the host agent performs the actual code review using its own LLM
+capabilities. No LLM endpoint is required on the OCR side.
+
+## When to use delegation mode
+
+Delegation mode is designed for subscription-based AI coding agents —
+such as Claude Code, Codex, Cursor, Open Code, Qoder, etc. — where you
+already have an LLM subscription bundled with the host agent. Instead
+of configuring a separate model endpoint for OCR, you reuse the host
+agent's existing subscription quota to perform the review.
+
+Use delegation mode when:
+
+1. Your AI coding agent runs on a subscription plan and you want to
+   reuse that quota for code review — no extra API key or model
+   configuration needed.
+2. You want OCR only for its engineering scaffolding — file filtering,
+   rule resolution, exclusion logic — while the host agent handles all
+   LLM reasoning.
+3. You're building a custom agent pipeline that needs structured inputs
+   (file list + rules) for its own review step.
+
+## Prerequisites
+
+The `ocr` CLI must be installed:
+
+```bash
+which ocr || npm install -g @alibaba-group/open-code-review
+```
+
+No LLM configuration (`ocr config set …` or environment variables) is
+needed — delegation mode never calls an LLM on the OCR side.
+
+## Install the skill / command
+
+### Claude Code — Command
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/delegate-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/delegate-review.md
+```
+
+### Any agent — Skill
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review-delegate
+```
+
+Or copy the manifest manually:
+
+```bash
+cp -R /path/to/open-code-review/skills/open-code-review-delegate ~/.claude/skills/
+```
+
+## Workflow
+
+### Step 1: Preview — determine what to review
+
+```bash
+ocr delegate preview [--from <ref> --to <ref>] [--commit <hash>] [--exclude <patterns>]
+```
+
+Outputs:
+
+- **mode** — workspace / range / commit
+- **ref metadata** — from, to, commit, merge\_base
+- **Reviewable file list** — paths, status, insertions/deletions
+- **Excluded files** — with exclusion reason
+
+Common invocations:
+
+| Scenario | Command |
+|----------|---------|
+| Workspace changes | `ocr delegate preview` |
+| Branch comparison | `ocr delegate preview --from main --to feature` |
+| Single commit | `ocr delegate preview -c abc123` |
+
+### Step 2: Get rules for files
+
+```bash
+ocr delegate rule <path1> <path2> ...
+```
+
+Pass the reviewable paths from Step 1. Output is grouped by rule
+content — files sharing the same rule appear under one group, avoiding
+repetition.
+
+### Step 3: Get diffs
+
+Use git directly, based on the mode/ref info from Step 1:
+
+**Range mode** (merge\_base provided):
+```bash
+git diff <merge_base>..<to> -- <path>
+```
+
+**Commit mode**:
+```bash
+git show <commit> -- <path>
+```
+
+**Workspace mode**:
+```bash
+git diff HEAD -- <path>        # tracked files
+cat <path>                     # new untracked files
+```
+
+### Step 4: Review each file
+
+For each reviewable file:
+
+1. Get its diff (Step 3)
+2. Consult the matching Rule Group (Step 2) as the review checklist
+3. Conduct a thorough review, using context exploration as needed
+
+### Step 5: Report
+
+Classify each finding by severity:
+
+- **Critical/High** — bugs, security issues, data loss risks. Always report.
+- **Medium** — performance concerns, error handling gaps. Report with context.
+- **Low** — style nits, minor suggestions. Discard silently unless clearly valuable.
+
+## Sub-commands reference
+
+| Command | Purpose |
+|---------|---------|
+| `ocr delegate preview` | List reviewable files + mode/ref metadata |
+| `ocr delegate rule <path...>` | Resolve review rules grouped by content |
+
+## Shared flags
+
+| Flag | Description |
+|------|-------------|
+| `--from <ref>` | Source ref for range mode |
+| `--to <ref>` | Target ref for range mode |
+| `-c, --commit <hash>` | Single commit mode |
+| `--repo <path>` | Repository root (default: cwd) |
+| `--rule <path>` | Custom rule.json path |
+| `--exclude <patterns>` | Comma-separated exclude patterns |
+| `-b, --background <text>` | Business context |
+| `-B, --background-file <path>` | Business context from Markdown file |
+
+## Comparison with other integration modes
+
+| Mode | Who calls the LLM? | Use case |
+|------|-------------------|----------|
+| [Agent Skill](../agent-skill/) | OCR | Agent invokes `ocr review`; OCR drives the full review |
+| [Command (Claude Code)](../claude-code/) | OCR | Slash command in Claude Code; OCR drives the review |
+| **Delegation Mode** | Host agent | OCR provides scaffolding; agent drives the review |
+| [Direct Subprocess](../subprocess/) | OCR | Manual CLI invocation |
+
+## See Also
+
+- [Agent Skill](../agent-skill/) — OCR drives the full review on behalf of the agent.
+- [Command (Claude Code)](../claude-code/) — slash-command flavor with auto-fix.
+- [Direct Subprocess](../subprocess/) — bypass skills/commands, call CLI directly.

--- a/pages/src/content/docs/index.ts
+++ b/pages/src/content/docs/index.ts
@@ -16,6 +16,7 @@ import enAgentSkill from './en/integrations/agent-skill.md';
 import enClaudeCode from './en/integrations/claude-code.md';
 import enSubprocess from './en/integrations/subprocess.md';
 import enCicd from './en/integrations/ci.md';
+import enDelegate from './en/integrations/delegate.md';
 import enContributing from './en/contributing.md';
 import enFaq from './en/faq.md';
 
@@ -35,6 +36,7 @@ import zhAgentSkill from './zh/integrations/agent-skill.md';
 import zhClaudeCode from './zh/integrations/claude-code.md';
 import zhSubprocess from './zh/integrations/subprocess.md';
 import zhCicd from './zh/integrations/ci.md';
+import zhDelegate from './zh/integrations/delegate.md';
 import zhContributing from './zh/contributing.md';
 import zhFaq from './zh/faq.md';
 
@@ -54,6 +56,7 @@ import jaAgentSkill from './ja/integrations/agent-skill.md';
 import jaClaudeCode from './ja/integrations/claude-code.md';
 import jaSubprocess from './ja/integrations/subprocess.md';
 import jaCicd from './ja/integrations/ci.md';
+import jaDelegate from './ja/integrations/delegate.md';
 import jaContributing from './ja/contributing.md';
 import jaFaq from './ja/faq.md';
 
@@ -73,6 +76,7 @@ export type DocSlug =
   | 'claude-code'
   | 'subprocess'
   | 'cicd'
+  | 'delegate'
   | 'contributing'
   | 'faq';
 
@@ -92,6 +96,7 @@ const enDocs: Record<DocSlug, string> = {
   'claude-code': enClaudeCode,
   'subprocess': enSubprocess,
   'cicd': enCicd,
+  'delegate': enDelegate,
   'contributing': enContributing,
   'faq': enFaq,
 };
@@ -112,6 +117,7 @@ const zhDocs: Record<DocSlug, string> = {
   'claude-code': zhClaudeCode,
   'subprocess': zhSubprocess,
   'cicd': zhCicd,
+  'delegate': zhDelegate,
   'contributing': zhContributing,
   'faq': zhFaq,
 };
@@ -132,6 +138,7 @@ const jaDocs: Record<DocSlug, string> = {
   'claude-code': jaClaudeCode,
   'subprocess': jaSubprocess,
   'cicd': jaCicd,
+  'delegate': jaDelegate,
   'contributing': jaContributing,
   'faq': jaFaq,
 };

--- a/pages/src/content/docs/ja/integrations/delegate.md
+++ b/pages/src/content/docs/ja/integrations/delegate.md
@@ -1,0 +1,151 @@
+---
+title: デリゲーションモード
+sidebar:
+  order: 5
+---
+
+OCR が確定的エンジニアリング（ファイル選択、ルール解決）を担当し、ホストエージェントが自身の LLM 能力を使って実際のコードレビューを行います。OCR 側に LLM エンドポイントは不要です。
+
+## デリゲーションモードを使うタイミング
+
+デリゲーションモードは、サブスクリプション型の AI コーディングエージェント向けに設計されています — Claude Code、Codex、Cursor、Open Code、Qoder など。これらのツールには LLM サブスクリプションが組み込まれており、デリゲーションモードを使えばホストエージェントの既存サブスクリプション枠をそのままコードレビューに活用できます。追加のモデル設定や API キーは不要です。
+
+以下の場合に使用してください：
+
+1. AI コーディングエージェントがサブスクリプション制で、その枠をコードレビューに再利用したい場合 — 追加の API キーやモデル設定は不要。
+2. OCR のエンジニアリング機能のみ（ファイルフィルタリング、ルール解決、除外ロジック）を利用し、LLM 推論はホストエージェントに任せたい場合。
+3. 構造化された入力（ファイルリスト＋ルール）を独自のレビューステップに必要とするカスタムエージェントパイプラインを構築している場合。
+
+## 前提条件
+
+`ocr` CLI がインストールされている必要があります：
+
+```bash
+which ocr || npm install -g @alibaba-group/open-code-review
+```
+
+LLM 設定（`ocr config set …` や環境変数）は不要です — デリゲーションモードは OCR 側で LLM を呼び出しません。
+
+## Skill / Command のインストール
+
+### Claude Code — Command
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/delegate-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/delegate-review.md
+```
+
+### 任意のエージェント — Skill
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review-delegate
+```
+
+または手動コピー：
+
+```bash
+cp -R /path/to/open-code-review/skills/open-code-review-delegate ~/.claude/skills/
+```
+
+## ワークフロー
+
+### ステップ 1：Preview — レビュー対象の決定
+
+```bash
+ocr delegate preview [--from <ref> --to <ref>] [--commit <hash>] [--exclude <patterns>]
+```
+
+出力内容：
+
+- **mode** — workspace / range / commit
+- **ref メタデータ** — from、to、commit、merge\_base
+- **レビュー可能ファイルリスト** — パス、ステータス、挿入/削除行数
+- **除外ファイル** — 除外理由付き
+
+よく使うパターン：
+
+| シナリオ | コマンド |
+|----------|---------|
+| ワークスペースの変更 | `ocr delegate preview` |
+| ブランチ比較 | `ocr delegate preview --from main --to feature` |
+| 単一コミット | `ocr delegate preview -c abc123` |
+
+### ステップ 2：ファイルのルール取得
+
+```bash
+ocr delegate rule <path1> <path2> ...
+```
+
+ステップ 1 のレビュー可能パスを渡します。出力はルール内容でグループ化されます — 同じルールを共有するファイルは1つのグループにまとめられ、重複を避けます。
+
+### ステップ 3：diff の取得
+
+ステップ 1 の mode/ref 情報に基づき、git を直接使用：
+
+**Range モード**（merge\_base あり）：
+```bash
+git diff <merge_base>..<to> -- <path>
+```
+
+**Commit モード**：
+```bash
+git show <commit> -- <path>
+```
+
+**Workspace モード**：
+```bash
+git diff HEAD -- <path>        # 追跡ファイル
+cat <path>                     # 新規未追跡ファイル
+```
+
+### ステップ 4：各ファイルのレビュー
+
+レビュー可能な各ファイルについて：
+
+1. diff を取得（ステップ 3）
+2. 対応するルールグループ（ステップ 2）をレビューチェックリストとして参照
+3. コンテキスト探索を必要に応じて行い、徹底的にレビュー
+
+### ステップ 5：レポート
+
+重要度で分類：
+
+- **Critical/High** — バグ、セキュリティ問題、データ損失リスク。常に報告。
+- **Medium** — パフォーマンスの懸念、エラーハンドリングの欠落。コンテキスト付きで報告。
+- **Low** — スタイルの提案、軽微な改善。明確に価値がない限り静かに破棄。
+
+## サブコマンドリファレンス
+
+| コマンド | 目的 |
+|----------|------|
+| `ocr delegate preview` | レビュー可能ファイル＋mode/ref メタデータの一覧 |
+| `ocr delegate rule <path...>` | 内容別にグループ化されたレビュールールの解決 |
+
+## 共通フラグ
+
+| フラグ | 説明 |
+|--------|------|
+| `--from <ref>` | Range モードのソース参照 |
+| `--to <ref>` | Range モードのターゲット参照 |
+| `-c, --commit <hash>` | 単一コミットモード |
+| `--repo <path>` | リポジトリルート（デフォルト：cwd） |
+| `--rule <path>` | カスタム rule.json パス |
+| `--exclude <patterns>` | カンマ区切りの除外パターン |
+| `-b, --background <text>` | ビジネスコンテキスト |
+| `-B, --background-file <path>` | Markdown ファイルからビジネスコンテキストを読み込み |
+
+## 他の統合モードとの比較
+
+| モード | LLM を呼ぶのは？ | ユースケース |
+|--------|-----------------|-------------|
+| [Agent Skill](../agent-skill/) | OCR | Agent が `ocr review` を呼び出し、OCR が完全なレビューを駆動 |
+| [Command（Claude Code）](../claude-code/) | OCR | Claude Code のスラッシュコマンド、OCR がレビューを駆動 |
+| **デリゲーションモード** | ホストエージェント | OCR がスキャフォールディングを提供、Agent がレビューを駆動 |
+| [Direct Subprocess](../subprocess/) | OCR | 手動 CLI 呼び出し |
+
+## 関連項目
+
+- [Agent Skill](../agent-skill/) — OCR がエージェントに代わって完全なレビューを駆動。
+- [Command（Claude Code）](../claude-code/) — スラッシュコマンド形式、自動修正付き。
+- [Direct Subprocess](../subprocess/) — skill/command をバイパスし、CLI を直接呼び出し。

--- a/pages/src/content/docs/zh/integrations/delegate.md
+++ b/pages/src/content/docs/zh/integrations/delegate.md
@@ -1,0 +1,151 @@
+---
+title: 委托模式
+sidebar:
+  order: 5
+---
+
+OCR 负责确定性工程（文件筛选、规则解析），宿主 Agent 使用自身的 LLM 能力执行实际的代码审查。OCR 端无需配置 LLM。
+
+## 何时使用委托模式
+
+委托模式专为订阅制 AI 编码代理设计 — 如 Claude Code、Codex、Cursor、Open Code、Qoder 等。这些工具已内置 LLM 订阅额度，使用委托模式可以直接复用宿主 Agent 的订阅额度进行代码审查，无需额外配置模型或 API Key。
+
+适用于以下场景：
+
+1. 你的 AI 编码代理使用订阅制，希望复用已有额度进行代码审查 — 无需额外配置 API Key 或模型端点。
+2. 你只需要 OCR 的工程脚手架 — 文件过滤、规则解析、排除逻辑 — 由宿主 Agent 负责所有 LLM 推理。
+3. 你正在构建自定义 Agent 流水线，需要结构化输入（文件列表 + 规则）作为自身审查步骤的输入。
+
+## 前置条件
+
+需要安装 `ocr` CLI：
+
+```bash
+which ocr || npm install -g @alibaba-group/open-code-review
+```
+
+无需配置 LLM（`ocr config set …` 或环境变量）— 委托模式在 OCR 端不调用任何 LLM。
+
+## 安装 Skill / Command
+
+### Claude Code — Command
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/delegate-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/delegate-review.md
+```
+
+### 任意 Agent — Skill
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review-delegate
+```
+
+或手动复制：
+
+```bash
+cp -R /path/to/open-code-review/skills/open-code-review-delegate ~/.claude/skills/
+```
+
+## 工作流程
+
+### 第 1 步：Preview — 确定审查范围
+
+```bash
+ocr delegate preview [--from <ref> --to <ref>] [--commit <hash>] [--exclude <patterns>]
+```
+
+输出内容：
+
+- **mode** — workspace / range / commit
+- **ref 元数据** — from、to、commit、merge\_base
+- **可审查文件列表** — 路径、状态、插入/删除行数
+- **已排除文件** — 及排除原因
+
+常见用法：
+
+| 场景 | 命令 |
+|------|------|
+| 工作区变更 | `ocr delegate preview` |
+| 分支对比 | `ocr delegate preview --from main --to feature` |
+| 单次提交 | `ocr delegate preview -c abc123` |
+
+### 第 2 步：获取文件规则
+
+```bash
+ocr delegate rule <path1> <path2> ...
+```
+
+传入第 1 步中的可审查文件路径。输出按规则内容分组 — 共享相同规则的文件归为一组，避免重复。
+
+### 第 3 步：获取 diff
+
+根据第 1 步的 mode/ref 信息，使用 git 直接获取：
+
+**Range 模式**（有 merge\_base）：
+```bash
+git diff <merge_base>..<to> -- <path>
+```
+
+**Commit 模式**：
+```bash
+git show <commit> -- <path>
+```
+
+**Workspace 模式**：
+```bash
+git diff HEAD -- <path>        # 已跟踪文件
+cat <path>                     # 新的未跟踪文件
+```
+
+### 第 4 步：审查每个文件
+
+对每个可审查文件：
+
+1. 获取其 diff（第 3 步）
+2. 参照匹配的规则组（第 2 步）作为审查清单
+3. 进行深入审查，按需探索上下文
+
+### 第 5 步：报告
+
+按严重程度分类：
+
+- **Critical/High** — Bug、安全问题、数据丢失风险。始终报告。
+- **Medium** — 性能问题、错误处理缺失。附带上下文报告。
+- **Low** — 风格建议、细微改进。静默丢弃，除非确有价值。
+
+## 子命令参考
+
+| 命令 | 用途 |
+|------|------|
+| `ocr delegate preview` | 列出可审查文件 + mode/ref 元数据 |
+| `ocr delegate rule <path...>` | 按内容分组解析审查规则 |
+
+## 通用标志
+
+| 标志 | 描述 |
+|------|------|
+| `--from <ref>` | Range 模式的源引用 |
+| `--to <ref>` | Range 模式的目标引用 |
+| `-c, --commit <hash>` | 单次提交模式 |
+| `--repo <path>` | 仓库根目录（默认：cwd） |
+| `--rule <path>` | 自定义 rule.json 路径 |
+| `--exclude <patterns>` | 逗号分隔的排除模式 |
+| `-b, --background <text>` | 业务上下文 |
+| `-B, --background-file <path>` | 从 Markdown 文件读取业务上下文 |
+
+## 与其他集成方式的对比
+
+| 模式 | 谁调用 LLM？ | 适用场景 |
+|------|-------------|----------|
+| [Agent Skill](../agent-skill/) | OCR | Agent 调用 `ocr review`，OCR 驱动完整审查 |
+| [Command（Claude Code）](../claude-code/) | OCR | Claude Code 中的斜杠命令，OCR 驱动审查 |
+| **委托模式** | 宿主 Agent | OCR 提供脚手架，Agent 驱动审查 |
+| [Direct Subprocess](../subprocess/) | OCR | 手动 CLI 调用 |
+
+## 另请参阅
+
+- [Agent Skill](../agent-skill/) — OCR 代表 Agent 驱动完整审查。
+- [Command（Claude Code）](../claude-code/) — 斜杠命令风格，含自动修复。
+- [Direct Subprocess](../subprocess/) — 跳过 skill/command，直接调用 CLI。

--- a/pages/src/i18n/en.ts
+++ b/pages/src/i18n/en.ts
@@ -272,6 +272,7 @@ export const en: TranslationKeys = {
   'docs.sidebar.integrations': 'Integrations',
   'docs.sidebar.agentSkill': 'Agent Skill',
   'docs.sidebar.claudeCode': 'Command (Claude Code)',
+  'docs.sidebar.delegate': 'Delegation Mode',
   'docs.sidebar.subprocess': 'Direct Subprocess',
   'docs.sidebar.cicd': 'CI/CD',
   'docs.sidebar.contributing': 'Contributing',

--- a/pages/src/i18n/ja.ts
+++ b/pages/src/i18n/ja.ts
@@ -274,6 +274,7 @@ export const ja: TranslationKeys = {
   'docs.sidebar.integrations': '統合',
   'docs.sidebar.agentSkill': 'Agent Skill',
   'docs.sidebar.claudeCode': 'Command（Claude Code）',
+  'docs.sidebar.delegate': 'デリゲーションモード',
   'docs.sidebar.subprocess': 'Direct Subprocess',
   'docs.sidebar.cicd': 'CI/CD',
   'docs.sidebar.contributing': 'コントリビュート',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -274,6 +274,7 @@ export const zh: TranslationKeys = {
   'docs.sidebar.integrations': '集成',
   'docs.sidebar.agentSkill': 'Agent Skill',
   'docs.sidebar.claudeCode': 'Command（Claude Code）',
+  'docs.sidebar.delegate': '委托模式',
   'docs.sidebar.subprocess': 'Direct Subprocess',
   'docs.sidebar.cicd': 'CI/CD',
   'docs.sidebar.contributing': '贡献',

--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -50,6 +50,7 @@ const sidebarTree: SidebarGroup[] = [
         children: [
           { id: 'sb-agent-skill', labelKey: 'docs.sidebar.agentSkill', slug: 'agent-skill' },
           { id: 'sb-claude-code', labelKey: 'docs.sidebar.claudeCode', slug: 'claude-code' },
+          { id: 'sb-delegate', labelKey: 'docs.sidebar.delegate', slug: 'delegate' },
           { id: 'sb-subprocess', labelKey: 'docs.sidebar.subprocess', slug: 'subprocess' },
           { id: 'sb-cicd', labelKey: 'docs.sidebar.cicd', slug: 'cicd' },
         ],

--- a/pages/src/styles/docs-markdown.css
+++ b/pages/src/styles/docs-markdown.css
@@ -100,6 +100,14 @@
   padding-left: 24px;
 }
 
+.docs-markdown ul {
+  list-style-type: disc;
+}
+
+.docs-markdown ol {
+  list-style-type: decimal;
+}
+
 .docs-markdown li {
   margin-bottom: 6px;
   color: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
## Summary

- Add a new **Delegation Mode** page under Integrations in the docs site, documenting the `ocr delegate` subcommand workflow for subscription-based AI coding agents (Claude Code, Codex, Cursor, Open Code, Qoder)
- New documentation in English, Chinese, and Japanese (`integrations/delegate.md`)
- Register the `delegate` slug, sidebar entry, and i18n labels
- Fix `list-style-type` reset caused by Tailwind Preflight so ordered/unordered lists render correctly in docs

## Test plan

- [ ] `cd pages && npm run build` passes without errors
- [ ] Visit `/docs/delegate` — page renders correctly with all sections
- [ ] Sidebar shows "Delegation Mode" under Integrations
- [ ] Ordered lists (1. 2. 3.) and unordered lists display markers correctly
- [ ] Search (⌘K) finds "delegate" content
- [ ] Prev/Next pagination works correctly