### PR TITLE
[codex] fix(vscode): force-kill unresponsive reviews

### DIFF
--- a/extensions/vscode/src/extension/services/CliService.ts
+++ b/extensions/vscode/src/extension/services/CliService.ts
@@ -158,7 +158,10 @@ export class CliService {
     if (this.current && this.current.pid) {
       this.current.kill('SIGTERM');
       const proc = this.current;
-      setTimeout(() => { if (!proc.killed) proc.kill('SIGKILL'); }, 3000);
+      const forceKillTimer = setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGKILL');
+      }, 3000);
+      proc.once('close', () => clearTimeout(forceKillTimer));
     }
   }
 }

--- a/extensions/vscode/src/extension/services/__tests__/CliService.cancel.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/CliService.cancel.test.ts
@@ -1,0 +1,68 @@
+process.env.OCR_SKIP_SHELL_RESOLVE = '1';
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { CliService } from '../CliService';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: jest.fn(),
+}));
+
+const mockedSpawn = jest.mocked(spawn);
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    pid: 123,
+    killed: false,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: jest.fn<(signal?: NodeJS.Signals | number) => boolean>(),
+  });
+  proc.kill.mockImplementation((signal) => {
+    proc.killed = true;
+    if (signal === 'SIGKILL') proc.signalCode = 'SIGKILL';
+    return true;
+  });
+  return proc;
+}
+
+describe('CliService.cancel', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    mockedSpawn.mockReset();
+  });
+
+  it('子进程忽略 SIGTERM 时，超时后发送 SIGKILL', () => {
+    jest.useFakeTimers();
+    const proc = createMockProcess();
+    mockedSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const svc = new CliService('node');
+    void svc.runRaw([], '.', () => {});
+    svc.cancel();
+    jest.advanceTimersByTime(3000);
+
+    expect(proc.kill).toHaveBeenNthCalledWith(1, 'SIGTERM');
+    expect(proc.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+  });
+
+  it('子进程已正常退出时，不再发送 SIGKILL', async () => {
+    jest.useFakeTimers();
+    const proc = createMockProcess();
+    mockedSpawn.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const svc = new CliService('node');
+    const run = svc.runRaw([], '.', () => {});
+    svc.cancel();
+    proc.exitCode = 0;
+    proc.emit('close', 0);
+    await run;
+    jest.advanceTimersByTime(3000);
+
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});


### PR DESCRIPTION
## Background

The VS Code extension sends `SIGTERM` when a user cancels an active review and is intended to escalate to `SIGKILL` after three seconds if the CLI process does not exit.

## Root cause

`ChildProcess.killed` only indicates that a signal was successfully sent. It does not indicate that the child process has exited. A process that ignores `SIGTERM` therefore has `killed === true` while `exitCode` and `signalCode` remain `null`, preventing the existing timeout from ever sending `SIGKILL`.

## Fix

- Check `exitCode` and `signalCode` to determine whether the child is still running before escalating to `SIGKILL`.
- Clear the escalation timer when the child emits `close` to avoid signaling a process that already exited.
- Add regression tests for both an unresponsive child and a child that exits normally after `SIGTERM`.

## Verification

- `yarn install --frozen-lockfile` (Node.js 24.18.0)
- `yarn lint` - 0 errors (1 pre-existing warning in `IdleView.tsx`)
- `yarn test --runInBand` - 11 suites, 94/94 tests passed
- `yarn build` - production webpack build passed

## Related

- #95 introduced the VS Code extension and its cancellation flow.
