### PR TITLE
feat(rules): add macro correctness checks to Rust review

### DIFF
--- a/internal/config/rules/rule_docs/rust.md
+++ b/internal/config/rules/rule_docs/rust.md
@@ -46,6 +46,14 @@
 - Public structs, enums, traits, and errors should have useful names, visibility, trait derives, and documentation appropriate to the crate boundary
 - Avoid exposing concrete collection or synchronization types in public APIs when a slice, iterator, trait, or narrower abstraction would preserve flexibility
 
+#### Macros and Metaprogramming
+Only flag when the diff actually defines a `macro_rules!` or procedural macro; do not report on ordinary macro invocations.
+- An `$x:expr` fragment interpolated more than once in the expansion, so the caller's expression — and any side effects — runs multiple times; bind it to a `let` once inside the expansion
+- Exported or publicly used macros that reference items without `$crate::`, so name resolution breaks or binds the wrong item when the macro is invoked from another crate
+- Token-tree (`$t:tt`) fragments re-emitted without parentheses, where operator precedence can silently change the intended meaning; this applies only to token-level (`tt`) interpolation, since an `:expr` fragment and a whole expansion are each parsed as one complete expression
+- Procedural macros that `unwrap()`, `expect()`, or `panic!` on malformed input instead of emitting a `syn::Error` / `compile_error!` with a useful span
+- Macro-hygiene assumptions that break: generated identifiers relying on names from the call-site scope, or items that collide when the macro is invoked more than once in the same module
+
 #### Security-Sensitive Code
 - Validate path, URL, command, SQL, and serialized input before use; do not build shell commands or SQL with unchecked string concatenation
 - Do not log secrets, tokens, credentials, private keys, or personally identifiable information


### PR DESCRIPTION
## What & why

`internal/config/rules/rule_docs/rust.md` is otherwise thorough — ownership/lifetimes, `unsafe` boundaries, async cancellation, atomics ordering — but has **no coverage of macros**, a high-bug-density corner of Rust. This adds a scoped `#### Macros and Metaprogramming` section for the well-known `macro_rules!` / procedural-macro footguns:

- an `$x:expr` fragment interpolated more than once → the caller's expression (and its side effects) runs multiple times
- exported macros referencing items without `$crate::` → name resolution breaks when invoked from another crate
- token-tree (`$t:tt`) fragments re-emitted without parentheses → operator precedence can silently change meaning
- procedural macros that `panic!`/`unwrap()` on malformed input instead of emitting `syn::Error` / `compile_error!`
- hygiene assumptions that break: call-site name capture, or collisions when a macro is invoked more than once

The section is **guarded** — "only flag when the diff actually defines a `macro_rules!` or procedural macro" — mirroring how the existing async/concurrency sections gate themselves, so it preserves the doc's precision-over-recall bias and does not fire on ordinary macro *invocations*.

**No wiring changes:** `**/*.rs` already maps to `rust.md` in `system_rules.json`, and `.rs` is already in `supported_file_types.json`.

## Why review has to catch these (the compiler doesn't)

Verified against `rustc`:

- **Double evaluation** — compiles clean; the side effect simply runs twice at runtime. No diagnostic.
- **Missing `$crate::`** — the *defining* crate compiles with no warning at all; a consumer crate then fails with `error[E0433]: failed to resolve: use of unresolved module or unlinked crate`. The breakage is displaced into someone else's build, which is exactly why it survives local CI.

## Does it change reviewer behavior? (indicative A/B eval)

The section was injected via the existing `--rule` merge mechanism as the **only** variable between arms, same model on both arms, against a fixture of planted macro defects:

| Model | Baseline (stock `rust.md`) | With this section |
|-------|:--:|:--:|
| Claude Haiku 4.5 | **0 / 6** runs flagged | **5 / 6** runs flagged |
| Claude Opus 4.6 | **1 / 4** runs flagged | **3 / 3** runs flagged |

Small N — indicative, not statistical.

**Disclosure:** the fixture originally planted three defects, but follow-up verification with `rustc` showed one of them (operator precedence on an `:expr` expansion) is **not** a real Rust defect — macro expansion is AST-level, so `:expr` fragments and whole expansions are atomic. That rule bullet has been narrowed to `tt`-fragment interpolation (see the comment below), and the eval's signal should be read as resting on the two independently verified defects above.

`go test ./internal/config/rules/...` passes.