### PR TITLE
docs: fix broken integration links

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -111,7 +111,7 @@ npm install -g @alibaba-group/open-code-review
 
 **1. LLMの設定**
 
-コードレビューの前にLLMの設定が必要です。[デリゲートモード](https://open-codereview.ai/docs/integrations/delegate)を使用する場合は不要です。
+コードレビューの前にLLMの設定が必要です。[デリゲートモード](https://open-codereview.ai/docs/delegate)を使用する場合は不要です。
 
 ```bash
 ocr config provider          # ビルトインプロバイダーを選択またはカスタムプロバイダーを追加
@@ -163,9 +163,9 @@ ocr delegate rule src/main.go src/handler.go
 - [設定](https://open-codereview.ai/docs/configuration) — 設定キーと環境変数
 - [MCP サーバー](https://open-codereview.ai/docs/mcp) — 外部ツールでレビューエージェントを拡張
 - コーディングエージェント連携 — OCR を Claude Code、Codex、Cursor などに統合
-  - [Skill](https://open-codereview.ai/docs/integrations/agent-skill) — 再利用可能なエージェントスキルとしてインストール
-  - [Plugin](https://open-codereview.ai/docs/integrations/claude-code) — Claude Code / Codex / Cursor プラグインとしてインストール
-  - [デリゲートモード](https://open-codereview.ai/docs/integrations/delegate) — エージェント自身の LLM でレビューを実行
+  - [Skill](https://open-codereview.ai/docs/agent-skill) — 再利用可能なエージェントスキルとしてインストール
+  - [Plugin](https://open-codereview.ai/docs/claude-code) — Claude Code / Codex / Cursor プラグインとしてインストール
+  - [デリゲートモード](https://open-codereview.ai/docs/delegate) — エージェント自身の LLM でレビューを実行
 - [CI/CD 連携](https://open-codereview.ai/docs/cicd) — GitHub Actions、GitLab CI、GitFlic CI、Gerrit との統合
 - [セッションビューアー](https://open-codereview.ai/docs/viewer) — ブラウザでレビューセッションを閲覧・再生
 - [テレメトリー](https://open-codereview.ai/docs/telemetry) — 可観測性のためのOpenTelemetry統合

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -111,7 +111,7 @@ npm install -g @alibaba-group/open-code-review
 
 **1. LLM 설정**
 
-코드 리뷰 전에 LLM 설정이 필요합니다. [위임 모드](https://open-codereview.ai/docs/integrations/delegate)를 사용하는 경우에는 불필요합니다.
+코드 리뷰 전에 LLM 설정이 필요합니다. [위임 모드](https://open-codereview.ai/docs/delegate)를 사용하는 경우에는 불필요합니다.
 
 ```bash
 ocr config provider          # built-in provider 선택 또는 custom provider 추가
@@ -163,9 +163,9 @@ ocr delegate rule src/main.go src/handler.go
 - [설정](https://open-codereview.ai/docs/configuration) — 설정 키와 환경 변수
 - [MCP 서버](https://open-codereview.ai/docs/mcp) — 외부 도구로 리뷰 에이전트 확장
 - 코딩 에이전트 연동 — OCR을 Claude Code, Codex, Cursor 등에 통합
-  - [Skill](https://open-codereview.ai/docs/integrations/agent-skill) — 재사용 가능한 에이전트 스킬로 설치
-  - [Plugin](https://open-codereview.ai/docs/integrations/claude-code) — Claude Code / Codex / Cursor 플러그인으로 설치
-  - [위임 모드](https://open-codereview.ai/docs/integrations/delegate) — 에이전트 자체 LLM으로 리뷰 수행
+  - [Skill](https://open-codereview.ai/docs/agent-skill) — 재사용 가능한 에이전트 스킬로 설치
+  - [Plugin](https://open-codereview.ai/docs/claude-code) — Claude Code / Codex / Cursor 플러그인으로 설치
+  - [위임 모드](https://open-codereview.ai/docs/delegate) — 에이전트 자체 LLM으로 리뷰 수행
 - [CI/CD 연동](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI, Gerrit 통합
 - [세션 뷰어](https://open-codereview.ai/docs/viewer) — 브라우저에서 리뷰 세션 탐색 및 재생
 - [텔레메트리](https://open-codereview.ai/docs/telemetry) — 관측성을 위한 OpenTelemetry 통합

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For other installation methods (install script, GitHub Release binary, from sour
 
 **1. Configure LLM**
 
-You must configure an LLM before reviewing code, unless you use [Delegation Mode](https://open-codereview.ai/docs/integrations/delegate).
+You must configure an LLM before reviewing code, unless you use [Delegation Mode](https://open-codereview.ai/docs/delegate).
 
 ```bash
 ocr config provider          # Select a built-in provider or add a custom one
@@ -163,9 +163,9 @@ Full documentation lives at **[open-codereview.ai/docs](https://open-codereview.
 - [Configuration](https://open-codereview.ai/docs/configuration) — config keys and environment variables
 - [MCP Server](https://open-codereview.ai/docs/mcp) — extend the review agent with external tools
 - Coding Agent Integrations — integrate OCR into Claude Code, Codex, Cursor, etc.
-  - [Skill](https://open-codereview.ai/docs/integrations/agent-skill) — install as a reusable agent skill
-  - [Plugin](https://open-codereview.ai/docs/integrations/claude-code) — install as a Claude Code / Codex / Cursor plugin
-  - [Delegation Mode](https://open-codereview.ai/docs/integrations/delegate) — let your agent review using its own LLM
+  - [Skill](https://open-codereview.ai/docs/agent-skill) — install as a reusable agent skill
+  - [Plugin](https://open-codereview.ai/docs/claude-code) — install as a Claude Code / Codex / Cursor plugin
+  - [Delegation Mode](https://open-codereview.ai/docs/delegate) — let your agent review using its own LLM
 - [CI/CD Integration](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI, and Gerrit integration
 - [Session Viewer](https://open-codereview.ai/docs/viewer) — browse and replay review sessions in browser
 - [Telemetry](https://open-codereview.ai/docs/telemetry) — OpenTelemetry integration for observability

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -111,7 +111,7 @@ npm install -g @alibaba-group/open-code-review
 
 **1. Настройте LLM**
 
-Перед запуском ревью необходимо настроить LLM, если только вы не используете [режим делегирования](https://open-codereview.ai/docs/integrations/delegate).
+Перед запуском ревью необходимо настроить LLM, если только вы не используете [режим делегирования](https://open-codereview.ai/docs/delegate).
 
 ```bash
 ocr config provider          # Выбрать встроенного провайдера или добавить пользовательский
@@ -163,9 +163,9 @@ ocr delegate rule src/main.go src/handler.go
 - [Конфигурация](https://open-codereview.ai/docs/configuration) — ключи конфигурации и переменные окружения
 - [MCP-сервер](https://open-codereview.ai/docs/mcp) — расширение агента ревью внешними инструментами
 - Интеграция с кодинг-агентами — встраивание OCR в Claude Code, Codex, Cursor и др.
-  - [Skill](https://open-codereview.ai/docs/integrations/agent-skill) — установка как переиспользуемый навык агента
-  - [Plugin](https://open-codereview.ai/docs/integrations/claude-code) — установка как плагин Claude Code / Codex / Cursor
-  - [Режим делегирования](https://open-codereview.ai/docs/integrations/delegate) — агент ревьюит своей собственной LLM
+  - [Skill](https://open-codereview.ai/docs/agent-skill) — установка как переиспользуемый навык агента
+  - [Plugin](https://open-codereview.ai/docs/claude-code) — установка как плагин Claude Code / Codex / Cursor
+  - [Режим делегирования](https://open-codereview.ai/docs/delegate) — агент ревьюит своей собственной LLM
 - [Интеграция с CI/CD](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI и Gerrit
 - [Просмотр сессий](https://open-codereview.ai/docs/viewer) — просмотр и воспроизведение сессий ревью в браузере
 - [Телеметрия](https://open-codereview.ai/docs/telemetry) — интеграция с OpenTelemetry для наблюдаемости

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,7 +111,7 @@ npm install -g @alibaba-group/open-code-review
 
 **1. 配置 LLM**
 
-在审查代码之前，必须先配置 LLM。除非你使用[委托模式](https://open-codereview.ai/docs/integrations/delegate)。
+在审查代码之前，必须先配置 LLM。除非你使用[委托模式](https://open-codereview.ai/docs/delegate)。
 
 ```bash
 ocr config provider          # 选择内置供应商或添加自定义供应商
@@ -163,9 +163,9 @@ ocr delegate rule src/main.go src/handler.go
 - [配置](https://open-codereview.ai/docs/configuration) —— 配置项与环境变量
 - [MCP 服务器](https://open-codereview.ai/docs/mcp) —— 用外部工具扩展评审 agent
 - 编程 Agent 集成 —— 将 OCR 集成到 Claude Code、Codex、Cursor 等
-  - [Skill](https://open-codereview.ai/docs/integrations/agent-skill) —— 作为可复用的 Agent Skill 安装
-  - [Plugin](https://open-codereview.ai/docs/integrations/claude-code) —— 作为 Claude Code / Codex / Cursor 插件安装
-  - [委托模式](https://open-codereview.ai/docs/integrations/delegate) —— 让 Agent 使用自身的 LLM 进行评审
+  - [Skill](https://open-codereview.ai/docs/agent-skill) —— 作为可复用的 Agent Skill 安装
+  - [Plugin](https://open-codereview.ai/docs/claude-code) —— 作为 Claude Code / Codex / Cursor 插件安装
+  - [委托模式](https://open-codereview.ai/docs/delegate) —— 让 Agent 使用自身的 LLM 进行评审
 - [CI/CD 集成](https://open-codereview.ai/docs/cicd) —— 支持 GitHub Actions、GitLab CI、GitFlic CI、Gerrit 集成
 - [会话查看器](https://open-codereview.ai/docs/viewer) —— 在浏览器中浏览和回放评审会话
 - [遥测](https://open-codereview.ai/docs/telemetry) —— OpenTelemetry 集成，用于可观测性


### PR DESCRIPTION
## Summary

Fix the integration documentation links in the main README and all localized README variants. The old `/docs/integrations/...` URLs do not match the documentation app routes; these now point to the corresponding `/docs/...` pages.

Closes #446

## Validation

- Updated all 20 affected links across five README files
- Verified no stale `/docs/integrations/` paths remain with `rg`
- Documentation-only change