### PR TITLE
ci(pages): add Pages CI workflow for typecheck and build

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -1,0 +1,38 @@
+name: Pages CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pages/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: self-hosted
+    timeout-minutes: 15
+    container:
+      image: node:24
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trust workspace
+        run: git config --global --replace-all safe.directory '*'
+
+      - name: Install dependencies
+        working-directory: pages
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: pages
+        run: npm run typecheck
+
+      - name: Build
+        working-directory: pages
+        run: npm run build


### PR DESCRIPTION
## What

Adds a new `.github/workflows/pages-ci.yml` workflow that runs on pull requests touching `pages/**`. The job installs dependencies with `npm ci` and runs `typecheck` followed by `build`.

## Why

The `pages/` frontend previously had **no PR-level quality gating**. The only existing workflow, `deploy-pages.yml`, runs solely on push to `main` (build + deploy), so type errors and build breakages were only surfaced *after* merge.

This workflow closes that gap by validating the frontend at PR time, reusing the already-present `typecheck` script (`tsc --noEmit`) that was defined in `package.json` but never wired into CI.

## Details

- Triggers only on `pull_request` to `main` with a `paths: ['pages/**']` filter, so unrelated changes don't run it.
- Uses `npm ci` for reproducible, lockfile-pinned installs.
- Mirrors conventions from existing workflows (`self-hosted` runner, `node:24` container, `Trust workspace` step, `concurrency` with `cancel-in-progress`, `timeout-minutes`).
- Leaves `deploy-pages.yml` untouched — this workflow handles quality gating, deploy handles publishing.

## Scope

This is the first of a planned, incremental rollout of frontend quality gating. Lint/format (ESLint + Prettier) and unit tests (Vitest) are deferred to follow-up PRs.