### PR TITLE
fix(vscode): bound brace-expansion resolution to avoid poisoned 5.x

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -113,7 +113,7 @@
     "js-yaml": ">=4.3.0",
     "minimatch": "^9.0.7",
     "@typescript-eslint/typescript-estree/minimatch": "^9.0.7",
-    "brace-expansion": ">=2.1.2",
+    "brace-expansion": ">=2.1.2 <3",
     "fast-uri": ">=3.1.4",
     "linkify-it": ">=5.0.2"
   },

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -1540,10 +1540,10 @@ babel-preset-jest@^29.6.3:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
-balanced-match@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
-  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -1581,12 +1581,12 @@ boundary@^2.0.0:
   resolved "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz#169c8b1f0d44cf2c25938967a328f37e0a4e5efc"
   integrity sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==
 
-brace-expansion@>=2.1.2, brace-expansion@^2.0.2:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+"brace-expansion@>=2.1.2 <3", brace-expansion@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
-    balanced-match "^4.0.2"
+    balanced-match "^1.0.0"
 
 braces@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
## What
Bound the `brace-expansion` yarn resolution from the unbounded `>=2.1.2` to `>=2.1.2 <3`, and regenerate `extensions/vscode/yarn.lock`.

## Why
The `resolutions` entry added in #445 (`"brace-expansion": ">=2.1.2"`) had no upper bound, so yarn resolved it to the poisoned `5.0.7` release. brace-expansion 5.x changed its export shape, so `minimatch`'s `import expand from 'brace-expansion'` gets `undefined`, crashing `yarn lint` with `brace_expansion_1.default is not a function`.

This went unnoticed because the lint workflow (`vscode-ext.yml`, #444) was added ~4.5h *after* #445 merged, and it only runs on PRs touching `extensions/vscode/**` — never on push to main. All recent dependabot PRs failed identically, inheriting main's poisoned lockfile.

## Changes
- `package.json`: `brace-expansion` resolution `>=2.1.2` -> `>=2.1.2 <3` (keeps the CVE-safe lower bound from #445, blocks the 5.x major).
- `yarn.lock`: `brace-expansion` `5.0.7` -> `2.1.2`; transitive `balanced-match` `4.0.4` -> `1.0.2`.

## Verification
- `yarn lint` — 0 errors
- `yarn compile` — success
- `yarn test` — 10 suites / 92 tests pass