### PR TITLE
feat(llm): add iFlytek Spark as a built-in provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -169,6 +169,21 @@ var registry = []Provider{
 		},
 	},
 	{
+		Name:        "iflytek",
+		DisplayName: "iFlytek Spark API",
+		Protocol:    ProtocolOpenAIChatCompletions,
+		BaseURL:     "https://spark-api-open.xf-yun.com/v1",
+		EnvVar:      "SPARK_API_KEY",
+		Models: []string{
+			"4.0Ultra",
+			"generalv3.5",
+			"max-32k",
+			"generalv3",
+			"pro-128k",
+			"lite",
+		},
+	},
+	{
 		Name:        "kimi",
 		DisplayName: "Kimi Moonshot API",
 		Protocol:    ProtocolOpenAIChatCompletions,

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -40,7 +40,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "kimi", "litellm", "mimo", "minimax", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -52,6 +52,7 @@ environment variable.
 | `deepseek` | openai | `https://api.deepseek.com` | `DEEPSEEK_API_KEY` |
 | `tencent-tokenhub` | openai | `https://tokenhub.tencentmaas.com/v1` | `TENCENT_TOKENHUB_API_KEY` |
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
+| `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -50,6 +50,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `deepseek` | openai | `https://api.deepseek.com` | `DEEPSEEK_API_KEY` |
 | `tencent-tokenhub` | openai | `https://tokenhub.tencentmaas.com/v1` | `TENCENT_TOKENHUB_API_KEY` |
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
+| `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -49,6 +49,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `deepseek` | openai | `https://api.deepseek.com` | `DEEPSEEK_API_KEY` |
 | `tencent-tokenhub` | openai | `https://tokenhub.tencentmaas.com/v1` | `TENCENT_TOKENHUB_API_KEY` |
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
+| `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |


### PR DESCRIPTION
## What

Adds **iFlytek Spark** as a built-in LLM provider.

The provider list already covers most major Chinese vendors — DashScope/Qwen, Volcano Engine, DeepSeek, Tencent Hunyuan, Kimi, Z.AI, Xiaomi MiMo, MiniMax, Baidu Qianfan — but iFlytek Spark was missing. Its official endpoint is OpenAI-compatible, so it slots in exactly like the other `openai`-protocol providers.

## Changes

- `internal/llm/providers.go` — new registry entry:
  - `BaseURL: https://spark-api-open.xf-yun.com/v1` (Spark's OpenAI-compatible HTTP endpoint; the API password is sent as a bearer token)
  - `EnvVar: SPARK_API_KEY`
  - Models are the exact `domain` values that endpoint accepts: `4.0Ultra`, `generalv3.5`, `max-32k`, `generalv3`, `pro-128k`, `lite`
- `internal/llm/providers_test.go` — added `iflytek` to the expected provider-order list (`ListProviders()` sorts by name, so it sits between `hy-tokenplan` and `kimi`)
- `pages/src/content/docs/{en,zh,ja}/configuration.md` — added the provider to the config table in all three locales

## Notes

- No new protocol or client code is needed — Spark rides the existing `ProtocolOpenAIChatCompletions` path, same as `deepseek`/`kimi`.
- I don't have a funded Spark API password, so there's no live end-to-end call in this PR. I verified statically that the sorted registry names match the updated `TestListProviders_Order` expectation exactly (18 providers, no duplicates) and that the three doc tables each gained one row. `make test` should confirm on CI.
- Endpoint and model ids are from iFlytek's official HTTP API docs (`spark-api-open.xf-yun.com/v1`); the WebSocket host `spark-api.xf-yun.com` uses HMAC-signed auth and is deliberately **not** used here.
