### PR TITLE
fix(viewer): use [ocr] log prefix for consistency

### DIFF
--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -154,7 +154,7 @@ func renderTemplate(w http.ResponseWriter, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := tmpl.Execute(w, data); err != nil {
 		// Partially written — just log
-		fmt.Printf("[viewer] template execution error: %v\n", err)
+		fmt.Printf("[ocr] template execution error: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
## Description

`renderTemplate` logged its template-execution error with a `[viewer]` prefix while the
rest of the project logs under the `[ocr` prefix family. That made the line invisible to
the usual `grep '\[ocr'` triage pass.

A census of bracketed prefixes across all Go sources shows `[viewer]` was the only
stdout prefix that shares no prefix with `[ocr`:

- `"[ocr]` — 100 sites
- `"[ocr session]` — 2 sites (`internal/session/history.go:127`,
  `internal/session/persist.go:123`), a deliberate sub-namespace within the same family,
  **left unchanged**
- `"[viewer]` — 1 site, the outlier fixed here

The other bracketed literals in the tree are not log prefixes and are untouched:
`[bug]`/`[low]` in `cmd/opencodereview/output_test.go` are `buildBadge()` expectations
for the `[category · severity]` finding tag; `[A] [M] [D] [R] [B] [S]` in
`output_helpers_test.go` are `statusBadge()` file-status badges; `internal/mcp/client.go:96`
is a content placeholder inside a message body.

The change is the prefix string only. Nothing consumes this text — no test, doc, script,
or CI check references `[viewer]`, so the blast radius is stdout formatting.
`TestRenderTemplate_ExecutionError` (`internal/viewer/server_extra_test.go:145`) does
exercise this exact error path, but asserts only the `Content-Type` header and never
inspects stdout, so it passes unchanged.

One observation while in the file, offered but **not** acted on to keep this diff at one
line: `renderTemplate` writes through raw `fmt.Printf` rather than the injectable
`stdout.Writer()` used elsewhere, which is why the line cannot be captured under
`stdout.Quiet()` and why no unit test pins the prefix. Happy to follow up separately if
maintainers want that made consistent.

AI assistance: Claude Code helped implement and verify this change. I reviewed the full
diff and take responsibility for it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing:
  - `make fmt`, `make vet`, `make check` — all clean
  - `grep -rn '\[viewer\]' --include="*.go" .` — now returns nothing
  - `go test ./internal/viewer/ -run TestRenderTemplate_ExecutionError` — passes

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works (the changed
      line is a `fmt.Printf` log prefix with no consumer; `renderTemplate` bypasses the
      injectable `stdout.Writer()`, so pinning the string would need either an invasive
      refactor or `os.Stdout` hijacking. Verified by grep instead — see above.)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

## Related Issues

Closes #415
