### PR TITLE
feat(allowlist): add Protocol Buffers (.proto) support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -46,6 +46,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".TFVARS", true},
 		{".bicep", true},
 		{".BICEP", true},
+		{".proto", true},
+		{".PROTO", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -77,5 +77,6 @@
   ".jl",
   ".hcl",
   ".tfvars",
-  ".bicep"
+  ".bicep",
+  ".proto"
 ]

--- a/internal/config/rules/rule_docs/protobuf.md
+++ b/internal/config/rules/rule_docs/protobuf.md
@@ -1,0 +1,39 @@
+> Favor precision over recall: only raise an issue when you are confident it is a real defect, and stay silent when the surrounding context is unclear — a false alarm costs more reviewer trust than a missed minor issue. Treat security and correctness findings as blocking, and style or idiom suggestions as non-blocking.
+
+#### Obvious Typos or Spelling Errors
+- Spelling errors in message, field, enum, enum-value, service, or rpc names at their declaration sites; do not report spelling errors at reference sites
+- Comments or option strings with spelling errors that affect readability of the public API surface
+
+#### Field Numbers and Wire Compatibility
+- Reused or renumbered field tags that break existing clients or servers (Wire Compatibility)
+- Changing a field's type, label (`optional`/`repeated`/`required`), or oneof membership in a way that breaks wire or JSON compatibility
+- Deleting a field without adding both its number and name to `reserved`
+- Renaming a field without `json_name` consideration when JSON clients depend on the old name
+- Do not flag purely additive new fields with fresh numbers, or documentation-only comment changes
+
+#### Message and Field Design
+- Missing `optional` (proto3) where absence must be distinguishable from the zero value
+- `map` used where order matters, or `repeated` used where key lookup would be clearer
+- oneof fields that leave an invalid zero-state representable when an explicit sentinel was intended
+- Nested messages that re-encode the same domain concept already modeled elsewhere in the package
+- Do not report stylistic preference for `message` vs `group` (groups are legacy) when the schema is already consistent
+
+#### Enums and Defaults
+- First enum value is not a zero `*_UNSPECIFIED` (or equivalent) sentinel
+- Relying on implicit zero defaults across schema versions when clients treat zero as meaningful data
+- Inserting new enum values in the middle of an existing numeric range used by older clients
+- Do not flag additive enum values appended at the end with new numbers
+
+#### Services and RPC Design
+- Non-idempotent methods modeled as if they were safe to retry without client-visible side effects
+- Multiple rpcs sharing the same request or response message type when distinct contracts would prevent accidental field coupling
+- Unbounded client/server streaming without documented flow control, page size, or deadline expectations
+- Missing request or response message wrappers that force primitive/scalar request bodies
+- Do not flag standard google.api annotations or well-known types used correctly
+
+#### Security and Resource Limits
+- `google.protobuf.Any` accepted from untrusted input without type allowlisting
+- Unbounded `repeated`/`map` fields or recursive message depth on untrusted payloads with no application-level limits
+- Secrets, tokens, or credentials embedded in field defaults, examples, or comments
+- File paths, URLs, or SQL fragments carried as unconstrained strings without validation guidance at the service boundary
+- Do not report when limits are enforced outside the schema and that boundary is clearly documented

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -24,6 +24,7 @@
     "**/*.c": "c.md",
     "**/*.py": "python.md",
     "**/*.{php,phtml}": "php.md",
+    "**/*.proto": "protobuf.md",
     "**/*.po": "po.md",
     "**/*.pot": "pot.md",
     "**/*.{graphql,gql}": "graphql.md",

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -102,6 +102,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"modules/network/vpc.hcl", "Overly Permissive Access"},
 		{"envs/prod.tfvars", "Hardcoded Secrets"},
 		{"infra/main.bicep", "Hardcoded Secrets"},
+		{"api/v1/user.proto", "Wire Compatibility"},
+		{"service.proto", "Wire Compatibility"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds **Protocol Buffers** as the first language-group contribution for tracking issue #470.

`.proto` files were skipped by both review paths because they were missing from the extension allowlist. This PR:

1. Allows `.proto` / `.PROTO` via `supported_file_types.json`
2. Maps `**/*.proto` → a dedicated `protobuf.md` rule doc (wire compatibility focus)
3. Adds table-driven tests for allowlist + rule resolution

No Go source changes. No exclude patterns (proto has no standard test-file convention per #470).

## Why this was needed

```text
diff / scan path
  → user include/exclude
  → allowedext.IsAllowedExt(ext)   ← .proto returned false → ExcludeExtension
  → allowedext.IsExcludedPath
  → SystemRule.Resolve             ← unmapped ext fell back to default.md
```

After this PR:

```text
.foo.proto
  → IsAllowedExt(".proto") = true
  → Resolve("**/*.proto") → rule_docs/protobuf.md  (Wire Compatibility)
```

## Changes

| File | Change |
|---|---|
| `internal/config/allowlist/supported_file_types.json` | append `.proto` |
| `internal/config/allowlist/allowed_ext_test.go` | `IsAllowedExt` cases for `.proto` / `.PROTO` |
| `internal/config/rules/system_rules.json` | `"**/*.proto": "protobuf.md"` |
| `internal/config/rules/rule_docs/protobuf.md` | **new** — wire compat, enums, RPC, security |
| `internal/config/rules/system_rules_test.go` | Resolve cases for `.proto` paths |

## Rule doc focus

- Field numbers / wire + JSON compatibility
- Message/field design (`optional`, map/repeated, oneof)
- Enum zero sentinels
- RPC/streaming design
- `Any` / unbounded payloads / secrets in defaults

## Test plan

- [x] `go test -run 'TestIsAllowedExt|TestResolve_DefaultRules' ./internal/config/allowlist/ ./internal/config/rules/`
- [x] `go test ./internal/config/...`
- [x] `make check`
- [x] `make test`
- [x] `grep -l "Wire Compatibility" rule_docs/*` → only `protobuf.md`

## Out of scope

- Other #470 language groups (Zig, GraphQL, Solidity, `.v` ambiguity, …)
- Exclude-pattern additions for proto
- Terraform/HCL rule doc for already-supported `.tf`

Part of #470.