### PR TITLE
fix(diff): review merge commits against their first parent

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -123,7 +123,11 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		combined.WriteString(out)
 
 	case ModeCommit:
-		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
+		// --diff-merges=first-parent: for merge commits, plain `git show`
+		// emits a combined diff ("diff --cc"), which ParseDiffText cannot
+		// parse — the commit would silently yield zero reviewable diffs.
+		// Diffs against the first parent instead, in regular unified format.
+		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "--diff-merges=first-parent", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
 		if err != nil {
 			return nil, fmt.Errorf("git show failed: %w", err)
 		}

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -466,3 +466,72 @@ func TestRangeDiffSurvivesExternalDiffTool(t *testing.T) {
 			"--no-ext-diff (issue #82). GIT_EXTERNAL_DIFF=%s", garbage)
 	}
 }
+
+// TestCommitDiffMergeCommitReviewsFirstParentDiff covers `ocr review --commit
+// <merge>`: plain `git show` renders merge commits as a combined diff
+// ("diff --cc"), which ParseDiffText cannot parse, so the review silently
+// reported "No supported files changed" for exactly the commits whose
+// conflict resolutions most need review. The provider must pass
+// --diff-merges=first-parent so a merge is diffed against its first parent
+// in regular unified format.
+func TestCommitDiffMergeCommitReviewsFirstParentDiff(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+	runGitTest(t, repo, "config", "commit.gpgsign", "false")
+
+	file := filepath.Join(repo, "conflicted.txt")
+	write := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+			t.Fatalf("write conflicted.txt: %v", err)
+		}
+	}
+
+	write("line1\nline2\nline3\n")
+	runGitTest(t, repo, "add", "conflicted.txt")
+	runGitTest(t, repo, "commit", "-q", "-m", "initial commit")
+
+	runGitTest(t, repo, "checkout", "-q", "-b", "feature")
+	write("line1\nfeature-change\nline3\n")
+	runGitTest(t, repo, "commit", "-q", "-a", "-m", "feature change")
+
+	runGitTest(t, repo, "checkout", "-q", "-")
+	write("line1\nmain-change\nline3\n")
+	runGitTest(t, repo, "commit", "-q", "-a", "-m", "main change")
+
+	// The merge conflicts; resolving it produces the risky content to review.
+	mergeCmd := exec.Command("git", "merge", "--no-edit", "feature")
+	mergeCmd.Dir = repo
+	if out, err := mergeCmd.CombinedOutput(); err == nil {
+		t.Fatalf("expected merge to conflict, got success:\n%s", out)
+	}
+	write("line1\nresolved-conflict\nline3\n")
+	runGitTest(t, repo, "add", "conflicted.txt")
+	runGitTest(t, repo, "commit", "-q", "--no-edit")
+
+	runner := gitcmd.New(0)
+	provider := NewCommitProvider(repo, "HEAD", runner)
+
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff (merge commit) returned error: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected exactly 1 diff for the merge commit, got %d: %+v", len(diffs), diffs)
+	}
+	d := diffs[0]
+	if d.NewPath != "conflicted.txt" {
+		t.Errorf("NewPath = %q, want conflicted.txt", d.NewPath)
+	}
+	if !strings.Contains(d.Diff, "+resolved-conflict") {
+		t.Errorf("diff does not contain the conflict resolution:\n%s", d.Diff)
+	}
+	if d.Insertions != 1 || d.Deletions != 1 {
+		t.Errorf("Insertions/Deletions = %d/%d, want 1/1", d.Insertions, d.Deletions)
+	}
+	if d.NewFileContent == "" {
+		t.Error("NewFileContent is empty: content was not read at the merge commit")
+	}
+}


### PR DESCRIPTION
## Description

`ocr review --commit <merge-commit>` silently reviews nothing and exits 0 with "No supported files changed", even when the merge commit contains conflict resolutions — precisely the content that most needs review.

Root cause: `ModeCommit` uses plain `git show <commit>` (`internal/diff/git.go`), which renders merge commits as a **combined diff** (`diff --cc` sections with `@@@` hunks and two-column prefixes). `ParseDiffText` only recognizes `diff --git a/... b/...` sections, so every combined section is dropped and the parse yields zero diffs. (Worse, a combined section following a regular one would be absorbed into the previous file's diff text.)

Reproduced with real git: on a merge commit with a conflict resolution, the provider returns `[]` (0 diffs) today.

## Fix

Pass `--diff-merges=first-parent` to the `git show` call so a merge commit is diffed against its first parent in regular unified format — the same "what did this change introduce" semantics `--commit` has for normal commits. Non-merge commits are unaffected (verified: root commits still diff against the empty tree, regular commits unchanged). The flag requires git ≥ 2.31; the project already requires git ≥ 2.41.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (`go test -race -count=1 ./...`)
- [x] New regression test `TestCommitDiffMergeCommitReviewsFirstParentDiff` builds a real repo with a conflicting merge, then asserts the provider returns exactly one diff containing the conflict resolution. **Fails on `main`** (`expected exactly 1 diff for the merge commit, got 0: []`), passes with the fix.
- [x] Manual testing: `git show` with the exact provider flags on merge and root commits, before/after.

## Checklist

- [x] My code follows the project's coding style (`gofmt -s`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable — behavior now matches user expectation)
- [ ] I have signed the CLA (will sign via the CLA bot)

## Related Issues

None filed.
