### PR TITLE
docs(telemetry): explain why checkMetricErr intentionally ignores errors

### DIFF
--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -67,9 +67,8 @@ func ensureMetrics() {
 	checkMetricErr(err)
 }
 
-// checkMetricErr intentionally ignores metric registration errors.
-// Telemetry is best-effort, and a failed metric registration 
-// should not break or interrupt the main application flow.
+// checkMetricErr intentionally ignores metric registration errors:
+// telemetry is best-effort and must not interrupt the main flow.
 func checkMetricErr(err error) {}
 
 func RecordReviewDuration(ctx context.Context, dur time.Duration) {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -67,6 +67,9 @@ func ensureMetrics() {
 	checkMetricErr(err)
 }
 
+// checkMetricErr intentionally ignores metric registration errors.
+// Telemetry is best-effort, and a failed metric registration 
+// should not break or interrupt the main application flow.
 func checkMetricErr(err error) {}
 
 func RecordReviewDuration(ctx context.Context, dur time.Duration) {


### PR DESCRIPTION
## Description

Added a doc comment to `checkMetricErr` to clarify that silently discarding the metric registration error is intentional (best-effort telemetry).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally (ignoring OS-specific permission test skips on Windows)
- [x] `make check` passes locally (ran `go mod tidy`, `go fmt`, and `go vet`)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)

## Related Issues

Fixes #416