### PR TITLE
ci: cancel superseded CI runs on the same PR or branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: self-hosted


### PR DESCRIPTION
## Description

Every push to a PR started a fresh CI run while the previous one kept executing to
completion. Since only the newest commit matters, those superseded runs were holding
`self-hosted` runners for results nobody would read.

This adds a top-level `concurrency` group to `.github/workflows/ci.yml`, placed after
`permissions:` and before `jobs:` exactly as the issue specifies:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This is the pattern [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox) applies
across its CI workflows, and it is also **byte-identical** to the block already running in
`.github/workflows/ocr-review.yml:20-22` — so it introduces the repo's existing idiom
rather than a second one.

```mermaid
graph TD
  subgraph before["before — superseded runs hold runners"]
    P1["push c1"] --> R1["CI run 1 · runs to completion"]
    P2["push c2"] --> R2["CI run 2 · runs to completion"]
    P3["push c3"] --> R3["CI run 3 · the only one read"]
    R1 -.->|occupies| X(["self-hosted pool"])
    R2 -.->|occupies| X
    R3 --> X
  end
  subgraph after["after — only the newest survives"]
    Q1["push c1"] --> S1["CI run 1 · cancelled"]
    Q2["push c2"] --> S2["CI run 2 · cancelled"]
    Q3["push c3"] --> S3["CI run 3 · completes"]
    S3 --> Y(["self-hosted pool"])
  end
```

## Verification

Beyond linting, I ran this live on a fork to confirm the behaviour rather than assume it.

**1. Pull-request path** — opened a PR, then pushed a second commit:

| Run | Workflow | SHA | Outcome |
|---|---|---|---|
| 29816697060 | CI | superseded | **cancelled after 38s** |
| 29816740450 | CI | newest | queued normally |
| 29816697162 | OpenCodeReview PR Review | superseded | **untouched** |

The third row is the useful negative control. When the new CI run started it cancelled
everything in *its* group — and the review workflow's run for the same superseded commit
survived that sweep. Had the two group strings collided, it would have been cancelled too,
so this is direct evidence that the `github.workflow` prefix keeps the groups distinct and
that the change cannot cross-cancel the review workflow, even though both use an identical
group expression.

Baseline for comparison: before this change, two CI runs from a single PR both sat queued
and expired together at the 24-hour timeout.

**2. Push-to-main path** — pushed twice to a branch's `main` in quick succession:

| Run | SHA | Concurrency block present? | Outcome |
|---|---|---|---|
| 29817143798 | newest | yes | queued |
| 29817130909 | superseded | yes | **cancelled** |
| 29817065512 | earlier commit | **no** | **still queued** |

The last row is an unintentional but decisive control: a run from a commit *without* the
block, on the same branch, was not cancelled. That rules out any cause for the cancellation
other than this change, and it confirms the `github.ref` fallback branch of the expression
works — the path the PR-based test never exercised.

**3. `actionlint` v1.7.12** — exit 0, zero diagnostics, on `ci.yml` and on all four
workflows together. This validates the Actions schema and expression syntax, not merely
YAML well-formedness.

## Why the other workflows are untouched

| Workflow | Decision |
|---|---|
| `ci.yml` | **changed** — the only workflow that lacked concurrency handling |
| `ocr-review.yml` | already has the identical block |
| `deploy-pages.yml` | already has `group: "pages"` / `cancel-in-progress: false` — GitHub's documented Pages pattern; cancelling `actions/deploy-pages@v4` mid-flight can strand a deployment |
| `release.yml` | **must never cancel.** Runs are keyed to a unique tag so overlap is already near-impossible, and aborting mid-`npm-publish` would leave platform packages published while the meta package's `optionalDependencies` reference versions that were never pushed. `npm publish` is not reversible. |

The root `action.yml` is a composite action, which cannot declare `concurrency`, so it is
unaffected.

## Notes and limitations

- The `github.event.pull_request.number ||` term is technically redundant for
  `pull_request` events, where `github.ref` is already the unique `refs/pull/N/merge`. I
  kept it so this block stays identical to the one in `ocr-review.yml` — one pattern in the
  repo is worth more than saving a token.
- **Not verified by experiment:** simultaneous updates to two *different* PRs isolating from
  each other. That follows from the group strings differing by PR number, but I did not
  observe it directly.
- Cancelling a `self-hosted` job mid-`go test -race` relies on the runner tearing down its
  job container cleanly. This is not a new risk — `ocr-review.yml` already pairs
  `self-hosted` + `container:` with `cancel-in-progress: true` — but it does extend it to a
  heavier job, so it may be worth an eye on runner health after the first burst of
  cancellations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `actionlint` v1.7.12 clean on all four workflows
- [x] Live fork test of both the pull-request and push-to-main paths, each with a control
      run that correctly survived (see Verification above)
- [x] Byte-identity check against `ocr-review.yml:20-22` — `diff` reports no difference
- [x] The `test` check on this PR is itself a live exercise of the changed file

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works — n/a, workflow config
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

## One question for maintainers

The acceptance criteria ask for push-to-main runs to cancel stale ones too, and that is what
this implements. Flagging the tradeoff so it stays a deliberate choice: if two merges to
`main` land within the 15-minute CI window, the first commit's run is cancelled and keeps a
`cancelled` conclusion permanently — it never gets a green record. Nothing gates on that
(`release.yml` triggers purely on tag push, with no `workflow_run` or `needs` on CI), so
there is no pipeline breakage; it only means an individual main commit can lack a passing
CI record.

Some projects guard against this with a conditional instead:

```yaml
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

I deliberately did **not** do that, because the acceptance criteria are explicit and plain
`true` keeps a single pattern in the repo. Happy to switch in a one-line follow-up if you
prefer the guarded form — entirely your call.

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.

## Related Issues

Closes #422
