### PR TITLE
fix(llmloop): drain per-file comment work without racing pool submissions

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -618,9 +618,12 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, string,
 	if err == nil {
 		// REVIEW_FILTER_TASK runs after the main loop and decides which of the
 		// just-collected comments to drop. It needs to see comments produced by
-		// the async CommentWorkerPool, so wait for that to drain first.
+		// this file's async CommentWorkerPool units, so wait for those to drain
+		// first. This must be keyed to newPath: a pool-wide Await here would run
+		// concurrently with other files' Submit calls and misuses sync.WaitGroup
+		// ("Add called concurrently with Wait").
 		if a.args.CommentWorkerPool != nil {
-			a.args.CommentWorkerPool.Await()
+			a.args.CommentWorkerPool.AwaitKey(newPath)
 		}
 		a.executeReviewFilter(ctx, d, newPath)
 	}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -382,7 +382,7 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 			pool := r.deps.CommentWorkerPool
 			asyncCtx := context.WithoutCancel(ctx)
 			toolName := t.Name()
-			pool.Submit(func() ([]model.LlmComment, error) {
+			pool.SubmitFor(newPath, func() ([]model.LlmComment, error) {
 				defer func() {
 					dur := time.Since(startTime)
 					telemetry.RecordToolResult(toolSpan, toolName, dur.Milliseconds(), nil)

--- a/internal/llmloop/pool.go
+++ b/internal/llmloop/pool.go
@@ -37,6 +37,12 @@ type CommentWorkerPool struct {
 	wg        sync.WaitGroup
 	resultsMu sync.Mutex
 	results   []model.LlmComment
+
+	// keys tracks per-key WaitGroups so callers can drain only the units
+	// submitted under one key (e.g. one reviewed file) without waiting for
+	// — or racing — submissions made under other keys.
+	keysMu sync.Mutex
+	keys   map[string]*sync.WaitGroup
 }
 
 // NewCommentWorkerPool creates a pool with the given concurrency limit.
@@ -53,7 +59,36 @@ func NewCommentWorkerPool(workerCount int) *CommentWorkerPool {
 // Submit runs f in a background goroutine bounded by the semaphore.
 // When f completes its return value is collected internally.
 func (p *CommentWorkerPool) Submit(f func() ([]model.LlmComment, error)) {
+	p.submit(f, nil)
+}
+
+// SubmitFor is Submit plus registration under key, so AwaitKey can wait for
+// exactly the units submitted under that key instead of the whole pool.
+//
+// Callers must guarantee that all SubmitFor calls for a given key
+// happen-before the matching AwaitKey call for that key — the same contract
+// as Await, but scoped to one key. Per-file review satisfies this because a
+// file's tool-use loop finishes submitting before its AwaitKey runs.
+func (p *CommentWorkerPool) SubmitFor(key string, f func() ([]model.LlmComment, error)) {
+	p.keysMu.Lock()
+	if p.keys == nil {
+		p.keys = make(map[string]*sync.WaitGroup)
+	}
+	kwg := p.keys[key]
+	if kwg == nil {
+		kwg = &sync.WaitGroup{}
+		p.keys[key] = kwg
+	}
+	kwg.Add(1)
+	p.keysMu.Unlock()
+	p.submit(f, kwg)
+}
+
+func (p *CommentWorkerPool) submit(f func() ([]model.LlmComment, error), kwg *sync.WaitGroup) {
 	p.wg.Go(func() {
+		if kwg != nil {
+			defer kwg.Done()
+		}
 		p.semaphore <- struct{}{}
 		defer func() { <-p.semaphore }()
 		// Contain a panic in the submitted work so one bad unit of work cannot
@@ -87,7 +122,26 @@ func (p *CommentWorkerPool) Submit(f func() ([]model.LlmComment, error)) {
 // calls wg.Go (which does wg.Add(1) synchronously), so a Submit racing Await
 // would risk sync.WaitGroup's "Add called concurrently with Wait" panic.
 // Callers must ensure every Submit has returned before calling Await.
+// Callers that need to drain while other submissions are still in flight
+// must use SubmitFor/AwaitKey instead.
 func (p *CommentWorkerPool) Await() []model.LlmComment {
 	p.wg.Wait()
 	return p.results
+}
+
+// AwaitKey blocks until every unit submitted under key so far has completed.
+// It never touches the pool-wide WaitGroup, so it is safe to call while other
+// keys still have SubmitFor calls in flight — unlike Await.
+//
+// The caller must ensure no SubmitFor with the same key runs concurrently
+// with AwaitKey (see SubmitFor's contract). Waiting on an unknown key
+// returns immediately.
+func (p *CommentWorkerPool) AwaitKey(key string) {
+	p.keysMu.Lock()
+	kwg := p.keys[key]
+	p.keysMu.Unlock()
+	if kwg == nil {
+		return
+	}
+	kwg.Wait()
 }

--- a/internal/llmloop/pool_test.go
+++ b/internal/llmloop/pool_test.go
@@ -2,8 +2,11 @@ package llmloop
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/open-code-review/open-code-review/internal/model"
 )
@@ -116,5 +119,122 @@ func TestCommentWorkerPool_PanicIsIsolated(t *testing.T) {
 	}
 	if results[0].Path != "healthy.go" {
 		t.Errorf("Path = %q, want healthy.go", results[0].Path)
+	}
+}
+
+// TestCommentWorkerPool_AwaitKeyWaitsForOwnKey verifies that AwaitKey blocks
+// until the units submitted under its key complete, without waiting for units
+// registered under other keys.
+func TestCommentWorkerPool_AwaitKeyWaitsForOwnKey(t *testing.T) {
+	p := NewCommentWorkerPool(2)
+
+	release := make(chan struct{})
+	ownDone := make(chan struct{})
+	p.SubmitFor("own.go", func() ([]model.LlmComment, error) {
+		close(ownDone)
+		<-release
+		return []model.LlmComment{{Path: "own.go", Content: "mine"}}, nil
+	})
+	// A slow unit under a different key must not be required for AwaitKey("own.go").
+	p.SubmitFor("other.go", func() ([]model.LlmComment, error) {
+		<-release
+		return []model.LlmComment{{Path: "other.go", Content: "theirs"}}, nil
+	})
+
+	awaitReturned := make(chan struct{})
+	go func() {
+		p.AwaitKey("own.go")
+		close(awaitReturned)
+	}()
+
+	<-ownDone
+	close(release)
+	select {
+	case <-awaitReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AwaitKey did not return after its own key's work completed")
+	}
+
+	// The whole pool is drained by Await; both keyed units' results are present.
+	results := p.Await()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}
+
+// TestCommentWorkerPool_AwaitKeyConcurrentSubmitOtherKey is the regression
+// test for the review-path race: one file's goroutine draining its async
+// comment work while other files' loops keep submitting. A pool-wide Await in
+// this pattern misuses sync.WaitGroup ("Add called concurrently with Wait");
+// the keyed API must stay panic-free.
+func TestCommentWorkerPool_AwaitKeyConcurrentSubmitOtherKey(t *testing.T) {
+	p := NewCommentWorkerPool(4)
+
+	stop := make(chan struct{})
+	var submits atomic.Int64
+	var producerWg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		producerWg.Add(1)
+		go func() {
+			defer producerWg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					p.SubmitFor("producer.go", func() ([]model.LlmComment, error) {
+						return nil, nil
+					})
+					submits.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Concurrently drain per-goroutine keys that occasionally have real work.
+	// Each key is used by exactly one goroutine (submit-then-await in program
+	// order), matching the per-file usage in the review path.
+	var drained atomic.Int64
+	var drainerWg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		key := fmt.Sprintf("drainer-%d.go", i)
+		drainerWg.Add(1)
+		go func() {
+			defer drainerWg.Done()
+			for j := 0; j < 200; j++ {
+				p.SubmitFor(key, func() ([]model.LlmComment, error) {
+					return []model.LlmComment{{Path: key}}, nil
+				})
+				p.AwaitKey(key)
+				drained.Add(1)
+			}
+		}()
+	}
+	drainerWg.Wait()
+	close(stop)
+	producerWg.Wait()
+
+	if drained.Load() != 800 {
+		t.Errorf("drained = %d, want 800", drained.Load())
+	}
+	if submits.Load() == 0 {
+		t.Error("producers never submitted")
+	}
+	p.Await()
+}
+
+// TestCommentWorkerPool_AwaitKeyUnknown verifies waiting on a key with no
+// submissions returns immediately.
+func TestCommentWorkerPool_AwaitKeyUnknown(t *testing.T) {
+	p := NewCommentWorkerPool(2)
+	done := make(chan struct{})
+	go func() {
+		p.AwaitKey("never-submitted.go")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AwaitKey on unknown key blocked")
 	}
 }


### PR DESCRIPTION
## Description

Fixes a `sync.WaitGroup` race in the concurrent review path: `executeSubtask` calls the **pool-wide** `CommentWorkerPool.Await()` from inside each per-file goroutine (before running the review filter), while other files' tool-use loops are still calling `pool.Submit()` for their own `code_comment` work.

The pool's own doc states the contract this violates:

> Concurrency contract: Await must not run concurrently with Submit. Submit calls wg.Go (which does wg.Add(1) synchronously), so a Submit racing Await would risk sync.WaitGroup's "Add called concurrently with Wait" panic.

`Await`/`Submit` share one `sync.WaitGroup`, so when file A's goroutine is blocked in `Await()` and file B's loop calls `Submit()`, the runtime can panic with `sync: WaitGroup misuse: Add called concurrently with Wait` or `sync: WaitGroup is reused before previous Wait has returned` (a `wg.Go` → `Add(1)` landing while `Wait` is blocked, or in the wake-up window after the counter reaches 0). The panic is recovered by the subtask wrapper in `dispatchSubtasks`, so the observable symptom is a **spurious per-file failure** (`subtask_error`, counted toward the "all N file review(s) failed" rollup); depending on the interleaving the counter can also be left corrupted so the final `Await` never returns. Every multi-file `ocr review` exercises this pattern — the pool is always installed and `code_comment` always takes the async path.

## Fix

Add `SubmitFor(key, f)` / `AwaitKey(key)` so a caller can drain only the units submitted under one key:

- `internal/llmloop/pool.go` — per-key `sync.WaitGroup` map alongside the pool-wide one; `Submit` behavior unchanged.
- `internal/llmloop/loop.go` — async `code_comment` work is submitted under the reviewed file's path.
- `internal/agent/agent.go` — the pre-review-filter drain uses `AwaitKey(newPath)`.

A file's loop submits all of its async comment work before its own `AwaitKey` runs (same goroutine, program order), so the per-key Add/Wait pairing is race-free, and draining no longer waits for — or crashes into — other files' in-flight submissions. The pool-wide `Await` remains for the end-of-run call sites (`dispatchSubtasks` after `wg.Wait()`, the scan batch loop), where all submissions have finished and the contract holds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (`go test -race -count=1 ./...`)
- [x] New pool unit tests: `AwaitKey` waits for its own key while other keys still have in-flight work; concurrent `SubmitFor` (other keys) + `AwaitKey` stress test under `-race`; unknown-key wait returns immediately.
- [x] Manual testing: with the pre-fix code, a standalone reproduction of the review-path pattern (one goroutine in a global `Await` loop while others `Submit`) either hangs (10-minute test timeout, counter starvation) or panics with the `sync.WaitGroup` misuse errors above; the keyed API is panic-free under the same pattern.

## Checklist

- [x] My code follows the project's coding style (`gofmt -s`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable — internal concurrency change)
- [ ] I have signed the CLA (will sign via the CLA bot)

## Related Issues

None filed.
