### PR TITLE
docs(pages): note that LLM API key is optional in delegation mode

### DIFF
--- a/pages/src/content/docs/en/quickstart.md
+++ b/pages/src/content/docs/en/quickstart.md
@@ -10,7 +10,7 @@ Get your first code review running in a few minutes.
 
 - **Git ≥ 2.41**
 - **Node.js ≥ 18**
-- **LLM API key**
+- **LLM API key** (not needed if using [Delegation Mode](../integrations/delegate/))
 
 ## Step 1 — Install the CLI
 
@@ -25,6 +25,8 @@ ocr version
 > See [Installation](../installation/) for more methods.
 
 ## Step 2 — Configure an LLM
+
+> If you're using [Delegation Mode](../integrations/delegate/) (e.g. running inside Claude Code), the host agent supplies the model — skip to Step 4.
 
 ```bash
 ocr config provider

--- a/pages/src/content/docs/ja/quickstart.md
+++ b/pages/src/content/docs/ja/quickstart.md
@@ -10,7 +10,7 @@ sidebar:
 
 - **Git ≥ 2.41**
 - **Node.js ≥ 18**
-- **LLM API key**
+- **LLM API key**（[委任モード](../integrations/delegate/)使用時は不要）
 
 ## ステップ 1 —— CLI をインストールする
 
@@ -25,6 +25,8 @@ ocr version
 > その他の方法は [インストール](../installation/) を参照してください。
 
 ## ステップ 2 —— LLM を設定する
+
+> [委任モード](../integrations/delegate/)を使用している場合（例：Claude Code 内で実行）、ホスト agent がモデルを提供します —— ステップ 4 に進んでください。
 
 ```bash
 ocr config provider

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -10,7 +10,7 @@ sidebar:
 
 - **Git ≥ 2.41**
 - **Node.js ≥ 18**
-- **LLM API key**
+- **LLM API key**（使用[委托模式](../integrations/delegate/)时不需要）
 
 ## 第 1 步 —— 安装 CLI
 
@@ -25,6 +25,8 @@ ocr version
 > 更多方式见 [安装](../installation/)。
 
 ## 第 2 步 —— 配置 LLM
+
+> 如果你使用的是[委托模式](../integrations/delegate/)（如在 Claude Code 中运行），宿主 agent 会提供模型 —— 可直接跳到第 4 步。
 
 ```bash
 ocr config provider


### PR DESCRIPTION
## Summary

- Add a parenthetical note to the quickstart prerequisites clarifying that an LLM API key is not needed when using Delegation Mode.
- Add a tip blockquote before Step 2 telling delegation-mode users (e.g. running inside Claude Code) they can skip Steps 2–3 and go straight to Step 4.
- Applied across all three locale versions (en, zh, ja).