### PR TITLE
chore: route security reports to private advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "\U0001F512 Report a Security Vulnerability"
+    url: https://github.com/alibaba/open-code-review/security/advisories/new
+    about: Please report vulnerabilities privately, not as public issues. See SECURITY.md.
   - name: "\U0001F4AC Questions & Help"
     url: https://github.com/alibaba/open-code-review/discussions/categories/q-a
     about: Ask questions or get help with configuration in Discussions.


### PR DESCRIPTION
## Description

`SECURITY.md:16` already routes reporters to GitHub Private Vulnerability Reporting. The issue
chooser has no route to it. `.github/ISSUE_TEMPLATE/config.yml` offers only two
Discussions links, and `blank_issues_enabled: false` means a reporter cannot open a freeform
issue either. So someone holding a credential-leak bug arrives at the chooser, finds no security
option, and files on the public **Bug Report** form — which is exactly the outcome `SECURITY.md`
exists to prevent.

Having no security *template* is the correct pattern — only the route was missing.

```diff
 blank_issues_enabled: false
 contact_links:
+  - name: "🔒 Report a Security Vulnerability"
+    url: https://github.com/alibaba/open-code-review/security/advisories/new
+    about: Please report vulnerabilities privately, not as public issues. See SECURITY.md.
   - name: "💬 Questions & Help"
```

With `blank_issues_enabled: false` the chooser is
three rows, and someone holding a vulnerability should not have to read past two Discussions
links to find the private channel — so the security row goes **first**.

The URL is byte-identical to the one already in `SECURITY.md:16`, so there is no second source
of truth to drift.

## Verification

Private vulnerability reporting is actually enabled on this repo, so the link resolves to a live
form rather than a 404:

```
$ gh api repos/alibaba/open-code-review/private-vulnerability-reporting
{"enabled":true}
```

Also checked:

- `yaml.safe_load` parses the file; `contact_links[0]['name']` is the 🔒 row, 3 rows total
- The `\U0001F512` escape form matches the file's existing style for the other two entries
- The URL matches `SECURITY.md:16` exactly (one occurrence in each file)

## Limitations

I could not verify the rendered chooser upstream; the API call above is the evidence that the
link is live. Nothing in CI validates
`.github/ISSUE_TEMPLATE/config.yml`, so the `test` check does not exercise this change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `gh api repos/alibaba/open-code-review/private-vulnerability-reporting` → `{"enabled":true}`
- [x] `yaml.safe_load` parses; security row asserted to be `contact_links[0]`
- [x] URL cross-checked against `SECURITY.md:16`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, issue-chooser config
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable — `SECURITY.md` already
      documents the process; this only adds the missing route to it)
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
