### PR TITLE
ci: pin govulncheck, narrow release permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
           govulncheck ./...
 
       - name: Test with coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Two independent hardening changes to the CI/release workflows, two lines total.

The second is the project's own documented review rule rather than my preference.
`internal/config/rules/rule_docs/github_workflows.md:4` says each job "should declare only the
permissions it needs". This PR applies that to the repo's own release workflow.

### 1. Pin `govulncheck` — for reproducibility, not supply chain

`ci.yml:33` runs `go install golang.org/x/vuln/cmd/govulncheck@latest`, so a new govulncheck
release can turn CI red on an unchanged tree. The gate is real: `e6e5da0` (*"ci: bump Go image to
1.26.5 to fix GO-2026-5856 govulncheck failure"*) is a stdlib vulnerability it caught. The
vulnerability database is fetched at runtime, independently of the binary version, so pinning
does not stale the scan — a pinned v1.6.0 binary reported `DB updated: 2026-07-08`,
`No vulnerabilities found.`, exit 0.

### 2. Narrow `release.yml` workflow-level permissions

`release.yml:7-8` grants workflow-level `contents: write`. Only one job actually inherits it, and
that job never writes. Traced all three:

| Job | Job-level `permissions:` | What it needs | Effect of narrowing |
|---|---|---|---|
| `build` (`:11`) | **none — inherits** | checkout (read); `upload-artifact@v4` authenticates with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN` | **the only affected job** — and it never writes, so: safe |
| `release` (`:58`) | `:61-64` `contents: write`, `id-token: write`, `attestations: write` | gh-release needs write; attestation needs id-token + attestations | **unaffected** |
| `npm-publish` (`:159`) | `:164-165` `contents: read` | checkout; npm auth is `secrets.NPM_TOKEN` | **unaffected** |

Job-level `permissions:` replaces the inherited set entirely, so `release` and `npm-publish`
are already fully insulated today. Narrowing is a strict no-op for them, and drops an unused
write grant from `build`, whose lines 11-57 contain only `actions/checkout@v4` and
`actions/upload-artifact@v4` — no `GITHUB_TOKEN`, no `gh`.

## Verification

`actionlint` v1.7.12 exit 0 across all four workflows, and `yaml.safe_load` on both changed
files. The permission matrix above was asserted from the parsed YAML after the edit, not eyeballed.

## Limitations

`release.yml` only fires on `push: tags: ['v*']`, so the permission narrowing cannot be proven by
this PR's checks — the first real exercise is the next release, and the evidence is the traced
matrix above. If `build` ever gains a step that writes via `GITHUB_TOKEN` it will need its own
job-level block. Dependabot's `github-actions` ecosystem does not cover `go install` lines, so
bumping the govulncheck pin stays manual.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] Installed `govulncheck@v1.6.0`, confirmed `Scanner: govulncheck@v1.6.0`, a runtime-fetched
      `DB updated: 2026-07-08`, and `No vulnerabilities found.` with exit 0
- [x] Re-resolved the current govulncheck release at ship time rather than trusting earlier notes
- [x] Traced and asserted the full three-job permission matrix after the edit
- [x] Confirmed `build` contains no `GITHUB_TOKEN` or `gh` usage
- [x] `actionlint` v1.7.12 — exit 0

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, workflow config
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff
and take responsibility for it.
