### PR TITLE
fix(tool): normalize code comment metadata enums

### DIFF
--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -4,9 +4,44 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/open-code-review/open-code-review/internal/model"
 )
+
+const (
+	codeCommentCategoryBug             = "bug"
+	codeCommentCategorySecurity        = "security"
+	codeCommentCategoryPerformance     = "performance"
+	codeCommentCategoryMaintainability = "maintainability"
+	codeCommentCategoryTest            = "test"
+	codeCommentCategoryStyle           = "style"
+	codeCommentCategoryDocumentation   = "documentation"
+	codeCommentCategoryOther           = "other"
+
+	codeCommentSeverityCritical = "critical"
+	codeCommentSeverityHigh     = "high"
+	codeCommentSeverityMedium   = "medium"
+	codeCommentSeverityLow      = "low"
+)
+
+var validCodeCommentCategories = map[string]struct{}{
+	codeCommentCategoryBug:             {},
+	codeCommentCategorySecurity:        {},
+	codeCommentCategoryPerformance:     {},
+	codeCommentCategoryMaintainability: {},
+	codeCommentCategoryTest:            {},
+	codeCommentCategoryStyle:           {},
+	codeCommentCategoryDocumentation:   {},
+	codeCommentCategoryOther:           {},
+}
+
+var validCodeCommentSeverities = map[string]struct{}{
+	codeCommentSeverityCritical: {},
+	codeCommentSeverityHigh:     {},
+	codeCommentSeverityMedium:   {},
+	codeCommentSeverityLow:      {},
+}
 
 // CodeCommentProvider submits review comments to the per-Agent CommentCollector.
 type CodeCommentProvider struct {
@@ -69,10 +104,10 @@ func ParseComments(args map[string]any) ([]model.LlmComment, string) {
 			cm.Thinking = thinking
 		}
 		if category, ok := obj["category"].(string); ok {
-			cm.Category = category
+			cm.Category = normalizeCodeCommentCategory(category)
 		}
 		if severity, ok := obj["severity"].(string); ok {
-			cm.Severity = severity
+			cm.Severity = normalizeCodeCommentSeverity(severity)
 		}
 		if path, ok := args["path"].(string); ok {
 			cm.Path = path
@@ -85,4 +120,20 @@ func ParseComments(args map[string]any) ([]model.LlmComment, string) {
 		comments = append(comments, cm)
 	}
 	return comments, ""
+}
+
+func normalizeCodeCommentCategory(category string) string {
+	normalized := strings.ToLower(category)
+	if _, ok := validCodeCommentCategories[normalized]; ok {
+		return normalized
+	}
+	return codeCommentCategoryOther
+}
+
+func normalizeCodeCommentSeverity(severity string) string {
+	normalized := strings.ToLower(severity)
+	if _, ok := validCodeCommentSeverities[normalized]; ok {
+		return normalized
+	}
+	return codeCommentSeverityLow
 }

--- a/internal/tool/code_comment_test.go
+++ b/internal/tool/code_comment_test.go
@@ -192,6 +192,64 @@ func TestParseComments_CategorySeverity(t *testing.T) {
 			t.Errorf("severity = %q, want empty", comments[0].Severity)
 		}
 	})
+
+	t.Run("normalizes casing", func(t *testing.T) {
+		args := map[string]any{
+			"path": "main.go",
+			"comments": []any{
+				map[string]any{
+					"content":       "Potential nil pointer dereference.",
+					"existing_code": "x := *p",
+					"category":      "Security",
+					"severity":      "Critical",
+				},
+			},
+		}
+		comments, errMsg := ParseComments(args)
+		if errMsg != "" {
+			t.Fatalf("unexpected error message: %s", errMsg)
+		}
+		if len(comments) != 1 {
+			t.Fatalf("expected 1 comment, got %d", len(comments))
+		}
+		if got := comments[0].Category; got != "security" {
+			t.Errorf("category = %q, want %q", got, "security")
+		}
+		if got := comments[0].Severity; got != "critical" {
+			t.Errorf("severity = %q, want %q", got, "critical")
+		}
+	})
+}
+
+func TestParseComments_CategorySeveritySchemaDrift(t *testing.T) {
+	args := map[string]any{
+		"path": "main.go",
+		"comments": []any{
+			map[string]any{
+				"content":       "Use the canonical metadata fallback.",
+				"existing_code": "value := compute()",
+				"category":      "correctness",
+				"severity":      "info",
+			},
+		},
+	}
+
+	comments, errMsg := ParseComments(args)
+	if errMsg != "" {
+		t.Fatalf("unexpected error message: %s", errMsg)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if got := comments[0].Category; got != "other" {
+		t.Errorf("category = %q, want %q", got, "other")
+	}
+	if got := comments[0].Severity; got != "low" {
+		t.Errorf("severity = %q, want %q", got, "low")
+	}
+	if got := comments[0].Content; got != "Use the canonical metadata fallback." {
+		t.Errorf("content = %q", got)
+	}
 }
 
 // TestLlmComment_JSONCategorySeverity verifies category and severity serialize as


### PR DESCRIPTION
## Description

Normalizes `code_comment` category and severity values at the parser boundary so undocumented model output does not silently pass through as canonical metadata. Unknown categories fall back to `other`, unknown severities fall back to `low`, valid mixed-case values are canonicalized to lowercase, and the comment content/location are preserved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Test verification (RED → GREEN)

RED on upstream-base behavior with the new regression test:

```text
--- FAIL: TestParseComments_CategorySeveritySchemaDrift (0.00s)
    code_comment_test.go:218: category = "correctness", want "other"
    code_comment_test.go:221: severity = "info", want "low"
FAIL
FAIL	github.com/open-code-review/open-code-review/internal/tool	0.010s
```

RED for the OCR review-bot casing counterexample before the lowercase fix:

```text
--- FAIL: TestParseComments_CategorySeverity (0.00s)
    --- FAIL: TestParseComments_CategorySeverity/normalizes_casing (0.00s)
        code_comment_test.go:216: category = "other", want "security"
        code_comment_test.go:219: severity = "low", want "critical"
FAIL
FAIL	github.com/open-code-review/open-code-review/internal/tool	0.006s
```

GREEN after the fix:

```text
ok  	github.com/open-code-review/open-code-review/internal/tool	0.011s
```

Full local Go CI replay in `golang:1.26.5`:

```text
gofmt -s -l .
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -v -race -count=1 -coverprofile=coverage.out ./...
Total coverage: 81.6%
go build -o /dev/null ./cmd/opencodereview
```

Cross-compile check started in `golang:1.26.5` and built `linux/arm64` and `darwin/amd64`; later targets were blocked by runner disk exhaustion during link (`no space left on device`).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Fixes #477
