### PR TITLE
docs(ci): pass untrusted PR fields via env to prevent script injection

### DIFF
--- a/pages/src/content/docs/en/integrations/ci.md
+++ b/pages/src/content/docs/en/integrations/ci.md
@@ -120,13 +120,23 @@ semantic convention like `feat(auth): add OAuth2 support`):
 
 ```yaml
 - name: Run OCR review
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review \
-      --background "${{ github.event.pull_request.title }}" \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}" \
+      --background "$PR_TITLE" \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF" \
       --format json --audience agent
 ```
+
+Pass PR-controlled values through `env:` rather than
+interpolating `${{ }}` directly into `run:`. GitHub substitutes
+`${{ }}` textually *before* the shell parses the line, so a PR
+title or branch name containing shell metacharacters would
+execute on your runner.
 
 #### Custom rules
 
@@ -134,10 +144,13 @@ Pass a project-specific rule file with `--rule`:
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --rule ./my-rules.json \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 See [Review Rules](../../review-rules/) for the schema.
@@ -149,10 +162,13 @@ to stay under your LLM provider's rate limits:
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --concurrency 5 \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 #### Trigger pattern

--- a/pages/src/content/docs/ja/integrations/ci.md
+++ b/pages/src/content/docs/ja/integrations/ci.md
@@ -83,13 +83,19 @@ curl -o .github/workflows/ocr-review.yml \
 
 ```yaml
 - name: Run OCR review
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review \
-      --background "${{ github.event.pull_request.title }}" \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}" \
+      --background "$PR_TITLE" \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF" \
       --format json --audience agent
 ```
+
+PR で制御可能な値は `${{ }}` を `run:` に直接展開するのではなく、`env:` 経由で渡してください。GitHub は `${{ }}` を shell が行を解析する *前に* テキストとして置換するため、shell のメタ文字を含む PR タイトルやブランチ名が runner 上で実行されてしまいます。
 
 #### カスタムルール
 
@@ -97,10 +103,13 @@ curl -o .github/workflows/ocr-review.yml \
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --rule ./my-rules.json \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 スキーマは[レビュールール](../../review-rules/)を参照してください。
@@ -111,10 +120,13 @@ curl -o .github/workflows/ocr-review.yml \
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --concurrency 5 \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 #### トリガーモード

--- a/pages/src/content/docs/zh/integrations/ci.md
+++ b/pages/src/content/docs/zh/integrations/ci.md
@@ -101,13 +101,21 @@ curl -o .github/workflows/ocr-review.yml \
 
 ```yaml
 - name: Run OCR review
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review \
-      --background "${{ github.event.pull_request.title }}" \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}" \
+      --background "$PR_TITLE" \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF" \
       --format json --audience agent
 ```
+
+把 PR 可控的值通过 `env:` 传入，不要把 `${{ }}` 直接插值进 `run:`。GitHub 在
+shell 解析该行 *之前* 就已把 `${{ }}` 做了文本替换，因此包含 shell 元字符的 PR
+标题或分支名会在你的 runner 上被执行。
 
 #### 自定义规则
 
@@ -115,10 +123,13 @@ curl -o .github/workflows/ocr-review.yml \
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --rule ./my-rules.json \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 schema 见[评审规则](../../review-rules/)。
@@ -129,10 +140,13 @@ schema 见[评审规则](../../review-rules/)。
 
 ```yaml
 - name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
   run: |
     ocr review --concurrency 5 \
-      --from "origin/${{ github.base_ref }}" \
-      --to "origin/${{ github.head_ref }}"
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
 ```
 
 #### 触发模式


### PR DESCRIPTION
## Description

The CI integration docs teach a snippet that interpolates three attacker-controlled PR fields
directly inside a shell `run:` block:

```yaml
- name: Run OCR review
  run: |
    ocr review \
      --background "${{ github.event.pull_request.title }}" \
      --from "origin/${{ github.base_ref }}" \
      --to "origin/${{ github.head_ref }}" \
      --format json --audience agent
```

`${{ }}` is textual substitution performed *before* the shell parses the line, so the quotes in
the rendered command belong to the attacker. Anyone who copies this snippet, which is what the
page tells them to do, gets arbitrary command execution on their runner from a PR title.

This moves all three fields into `env:` and references them as shell variables, plus a short
note.

This is already the repo's own rule. `internal/config/rules/rule_docs/github_workflows.md:6`:

> **Script injection**: Expressions like `${{ github.event.issue.title }}` used directly in
> `run:` blocks enable code injection. These must be passed through environment variables instead

`action.yml` complies (all ten inputs hoisted at `:228-238`), and the GitLab half of this same
page already uses `"$CI_MERGE_REQUEST_TITLE"`. The GitHub Actions section was the lone outlier.

## Verification

A live run of the attack: two jobs differing only in how the title reaches the shell, one PR
titled `demo"; echo PWNED_INJECTION_SUCCEEDED; #`.

Run [`29827744839`](https://github.com/chethanuk/open-code-review/actions/runs/29827744839). The
`vulnerable` job's rendered command, as GitHub logged it:

```
##[group]Run echo "background=demo"; echo PWNED_INJECTION_SUCCEEDED; #"
```

The payload became a second statement and executed. In the `safe` job the identical title printed
as literal text. The harness step was an `echo "background=..."`, not a real `ocr review`, and the
injected payload was itself a bare `echo`; the test PR and branch are deleted.

Branch names are injectable too, not just the title: `a";id;"b`, `a$(id)b` and `a;id;b` are all
valid per `git check-ref-format`, and a fork PR lets the attacker choose the branch name. There
is also a non-malicious case: `a$HOMEb` is a legal branch name that the old form silently
expands, building the wrong ref. So this is a correctness fix as well as a security one.

Before: 21 `${{ github.* }}` expressions inside `run:` blocks. After: 0, with all 21 surviving as
`env:` assignments. The three YAML blocks were byte-identical across locales before and still are.

## Limitations

Docs-only, so nothing in CI renders or lints these snippets and the `test` check does not
exercise this change. The reproduction ran on a GitHub-hosted runner in a fork, not this repo's
`self-hosted` pool, though the mechanism is GitHub's expression substitution and happens before
any runner-specific behaviour.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] Reproduced the injection end to end on a real runner and captured the log line
- [x] Confirmed the `env:` form treats the same payload as literal data
- [x] Asserted 21 → 0 `${{ github.* }}` expressions inside `run:` blocks
- [x] Confirmed the three locales remain byte-identical

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
