### PR TITLE
fix(config): preserve hand-edited timeout_sec across config round-trips

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -194,6 +194,7 @@ type ProviderEntry struct {
 	Model        string            `json:"model,omitempty"`
 	Models       []string          `json:"models,omitempty"`
 	AuthHeader   string            `json:"auth_header,omitempty"`
+	TimeoutSec   int               `json:"timeout_sec,omitempty"` // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 }
@@ -226,6 +227,7 @@ type LlmConfig struct {
 	Model        string            `json:"model,omitempty"`
 	Protocol     string            `json:"protocol,omitempty"`      // canonical protocol name; takes priority over UseAnthropic
 	UseAnthropic *bool             `json:"use_anthropic,omitempty"` // nil = default true; false = OpenAI protocol (legacy fallback)
+	TimeoutSec   int               `json:"timeout_sec,omitempty"`   // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 }

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -1151,3 +1151,63 @@ func TestEnsureModelInList(t *testing.T) {
 		t.Errorf("new model should append: got %v, want %v", got, want)
 	}
 }
+
+// TestConfigRoundTripPreservesTimeoutSec guards against silent config loss:
+// the resolver reads providers.<name>.timeout_sec / llm.timeout_sec (the docs
+// tell users to hand-edit them), but the cmd-side Config struct used to lack
+// the field, so any loadOrCreateConfig + saveConfig cycle (every
+// `ocr config set`, `ocr config model`, interactive provider setup, ...)
+// silently dropped the key and reverted requests to the default timeout.
+func TestConfigRoundTripPreservesTimeoutSec(t *testing.T) {
+	configPath := t.TempDir() + "/config.json"
+	original := `{
+    "provider": "ollama",
+    "providers": {
+        "ollama": {
+            "url": "http://127.0.0.1:11434/v1",
+            "protocol": "openai",
+            "model": "qwen3",
+            "timeout_sec": 900
+        }
+    },
+    "custom_providers": {
+        "my-gateway": {
+            "url": "https://gw.example.com/v1",
+            "protocol": "openai",
+            "timeout_sec": 120
+        }
+    },
+    "llm": {
+        "timeout_sec": 60
+    }
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Emulate an unrelated `ocr config set` round-trip.
+	cfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("loadOrCreateConfig: %v", err)
+	}
+	if err := setConfigValue(cfg, "language", "Chinese"); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	reloaded, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := reloaded.Providers["ollama"].TimeoutSec; got != 900 {
+		t.Errorf("providers.ollama.timeout_sec = %d, want 900 (lost in round-trip)", got)
+	}
+	if got := reloaded.CustomProviders["my-gateway"].TimeoutSec; got != 120 {
+		t.Errorf("custom_providers.my-gateway.timeout_sec = %d, want 120 (lost in round-trip)", got)
+	}
+	if got := reloaded.Llm.TimeoutSec; got != 60 {
+		t.Errorf("llm.timeout_sec = %d, want 60 (lost in round-trip)", got)
+	}
+}


### PR DESCRIPTION
## Description

`ocr config set` (and every other config write: `ocr config model`, interactive provider setup, `config unset`, ...) silently **deletes** a hand-edited `timeout_sec` from `~/.opencodereview/config.json`.

The LLM resolver honors `providers.<name>.timeout_sec` / `custom_providers.<name>.timeout_sec` / `llm.timeout_sec`, and the docs explicitly tell users to hand-edit them into `config.json` (they're intentionally not settable via `ocr config set`). But the cmd-side `ProviderEntry`/`LlmConfig` structs in `cmd/opencodereview/config_cmd.go` lack the field, so when `saveConfig` rewrites the whole file after an unrelated change, the key is gone and the per-request timeout silently reverts to the 300s default.

Reproduced on `main`: a config containing `"timeout_sec": 900` for a provider loses the key after one `loadOrCreateConfig` + `saveConfig` round-trip.

## Fix

Add `TimeoutSec int \`json:"timeout_sec,omitempty"\`` to both cmd-side structs (mirroring the resolver-side structs in `internal/llm/resolver.go`), so the value survives round-trips. This intentionally does **not** add `ocr config set <...>.timeout_sec` write support, matching the documented behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (`go test -race -count=1 ./...`)
- [x] New regression test `TestConfigRoundTripPreservesTimeoutSec`: hand-edited `timeout_sec` values in `providers`, `custom_providers`, and `llm` sections survive an unrelated `ocr config set` round-trip. Fails on `main` (field absent), passes with the fix.

## Checklist

- [x] My code follows the project's coding style (`gofmt -s`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable — the docs already describe the key; it now actually survives)
- [ ] I have signed the CLA (will sign via the CLA bot)

## Related Issues

None filed.
