### PR TITLE
docs(pages): document PowerShell install.ps1 on installation pages

### DIFF
--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -58,9 +58,17 @@ It honours two environment variables:
 | `OCR_INSTALL_DIR` | `/usr/local/bin` | Where to place the `ocr` binary. |
 | `OCR_VERSION` | latest release | Pin a specific release tag (e.g. `v1.2.3`). |
 
-The script supports `darwin` and `linux` on `amd64` / `arm64`; for
-Windows, use the [GitHub Release binary](#github-release-binary) or
-[NPM](#npm-recommended) path instead.
+The script supports `darwin` and `linux` on `amd64` / `arm64`.
+
+On Windows (PowerShell 5.1+), use the PowerShell installer instead:
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+It honours the same `OCR_INSTALL_DIR` and `OCR_VERSION` variables (set via
+`$env:OCR_INSTALL_DIR` / `$env:OCR_VERSION`). The default install location is
+`%LOCALAPPDATA%\Programs\ocr`.
 
 ## GitHub Release binary
 

--- a/pages/src/content/docs/ja/installation.md
+++ b/pages/src/content/docs/ja/installation.md
@@ -56,9 +56,17 @@ curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/insta
 | `OCR_INSTALL_DIR` | `/usr/local/bin` | `ocr` バイナリを配置する場所。 |
 | `OCR_VERSION` | 最新 release | 特定の release tag に固定します（例：`v1.2.3`）。 |
 
-このスクリプトは `darwin` と `linux` の `amd64` / `arm64` をサポートします。Windows では
-[GitHub Release バイナリ](#github-release-binary) または [NPM](#npm-recommended)
-の方法を使用してください。
+このスクリプトは `darwin` と `linux` の `amd64` / `arm64` をサポートします。
+
+Windows（PowerShell 5.1+）では、代わりに PowerShell インストーラーを使用してください：
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+同じ `OCR_INSTALL_DIR` と `OCR_VERSION` を認識します（`$env:OCR_INSTALL_DIR` /
+`$env:OCR_VERSION` で設定）。デフォルトのインストール先は
+`%LOCALAPPDATA%\Programs\ocr` です。
 
 ## GitHub Release バイナリ
 

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -54,9 +54,16 @@ curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/insta
 | `OCR_INSTALL_DIR` | `/usr/local/bin` | 放置 `ocr` 二进制的位置。 |
 | `OCR_VERSION` | 最新 release | 固定到某个 release tag（如 `v1.2.3`）。 |
 
-该脚本支持 `darwin` 与 `linux` 的 `amd64` / `arm64`；Windows 请改用
-[GitHub Release 二进制](#github-release-binary)或 [NPM](#npm-recommended)
-方式。
+该脚本支持 `darwin` 与 `linux` 的 `amd64` / `arm64`。
+
+在 Windows（PowerShell 5.1+）上，请改用 PowerShell 安装脚本：
+
+```powershell
+irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+```
+
+它同样识别 `OCR_INSTALL_DIR` 与 `OCR_VERSION`（通过 `$env:OCR_INSTALL_DIR` /
+`$env:OCR_VERSION` 设置）。默认安装位置为 `%LOCALAPPDATA%\Programs\ocr`。
 
 ## GitHub Release 二进制
 


### PR DESCRIPTION
## Summary

- Replace the Windows “use Release binary or NPM” note on the docs Installation page with the `install.ps1` one-liner.
- Document that PowerShell honours the same `OCR_INSTALL_DIR` / `OCR_VERSION` env vars (via `$env:…`) and defaults to `%LOCALAPPDATA%\Programs\ocr`.
- Applied across all three locale versions (en, zh, ja).

Follow-up to #397 / #396 — README already covered `install.ps1`; the docs site did not.

## Validation

- [x] `cd pages && npm install && npm run typecheck`
- [x] `cd pages && npm run build`
- [x] `make check` passes
- [x] `make test` passes

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #398 