### PR TITLE
ci: add timeout-minutes to the release and pages jobs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: self-hosted
+    timeout-minutes: 10
     container:
       image: node:24
     steps:
@@ -50,6 +51,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: self-hosted
+    timeout-minutes: 15
     container:
       image: node:24
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   build:
     runs-on: self-hosted
+    timeout-minutes: 15
     container:
       image: golang:1.26.5
     strategy:
@@ -58,6 +59,7 @@ jobs:
   release:
     needs: build
     runs-on: self-hosted
+    timeout-minutes: 20
     permissions:
       contents: write
       id-token: write
@@ -159,6 +161,7 @@ jobs:
   npm-publish:
     needs: release
     runs-on: self-hosted
+    timeout-minutes: 15
     container:
       image: node:24
     permissions:


### PR DESCRIPTION
## Description

`3f41551` ("ci: add govulncheck, job timeout, dependabot and preserve debug symbols in dev
builds") introduced `timeout-minutes: 15` on the CI `test` job. This extends that policy to the
five jobs that still don't have one.

| Workflow | Job | Before | After | Observed runtime |
|---|---|---|---|---|
| `ci.yml` | `test` | 15 | unchanged | |
| `ocr-review.yml` | `code-review` | 30 | unchanged | |
| `release.yml` | `build` | — | **15** | 0.53–0.63 min |
| `release.yml` | `release` | — | **20** | 7.03–7.08 min |
| `release.yml` | `npm-publish` | — | **15** | 3.25–3.28 min |
| `deploy-pages.yml` | `build` | — | **10** | 0.93–0.96 min |
| `deploy-pages.yml` | `deploy` | — | **15** | 0.18 min |

The runners are **self-hosted**: a hung job squats a real machine for GitHub's ~6 hour default
rather than a hosted VM you don't own. `npm-publish` is the worst case — it can hang mid-publish.

Runtimes are from `gh run view <id> --repo alibaba/open-code-review --json jobs`, three runs
each. `release` is deliberately the loosest at 20 and has the least headroom (2.8×): it installs
git, does a `fetch-depth: 0` clone, downloads artifacts, computes checksums, uploads 6 files and
runs attestation.

`deploy` gets 15 rather than 10 because `actions/deploy-pages@v4` has its own 10-minute
(600000 ms) internal polling timeout, so a job timeout of 10 would fire at the same moment and
surface an ambiguous *"job cancelled"* instead of the action's own error.

## Verification

Every job in the repo now declares a timeout:

```
.github/workflows/ci.yml           jobs= 1 missing= []
.github/workflows/deploy-pages.yml jobs= 2 missing= []
.github/workflows/ocr-review.yml   jobs= 1 missing= []
.github/workflows/release.yml      jobs= 3 missing= []
```

`actionlint` v1.7.12 exits 0 on all four workflows, and I re-fetched
`actions/deploy-pages@v4`'s `action.yml` to confirm the 600000 ms claim first-hand.

## Limitations

No behaviour change unless a job exceeds its limit, and none comes close today — so this cannot
be positively demonstrated by a CI run; the measurements are the evidence. I did not hang a job
to watch a timeout fire. Values are calibrated against current runtimes on the current pool;
`release` at 20 is the first that would need revisiting.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] Measured all five job durations across three real upstream runs each
- [x] Schema assertion: every job in all four workflows now has `timeout-minutes`
- [x] `actionlint` v1.7.12 — exit 0
- [x] Independently confirmed `actions/deploy-pages@v4`'s 600000 ms internal timeout, which is
      why `deploy` is 15 rather than 10

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, workflow config
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
