### PR TITLE
fix(pages): scroll docs deep links on load

### DIFF
--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
@@ -19,6 +19,28 @@ function decodeFragment(fragment: string): string {
   } catch {
     return fragment;
   }
+}
+
+// Markdown renders a frame or more after navigation, so a fragment's heading
+// may not exist yet. Retry across a few frames; the returned canceller stops a
+// stale chain when navigation moves on.
+function scrollToFragmentWhenReady(id: string): () => void {
+  let frame = 0;
+  let cancelled = false;
+  const tryScroll = (attempts: number) => {
+    if (cancelled) return;
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else if (attempts < 10) {
+      frame = requestAnimationFrame(() => tryScroll(attempts + 1));
+    }
+  };
+  frame = requestAnimationFrame(() => tryScroll(0));
+  return () => {
+    cancelled = true;
+    cancelAnimationFrame(frame);
+  };
 }
 
 /* ─── Sidebar tree data ─── */
@@ -138,6 +160,7 @@ if (process.env.NODE_ENV !== 'production' && validSlugs.size !== flatDocList.len
 const DocsPage: React.FC = () => {
   const { slug: slugParam } = useParams<{ slug?: string }>();
   const navigate = useNavigate();
+  const { hash } = useLocation();
   /* Active doc slug is derived from the URL param, falling back to quickstart */
   const activeSlug: DocSlug =
     slugParam && validSlugs.has(slugParam as DocSlug) ? (slugParam as DocSlug) : 'quickstart';
@@ -148,6 +171,8 @@ const DocsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchSelectedIdx, setSearchSelectedIdx] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  /* Cancels an in-flight click-triggered scroll when a newer one starts */
+  const cancelPendingScroll = useRef<(() => void) | null>(null);
   const { t, language } = useTranslation();
   const { isMobile } = useResponsive();
   const contentRef = React.useRef<HTMLDivElement>(null);
@@ -158,6 +183,13 @@ const DocsPage: React.FC = () => {
   const docContent = useMemo(() => getDocContent(activeSlug, language), [activeSlug, language]);
   const docTitle = useMemo(() => getDocTitle(activeSlug, language), [activeSlug, language]);
   const headings = useMemo(() => extractHeadings(docContent), [docContent]);
+
+  /* Scroll direct links after their markdown heading has rendered */
+  useEffect(() => {
+    const fragment = hash.startsWith('#') ? hash.slice(1) : hash;
+    if (!fragment) return;
+    return scrollToFragmentWhenReady(decodeFragment(fragment));
+  }, [hash, docContent]);
 
   /* Track active heading via IntersectionObserver */
   useEffect(() => {
@@ -230,15 +262,8 @@ const DocsPage: React.FC = () => {
       const anchor2raw = href.split('#')[1];
       const anchor2 = anchor2raw ? decodeFragment(anchor2raw) : undefined;
       if (anchor2) {
-        const tryScroll = (attempts: number) => {
-          const el = document.getElementById(anchor2);
-          if (el) {
-            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          } else if (attempts < 10) {
-            requestAnimationFrame(() => tryScroll(attempts + 1));
-          }
-        };
-        requestAnimationFrame(() => tryScroll(0));
+        cancelPendingScroll.current?.();
+        cancelPendingScroll.current = scrollToFragmentWhenReady(anchor2);
       }
     }
   }, [navigateToDoc]);


### PR DESCRIPTION
## Description

Direct docs links now scroll to their fragment after the rendered markdown heading is available. The effect reads React Router's location hash, decodes percent-encoded fragments, retries briefly while content renders, and cancels stale retries when navigation changes.

Since #407 switched the site to BrowserRouter, verification used the equivalent clean URLs under `/docs/...`.

AI assistance: OpenAI Codex helped implement and verify this change. I reviewed the full diff and take responsibility for it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing:
  - `make check`
  - `cd pages && npm run typecheck`
  - `cd pages && npm run build`
  - Playwright: direct English fragment
  - Playwright: encoded CJK fragment
  - Playwright: fragment change after mount
  - Playwright: unknown fragment produces no error
  - Playwright: existing cross-page click still scrolls

## Screenshots

Before, a directly loaded fragment remains at the top of the FAQ:

![Before](https://raw.githubusercontent.com/fjbarrett/open-code-review/aca0fd1f21fc731f32af727cb6a8dc80d98444b0/screenshots/docs-deep-link-before-2026-07-20-151cc75.png)

After, the same URL scrolls to the requested FAQ section:

![After](https://raw.githubusercontent.com/fjbarrett/open-code-review/aca0fd1f21fc731f32af727cb6a8dc80d98444b0/screenshots/docs-deep-link-after-2026-07-20.png)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works (the frontend currently has no automated test runner; covered with Playwright browser verification above)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

## Related Issues

Closes #412
