### PR TITLE
feat: add install.ps1 for Windows one-line install

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -148,6 +148,18 @@ $env:OCR_VERSION = "v1.3.13"
 irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
 ```
 
+リモートスクリプトをシェルに直接パイプすると、インターネット上のコードが実行されます。先にダウンロードして内容を確認してから実行することを推奨します：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+notepad install.ps1   # 確認後: .\install.ps1
+```
+
 <details>
 <summary>手動ダウンロード（Windows を含む全プラットフォーム）</summary>
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -134,6 +134,20 @@ OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
 ```
 
+Windows（PowerShell 5.1+）では：
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+このスクリプトは適切な Windows リリースバイナリを選択し、SHA-256 チェックサムを検証して、`ocr.exe` として `%LOCALAPPDATA%\Programs\ocr` にインストールします。インストール先は `OCR_INSTALL_DIR` で、リリースバージョンは `OCR_VERSION` で上書きできます：
+
+```powershell
+$env:OCR_INSTALL_DIR = "$env:USERPROFILE\bin"
+$env:OCR_VERSION = "v1.3.13"
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
 <details>
 <summary>手動ダウンロード（Windows を含む全プラットフォーム）</summary>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -148,6 +148,18 @@ $env:OCR_VERSION = "v1.3.13"
 irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
 ```
 
+원격 스크립트를 셸로 바로 파이프하면 인터넷의 코드가 실행됩니다. 먼저 다운로드해 내용을 확인한 뒤 실행하는 방식을 권장합니다:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+notepad install.ps1   # 확인 후: .\install.ps1
+```
+
 <details>
 <summary>수동 다운로드 (Windows 포함 모든 플랫폼)</summary>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -134,6 +134,20 @@ OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
 ```
 
+Windows (PowerShell 5.1+)에서는:
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+이 스크립트는 알맞은 Windows 릴리스 binary를 선택하고 SHA-256 체크섬을 검증한 뒤 `ocr.exe`로 `%LOCALAPPDATA%\Programs\ocr`에 설치합니다. 설치 위치는 `OCR_INSTALL_DIR`로, 릴리스 버전은 `OCR_VERSION`으로 재정의할 수 있습니다:
+
+```powershell
+$env:OCR_INSTALL_DIR = "$env:USERPROFILE\bin"
+$env:OCR_VERSION = "v1.3.13"
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
 <details>
 <summary>수동 다운로드 (Windows 포함 모든 플랫폼)</summary>
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ $env:OCR_VERSION = "v1.3.13"
 irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
 ```
 
+Piping a remote script into a shell executes code from the internet. Prefer downloading and inspecting first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+notepad install.ps1   # review, then: .\install.ps1
+```
+
 <details>
 <summary>Manual download (all platforms, including Windows)</summary>
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
 ```
 
+On Windows (PowerShell 5.1+):
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+The script picks the right Windows release binary, verifies its SHA-256 checksum, and installs it as `ocr.exe` in `%LOCALAPPDATA%\Programs\ocr`. Override the target with `OCR_INSTALL_DIR` or pin a release with `OCR_VERSION`:
+
+```powershell
+$env:OCR_INSTALL_DIR = "$env:USERPROFILE\bin"
+$env:OCR_VERSION = "v1.3.13"
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
 <details>
 <summary>Manual download (all platforms, including Windows)</summary>
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -134,6 +134,20 @@ OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
 ```
 
+В Windows (PowerShell 5.1+):
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+Скрипт сам выбирает подходящий Windows-бинарный файл релиза, проверяет его контрольную сумму SHA-256 и устанавливает его как `ocr.exe` в `%LOCALAPPDATA%\Programs\ocr`. Каталог установки можно переопределить через `OCR_INSTALL_DIR`, а версию релиза зафиксировать через `OCR_VERSION`:
+
+```powershell
+$env:OCR_INSTALL_DIR = "$env:USERPROFILE\bin"
+$env:OCR_VERSION = "v1.3.13"
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
 <details>
 <summary>Ручная загрузка (все платформы, включая Windows)</summary>
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -148,6 +148,18 @@ $env:OCR_VERSION = "v1.3.13"
 irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
 ```
 
+Передача удалённого скрипта напрямую в shell выполняет код из интернета. Лучше сначала скачать и просмотреть скрипт:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+notepad install.ps1   # просмотрите, затем: .\install.ps1
+```
+
 <details>
 <summary>Ручная загрузка (все платформы, включая Windows)</summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,20 @@ OCR_INSTALL_DIR="$HOME/.local/bin" OCR_VERSION=v1.3.13 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh)"
 ```
 
+在 Windows 上（PowerShell 5.1+）：
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+该脚本会自动选择匹配的 Windows 发布二进制文件，校验其 SHA-256 校验和，并将其作为 `ocr.exe` 安装到 `%LOCALAPPDATA%\Programs\ocr`。可通过 `OCR_INSTALL_DIR` 覆盖安装目录，或通过 `OCR_VERSION` 指定发布版本：
+
+```powershell
+$env:OCR_INSTALL_DIR = "$env:USERPROFILE\bin"
+$env:OCR_VERSION = "v1.3.13"
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
 <details>
 <summary>手动下载（所有平台，包括 Windows）</summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,6 +148,18 @@ $env:OCR_VERSION = "v1.3.13"
 irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
 ```
 
+将远程脚本直接管道到 shell 会执行来自互联网的代码。建议先下载并检查后再运行：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+notepad install.ps1   # 检查后执行: .\install.ps1
+```
+
 <details>
 <summary>手动下载（所有平台，包括 Windows）</summary>
 

--- a/install.ps1
+++ b/install.ps1
@@ -15,11 +15,8 @@ function Err([string]$Message) {
 
 function Get-OcrArch {
     $arch = $env:PROCESSOR_ARCHITECTURE
-    if ([string]::IsNullOrEmpty($arch) -and [System.Environment]::Is64BitOperatingSystem) {
-        $arch = 'AMD64'
-    }
     if ([string]::IsNullOrEmpty($arch)) {
-        Err 'could not determine processor architecture'
+        Err 'unable to detect architecture (PROCESSOR_ARCHITECTURE is empty); please set it manually'
     }
     switch -Regex ($arch) {
         '^(AMD64|X64|x86_64)$' { return 'amd64' }

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,8 @@
 # Install the ocr (Open Code Review) CLI from GitHub releases on Windows.
 #   irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+# Prefer to inspect first:
+#   irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+#   notepad install.ps1   # review, then: .\install.ps1
 # Env: OCR_INSTALL_DIR (default $env:LOCALAPPDATA\Programs\ocr), OCR_VERSION (default latest).
 # Requires PowerShell 5.1+ or PowerShell 7+.
 
@@ -15,10 +18,13 @@ function Get-OcrArch {
     if ([string]::IsNullOrEmpty($arch) -and [System.Environment]::Is64BitOperatingSystem) {
         $arch = 'AMD64'
     }
+    if ([string]::IsNullOrEmpty($arch)) {
+        Err 'could not determine processor architecture'
+    }
     switch -Regex ($arch) {
         '^(AMD64|X64|x86_64)$' { return 'amd64' }
         '^(ARM64|aarch64)$' { return 'arm64' }
-        default { Err "unsupported architecture: $arch" }
+        default { Err "unsupported architecture: $arch (only amd64 and arm64 are supported)" }
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,139 @@
+# Install the ocr (Open Code Review) CLI from GitHub releases on Windows.
+#   irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+# Env: OCR_INSTALL_DIR (default $env:LOCALAPPDATA\Programs\ocr), OCR_VERSION (default latest).
+# Requires PowerShell 5.1+ or PowerShell 7+.
+
+$ErrorActionPreference = 'Stop'
+
+function Err([string]$Message) {
+    [Console]::Error.WriteLine("error: $Message")
+    exit 1
+}
+
+function Get-OcrArch {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if ([string]::IsNullOrEmpty($arch) -and [System.Environment]::Is64BitOperatingSystem) {
+        $arch = 'AMD64'
+    }
+    switch -Regex ($arch) {
+        '^(AMD64|X64|x86_64)$' { return 'amd64' }
+        '^(ARM64|aarch64)$' { return 'arm64' }
+        default { Err "unsupported architecture: $arch" }
+    }
+}
+
+function Resolve-OcrVersion([string]$Repo) {
+    $version = $env:OCR_VERSION
+    if (-not [string]::IsNullOrWhiteSpace($version)) {
+        return $version.Trim()
+    }
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    } catch {
+        Err "failed to fetch latest release info from github api"
+    }
+    if (-not $release.tag_name) {
+        Err 'could not resolve latest release tag'
+    }
+    return [string]$release.tag_name
+}
+
+function Get-ChecksumFromFile([string]$ChecksumFile, [string]$AssetName) {
+    foreach ($line in Get-Content -LiteralPath $ChecksumFile) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $parts = $line.Trim() -split '\s+', 2
+        if ($parts.Count -eq 2 -and $parts[1] -eq $AssetName) {
+            return $parts[0].ToLowerInvariant()
+        }
+    }
+    return $null
+}
+
+function Install-OcrBinary([string]$Source, [string]$InstallDir, [string]$BinName) {
+    try {
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+        $dest = Join-Path $InstallDir $BinName
+        Copy-Item -LiteralPath $Source -Destination $dest -Force
+    } catch {
+        Err "$InstallDir is not writable; set OCR_INSTALL_DIR to a writable path"
+    }
+}
+
+function Show-PostInstallPathNotice([string]$BinName, [string]$InstallDir) {
+    $pathEntries = $env:PATH -split ';' | ForEach-Object { $_.TrimEnd('\') }
+    $normalizedInstall = $InstallDir.TrimEnd('\')
+    $onPath = $false
+    foreach ($entry in $pathEntries) {
+        if ($entry -and [string]::Equals($entry, $normalizedInstall, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $onPath = $true
+            break
+        }
+    }
+    if (-not $onPath) {
+        Write-Host "note: $InstallDir is not on your PATH; add it or run $InstallDir\$BinName directly"
+        return
+    }
+    if (-not (Get-Command $BinName -ErrorAction SilentlyContinue)) {
+        Write-Host "note: open a new shell so $BinName resolves on PATH"
+    }
+}
+
+# Ensure TLS 1.2 for Windows PowerShell 5.1 (Invoke-WebRequest / Invoke-RestMethod).
+try {
+    [Net.ServicePointManager]::SecurityProtocol = `
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+    # Ignore if the runtime already negotiates modern TLS.
+}
+
+$Repo = 'alibaba/open-code-review'
+$Bin = 'ocr.exe'
+$AssetPrefix = 'opencodereview'
+$DefaultInstallDir = Join-Path $env:LOCALAPPDATA 'Programs\ocr'
+$InstallDir = if (-not [string]::IsNullOrWhiteSpace($env:OCR_INSTALL_DIR)) {
+    $env:OCR_INSTALL_DIR.Trim()
+} else {
+    $DefaultInstallDir
+}
+
+$arch = Get-OcrArch
+$os = 'windows'
+$Version = Resolve-OcrVersion $Repo
+$asset = "$AssetPrefix-$os-$arch.exe"
+$base = "https://github.com/$Repo/releases/download/$Version"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("ocr-install-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+try {
+    $assetPath = Join-Path $tmp $asset
+    $sumPath = Join-Path $tmp 'sha256sum.txt'
+
+    Write-Host "downloading $Bin $Version ($os/$arch)..."
+    try {
+        Invoke-WebRequest -Uri "$base/$asset" -OutFile $assetPath -UseBasicParsing
+    } catch {
+        Err "download failed: $base/$asset"
+    }
+    try {
+        Invoke-WebRequest -Uri "$base/sha256sum.txt" -OutFile $sumPath -UseBasicParsing
+    } catch {
+        Err 'sha256sum.txt download failed'
+    }
+
+    $want = Get-ChecksumFromFile $sumPath $asset
+    if ([string]::IsNullOrEmpty($want)) {
+        Err "no checksum entry for $asset in sha256sum.txt"
+    }
+    $got = (Get-FileHash -LiteralPath $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($got -ne $want) {
+        Err "checksum mismatch for $asset (got $got, want $want)"
+    }
+
+    Install-OcrBinary $assetPath $InstallDir $Bin
+
+    Write-Host "installed $Bin $Version -> $InstallDir\$Bin"
+    Show-PostInstallPathNotice $Bin $InstallDir
+} finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Install the ocr (Open Code Review) CLI from GitHub releases.
 #   curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+# Prefer to inspect first:
+#   curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+#   less install.sh && sh install.sh
 # Env: OCR_INSTALL_DIR (default /usr/local/bin), OCR_VERSION (default latest).
 set -eu
 

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ main() {
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   case "$os" in
     darwin|linux) ;;
-    *) err "unsupported OS: $os (download the Windows binary from GitHub releases)" ;;
+    *) err "unsupported OS: $os (on Windows use: irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex)" ;;
   esac
 
   arch="$(uname -m)"


### PR DESCRIPTION
## Description

Adds a PowerShell installer so Windows users get the same one-command experience as macOS/Linux with `install.sh`:

```powershell
irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
```

The script detects amd64/arm64, resolves the latest release (or `OCR_VERSION`), downloads `opencodereview-windows-<arch>.exe` and `sha256sum.txt`, verifies the SHA-256 checksum with `Get-FileHash`, and installs `ocr.exe` to `%LOCALAPPDATA%\Programs\ocr` (overridable via `OCR_INSTALL_DIR`). It also prints a PATH notice when the install directory is not on PATH.

Also updates `install.sh`'s unsupported-OS hint to point at this one-liner, and documents the PowerShell install path in `README.md` and all localized README variants.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

- `pwsh` AST parse check of `install.ps1` — clean
- `sh -n install.sh` — clean
- Confirmed live release `v1.7.12` `sha256sum.txt` contains entries for both `opencodereview-windows-amd64.exe` and `opencodereview-windows-arm64.exe`
- `make check` and `make test` — passed

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues
Fixes #396 