### PR TITLE
fix(diff): anchor binary marker and count +/- lines by hunk state

### DIFF
--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -16,7 +16,10 @@ import (
 
 var (
 	diffHeaderRe = regexp.MustCompile(`^diff --git a/(.+?) b/(.+)$`)
-	binaryRe     = regexp.MustCompile(`Binary files `)
+	// Anchored: git emits the marker at column 0 ("Binary files a/x and b/y
+	// differ"). Content lines inside hunks always carry a leading "+", "-"
+	// or " " prefix, so an anchored match can never misfire on file content.
+	binaryRe = regexp.MustCompile(`^Binary files `)
 )
 
 // ParseDiffText splits the unified diff text into per-file Diff structs.
@@ -29,6 +32,13 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 	var diffs []model.Diff
 	var current *model.Diff
 	var buf strings.Builder
+	// inHunk tracks whether the current line sits inside a "@@" hunk of the
+	// current file's section. Only hunk content lines carry a leading
+	// "+"/"-"/" " marker, so insertion/deletion counting and the binary
+	// marker must look at hunk state: outside a hunk, "+++ b/file" and
+	// "--- a/file" are headers, not content; inside a hunk, an added line
+	// like "++i" renders as "+++i" and still counts as an insertion.
+	inHunk := false
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -46,13 +56,16 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 				OldPath: m[1],
 				NewPath: m[2],
 			}
+			inHunk = false
 		}
 		if current == nil {
 			continue
 		}
 
 		switch {
-		case binaryRe.MatchString(line):
+		case strings.HasPrefix(line, "@@"):
+			inHunk = true
+		case !inHunk && binaryRe.MatchString(line):
 			current.IsBinary = true
 		// Extended header lines (unambiguous: content lines always carry a
 		// leading "+", "-" or " " prefix, so a bare prefix match is safe).
@@ -69,13 +82,15 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 			current.NewPath = strings.TrimPrefix(line, "rename to ")
 			current.IsRenamed = true
 		// git emits "--- /dev/null" / "+++ /dev/null" without a/ b/ prefixes.
-		case line == "--- /dev/null":
+		// Guarded by inHunk: inside a hunk the same strings can be content
+		// (e.g. an added line "++ /dev/null").
+		case !inHunk && line == "--- /dev/null":
 			current.IsNew = true
-		case line == "+++ /dev/null":
+		case !inHunk && line == "+++ /dev/null":
 			current.IsDeleted = true
-		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+		case inHunk && strings.HasPrefix(line, "+"):
 			current.Insertions++
-		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+		case inHunk && strings.HasPrefix(line, "-"):
 			current.Deletions++
 		}
 		buf.WriteString(line)

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -129,3 +129,101 @@ index 0000000..1234567
 		t.Errorf("Insertions = %d, want 2", d.Insertions)
 	}
 }
+
+// TestParseDiffText_BinaryMarkerAnchored guards two binary-detection cases:
+// a text file whose CONTENT mentions "Binary files " must not be classified
+// as binary (the unanchored regex used to match any line in the section and
+// the file was silently excluded from review), while a real binary diff must
+// still be detected.
+func TestParseDiffText_BinaryMarkerAnchored(t *testing.T) {
+	diffText := `diff --git a/docs.md b/docs.md
+index 1234567..89abcde 100644
+--- a/docs.md
++++ b/docs.md
+@@ -1,2 +1,3 @@
+ line1
++Note: Binary files are handled specially by git.
+ line2
+diff --git a/blob.bin b/blob.bin
+index 1234567..89abcde 100644
+Binary files a/blob.bin and b/blob.bin differ
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
+	}
+	if diffs[0].IsBinary {
+		t.Errorf("docs.md IsBinary = true, want false (content line mentioning "+
+			"'Binary files ' must not mark the file binary); diff:\n%s", diffText)
+	}
+	if diffs[0].Insertions != 1 {
+		t.Errorf("docs.md Insertions = %d, want 1", diffs[0].Insertions)
+	}
+	if !diffs[1].IsBinary {
+		t.Errorf("blob.bin IsBinary = false, want true")
+	}
+}
+
+// TestParseDiffText_CountsContentLinesWithPlusMinusPrefix covers content
+// lines that themselves begin with "++"/"--": an added line "++i" renders in
+// the diff as "+++i", and the old "exclude +++/--- header" guard used to drop
+// it from the insertion count (same for deletions), skewing per-file stats
+// and the changeLines threshold that gates the plan phase.
+func TestParseDiffText_CountsContentLinesWithPlusMinusPrefix(t *testing.T) {
+	diffText := `diff --git a/counter.go b/counter.go
+index 1234567..89abcde 100644
+--- a/counter.go
++++ b/counter.go
+@@ -1,3 +1,3 @@
+ func inc() {
+---oldFlag
++++newFlag
+ }
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Insertions != 1 {
+		t.Errorf("Insertions = %d, want 1 (added content line \"+++newFlag\")", d.Insertions)
+	}
+	if d.Deletions != 1 {
+		t.Errorf("Deletions = %d, want 1 (deleted content line \"---oldFlag\")", d.Deletions)
+	}
+}
+
+// TestParseDiffText_DevNullStringInsideHunk ensures an added content line
+// whose rendered form is exactly "+++ /dev/null" (i.e. the file gained a line
+// reading "++ /dev/null") is treated as hunk content, not as the deleted-file
+// header marker.
+func TestParseDiffText_DevNullStringInsideHunk(t *testing.T) {
+	diffText := `diff --git a/paths.txt b/paths.txt
+index 1234567..89abcde 100644
+--- a/paths.txt
++++ b/paths.txt
+@@ -1,1 +1,2 @@
+ first
++++ /dev/null
+`
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.IsDeleted {
+		t.Errorf("IsDeleted = true, want false (\"+++ /dev/null\" inside a hunk is content)")
+	}
+	if d.Insertions != 1 {
+		t.Errorf("Insertions = %d, want 1", d.Insertions)
+	}
+}


### PR DESCRIPTION
## Description

Fixes two line-classification bugs in `ParseDiffText` (`internal/diff/parser.go`), both of which silently lose or distort review input:

1. **Unanchored binary marker.** `binaryRe` (`Binary files `) was matched *anywhere* in a file's diff section, including hunk content lines. A text file whose change merely mentions the phrase — e.g. an added doc line `+Note: Binary files are handled specially by git.` — flips `IsBinary`, and the file is then silently excluded from review (`Skipping X — binary file`).

2. **`+++`/`---` header guard eats real content lines.** Insertions/Deletions counted `+`/`-` lines while excluding anything starting with `+++`/`---` to skip the file headers — but that guard also drops real content: an added line `++i` renders in the diff as `+++i`, a deleted line `--flag` as `---flag`. Besides skewing the reported per-file/total stats, the undercounted `changeLines` (`d.Insertions + d.Deletions`) gates the plan phase in the review agent, so a file whose changes mostly start with `++`/`--` (common in `.diff`/`.patch` fixtures and unindented increments) can wrongly skip planning.

## Fix

Track hunk state: a line belongs to a hunk only after the `@@` header, and inside a hunk every content line carries a leading `+`/`-`/` ` marker, so:

- `binaryRe` is anchored to column 0 (`^Binary files `, git's fixed emission format) and only consulted before the first hunk — content lines can never match.
- `+`/`-` counting only happens inside hunks, where `+++`/`---` strings are unambiguously content and are now counted correctly.
- The `--- /dev/null` / `+++ /dev/null` file-header markers are restricted to the pre-hunk region, so an added line `++ /dev/null` (rendered exactly as `+++ /dev/null`) can no longer be misread as a deleted-file header.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (`go test -race -count=1 ./...`)
- [x] Three new regression tests: content mentioning `Binary files ` no longer marks a file binary (real binary sections still detected); `+++newFlag`/`---oldFlag` content lines count as insertion/deletion; `+++ /dev/null` inside a hunk is treated as content. **All three fail on `main`**, pass with the fix.

## Checklist

- [x] My code follows the project's coding style (`gofmt -s`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [ ] I have signed the CLA (will sign via the CLA bot)

## Related Issues

None filed.
