### PR TITLE
refactor(agent,scan): share one 80% token threshold

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -591,7 +591,7 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, string,
 
 	tokenCount := llmloop.CountMessagesTokens(messages)
 	maxAllowed := a.args.Template.MaxTokens
-	tokenLimit := maxAllowed * 4 / 5 // 80% of MaxTokens
+	tokenLimit := llmloop.PromptTokenLimit(maxAllowed)
 	if tokenCount > tokenLimit {
 		msg := fmt.Sprintf("prompt tokens (%d) exceed %d%% of max_tokens(%d)", tokenCount, 80, maxAllowed)
 		fmt.Fprintf(stdout.Writer(), "[ocr] WARNING: %s for %s\n", msg, newPath)
@@ -787,7 +787,7 @@ func (a *Agent) resolveSystemRule(path string) string {
 
 // filterLargeDiffs drops diffs whose diff content alone consumes more than 80% of MaxTokens.
 func (a *Agent) filterLargeDiffs(diffs []model.Diff) []model.Diff {
-	limit := a.args.Template.MaxTokens * 4 / 5
+	limit := llmloop.PromptTokenLimit(a.args.Template.MaxTokens)
 	if limit <= 0 {
 		return diffs
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -396,6 +396,41 @@ func TestFilterLargeDiffs(t *testing.T) {
 	}
 }
 
+// exactNTokens builds a string that llm.CountTokens reports as exactly n
+// tokens, failing loudly if the tokenizer disagrees so fixture drift cannot
+// silently weaken the boundary assertions below.
+func exactNTokens(t *testing.T, n int) string {
+	t.Helper()
+	s := strings.TrimSpace(strings.Repeat("a ", n))
+	if got := llm.CountTokens(s); got != n {
+		t.Fatalf("fixture drift: llm.CountTokens(<%d-token string>) = %d, want %d", n, got, n)
+	}
+	return s
+}
+
+// TestFilterLargeDiffs_Boundary pins the 80% threshold exactly: with
+// MaxTokens=100 the limit is 80, so an 80-token diff is kept and an 81-token
+// one is dropped. TestFilterLargeDiffs above uses margins wide enough to pass
+// at any threshold, so it does not pin the value.
+func TestFilterLargeDiffs_Boundary(t *testing.T) {
+	a := New(Args{
+		Template: template.Template{MaxTokens: 100},
+	})
+
+	diffs := []model.Diff{
+		{NewPath: "at-limit.go", Diff: exactNTokens(t, 80)},
+		{NewPath: "over-limit.go", Diff: exactNTokens(t, 81)},
+	}
+
+	kept := a.filterLargeDiffs(diffs)
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept diff, got %d", len(kept))
+	}
+	if kept[0].NewPath != "at-limit.go" {
+		t.Errorf("kept wrong file: got %s, want at-limit.go", kept[0].NewPath)
+	}
+}
+
 func TestFilterLargeDiffs_ZeroMaxTokens(t *testing.T) {
 	a := New(Args{
 		Template: template.Template{MaxTokens: 0},

--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -19,6 +19,14 @@ const (
 	tokenWarningThreshold = 0.80 // immediate sync compression
 )
 
+// PromptTokenLimit returns tokenWarningThreshold (80%) of maxTokens. It is
+// shared by the agent and scan pre-flight gates, their large-input filters, and
+// computeActiveZoneSize so the threshold has a single definition. Non-positive
+// input is not special-cased — each caller decides what that means.
+func PromptTokenLimit(maxTokens int) int {
+	return int(float64(maxTokens) * tokenWarningThreshold)
+}
+
 // round groups consecutive messages starting with an assistant message
 // followed by zero or more tool result messages.
 type round struct {
@@ -88,7 +96,7 @@ func groupIntoRounds(messages []llm.Message, start int) []round {
 // remaining token budget after accounting for the frozen zone and the
 // compressed summary.
 func computeActiveZoneSize(rounds []round, messages []llm.Message, maxTokens int, reservedTokens int) int {
-	budget := int(float64(maxTokens)*tokenWarningThreshold) - reservedTokens
+	budget := PromptTokenLimit(maxTokens) - reservedTokens
 	if budget <= 0 {
 		return 0
 	}

--- a/internal/llmloop/compression_test.go
+++ b/internal/llmloop/compression_test.go
@@ -175,3 +175,40 @@ func TestCopyMessages(t *testing.T) {
 		t.Error("copyMessages should return independent slice")
 	}
 }
+
+func TestPromptTokenLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{name: "zero", maxTokens: 0, want: 0},
+		{name: "one truncates to zero", maxTokens: 1, want: 0},
+		{name: "four truncates to three", maxTokens: 4, want: 3},
+		{name: "five rounds to exact 4.0 via float half-ULP", maxTokens: 5, want: 4},
+		{name: "typical 4k context", maxTokens: 4096, want: 3276},
+		{name: "default max tokens", maxTokens: 58888, want: 47110},
+		{name: "typical 128k context", maxTokens: 128000, want: 102400},
+		{name: "typical 200k context", maxTokens: 200000, want: 160000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PromptTokenLimit(tt.maxTokens); got != tt.want {
+				t.Errorf("PromptTokenLimit(%d) = %d, want %d", tt.maxTokens, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPromptTokenLimitMatchesReplacedExpression pins the one-time migration:
+// PromptTokenLimit replaced a literal `maxTokens*4/5` at four call sites, so the
+// float form must agree with the integer form it replaced across the realistic
+// max_tokens range. This is specific to tokenWarningThreshold being 0.80 — if the
+// threshold ever changes, delete this test rather than "fixing" it.
+func TestPromptTokenLimitMatchesReplacedExpression(t *testing.T) {
+	for _, maxTokens := range []int{0, 1, 2, 3, 4, 5, 7, 40, 100, 1000, 4096, 8192, 32768, 58888, 128000, 200000, 1_000_000} {
+		if got, want := PromptTokenLimit(maxTokens), maxTokens*4/5; got != want {
+			t.Errorf("PromptTokenLimit(%d) = %d, want %d (maxTokens*4/5)", maxTokens, got, want)
+		}
+	}
+}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -437,7 +437,7 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, toolCalls []llm.ToolCall, results []tool.ToolCallResult, messages *[]llm.Message, filePath string, st *compressionState) bool {
 	maxAllowed := r.deps.Template.MaxTokens
 	softLimit := int(float64(maxAllowed) * tokenSoftThreshold)
-	warnLimit := int(float64(maxAllowed) * tokenWarningThreshold)
+	warnLimit := PromptTokenLimit(maxAllowed)
 
 	r.tryApplyPendingCompression(st, messages)
 

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -318,7 +318,7 @@ func (a *Agent) filterScanItems(items []model.ScanItem) []model.ScanItem {
 
 // filterLargeScans drops items whose content exceeds 80% of MaxTokens.
 func (a *Agent) filterLargeScans(items []model.ScanItem) []model.ScanItem {
-	limit := a.args.Template.MaxTokens * 4 / 5
+	limit := llmloop.PromptTokenLimit(a.args.Template.MaxTokens)
 	if limit <= 0 {
 		return items
 	}
@@ -552,7 +552,7 @@ func (a *Agent) executeSubtask(ctx context.Context, it model.ScanItem) error {
 
 	tokenCount := llmloop.CountMessagesTokens(messages)
 	maxAllowed := a.args.Template.MaxTokens
-	tokenLimit := maxAllowed * 4 / 5
+	tokenLimit := llmloop.PromptTokenLimit(maxAllowed)
 	if tokenCount > tokenLimit {
 		msg := fmt.Sprintf("prompt tokens (%d) exceed %d%% of max_tokens(%d)", tokenCount, 80, maxAllowed)
 		fmt.Fprintf(stdout.Writer(), "[ocr] WARNING: %s for %s\n", msg, it.Path)

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-code-review/open-code-review/internal/config/template"
+	"github.com/open-code-review/open-code-review/internal/llm"
 	"github.com/open-code-review/open-code-review/internal/llmloop"
 	"github.com/open-code-review/open-code-review/internal/model"
 	"github.com/open-code-review/open-code-review/internal/session"
@@ -248,6 +249,40 @@ func TestFilterLargeScans(t *testing.T) {
 		if it.Path == "huge.go" {
 			t.Errorf("huge.go should have been filtered")
 		}
+	}
+}
+
+// exactNTokens builds a string that llm.CountTokens reports as exactly n
+// tokens, failing loudly if the tokenizer disagrees so fixture drift cannot
+// silently weaken the boundary assertions below.
+func exactNTokens(t *testing.T, n int) string {
+	t.Helper()
+	s := strings.TrimSpace(strings.Repeat("a ", n))
+	if got := llm.CountTokens(s); got != n {
+		t.Fatalf("fixture drift: llm.CountTokens(<%d-token string>) = %d, want %d", n, got, n)
+	}
+	return s
+}
+
+// TestFilterLargeScans_Boundary pins the 80% threshold exactly: with
+// MaxTokens=100 the limit is 80, so an 80-token item is kept and an 81-token
+// one is dropped. TestFilterLargeScans above uses margins wide enough to pass
+// at any threshold, so it does not pin the value.
+func TestFilterLargeScans_Boundary(t *testing.T) {
+	tpl := makeTemplateWithFullScan()
+	tpl.MaxTokens = 100 // threshold = 80
+	a := newAgentForTest(t, tpl)
+
+	in := []model.ScanItem{
+		{Path: "at-limit.go", Content: exactNTokens(t, 80)},
+		{Path: "over-limit.go", Content: exactNTokens(t, 81)},
+	}
+	out := a.filterLargeScans(in)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 kept, got %d", len(out))
+	}
+	if out[0].Path != "at-limit.go" {
+		t.Errorf("kept wrong file: got %s, want at-limit.go", out[0].Path)
 	}
 }
 


### PR DESCRIPTION
## Description

The "80% of `max_tokens`" prompt ceiling had two encodings that could drift apart.

`tokenWarningThreshold = 0.80` is defined at `internal/llmloop/compression.go:19`, but it
is unexported — so the four call sites outside `llmloop` could not reach it and each
hardcoded `* 4 / 5` instead. This adds a small exported helper so every site shares the
single definition.

```mermaid
graph LR
  subgraph before["before — two encodings, six sites"]
    A1["agent.go:594<br/>maxAllowed * 4 / 5"]
    A2["agent.go:789<br/>MaxTokens * 4 / 5"]
    A3["scan/agent.go:321<br/>MaxTokens * 4 / 5"]
    A4["scan/agent.go:555<br/>maxAllowed * 4 / 5"]
    A5["compression.go:101<br/>int(float64(x)*tokenWarningThreshold)"]
    A6["loop.go:440<br/>int(float64(x)*tokenWarningThreshold)"]
  end
  subgraph after["after — one"]
    H["llmloop.PromptTokenLimit(maxTokens)"]
    C["tokenWarningThreshold = 0.80<br/>compression.go:19"]
    H --> C
  end
  A1 --> H
  A2 --> H
  A3 --> H
  A4 --> H
  A5 --> H
  A6 --> H
```

All six sites now route through the helper. `loop.go:439`'s `softLimit` is left inline
because it uses the separate `tokenSoftThreshold` (60%) constant, which has a single
consumer and stays unexported.

### Behaviour is unchanged

The replaced integer form `x * 4 / 5` and the helper's `int(float64(x) * 0.80)` agree
across every reachable input. `0.80` in float64 is `0.80000000000000004…`, i.e. strictly
*above* exact 4/5, so for positive `x` the product never rounds below the exact value and
truncation lands on the same integer. Brute-forced over `x ∈ [-5_000_000, +5_000_000]`:
zero divergences. Negatives agree too, since Go integer division truncates toward zero.
The first divergence is at `x = 2^52` (~4.5 quadrillion tokens).

The float form is also the more robust of the two at extremes: `x * 4` overflows `int64`
above `MaxInt64/4`, where the old expression silently returned `0` — i.e. "no limit".

`MaxTokens` is validated `> 0` at `internal/config/template/template.go:189` and `:203`
before any agent is constructed, so the non-positive case is unreachable in production;
the existing `_ZeroMaxTokens` / `_NoLimit` tests still pin the guards for direct
construction.

### Out of scope

Left alone deliberately, to keep this a mechanical refactor: the literal `80` in
user-facing message strings and doc comments (`agent.go:596,788,800,809`;
`scan/agent.go:319,330,338,557`; `llmloop/loop.go:434-435`), and the `* 4 / 5` example in
`pages/src/content/docs/{en,zh,ja}/architecture.md`. Those are display copy and prose, not
the arithmetic this issue targets. Glad to follow up separately if wanted.

One observation, no change made: `Template.MaxTokens` is also sent to the provider as the
*output* cap (`internal/llm/client.go:493` `MaxCompletionTokens`,
`internal/llm/responses_client.go:188` `MaxOutputTokens`), so this helper is really "80%
of the output cap, used as a prompt budget". That conflation predates this PR — I kept the
existing semantics rather than changing them, but if you'd prefer the helper named
`WarnTokenLimit` to tie it to the constant rather than implying a prompt/completion
distinction the config doesn't make, that's a one-line change.

AI assistance: Claude Code helped implement and verify this change. I reviewed the full
diff and take responsibility for it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally (full suite, `-race`, 23 packages, zero failures)
- [x] Manual testing:
  - `make fmt`, `make vet`, `make check` — clean
  - `make coverage` — 81.5%, above the 80% gate; `PromptTokenLimit` itself at 100%
  - `go test ./internal/llmloop/ -run TestPromptTokenLimit -v` — 8 subtests + parity test pass
  - `go test ./internal/agent/ ./internal/scan/ -run 'FilterLarge' -v` — 6/6 pass
  - `grep -rn "4 / 5" --include="*.go" .` — empty

### Mutation-tested the new boundary tests

The pre-existing `TestFilterLargeDiffs` / `TestFilterLargeScans` use margins wide enough
to pass at any threshold, so before this PR nothing actually pinned 80%. I verified the
new tests close that gap by mutating the constant in both directions:

| Test | 0.80 | 0.75 | 0.85 |
|---|---|---|---|
| `TestFilterLargeDiffs` | PASS | PASS | PASS |
| `TestFilterLargeDiffs_Boundary` | PASS | **FAIL** | **FAIL** |
| `TestFilterLargeScans` | PASS | PASS | PASS |
| `TestFilterLargeScans_Boundary` | PASS | **FAIL** | **FAIL** |

Both new tests are two-sided mutation killers; the pre-existing ones survive both mutants.

### Tests added

- `TestPromptTokenLimit` — table-driven, expectations hand-computed rather than derived
  from the implementation (which would tautologically pass). The `maxTokens: 5` row is the
  load-bearing one: the exact product is `4.000000000000000222`, and the half-ULP at `4.0`
  makes it round down to exactly `4.0` and truncate to 4, not 3.
- `TestPromptTokenLimitMatchesReplacedExpression` — parity with the removed `x*4/5` form.
  Documented as specific to `0.80`, to be deleted rather than "fixed" if the threshold moves.
- `TestFilterLargeDiffs_Boundary` / `TestFilterLargeScans_Boundary` — with `MaxTokens=100`
  the limit is 80, so an exactly-80-token input is kept and an exactly-81-token one is
  dropped. Fixtures are built through `llm.CountTokens` — the same function the code under
  test uses — and `t.Fatalf` if the tokenizer ever disagrees, so drift fails loudly rather
  than quietly weakening the assertion.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

## Related Issues

Closes #417
