### PR TITLE
docs(examples): OCR_LLM_MODEL is required, not optional — fix the GitLab example

### DIFF
--- a/examples/gitflic_ci/README.md
+++ b/examples/gitflic_ci/README.md
@@ -39,7 +39,7 @@ Go to **Settings → CI/CD → Variables** and add:
 | `OCR_LLM_URL` | Yes | LLM API endpoint URL |
 | `OCR_LLM_AUTH_TOKEN` | Yes | LLM API authentication token |
 | `GITFLIC_TOKEN` | Yes | GitFlic access token used to post discussions |
-| `OCR_LLM_MODEL` | No | Model name (e.g., `gpt-4o`) |
+| `OCR_LLM_MODEL` | Yes | Model name (e.g., `gpt-4o`) — OCR has no built-in default model and fails when this is unset |
 | `GITFLIC_API_URL` | No | REST API base URL for self-hosted GitFlic (default: `https://api.gitflic.ru`) |
 
 > **Note:** GitFlic CI/CD does not accept variables with values shorter than 8 characters, so `use_anthropic` cannot be set as a CI variable. The pipeline sets it to `false`; to use Anthropic Claude models, edit `gitflic-ci.yaml` directly.

--- a/examples/gitlab_ci/.gitlab-ci.yml
+++ b/examples/gitlab_ci/.gitlab-ci.yml
@@ -7,9 +7,10 @@
 # Required CI/CD Variables (Settings → CI/CD → Variables):
 #   OCR_LLM_URL        - LLM API endpoint (e.g., https://api.openai.com/v1/chat/completions)
 #   OCR_LLM_AUTH_TOKEN - Authentication token for the LLM API (mark as "Masked")
+#   OCR_LLM_MODEL      - Model name (e.g., gpt-4o). OCR has no built-in default model; the
+#                        pipeline fails fast if this is unset.
 #
 # Optional CI/CD Variables:
-#   OCR_LLM_MODEL      - Model name (default: gpt-4o)
 #   GITLAB_API_TOKEN   - GitLab Personal/Project Access Token with "api" scope
 #                        (falls back to CI_JOB_TOKEN if not set)
 #
@@ -48,12 +49,14 @@ code-review:
     - echo "OpenCodeReview installed with version:" && ocr version || true
 
     # Configure OCR
-    - mkdir -p ~/.open-code-review
     # Gitlab CI/CD does not support configuring variables with value length less than 8, so you can't set use_anthropic as a CI variable
     - |
-      ocr config set llm.url $OCR_LLM_URL
-      ocr config set llm.auth_token $OCR_LLM_AUTH_TOKEN
-      ocr config set llm.model $OCR_LLM_MODEL
+      : "${OCR_LLM_URL:?set OCR_LLM_URL in Settings -> CI/CD -> Variables}"
+      : "${OCR_LLM_AUTH_TOKEN:?set OCR_LLM_AUTH_TOKEN in Settings -> CI/CD -> Variables}"
+      : "${OCR_LLM_MODEL:?set OCR_LLM_MODEL in Settings -> CI/CD -> Variables}"
+      ocr config set llm.url "$OCR_LLM_URL"
+      ocr config set llm.auth_token "$OCR_LLM_AUTH_TOKEN"
+      ocr config set llm.model "$OCR_LLM_MODEL"
       ocr config set llm.use_anthropic false
       ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'
 

--- a/examples/gitlab_ci/README.md
+++ b/examples/gitlab_ci/README.md
@@ -38,7 +38,7 @@ Go to your project's **Settings → CI/CD → Variables** and add:
 |----------|----------|--------|-------------|
 | `OCR_LLM_URL` | Yes | No | LLM API endpoint URL (e.g., `https://api.openai.com/v1/chat/completions`) |
 | `OCR_LLM_AUTH_TOKEN` | Yes | Yes | API authentication token |
-| `OCR_LLM_MODEL` | No | No | Model name (defaults to `gpt-4o`) |
+| `OCR_LLM_MODEL` | Yes | No | Model name (e.g., `gpt-4o`) — OCR has no built-in default model and fails when this is unset |
 | `GITLAB_API_TOKEN` | No | Yes | GitLab access token with `api` scope (falls back to `CI_JOB_TOKEN` if not set) |
 
 > **Note:** GitLab CI/CD does not support variables with values shorter than 8 characters, so `use_anthropic` cannot be set as a CI variable. The pipeline sets it to `false` by default. If you need to use Anthropic Claude models, you'll need to modify the `.gitlab-ci.yml` script directly.
@@ -145,11 +145,13 @@ script:
   - npm install -g @alibaba-group/open-code-review
 
   # Configure OCR
-  - mkdir -p ~/.open-code-review
   - |
-    ocr config set llm.url $OCR_LLM_URL
-    ocr config set llm.auth_token $OCR_LLM_AUTH_TOKEN
-    ocr config set llm.model $OCR_LLM_MODEL
+    : "${OCR_LLM_URL:?set OCR_LLM_URL in Settings -> CI/CD -> Variables}"
+    : "${OCR_LLM_AUTH_TOKEN:?set OCR_LLM_AUTH_TOKEN in Settings -> CI/CD -> Variables}"
+    : "${OCR_LLM_MODEL:?set OCR_LLM_MODEL in Settings -> CI/CD -> Variables}"
+    ocr config set llm.url "$OCR_LLM_URL"
+    ocr config set llm.auth_token "$OCR_LLM_AUTH_TOKEN"
+    ocr config set llm.model "$OCR_LLM_MODEL"
     ocr config set llm.use_anthropic false
     ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'
 


### PR DESCRIPTION
## Description

The GitLab example documents `OCR_LLM_MODEL` as optional with a `gpt-4o` default. It is
required, and no such default exists anywhere in the codebase. A user who follows the docs and
leaves it unset gets a red pipeline and this:

```
Error: usage: ocr config set <key> <value>
e.g., ocr config set llm.model claude-opus-4-6
```

Three places make the claim: `examples/gitlab_ci/.gitlab-ci.yml:12`,
`examples/gitlab_ci/README.md:41`, `examples/gitflic_ci/README.md:42`. The code disagrees —
`internal/llm/resolver.go:411` treats an empty model as unresolved, same guard on the env path
at `:169` — and there is no `gpt-4o` fallback to fall back to. The only occurrence in non-test
Go code is a provider catalogue entry:

```
$ grep -rn 'gpt-4o' --include='*.go' . | grep -v _test.go
internal/llm/providers.go:292:			"openai/gpt-4o",
```

Unquoted `$OCR_LLM_MODEL` word-splits away, so the command hits the `len(args) < 3` guard at
`cmd/opencodereview/flags.go:268` and returns the usage error; GitLab jobs run under `set -e`, so
the job dies there.

## The fix

```diff
-      ocr config set llm.url $OCR_LLM_URL
-      ocr config set llm.auth_token $OCR_LLM_AUTH_TOKEN
-      ocr config set llm.model $OCR_LLM_MODEL
+      : "${OCR_LLM_URL:?set OCR_LLM_URL in Settings -> CI/CD -> Variables}"
+      : "${OCR_LLM_AUTH_TOKEN:?set OCR_LLM_AUTH_TOKEN in Settings -> CI/CD -> Variables}"
+      : "${OCR_LLM_MODEL:?set OCR_LLM_MODEL in Settings -> CI/CD -> Variables}"
+      ocr config set llm.url "$OCR_LLM_URL"
+      ocr config set llm.auth_token "$OCR_LLM_AUTH_TOKEN"
+      ocr config set llm.model "$OCR_LLM_MODEL"
```

`${VAR:?msg}` rather than `${VAR:-default}` deliberately: there is no correct default. `gpt-4o`
is wrong for every non-OpenAI endpoint this example targets. The guard and the quoting ship
together because quoting alone is not a no-op — `ocr config set llm.url ""` exits 0 with a
reassuring `Set llm.url = ` and writes nothing.

`examples/gitlab_ci/README.md:145-155` duplicates the whole broken snippet, so it gets the same
fix, and `examples/gitflic_ci/README.md:42`'s optionality claim is corrected. I did not touch
`examples/gitflic_ci/gitflic-ci.yaml` — changing its guard is a behaviour change to a different
example on a platform I could not verify.

`.gitlab-ci.yml:51` also creates `~/.open-code-review`. The real directory is
`~/.opencodereview`, no hyphens (`internal/session/persist.go:104`), and `ocr config set`
creates it itself. Dead line, removed.

## Verification

Run against a live LLM endpoint:

| Case | `OCR_LLM_MODEL` | Result |
|---|---|---|
| Before this PR | unset | **exit 1** — `usage: ocr config set <key> <value>`. Opaque, but immediate. |
| `if [ -n ]` guard (rejected) | unset | **exit 0**, no model configured → `ocr llm test` fails `no valid LLM endpoint configured`, swallowed by `\|\| true` |
| **This PR** | unset | **exit 1** — `OCR_LLM_MODEL: set OCR_LLM_MODEL in Settings -> CI/CD -> Variables` |
| **This PR** | set | **exit 0**, config written to `~/.opencodereview/config.json` |

With the variables set the fixed block runs clean end to end: `ocr llm test` →
`✓ Connection test successful`. `shellcheck -s bash` on the extracted script block: 3× SC2086,
exit 1 before; exit 0 after. `yaml.safe_load` on the changed `.gitlab-ci.yml` parses.

## Limitations

Not validated on a real gitlab.com pipeline. Everything above was proven locally against the
real `ocr` binary and a live endpoint, which exercises the exact failure path. The GitFlic README fix is docs only.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] Built the real binary and ran the extracted script block for every combination of
      set/unset variables — table above
- [x] Proved the rejected `if [ -n ]` variant reaches a green config step with no model, then
      fails at `ocr llm test` with `no valid LLM endpoint configured`
- [x] Proved quoting alone converts the hard failure into exit 0 with an empty config
- [x] Ran the fixed block end-to-end against a live LLM endpoint — `✓ Connection test successful`
- [x] `shellcheck -s bash` — 3× SC2086 before, clean after
- [x] `yaml.safe_load` on the changed `.gitlab-ci.yml`
- [x] Confirmed `~/.opencodereview/config.json` is written and `~/.open-code-review` never is

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, CI example + docs; no test
      harness executes `examples/`. Verified against the real binary instead, as above.
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
