### PR TITLE
ci: upgrade low-risk GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: golang:1.26.5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'
@@ -84,7 +84,7 @@ jobs:
           - {goos: windows, goarch: amd64}
           - {goos: windows, goarch: arm64}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: node:24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'
@@ -42,7 +42,7 @@ jobs:
           cp -r pages/dist/* _site/
           cp pages/logo.svg _site/logo.svg
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -45,7 +45,7 @@ jobs:
       # pull_request_target this checks out the trusted base branch; the
       # composite action performs its own full checkout (fetch-depth: 0) later.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'

--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: node:24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           - goos: windows
             goarch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'
@@ -70,7 +70,7 @@ jobs:
       - name: Install git
         run: apt-get update && apt-get install -y git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -144,7 +144,7 @@ jobs:
         run: sha256sum opencodereview-* | sort > sha256sum.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.notes.outputs.body }}
           files: |
@@ -152,7 +152,7 @@ jobs:
             sha256sum.txt
 
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             opencodereview-*
@@ -167,7 +167,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'

--- a/.github/workflows/vscode-ext.yml
+++ b/.github/workflows/vscode-ext.yml
@@ -23,14 +23,14 @@ jobs:
       run:
         working-directory: extensions/vscode
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Trust workspace
         run: git config --global --replace-all safe.directory '*'
         working-directory: .
 
       - name: Cache Yarn packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('extensions/vscode/yarn.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
 
     - name: Setup Node.js
       if: steps.check_deps.outputs.node_installed != 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -180,7 +180,7 @@ runs:
         echo "PR head sha: $HEAD_SHA"
 
     - name: Checkout base
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         # Checkout the trusted base, not the PR head. OCR reviews the
         # base-to-head diff from git objects; the head commit's blobs are
@@ -272,7 +272,7 @@ runs:
     - name: Post review comments
       if: env.OCR_EXIT_CODE == '0'
       id: post
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         OCR_INCREMENTAL_OVERLAP_THRESHOLD: ${{ inputs.incremental_overlap_threshold }}
       with:


### PR DESCRIPTION
## Summary

- Upgrade 8 GitHub Actions to their latest major versions (low-risk subset from #454)
- **Deliberately keeps `upload-artifact` and `download-artifact` at v4** to avoid artifact format and hash-enforcement breaking changes that could disrupt the release pipeline

### Upgraded actions

| Action | From | To |
|--------|------|----|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| actions/cache | v4 | v6 |
| actions/github-script | v7 | v9 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| softprops/action-gh-release | v2 | v3 |
| actions/attest-build-provenance | v2 | v4 |

### Deferred (high-risk, separate PR needed)

| Action | From | To | Risk |
|--------|------|----|------|
| actions/upload-artifact | v4 | v7 | Direct upload format changes |
| actions/download-artifact | v4 | v8 | Hash-mismatch now errors by default; no longer auto-unzips all files |

### Safety verification

- All upgraded actions require Runner >= v2.327.1 (Node 24 runtime); checkout v6+ in container jobs requires >= v2.329.0
- **Verified**: self-hosted runner is v2.335.1 (API + CI log + machine confirmed)
- checkout v7's fork-PR guard does NOT affect our `pull_request_target` workflow (default checkout without explicit `ref` is exempt)
- `actions/github-script` v9 remains CommonJS-compatible for our `post-review-comments.js` script

## Test plan

- [ ] CI passes on this PR (validates checkout, cache, setup-node work correctly)
- [ ] Manually trigger pages deploy to verify upload-pages-artifact + deploy-pages
- [ ] Next tag release will validate action-gh-release + attest-build-provenance (upload/download-artifact untouched)