### PR TITLE
feat(pages): expand Integrations sidebar group by default

### DIFF
--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -131,7 +131,7 @@ const DocsPage: React.FC = () => {
   /* Active doc slug is derived from the URL param, falling back to quickstart */
   const activeSlug: DocSlug =
     slugParam && validSlugs.has(slugParam as DocSlug) ? (slugParam as DocSlug) : 'quickstart';
-  const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({ 'sb-integrations': false });
+  const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({ 'sb-integrations': true });
   const [activeHeadingId, setActiveHeadingId] = useState<string>('');
   const [hoveredHeadingId, setHoveredHeadingId] = useState<string>('');
   const [searchOpen, setSearchOpen] = useState(false);


### PR DESCRIPTION
# feat(pages): expand Integrations sidebar group by default

## Problem

The **Integrations** group in the docs sidebar defaults to collapsed, so its child pages are hidden unless a visitor notices the chevron or lands on a child page via a deep link. Issue #388 asks for the group to be expanded by default for better discoverability.

## Change

One-line change in `pages/src/pages/DocsPage.tsx`: the initial `expandedItems` state for `sb-integrations` flips from `false` to `true`.

- `sb-integrations` is the only sidebar item with `children`, so this is the only group affected.
- `toggleExpand` flips per-id state, so clicking the header still collapses/re-expands the group.
- The auto-expand-on-active-child effect only ever sets `true`, so it does not conflict with the new default.

Note: the issue mentions 5 child pages; it is now 4 (Agent Skill, Command (Claude Code), Delegation Mode, CI/CD) after #390 removed the Direct Subprocess page.

## Verification

`pages/` has no test harness (scripts are `dev`/`typecheck`/`build` only), so this was verified manually in a browser against the issue's acceptance criteria:

- [x] Integrations group is expanded on initial load of `/#/docs`
- [x] Clicking the group header collapses it; clicking again re-expands it
- [x] With the group collapsed, deep-linking to a child slug (`/#/docs/claude-code`) auto-expands the group
- [x] No sidebar layout regressions (indentation, chevron, scroll all render as before)

Also green:

```
npm run typecheck
npm run build
```

Fixes #388
