### PR TITLE
ci: validate VS Code extension

### DIFF
--- a/.github/workflows/vscode-ext.yml
+++ b/.github/workflows/vscode-ext.yml
@@ -1,0 +1,46 @@
+name: VS Code Extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'extensions/vscode/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'extensions/vscode/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: self-hosted
+    timeout-minutes: 10
+    container:
+      image: node:24
+    defaults:
+      run:
+        working-directory: extensions/vscode
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trust workspace
+        run: git config --global --replace-all safe.directory '*'
+        working-directory: .
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Compile
+        run: yarn compile
+
+      - name: Test
+        run: yarn test

--- a/.github/workflows/vscode-ext.yml
+++ b/.github/workflows/vscode-ext.yml
@@ -1,10 +1,6 @@
 name: VS Code Extension
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'extensions/vscode/**'
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/vscode-ext.yml
+++ b/.github/workflows/vscode-ext.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     container:
-      image: node:24
+      image: node:24.4.1
     defaults:
       run:
         working-directory: extensions/vscode
@@ -32,6 +32,14 @@ jobs:
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'
         working-directory: .
+
+      - name: Cache Yarn packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('extensions/vscode/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

Add a dedicated CI job for the VS Code extension so extension-only changes and dependency updates cannot pass solely on the Go checks.

## What it checks

- Yarn lockfile integrity with `yarn install --frozen-lockfile`
- ESLint
- TypeScript/webpack compilation
- Jest tests

The workflow follows the repository's existing self-hosted/container conventions and only runs when `extensions/vscode/**` changes.

## Verification

- [x] Node 24.4.1 + Yarn 1.22.22
- [x] `yarn install --frozen-lockfile`
- [x] `yarn lint` (0 errors; 1 pre-existing warning)
- [x] `yarn compile`
- [x] `yarn test --runInBand` — 10 suites / 92 tests passed
- [x] `actionlint .github/workflows/vscode-ext.yml`
- [x] `git diff --check`

Fixes #441
