### PR TITLE
fix(ci): pin Pages CI container to node:24.18.0

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     container:
-      image: node:24
+      image: node:24.18.0
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Pin `pages-ci.yml` container image from the rolling `node:24` tag to `node:24.18.0`
- The rolling tag recently updated to a newer npm version that rejects `npm ci` with the existing lockfileVersion-3 lockfile, breaking all PRs that touch `pages/**` (e.g. #485, #457)
- `node:24.18.0` is the same version already used by `translation-sync.yml` and is known to work

## Context

The `pages-ci.yml` workflow was introduced in #442 with `image: node:24`. At the time, the rolling tag pointed to a compatible npm version. Docker Hub has since updated the tag, causing `npm ci` to fail with a lockfile incompatibility error.