### PR TITLE
feat(pages): serve landing site at custom-domain root with clean URLs

### DIFF
--- a/pages/public/CNAME
+++ b/pages/public/CNAME
@@ -1,0 +1,1 @@
+open-codereview.ai

--- a/pages/src/components/HeroSection.tsx
+++ b/pages/src/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
+import { Link } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import { useResponsive } from '../hooks/useResponsive';
 import ColorBends from './ColorBends';
@@ -313,8 +314,8 @@ const HeroSection: React.FC = () => {
           >
             {t('hero.quickStart')}
           </a>
-          <a
-            href="#/docs"
+          <Link
+            to="/docs"
             style={{
               height: 32,
               display: 'flex',
@@ -330,7 +331,7 @@ const HeroSection: React.FC = () => {
             }}
           >
             {t('hero.learnMore')}
-          </a>
+          </Link>
         </div>
 
         {/* Terminal */}

--- a/pages/src/index.tsx
+++ b/pages/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { LanguageProvider } from './i18n';
 import './styles/index.css';
@@ -16,9 +16,9 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <LanguageProvider>
-      <HashRouter>
+      <BrowserRouter>
         <App />
-      </HashRouter>
+      </BrowserRouter>
     </LanguageProvider>
   </React.StrictMode>
 );

--- a/pages/webpack.config.js
+++ b/pages/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
-    publicPath: process.env.NODE_ENV === 'production' ? '/open-code-review/' : '/'
+    publicPath: '/'
   },
   module: {
     rules: [
@@ -64,6 +64,13 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: './index.html',
       inject: 'body'
+    }),
+    // SPA fallback: serve the app shell for deep links / refreshes on client-side
+    // routes (BrowserRouter). GitHub Pages returns this for unknown paths.
+    new HtmlWebpackPlugin({
+      template: './index.html',
+      inject: 'body',
+      filename: '404.html'
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
## What

Prepares the landing site (`pages/`) to be served at the **root of the `open-codereview.ai` custom domain** and drops the `/#/` from URLs.

- **`webpack.config.js`**: `publicPath` → `/` so assets load at the domain root (previously hard-coded to the `/open-code-review/` GitHub Pages subpath). Adds a second `HtmlWebpackPlugin` that emits `404.html` (a copy of `index.html`) as an SPA deep-link fallback.
- **`src/index.tsx`**: `HashRouter` → `BrowserRouter` for clean paths (e.g. `/docs` instead of `/#/docs`).
- **`src/components/HeroSection.tsx`**: replace the hard-coded `href="#/docs"` anchor with a router `<Link to="/docs">` (the in-page `#quickstart` anchor is intentionally kept).
- **`public/CNAME`**: add `open-codereview.ai` so GitHub Pages serves the site at the custom-domain root.

## Why

The site is moving from `alibaba.github.io/open-code-review/` to the short custom domain `open-codereview.ai`. Serving at a subpath forces the ugly `/open-code-review/` asset prefix and the `HashRouter` `/#/` URLs. This change makes the build target the domain root and produces clean, shareable URLs.

## Release note ⚠️

Merging this to `main` triggers the Pages deploy, which activates the `CNAME` and makes GitHub Pages claim `open-codereview.ai` (and redirect the old subpath). **This must be merged in coordination with the DNS cutover** — if DNS is not yet pointing the domain at GitHub Pages, the site will be unreachable until it is.

Client-side routing (`BrowserRouter`) relies on the `404.html` fallback on plain GitHub Pages; once the site moves behind a CDN, the fallback should be handled by the CDN (404 → `index.html`, HTTP 200).

## Verification

- `npm run build` succeeds; `dist/index.html` references assets at root (`/bundle.js`), `dist/404.html` matches `index.html`, and `dist/CNAME` contains `open-codereview.ai`.
- `ocr review` on the diff: 0 comments.