### PR TITLE
ci: unify gofmt -s across Makefile and CI, reduce cross-compile timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
   cross-compile:
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 10
     container:
       image: golang:1.26.5
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ help: build
 	$(DIST_DIR)/$(BINARY_NAME) -h
 
 fmt:
-	$(GO) fmt $(PACKAGES)
+	gofmt -s -w .
 
 vet:
 	LC_ALL=C $(GO) vet $(PACKAGES)
 
 check:
 	$(GO) mod tidy
-	$(GO) fmt $(PACKAGES)
+	gofmt -s -w .
 	LC_ALL=C $(GO) vet $(PACKAGES)
 	@echo "check passed"
 


### PR DESCRIPTION
## Summary

- Align Makefile `fmt` and `check` targets with the CI gate from #433 by switching from `go fmt` to `gofmt -s -w .`. This prevents drift where `make fmt` passes locally but CI fails on simplification opportunities that `-s` catches.
- Reduce the `cross-compile` job timeout from 20 to 10 minutes — each leg completes in ~16s on self-hosted runners, so 10 minutes is more than sufficient while avoiding unnecessarily long hangs.

## Verification

- `make check` passes cleanly
- `gofmt -s -l .` produces no output (current code already conforms)
- No functional change to compiled code