### PR TITLE
ci(release): skip meta-package publish when the version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,15 @@ jobs:
           ' package.json > package.json.tmp && mv package.json.tmp package.json
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          pkg_name=$(jq -r '.name' package.json)
+          already=$(npm view "${pkg_name}@${VERSION}" version 2>/dev/null || true)
+          if [ "$already" = "$VERSION" ]; then
+            echo "Skip: ${pkg_name}@${VERSION} already published"
+          else
+            npm publish --access public
+            echo "Published: ${pkg_name}@${VERSION}"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

The platform-package loop already guards itself against republishing a version npm already has
(`release.yml:209-215`):

```bash
already=$(npm view "${pkg_name}@${VERSION}" version 2>/dev/null || true)
if [ "$already" = "$VERSION" ]; then
  echo "Skip: ${pkg_name}@${VERSION} already published"
else
  npm publish "$pkg_dir" --access public
  echo "Published: ${pkg_name}@${VERSION}"
fi
```

A dozen lines later the meta package is published unguarded (`release.yml:228-229`):

```yaml
- name: Publish to npm
  run: npm publish --access public
```

This applies the same guard to that last step, re-deriving `VERSION` and `pkg_name` since each
`run:` block is its own shell, so it is as re-runnable as the six before it.

Two states where it bites. Re-running an already-successful release: a maintainer clicks *Re-run
all jobs*, the six platform packages skip correctly, and the meta package hits `E403 cannot
publish over previously published version` — a red job on a complete, correct release, with no
way to green it short of cutting a new tag. And registry-accepted-but-client-errored: `npm
publish` exits non-zero after the registry committed the version (timeout or `ECONNRESET` on the
response), so every subsequent re-run fails permanently there.

Not fixed, since it is the obvious-sounding case: re-running a *partially-failed* release.
`Publish to npm` is the last step of the last job (`npm-publish` → `needs: release`, nothing
downstream), so if the platform loop failed the meta publish never ran, and a re-run publishes
it cleanly.

## Verification

Extracted the real step body and table-tested it against a stubbed `npm`, so both branches run
without touching the registry:

| Case | Before this PR | After this PR |
|---|---|---|
| Version **already published** | **exit 1**, `npm ERR! 403 cannot publish over previously published version` | **exit 0**, `Skip: @alibaba-group/open-code-review@1.2.3 already published`, and the publish is **never invoked** |
| **New** version | exit 0, publish invoked | exit 0, publish invoked, `Published: @alibaba-group/open-code-review@1.2.3` |

The load-bearing assertion is the absence of the stub's `STUB_PUBLISH_CALLED` marker in the
already-published row — the guard doesn't just swallow the error, it skips the call.

Also run:

- `actionlint` v1.7.12 — exit 0 on `release.yml`
- `yaml.safe_load` on the changed file — parses
- `shellcheck -s bash` on the extracted step body — exit 0, no findings
- The `Skip:` / `Published:` strings match `release.yml:211` and `:214` verbatim apart from
  indentation, so both paths read identically in a release log

## Limitations

The `npm view` → `npm publish` sequence is TOCTOU-racy and I left it that way: the registry
rejects duplicates atomically (`EPUBLISHCONFLICT`), so the race's worst case is exactly the
failure you get today. I stubbed `npm` rather than publishing test versions, and the `test`
check on this PR does not exercise `release.yml` at all — it only fires on `push: tags: ['v*']`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] Stubbed-`npm` table test of the extracted step body, both branches — table above
- [x] Confirmed the publish call is genuinely skipped (not just error-swallowed) in the
      already-published case
- [x] `actionlint` v1.7.12 — exit 0
- [x] `shellcheck -s bash` on the step body — exit 0
- [x] `yaml.safe_load` on `release.yml`
- [x] Byte-identity check of the log strings against `release.yml:211,214`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, workflow config; no harness
      executes `.github/workflows/`. Verified with the stub table test above.
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
