### PR TITLE
ci(translation-sync): remove redundant push trigger

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -42,6 +42,8 @@ jobs:
       # NON-BLOCKING: on PRs, warn (::warning) when a file under
       # pages/src/content/docs/en/** changed without its zh/ja counterpart.
       # continue-on-error keeps it advisory: it never fails the build.
+      # The event_name guard is intentional even though on: is PR-only today:
+      # if a push: trigger is reintroduced, base/head.sha would be empty.
       - name: Check docs translation sync
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -7,11 +7,6 @@ name: translation-sync
 # and a slow container pull here never delays core CI feedback.
 
 on:
-  push:
-    paths:
-      - "README*.md"
-      - "pages/src/content/docs/**"
-      - "scripts/github-actions/check-translation-sync.*"
   pull_request:
     paths:
       - "README*.md"


### PR DESCRIPTION
## Description

The `translation-sync` workflow triggered on both `push` and `pull_request`. Since merges go through PRs, the PR trigger already validates translation sync before merge — re-running on the post-merge push to `main` only re-exercises the blocking README check and wastes CI.

This removes the `push:` trigger block from `.github/workflows/translation-sync.yml`, leaving only `pull_request:` with the existing `paths:` filter. Jobs, container, steps, and env vars are unchanged.

Closes #459.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check` passes locally
- [x] Manual testing (describe below)

- Confirmed `on:` contains only `pull_request` with the original `paths:` filter
- Confirmed jobs/steps below `on:` are unchanged

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #459.