### PR TITLE
fix(agent): count only dispatchable files reviewed

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -257,9 +257,9 @@ func (a *Agent) ResumeInfo() *ResumeInfo {
 	return &info
 }
 
-// FilesReviewed returns the number of changed files included in this review.
+// FilesReviewed returns the number of dispatchable files included in this review.
 func (a *Agent) FilesReviewed() int64 {
-	return int64(len(a.diffs))
+	return countDispatchable(a.diffs)
 }
 
 // Diffs returns the parsed diffs loaded by the agent.

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -66,6 +66,22 @@ func TestAgent_Getters(t *testing.T) {
 	}
 }
 
+func TestAgentFilesReviewedCountsDispatchableDiffs(t *testing.T) {
+	a := New(Args{})
+	a.diffs = []model.Diff{
+		{NewPath: "kept.go", OldPath: "kept.go", Diff: "+kept"},
+		{NewPath: "removed.go", OldPath: "removed.go", Diff: "-removed", IsDeleted: true},
+		{NewPath: "also-kept.go", OldPath: "also-kept.go", Diff: "+more"},
+	}
+
+	if got := a.FilesReviewed(); got != 2 {
+		t.Errorf("FilesReviewed() = %d, want 2", got)
+	}
+	if got := len(a.Diffs()); got != 3 {
+		t.Errorf("Diffs() len = %d, want 3", got)
+	}
+}
+
 func TestAgent_RecordWarning(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test-model", session.SessionOptions{ReviewMode: "diff"})


### PR DESCRIPTION
## Description

Makes `files_reviewed` report the number of dispatchable files instead of the raw retained diff slice length. Deleted diffs remain available through `Diffs()` for context and line resolution, but they are no longer counted as reviewed files.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Test verification (RED → GREEN)

RED on upstream-base behavior with the new regression test:

```text
--- FAIL: TestAgentFilesReviewedCountsDispatchableDiffs (0.02s)
    coverage_test.go:78: FilesReviewed() = 3, want 2
FAIL
FAIL	github.com/open-code-review/open-code-review/internal/agent	0.027s
```

GREEN after the fix:

```text
ok  	github.com/open-code-review/open-code-review/internal/agent	0.016s
```

Full local Go CI replay in `golang:1.26.5`:

```text
gofmt -s -l .
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -v -race -count=1 -coverprofile=coverage.out ./...
Total coverage: 81.5%
go build -o /dev/null ./cmd/opencodereview
```

Cross-compile check started in `golang:1.26.5` and built `linux/arm64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`; the final target was blocked by runner disk exhaustion while compiling dependencies (`no space left on device`).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Fixes #480
