### PR TITLE
fix(vscode): use shell on Windows when spawning npm/ocr in CliService

### DIFF
--- a/extensions/vscode/src/extension/services/CliService.ts
+++ b/extensions/vscode/src/extension/services/CliService.ts
@@ -32,7 +32,12 @@ export class CliService {
 
   private probeCommand(bin: string, args: string[]): Promise<{ ok: boolean; version?: string }> {
     return new Promise((resolve) => {
-      const proc = spawn(resolveBin(bin), args, { env: getShellEnv() });
+      // Windows 下 npm/ocr 等是 .cmd 包装脚本，spawn 必须走 shell 才能执行（node.exe 可直接跑，
+      // 但 npm.cmd 不行），否则环境检测会误报"未检测到 npm"。参见 install() 的同款处理。
+      const proc = spawn(resolveBin(bin), args, {
+        env: getShellEnv(),
+        shell: process.platform === 'win32',
+      });
       let stdout = '';
       let errored = false;
       proc.stdout?.on('data', (d) => { stdout += d.toString(); });
@@ -108,9 +113,11 @@ export class CliService {
     envExtra?: Record<string, string>,
   ): Promise<string> {
     return new Promise((resolve, reject) => {
+      // 同 probeCommand：Windows 下 ocr 是 npm 装的 .cmd 包装脚本，需走 shell 才能执行。
       const proc = spawn(resolveBin(this.cliPath), args, {
         cwd,
         env: envExtra ? { ...getShellEnv(), ...envExtra } : getShellEnv(),
+        shell: process.platform === 'win32',
       });
       this.current = proc;
       let stdout = '';

--- a/extensions/vscode/src/extension/services/__tests__/CliService.shell.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/CliService.shell.test.ts
@@ -1,0 +1,78 @@
+// src/extension/services/__tests__/CliService.shell.test.ts
+//
+// Windows 下 node 是 node.exe（可被 spawn 直接执行），但 npm/ocr 是 npm.cmd / ocr.cmd 包装脚本，
+// Node 的 child_process.spawn 不加 shell 无法执行 .cmd，导致环境检测误报"未检测到 npm"（issue #453）
+// 以及 review 无法运行。这里 mock child_process.spawn，断言各平台传入的 shell 选项，
+// 从而在非 Windows 机器上也能验证该跨平台修复，且保证 macOS/Linux 行为不变（shell:false）。
+process.env.OCR_SKIP_SHELL_RESOLVE = '1';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import { CliService } from '../CliService';
+
+jest.mock('child_process');
+
+const mockSpawn = spawn as unknown as jest.Mock;
+const originalPlatform = process.platform;
+
+const setPlatform = (platform: string) =>
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+// 立即回显版本号并以 code 0 结束的假子进程，覆盖 probeCommand / runRaw 用到的最小接口。
+const fakeProc = () => {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter; pid: number; kill: () => void; killed: boolean;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.pid = 4242;
+  proc.kill = () => {};
+  proc.killed = false;
+  setImmediate(() => {
+    proc.stdout.emit('data', Buffer.from('v1.0.0\n'));
+    proc.emit('close', 0);
+  });
+  return proc;
+};
+
+const shellOf = (callIndex: number): boolean | undefined =>
+  (mockSpawn.mock.calls[callIndex]?.[2] as { shell?: boolean } | undefined)?.shell;
+
+describe('CliService spawn shell 选项（跨平台）', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockSpawn.mockImplementation(() => fakeProc());
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('Windows：probeCommand 的每次 spawn 都带 shell:true（否则 npm.cmd 无法执行）', async () => {
+    setPlatform('win32');
+    await new CliService('node').checkEnvironment(true);
+    expect(mockSpawn).toHaveBeenCalled();
+    for (const call of mockSpawn.mock.calls) {
+      expect((call[2] as { shell?: boolean }).shell).toBe(true);
+    }
+  });
+
+  it('非 Windows：probeCommand 的 spawn 不启用 shell（shell:false，行为不变）', async () => {
+    setPlatform('darwin');
+    await new CliService('node').checkEnvironment(true);
+    expect(mockSpawn).toHaveBeenCalled();
+    for (const call of mockSpawn.mock.calls) {
+      expect((call[2] as { shell?: boolean }).shell).toBe(false);
+    }
+  });
+
+  it('runRaw 跟随平台设置 shell 选项', async () => {
+    setPlatform('win32');
+    await new CliService('ocr').runRaw(['--version'], '.', () => {});
+    expect(shellOf(0)).toBe(true);
+
+    mockSpawn.mockClear();
+    setPlatform('linux');
+    await new CliService('ocr').runRaw(['--version'], '.', () => {});
+    expect(shellOf(0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

On Windows, `node` is `node.exe` (which `child_process.spawn` can execute directly), but `npm` and the `ocr` CLI are `.cmd` wrapper scripts. Node's `spawn` cannot execute a `.cmd` file unless `shell: true` is set. As reported in #453, this made the VS Code extension's environment-check page false-report **"npm not detected"** even though `npm --version` works in every terminal. The same gap would also stop `runRaw` from launching the `ocr` CLI to actually run a review on Windows.

The `install` method already sets `shell: process.platform === 'win32'`, but the two other spawn call sites did not:

- `probeCommand` — used for the `node` / `npm` / `ocr` environment detection.
- `runRaw` — used to run a review (and `llm test`).

This PR adds `shell: process.platform === 'win32'` to both, matching `install`'s existing pattern. On macOS/Linux the option evaluates to `false`, so behavior there is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `yarn test` passes locally in `extensions/vscode` (11 suites, 95 tests).
- [x] Added `CliService.shell.test.ts`, which mocks `child_process.spawn` and asserts the `shell` option per platform (`win32` → `true`, others → `false`) for both `probeCommand` and `runRaw`. I confirmed the new tests fail when the fix is reverted, so they actually guard the behavior.
- [x] `tsc --noEmit -p tsconfig.extension.json` and `eslint` pass (no new warnings).
- [ ] Manual testing on Windows — I don't have a Windows machine, so the live `npm.cmd` path was verified by code inspection against the root cause in #453 and the already-correct `install` method, plus the platform-conditional unit tests above. Behavior on macOS/Linux is provably unchanged (`shell` stays `false`).

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (no user-facing docs affected)
- [ ] I have signed the CLA (will sign when the CLA bot posts on this PR)

## Related Issues

Closes #453