### PR TITLE
feat(opencode): add native OpenCode integration

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -165,9 +165,10 @@ ocr delegate rule src/main.go src/handler.go
 - [レビュールール](https://open-codereview.ai/docs/review-rules) — レビュールールのカスタマイズ、パスフィルタリングとターゲティング
 - [設定](https://open-codereview.ai/docs/configuration) — 設定キーと環境変数
 - [MCP サーバー](https://open-codereview.ai/docs/mcp) — 外部ツールでレビューエージェントを拡張
-- コーディングエージェント連携 — OCR を Claude Code、Codex、Cursor などに統合
+- コーディングエージェント連携 — OCR を Claude Code、Codex、Cursor、OpenCode などに統合
   - [Skill](https://open-codereview.ai/docs/agent-skill) — 再利用可能なエージェントスキルとしてインストール
   - [Plugin](https://open-codereview.ai/docs/claude-code) — Claude Code / Codex / Cursor プラグインとしてインストール
+  - [OpenCode](plugins/open-code-review/opencode/README.md) — ネイティブレビュー・ツールとスラッシュコマンドをインストール
   - [デリゲートモード](https://open-codereview.ai/docs/delegate) — エージェント自身の LLM でレビューを実行
 - [CI/CD 連携](https://open-codereview.ai/docs/cicd) — GitHub Actions、GitLab CI、GitFlic CI、Gerrit との統合
 - [セッションビューアー](https://open-codereview.ai/docs/viewer) — ブラウザでレビューセッションを閲覧・再生

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -165,9 +165,10 @@ ocr delegate rule src/main.go src/handler.go
 - [리뷰 규칙](https://open-codereview.ai/docs/review-rules) — 리뷰 규칙 커스터마이징, 경로 필터링 및 타겟팅
 - [설정](https://open-codereview.ai/docs/configuration) — 설정 키와 환경 변수
 - [MCP 서버](https://open-codereview.ai/docs/mcp) — 외부 도구로 리뷰 에이전트 확장
-- 코딩 에이전트 연동 — OCR을 Claude Code, Codex, Cursor 등에 통합
+- 코딩 에이전트 연동 — OCR을 Claude Code, Codex, Cursor, OpenCode 등에 통합
   - [Skill](https://open-codereview.ai/docs/agent-skill) — 재사용 가능한 에이전트 스킬로 설치
   - [Plugin](https://open-codereview.ai/docs/claude-code) — Claude Code / Codex / Cursor 플러그인으로 설치
+  - [OpenCode](plugins/open-code-review/opencode/README.md) — 네이티브 리뷰 도구와 슬래시 명령 설치
   - [위임 모드](https://open-codereview.ai/docs/delegate) — 에이전트 자체 LLM으로 리뷰 수행
 - [CI/CD 연동](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI, Gerrit 통합
 - [세션 뷰어](https://open-codereview.ai/docs/viewer) — 브라우저에서 리뷰 세션 탐색 및 재생

--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ Full documentation lives at **[open-codereview.ai/docs](https://open-codereview.
 - [Review Rules](https://open-codereview.ai/docs/review-rules) — customize review rules with path filtering and targeting
 - [Configuration](https://open-codereview.ai/docs/configuration) — config keys and environment variables
 - [MCP Server](https://open-codereview.ai/docs/mcp) — extend the review agent with external tools
-- Coding Agent Integrations — integrate OCR into Claude Code, Codex, Cursor, etc.
+- Coding Agent Integrations — integrate OCR into Claude Code, Codex, Cursor, OpenCode, etc.
   - [Skill](https://open-codereview.ai/docs/agent-skill) — install as a reusable agent skill
   - [Plugin](https://open-codereview.ai/docs/claude-code) — install as a Claude Code / Codex / Cursor plugin
+  - [OpenCode](plugins/open-code-review/opencode/README.md) — install native review tools and slash commands
   - [Delegation Mode](https://open-codereview.ai/docs/delegate) — let your agent review using its own LLM
 - [CI/CD Integration](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI, and Gerrit integration
 - [Session Viewer](https://open-codereview.ai/docs/viewer) — browse and replay review sessions in browser

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -165,9 +165,10 @@ ocr delegate rule src/main.go src/handler.go
 - [Правила ревью](https://open-codereview.ai/docs/review-rules) — кастомизация правил ревью, фильтрация и таргетинг по путям
 - [Конфигурация](https://open-codereview.ai/docs/configuration) — ключи конфигурации и переменные окружения
 - [MCP-сервер](https://open-codereview.ai/docs/mcp) — расширение агента ревью внешними инструментами
-- Интеграция с кодинг-агентами — встраивание OCR в Claude Code, Codex, Cursor и др.
+- Интеграция с кодинг-агентами — встраивание OCR в Claude Code, Codex, Cursor, OpenCode и др.
   - [Skill](https://open-codereview.ai/docs/agent-skill) — установка как переиспользуемый навык агента
   - [Plugin](https://open-codereview.ai/docs/claude-code) — установка как плагин Claude Code / Codex / Cursor
+  - [OpenCode](plugins/open-code-review/opencode/README.md) — установка нативных инструментов ревью и slash-команд
   - [Режим делегирования](https://open-codereview.ai/docs/delegate) — агент ревьюит своей собственной LLM
 - [Интеграция с CI/CD](https://open-codereview.ai/docs/cicd) — GitHub Actions, GitLab CI, GitFlic CI и Gerrit
 - [Просмотр сессий](https://open-codereview.ai/docs/viewer) — просмотр и воспроизведение сессий ревью в браузере

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -165,9 +165,10 @@ ocr delegate rule src/main.go src/handler.go
 - [评审规则](https://open-codereview.ai/docs/review-rules) —— 深度定制规则进行评审，过滤路径、指定路径等
 - [配置](https://open-codereview.ai/docs/configuration) —— 配置项与环境变量
 - [MCP 服务器](https://open-codereview.ai/docs/mcp) —— 用外部工具扩展评审 agent
-- 编程 Agent 集成 —— 将 OCR 集成到 Claude Code、Codex、Cursor 等
+- 编程 Agent 集成 —— 将 OCR 集成到 Claude Code、Codex、Cursor、OpenCode 等
   - [Skill](https://open-codereview.ai/docs/agent-skill) —— 作为可复用的 Agent Skill 安装
   - [Plugin](https://open-codereview.ai/docs/claude-code) —— 作为 Claude Code / Codex / Cursor 插件安装
+  - [OpenCode](plugins/open-code-review/opencode/README.md) —— 安装原生审查工具和斜杠命令
   - [委托模式](https://open-codereview.ai/docs/delegate) —— 让 Agent 使用自身的 LLM 进行评审
 - [CI/CD 集成](https://open-codereview.ai/docs/cicd) —— 支持 GitHub Actions、GitLab CI、GitFlic CI、Gerrit 集成
 - [会话查看器](https://open-codereview.ai/docs/viewer) —— 在浏览器中浏览和回放评审会话

--- a/plugins/open-code-review/opencode/.gitignore
+++ b/plugins/open-code-review/opencode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/plugins/open-code-review/opencode/README.md
+++ b/plugins/open-code-review/opencode/README.md
@@ -1,0 +1,86 @@
+# OpenCode integration
+
+This integration exposes OpenCodeReview as native tools and slash commands in
+[OpenCode](https://opencode.ai/).
+
+It registers:
+
+- `ocr_review` — review workspace changes, one commit, or a ref range and
+  return structured JSON findings.
+- `ocr_health` — show the installed OCR version and test its configured LLM
+  connection.
+- `/ocr-review` and `/ocr-health` — convenient prompts that invoke the tools.
+
+Existing user commands with either name are preserved.
+
+## Prerequisites
+
+Install and configure OpenCodeReview first:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+ocr config provider
+ocr config model
+ocr llm test
+```
+
+## Install globally
+
+```bash
+mkdir -p ~/.config/opencode/plugins
+curl -fsSL \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/opencode/open-code-review.ts \
+  -o ~/.config/opencode/plugins/open-code-review.ts
+```
+
+Restart OpenCode after installation.
+
+## Install for one project
+
+Run this from the project root:
+
+```bash
+mkdir -p .opencode/plugins
+curl -fsSL \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/opencode/open-code-review.ts \
+  -o .opencode/plugins/open-code-review.ts
+```
+
+Commit the plugin file if the integration should be shared with the project.
+
+## Usage
+
+Use the registered commands:
+
+```text
+/ocr-review current workspace; focus on authentication regressions
+/ocr-review compare main to feature/auth-refresh
+/ocr-health
+```
+
+Or ask OpenCode naturally:
+
+```text
+Use ocr_review to review my current changes. The goal is to add rate limiting
+without changing the public API.
+```
+
+Set `preview` to `true` to inspect which files would be reviewed without making
+an LLM request.
+
+## Behavior and safety
+
+- Reviews use `--audience agent` and JSON output.
+- The process is launched with an argument array and `shell: false`.
+- Reviews have a 15-minute overall timeout and a 10 MiB output limit.
+- Cancelling the OpenCode tool terminates the OCR process.
+- OCR credentials remain in the existing OCR configuration or environment.
+- Workspace mode includes staged, unstaged, and untracked files.
+
+## Development
+
+```bash
+cd plugins/open-code-review/opencode
+npm install
+npm run check
+```

--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -132,7 +132,9 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
     let stdoutBytes = 0
     let stderrBytes = 0
     let settled = false
+    let closed = false
     let timer: ReturnType<typeof setTimeout> | undefined
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined
     let abort: (() => void) | undefined
 
     const finish = (callback: () => void): void => {
@@ -145,8 +147,18 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
       callback()
     }
 
-    const failForOutputLimit = (error: Error): void => {
+    const terminateChild = (): void => {
+      if (closed) return
       child.kill("SIGTERM")
+      forceKillTimer ??= setTimeout(() => {
+        if (!closed) {
+          child.kill("SIGKILL")
+        }
+      }, 3_000)
+    }
+
+    const failForOutputLimit = (error: Error): void => {
+      terminateChild()
       finish(() => reject(error))
     }
 
@@ -173,6 +185,8 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
     })
 
     child.on("close", (exitCode) => {
+      closed = true
+      clearTimeout(forceKillTimer)
       finish(() => {
         const result = {
           stdout: Buffer.concat(stdoutChunks).toString("utf8").trim(),
@@ -191,7 +205,7 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
     })
 
     abort = (): void => {
-      child.kill("SIGTERM")
+      terminateChild()
       finish(() => reject(new OcrExecutionError(
         "OpenCodeReview was cancelled by OpenCode.",
         {
@@ -204,7 +218,7 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
     options.signal?.addEventListener("abort", abort, { once: true })
 
     timer = setTimeout(() => {
-      child.kill("SIGTERM")
+      terminateChild()
       finish(() => reject(new OcrExecutionError(
         `OpenCodeReview timed out after ${Math.round(timeoutMs / 1000)} seconds.`,
         {
@@ -303,7 +317,7 @@ export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
         args: {},
         async execute(_args, context) {
           const cwd = context.worktree || context.directory || worktree
-          const [version, llm] = await Promise.all([
+          const [version, llm] = await Promise.allSettled([
             runOcr(["version"], {
               cwd,
               timeoutMs: 30_000,
@@ -315,11 +329,25 @@ export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
               signal: context.abort,
             }),
           ])
-          return [
-            version.stdout,
-            llm.stdout,
-            llm.stderr,
-          ].filter(Boolean).join("\n")
+          const rejected = [version, llm].find(
+            (result): result is PromiseRejectedResult => result.status === "rejected",
+          )
+          if (context.abort.aborted && rejected) {
+            throw rejected.reason
+          }
+
+          const parts: string[] = []
+          if (version.status === "fulfilled") {
+            parts.push(version.value.stdout)
+          } else {
+            parts.push(`Version check failed: ${version.reason?.message ?? "unknown error"}`)
+          }
+          if (llm.status === "fulfilled") {
+            parts.push(llm.value.stdout, llm.value.stderr)
+          } else {
+            parts.push(`LLM connection check failed: ${llm.reason?.message ?? "unknown error"}`)
+          }
+          return parts.filter(Boolean).join("\n")
         },
       }),
     },

--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -1,0 +1,327 @@
+import { spawn } from "node:child_process"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+
+interface ReviewInput {
+  repo?: string
+  commit?: string
+  from?: string
+  to?: string
+  resume?: string
+  background?: string
+  exclude?: string
+  model?: string
+  concurrency?: number
+  timeoutMinutes?: number
+  maxTools?: number
+  maxGitProcesses?: number
+  preview?: boolean
+}
+
+interface OcrInvocation {
+  command: string
+  prefixArgs: string[]
+}
+
+interface RunOptions {
+  cwd: string
+  timeoutMs?: number
+  maxOutputBytes?: number
+  invocation?: OcrInvocation
+  signal?: AbortSignal
+}
+
+interface RunResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+class OcrExecutionError extends Error {
+  readonly exitCode: number | null
+  readonly stderr: string
+  readonly stdout: string
+
+  constructor(message: string, result: {
+    exitCode: number | null
+    stderr?: string
+    stdout?: string
+  }) {
+    super(message)
+    this.name = "OcrExecutionError"
+    this.exitCode = result.exitCode
+    this.stderr = result.stderr ?? ""
+    this.stdout = result.stdout ?? ""
+  }
+}
+
+function pushValue(args: string[], flag: string, value: string | number | undefined): void {
+  if (value !== undefined && value !== "") {
+    args.push(flag, String(value))
+  }
+}
+
+function buildReviewArgs(input: ReviewInput): string[] {
+  const hasRange = input.from !== undefined || input.to !== undefined
+  if (hasRange && (!input.from || !input.to)) {
+    throw new Error("Both 'from' and 'to' are required for a branch comparison.")
+  }
+  if (input.commit && hasRange) {
+    throw new Error("Use either 'commit' or a 'from'/'to' range, not both.")
+  }
+  if (input.preview && input.resume) {
+    throw new Error("'preview' and 'resume' cannot be used together.")
+  }
+
+  const args = ["review", "--audience", "agent"]
+  if (!input.preview) {
+    args.push("--format", "json")
+  }
+
+  pushValue(args, "--repo", input.repo)
+  pushValue(args, "--commit", input.commit)
+  pushValue(args, "--from", input.from)
+  pushValue(args, "--to", input.to)
+  pushValue(args, "--resume", input.resume)
+  pushValue(args, "--background", input.background)
+  pushValue(args, "--exclude", input.exclude)
+  pushValue(args, "--model", input.model)
+  pushValue(args, "--concurrency", input.concurrency)
+  pushValue(args, "--timeout", input.timeoutMinutes)
+  pushValue(args, "--max-tools", input.maxTools)
+  pushValue(args, "--max-git-procs", input.maxGitProcesses)
+
+  if (input.preview) {
+    args.push("--preview")
+  }
+  return args
+}
+
+function appendChunk(
+  chunks: Uint8Array[],
+  currentBytes: number,
+  chunk: Uint8Array,
+  maxBytes: number,
+): number {
+  const nextBytes = currentBytes + chunk.byteLength
+  if (nextBytes > maxBytes) {
+    throw new Error(`OCR output exceeded the ${maxBytes}-byte safety limit.`)
+  }
+  chunks.push(chunk)
+  return nextBytes
+}
+
+async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
+  const invocation = options.invocation ?? { command: "ocr", prefixArgs: [] }
+  const timeoutMs = options.timeoutMs ?? 15 * 60 * 1000
+  const maxOutputBytes = options.maxOutputBytes ?? 10 * 1024 * 1024
+
+  return await new Promise<RunResult>((resolve, reject) => {
+    const child = spawn(
+      invocation.command,
+      [...invocation.prefixArgs, ...args],
+      {
+        cwd: options.cwd,
+        env: process.env,
+        shell: false,
+      },
+    )
+    child.stdin.end()
+
+    const stdoutChunks: Uint8Array[] = []
+    const stderrChunks: Uint8Array[] = []
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let abort: (() => void) | undefined
+
+    const finish = (callback: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (abort) {
+        options.signal?.removeEventListener("abort", abort)
+      }
+      callback()
+    }
+
+    const failForOutputLimit = (error: Error): void => {
+      child.kill("SIGTERM")
+      finish(() => reject(error))
+    }
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      try {
+        stdoutBytes = appendChunk(stdoutChunks, stdoutBytes, chunk, maxOutputBytes)
+      } catch (error) {
+        failForOutputLimit(error as Error)
+      }
+    })
+    child.stderr.on("data", (chunk: Buffer) => {
+      try {
+        stderrBytes = appendChunk(stderrChunks, stderrBytes, chunk, maxOutputBytes)
+      } catch (error) {
+        failForOutputLimit(error as Error)
+      }
+    })
+
+    child.on("error", (error) => {
+      const message = error.message.includes("ENOENT")
+        ? "OpenCodeReview is not installed or 'ocr' is not on PATH. Install it with: npm install -g @alibaba-group/open-code-review"
+        : `Failed to start OpenCodeReview: ${error.message}`
+      finish(() => reject(new OcrExecutionError(message, { exitCode: null })))
+    })
+
+    child.on("close", (exitCode) => {
+      finish(() => {
+        const result = {
+          stdout: Buffer.concat(stdoutChunks).toString("utf8").trim(),
+          stderr: Buffer.concat(stderrChunks).toString("utf8").trim(),
+          exitCode: exitCode ?? 1,
+        }
+        if (exitCode !== 0) {
+          reject(new OcrExecutionError(
+            result.stderr || result.stdout || `OpenCodeReview exited with code ${result.exitCode}.`,
+            result,
+          ))
+          return
+        }
+        resolve(result)
+      })
+    })
+
+    abort = (): void => {
+      child.kill("SIGTERM")
+      finish(() => reject(new OcrExecutionError(
+        "OpenCodeReview was cancelled by OpenCode.",
+        {
+          exitCode: null,
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stderr: Buffer.concat(stderrChunks).toString("utf8"),
+        },
+      )))
+    }
+    options.signal?.addEventListener("abort", abort, { once: true })
+
+    timer = setTimeout(() => {
+      child.kill("SIGTERM")
+      finish(() => reject(new OcrExecutionError(
+        `OpenCodeReview timed out after ${Math.round(timeoutMs / 1000)} seconds.`,
+        {
+          exitCode: null,
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stderr: Buffer.concat(stderrChunks).toString("utf8"),
+        },
+      )))
+    }, timeoutMs)
+
+    if (options.signal?.aborted) {
+      abort()
+    }
+  })
+}
+
+function formatReviewResult(result: RunResult, preview: boolean): string {
+  if (preview) {
+    return result.stdout || "No files changed."
+  }
+  try {
+    return JSON.stringify(JSON.parse(result.stdout), null, 2)
+  } catch {
+    throw new OcrExecutionError("OpenCodeReview returned invalid JSON.", result)
+  }
+}
+
+const optionalString = (description: string) =>
+  tool.schema.string().optional().describe(description)
+
+const optionalPositiveInt = (description: string) =>
+  tool.schema.number().int().positive().optional().describe(description)
+
+const reviewArgs = {
+  commit: optionalString("Review one commit against its parent."),
+  from: optionalString("Base ref for a branch/range comparison. Must be paired with 'to'."),
+  to: optionalString("Target ref for a branch/range comparison. Must be paired with 'from'."),
+  resume: optionalString("Resume a previous OCR review session by ID."),
+  background: optionalString("Business or requirement context that the implementation should satisfy."),
+  exclude: optionalString("Comma-separated gitignore-style exclusion patterns."),
+  model: optionalString("Override the model configured in OpenCodeReview."),
+  concurrency: optionalPositiveInt("Maximum concurrent file reviews."),
+  timeoutMinutes: optionalPositiveInt("Per-file OCR timeout in minutes."),
+  maxTools: optionalPositiveInt("Maximum tool-call rounds per file; OCR enforces a minimum of 10."),
+  maxGitProcesses: optionalPositiveInt("Maximum concurrent Git subprocesses."),
+  preview: tool.schema.boolean().optional().describe(
+    "List the files that would be reviewed without calling an LLM.",
+  ),
+}
+
+export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
+  await client.app.log({
+    body: {
+      service: "open-code-review",
+      level: "info",
+      message: "OpenCodeReview tools registered",
+    },
+  })
+
+  return {
+    config: async (config) => {
+      config.command ??= {}
+      config.command["ocr-review"] ??= {
+        description: "Review code changes with OpenCodeReview",
+        template:
+          "Use the ocr_review tool to review the requested target. " +
+          "Treat the following text as review intent, target details, and business context: $ARGUMENTS. " +
+          "If no target is specified, review the current workspace changes. " +
+          "Report findings by severity with exact file and line references.",
+      }
+      config.command["ocr-health"] ??= {
+        description: "Check OpenCodeReview and its LLM connection",
+        template:
+          "Use the ocr_health tool and explain any configuration problem concisely.",
+      }
+    },
+    tool: {
+      ocr_review: tool({
+        description:
+          "Run OpenCodeReview on workspace changes, one commit, or a ref range. " +
+          "Returns structured line-level findings as JSON. Use preview=true to inspect scope without LLM usage.",
+        args: reviewArgs,
+        async execute(args, context) {
+          const input = args as ReviewInput
+          const cwd = context.worktree || context.directory || worktree
+          const result = await runOcr(buildReviewArgs({
+            ...input,
+            repo: cwd,
+          }), { cwd, signal: context.abort })
+          return formatReviewResult(result, input.preview === true)
+        },
+      }),
+      ocr_health: tool({
+        description:
+          "Check the installed OpenCodeReview version and verify its configured LLM connection.",
+        args: {},
+        async execute(_args, context) {
+          const cwd = context.worktree || context.directory || worktree
+          const [version, llm] = await Promise.all([
+            runOcr(["version"], {
+              cwd,
+              timeoutMs: 30_000,
+              signal: context.abort,
+            }),
+            runOcr(["llm", "test"], {
+              cwd,
+              timeoutMs: 60_000,
+              signal: context.abort,
+            }),
+          ])
+          return [
+            version.stdout,
+            llm.stdout,
+            llm.stderr,
+          ].filter(Boolean).join("\n")
+        },
+      }),
+    },
+  }
+}

--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -129,8 +129,7 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
 
     const stdoutChunks: Uint8Array[] = []
     const stderrChunks: Uint8Array[] = []
-    let stdoutBytes = 0
-    let stderrBytes = 0
+    let outputBytes = 0
     let settled = false
     let closed = false
     let timer: ReturnType<typeof setTimeout> | undefined
@@ -164,14 +163,14 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
 
     child.stdout.on("data", (chunk: Buffer) => {
       try {
-        stdoutBytes = appendChunk(stdoutChunks, stdoutBytes, chunk, maxOutputBytes)
+        outputBytes = appendChunk(stdoutChunks, outputBytes, chunk, maxOutputBytes)
       } catch (error) {
         failForOutputLimit(error as Error)
       }
     })
     child.stderr.on("data", (chunk: Buffer) => {
       try {
-        stderrBytes = appendChunk(stderrChunks, stderrBytes, chunk, maxOutputBytes)
+        outputBytes = appendChunk(stderrChunks, outputBytes, chunk, maxOutputBytes)
       } catch (error) {
         failForOutputLimit(error as Error)
       }
@@ -240,7 +239,8 @@ function formatReviewResult(result: RunResult, preview: boolean): string {
     return result.stdout || "No files changed."
   }
   try {
-    return JSON.stringify(JSON.parse(result.stdout), null, 2)
+    JSON.parse(result.stdout)
+    return result.stdout
   } catch {
     throw new OcrExecutionError("OpenCodeReview returned invalid JSON.", result)
   }

--- a/plugins/open-code-review/opencode/package.json
+++ b/plugins/open-code-review/opencode/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "open-code-review-opencode-plugin-dev",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "check": "npm run typecheck && npm test"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "1.18.5",
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/plugins/open-code-review/opencode/test/open-code-review.test.mjs
+++ b/plugins/open-code-review/opencode/test/open-code-review.test.mjs
@@ -83,6 +83,17 @@ async function waitForProcessExit(pid, timeoutMs = 5_000) {
   throw new Error(`Process ${pid} did not exit within ${timeoutMs}ms`)
 }
 
+async function withShortOverallTimeout(timeoutMs, callback) {
+  const originalSetTimeout = globalThis.setTimeout
+  globalThis.setTimeout = (handler, delay, ...args) =>
+    originalSetTimeout(handler, delay === 15 * 60 * 1000 ? timeoutMs : delay, ...args)
+  try {
+    return await callback()
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+  }
+}
+
 test("module exposes only one OpenCode plugin entry point", async () => {
   const module = await import("../dist/open-code-review.js")
   assert.deepEqual(Object.keys(module), ["OpenCodeReviewPlugin"])
@@ -299,6 +310,37 @@ test("ocr_review force-kills a child that ignores cancellation", async () => {
   )
 })
 
+test("ocr_review terminates after its overall timeout", async () => {
+  await withFakeOcr(
+    "setInterval(() => {}, 1000)",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      await withShortOverallTimeout(20, async () => {
+        await assert.rejects(
+          hooks.tool.ocr_review.execute({}, toolContext(worktree)),
+          /timed out after 900 seconds/,
+        )
+      })
+    },
+  )
+})
+
+test("ocr_review enforces one output limit across stdout and stderr", async () => {
+  await withFakeOcr(
+    [
+      "process.stdout.write('a'.repeat(6 * 1024 * 1024))",
+      "process.stderr.write('b'.repeat(6 * 1024 * 1024))",
+    ].join("\n"),
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      await assert.rejects(
+        hooks.tool.ocr_review.execute({}, toolContext(worktree)),
+        /output exceeded the 10485760-byte safety limit/,
+      )
+    },
+  )
+})
+
 test("ocr_review rejects invalid JSON output", async () => {
   await withFakeOcr(
     "console.log('not json')",
@@ -308,6 +350,20 @@ test("ocr_review rejects invalid JSON output", async () => {
         hooks.tool.ocr_review.execute({}, toolContext(worktree)),
         /invalid JSON/,
       )
+    },
+  )
+})
+
+test("ocr_review preserves valid JSON after validation", async () => {
+  await withFakeOcr(
+    "console.log('{\"status\":\"success\",\"findings\":[]}')",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_review.execute(
+        {},
+        toolContext(worktree),
+      )
+      assert.equal(output, "{\"status\":\"success\",\"findings\":[]}")
     },
   )
 })

--- a/plugins/open-code-review/opencode/test/open-code-review.test.mjs
+++ b/plugins/open-code-review/opencode/test/open-code-review.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict"
+import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import test from "node:test"
+import { OpenCodeReviewPlugin } from "../dist/open-code-review.js"
+
+async function loadPlugin(worktree) {
+  const logs = []
+  const hooks = await OpenCodeReviewPlugin({
+    client: {
+      app: {
+        log: async (entry) => logs.push(entry),
+      },
+    },
+    worktree,
+  })
+  return { hooks, logs }
+}
+
+async function withFakeOcr(source, callback) {
+  const directory = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
+  const executable = join(directory, "ocr")
+  await writeFile(executable, `#!/usr/bin/env node\n${source}\n`)
+  await chmod(executable, 0o755)
+
+  const previousPath = process.env.PATH
+  process.env.PATH = `${directory}${delimiter}${previousPath ?? ""}`
+  try {
+    return await callback(directory)
+  } finally {
+    process.env.PATH = previousPath
+  }
+}
+
+function toolContext(worktree, signal = new AbortController().signal) {
+  return {
+    worktree,
+    directory: worktree,
+    abort: signal,
+  }
+}
+
+test("module exposes only one OpenCode plugin entry point", async () => {
+  const module = await import("../dist/open-code-review.js")
+  assert.deepEqual(Object.keys(module), ["OpenCodeReviewPlugin"])
+})
+
+test("plugin registers tools and preserves existing user commands", async () => {
+  const { hooks, logs } = await loadPlugin("/tmp/project")
+
+  assert.deepEqual(Object.keys(hooks.tool).sort(), ["ocr_health", "ocr_review"])
+  assert.equal(logs.length, 1)
+
+  const config = {
+    command: {
+      "ocr-review": {
+        template: "Keep my custom review command.",
+      },
+    },
+  }
+  await hooks.config(config)
+  assert.equal(config.command["ocr-review"].template, "Keep my custom review command.")
+  assert.match(config.command["ocr-health"].template, /ocr_health/)
+})
+
+test("ocr_review creates agent-friendly workspace arguments", async () => {
+  await withFakeOcr(
+    "console.log(JSON.stringify({status:'success', argv:process.argv.slice(2)}))",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_review.execute(
+        { background: "Add rate limiting" },
+        toolContext(worktree),
+      )
+      assert.deepEqual(JSON.parse(output).argv, [
+        "review",
+        "--audience",
+        "agent",
+        "--format",
+        "json",
+        "--repo",
+        worktree,
+        "--background",
+        "Add rate limiting",
+      ])
+    },
+  )
+})
+
+test("ocr_review passes suspicious-looking refs as one argv value without a shell", async () => {
+  await withFakeOcr(
+    "console.log(JSON.stringify({status:'success', argv:process.argv.slice(2)}))",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_review.execute(
+        {
+          commit: "main; touch /tmp/unsafe",
+          exclude: "**/*.generated.ts,dist/**",
+        },
+        toolContext(worktree),
+      )
+      assert.deepEqual(JSON.parse(output).argv, [
+        "review",
+        "--audience",
+        "agent",
+        "--format",
+        "json",
+        "--repo",
+        worktree,
+        "--commit",
+        "main; touch /tmp/unsafe",
+        "--exclude",
+        "**/*.generated.ts,dist/**",
+      ])
+    },
+  )
+})
+
+test("ocr_review rejects incompatible review targets before starting OCR", async () => {
+  const worktree = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
+  const { hooks } = await loadPlugin(worktree)
+
+  await assert.rejects(
+    hooks.tool.ocr_review.execute(
+      { commit: "abc", from: "main", to: "feature" },
+      toolContext(worktree),
+    ),
+    /either 'commit' or a 'from'\/'to' range/,
+  )
+  await assert.rejects(
+    hooks.tool.ocr_review.execute(
+      { from: "main" },
+      toolContext(worktree),
+    ),
+    /Both 'from' and 'to'/,
+  )
+  await assert.rejects(
+    hooks.tool.ocr_review.execute(
+      { preview: true, resume: "session-1" },
+      toolContext(worktree),
+    ),
+    /cannot be used together/,
+  )
+})
+
+test("preview omits JSON mode and adds --preview", async () => {
+  await withFakeOcr(
+    "console.log(process.argv.slice(2).join('\\n'))",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_review.execute(
+        { preview: true },
+        toolContext(worktree),
+      )
+      assert.deepEqual(output.split("\n"), [
+        "review",
+        "--audience",
+        "agent",
+        "--repo",
+        worktree,
+        "--preview",
+      ])
+    },
+  )
+})
+
+test("ocr_review reports non-zero exits with OCR output", async () => {
+  await withFakeOcr(
+    "console.error('missing credentials'); process.exit(7)",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      await assert.rejects(
+        hooks.tool.ocr_review.execute({}, toolContext(worktree)),
+        (error) => {
+          assert.equal(error.name, "OcrExecutionError")
+          assert.equal(error.exitCode, 7)
+          assert.match(error.message, /missing credentials/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test("ocr_review explains how to install a missing OCR executable", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
+  const previousPath = process.env.PATH
+  process.env.PATH = directory
+  try {
+    const { hooks } = await loadPlugin(directory)
+    await assert.rejects(
+      hooks.tool.ocr_review.execute({}, toolContext(directory)),
+      /npm install -g @alibaba-group\/open-code-review/,
+    )
+  } finally {
+    process.env.PATH = previousPath
+  }
+})
+
+test("ocr_review terminates when OpenCode cancels the tool", async () => {
+  await withFakeOcr(
+    "setInterval(() => {}, 1000)",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(), 20)
+      await assert.rejects(
+        hooks.tool.ocr_review.execute(
+          {},
+          toolContext(worktree, controller.signal),
+        ),
+        /cancelled by OpenCode/,
+      )
+    },
+  )
+})
+
+test("ocr_review rejects invalid JSON output", async () => {
+  await withFakeOcr(
+    "console.log('not json')",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      await assert.rejects(
+        hooks.tool.ocr_review.execute({}, toolContext(worktree)),
+        /invalid JSON/,
+      )
+    },
+  )
+})

--- a/plugins/open-code-review/opencode/test/open-code-review.test.mjs
+++ b/plugins/open-code-review/opencode/test/open-code-review.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { delimiter, join } from "node:path"
 import test from "node:test"
@@ -18,19 +18,29 @@ async function loadPlugin(worktree) {
   return { hooks, logs }
 }
 
-async function withFakeOcr(source, callback) {
+async function withTemporaryDirectory(callback) {
   const directory = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
-  const executable = join(directory, "ocr")
-  await writeFile(executable, `#!/usr/bin/env node\n${source}\n`)
-  await chmod(executable, 0o755)
-
-  const previousPath = process.env.PATH
-  process.env.PATH = `${directory}${delimiter}${previousPath ?? ""}`
   try {
     return await callback(directory)
   } finally {
-    process.env.PATH = previousPath
+    await rm(directory, { recursive: true, force: true })
   }
+}
+
+async function withFakeOcr(source, callback) {
+  return await withTemporaryDirectory(async (directory) => {
+    const executable = join(directory, "ocr")
+    await writeFile(executable, `#!/usr/bin/env node\n${source}\n`)
+    await chmod(executable, 0o755)
+
+    const previousPath = process.env.PATH
+    process.env.PATH = `${directory}${delimiter}${previousPath ?? ""}`
+    try {
+      return await callback(directory)
+    } finally {
+      process.env.PATH = previousPath
+    }
+  })
 }
 
 function toolContext(worktree, signal = new AbortController().signal) {
@@ -39,6 +49,38 @@ function toolContext(worktree, signal = new AbortController().signal) {
     directory: worktree,
     abort: signal,
   }
+}
+
+async function waitForFile(path, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      await access(path)
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`)
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if (error.code === "ESRCH") return false
+    throw error
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`Process ${pid} did not exit within ${timeoutMs}ms`)
 }
 
 test("module exposes only one OpenCode plugin entry point", async () => {
@@ -62,6 +104,14 @@ test("plugin registers tools and preserves existing user commands", async () => 
   await hooks.config(config)
   assert.equal(config.command["ocr-review"].template, "Keep my custom review command.")
   assert.match(config.command["ocr-health"].template, /ocr_health/)
+})
+
+test("fake OCR helper removes its temporary directory", async () => {
+  let temporaryDirectory
+  await withFakeOcr("", async (directory) => {
+    temporaryDirectory = directory
+  })
+  await assert.rejects(access(temporaryDirectory), { code: "ENOENT" })
 })
 
 test("ocr_review creates agent-friendly workspace arguments", async () => {
@@ -118,30 +168,31 @@ test("ocr_review passes suspicious-looking refs as one argv value without a shel
 })
 
 test("ocr_review rejects incompatible review targets before starting OCR", async () => {
-  const worktree = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
-  const { hooks } = await loadPlugin(worktree)
+  await withTemporaryDirectory(async (worktree) => {
+    const { hooks } = await loadPlugin(worktree)
 
-  await assert.rejects(
-    hooks.tool.ocr_review.execute(
-      { commit: "abc", from: "main", to: "feature" },
-      toolContext(worktree),
-    ),
-    /either 'commit' or a 'from'\/'to' range/,
-  )
-  await assert.rejects(
-    hooks.tool.ocr_review.execute(
-      { from: "main" },
-      toolContext(worktree),
-    ),
-    /Both 'from' and 'to'/,
-  )
-  await assert.rejects(
-    hooks.tool.ocr_review.execute(
-      { preview: true, resume: "session-1" },
-      toolContext(worktree),
-    ),
-    /cannot be used together/,
-  )
+    await assert.rejects(
+      hooks.tool.ocr_review.execute(
+        { commit: "abc", from: "main", to: "feature" },
+        toolContext(worktree),
+      ),
+      /either 'commit' or a 'from'\/'to' range/,
+    )
+    await assert.rejects(
+      hooks.tool.ocr_review.execute(
+        { from: "main" },
+        toolContext(worktree),
+      ),
+      /Both 'from' and 'to'/,
+    )
+    await assert.rejects(
+      hooks.tool.ocr_review.execute(
+        { preview: true, resume: "session-1" },
+        toolContext(worktree),
+      ),
+      /cannot be used together/,
+    )
+  })
 })
 
 test("preview omits JSON mode and adds --preview", async () => {
@@ -184,18 +235,19 @@ test("ocr_review reports non-zero exits with OCR output", async () => {
 })
 
 test("ocr_review explains how to install a missing OCR executable", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "ocr-opencode-test-"))
-  const previousPath = process.env.PATH
-  process.env.PATH = directory
-  try {
-    const { hooks } = await loadPlugin(directory)
-    await assert.rejects(
-      hooks.tool.ocr_review.execute({}, toolContext(directory)),
-      /npm install -g @alibaba-group\/open-code-review/,
-    )
-  } finally {
-    process.env.PATH = previousPath
-  }
+  await withTemporaryDirectory(async (directory) => {
+    const previousPath = process.env.PATH
+    process.env.PATH = directory
+    try {
+      const { hooks } = await loadPlugin(directory)
+      await assert.rejects(
+        hooks.tool.ocr_review.execute({}, toolContext(directory)),
+        /npm install -g @alibaba-group\/open-code-review/,
+      )
+    } finally {
+      process.env.PATH = previousPath
+    }
+  })
 })
 
 test("ocr_review terminates when OpenCode cancels the tool", async () => {
@@ -216,6 +268,37 @@ test("ocr_review terminates when OpenCode cancels the tool", async () => {
   )
 })
 
+test("ocr_review force-kills a child that ignores cancellation", async () => {
+  await withFakeOcr(
+    [
+      "require('node:fs').writeFileSync('ocr-child.pid', String(process.pid))",
+      "process.on('SIGTERM', () => {})",
+      "setInterval(() => {}, 1000)",
+    ].join("\n"),
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const controller = new AbortController()
+      const execution = hooks.tool.ocr_review.execute(
+        {},
+        toolContext(worktree, controller.signal),
+      )
+      const pidPath = join(worktree, "ocr-child.pid")
+      await waitForFile(pidPath)
+      const pid = Number(await readFile(pidPath, "utf8"))
+
+      controller.abort()
+      await assert.rejects(execution, /cancelled by OpenCode/)
+      try {
+        await waitForProcessExit(pid)
+      } finally {
+        if (isProcessRunning(pid)) {
+          process.kill(pid, "SIGKILL")
+        }
+      }
+    },
+  )
+})
+
 test("ocr_review rejects invalid JSON output", async () => {
   await withFakeOcr(
     "console.log('not json')",
@@ -225,6 +308,44 @@ test("ocr_review rejects invalid JSON output", async () => {
         hooks.tool.ocr_review.execute({}, toolContext(worktree)),
         /invalid JSON/,
       )
+    },
+  )
+})
+
+test("ocr_health reports both version success and LLM failure", async () => {
+  await withFakeOcr(
+    [
+      "if (process.argv[2] === 'version') {",
+      "  console.log('OpenCodeReview 1.2.3')",
+      "} else {",
+      "  console.error('missing LLM credentials')",
+      "  process.exitCode = 7",
+      "}",
+    ].join("\n"),
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_health.execute(
+        {},
+        toolContext(worktree),
+      )
+      assert.match(output, /OpenCodeReview 1\.2\.3/)
+      assert.match(output, /LLM connection check failed: missing LLM credentials/)
+    },
+  )
+})
+
+test("ocr_health preserves OpenCode cancellation", async () => {
+  await withFakeOcr(
+    "setInterval(() => {}, 1000)",
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const controller = new AbortController()
+      const execution = hooks.tool.ocr_health.execute(
+        {},
+        toolContext(worktree, controller.signal),
+      )
+      setTimeout(() => controller.abort(), 20)
+      await assert.rejects(execution, /cancelled by OpenCode/)
     },
   )
 })

--- a/plugins/open-code-review/opencode/tsconfig.json
+++ b/plugins/open-code-review/opencode/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "outDir": "dist",
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": [
+    "open-code-review.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add a project-local OpenCode plugin with native `ocr_review` and `ocr_health`
  tools;
- add `/ocr-review` and `/ocr-health` command templates without overwriting
  existing user commands;
- support workspace, commit, ref-range, resume, preview, model, concurrency,
  timeout, exclusion, and business-context options;
- document installation and usage in the plugin README and all root README
  translations.

Closes #497.

## Why

OpenCode users can already invoke the OCR CLI manually, but OpenCode cannot
discover OCR as agent tools or expose convenient review commands. This plugin
keeps OCR's existing configuration model while making reviews available in the
normal OpenCode workflow.

## Safety and behavior

- Reviews are always bound to the active OpenCode worktree.
- OCR is launched with an argument array and `shell: false`.
- Cancellation terminates the child process.
- Review runs have an overall timeout and output-size limit.
- `preview=true` inspects the review scope without making an OCR LLM request.
- The module exposes only the plugin entry point because OpenCode evaluates
  every named export as a plugin.

## Validation

- `npm run check` — TypeScript typecheck and 17 plugin tests
- `npm run test:github-actions`
- `make test`
- `make vet`
- `make build`
- OpenCode 1.18.5 runtime load and tool discovery
- End-to-end `openai/gpt-5.4` agent call to `ocr_review` with `preview=true`

## Validation gap

A live non-preview review was not run because OCR requires its own configured
LLM credentials; the OpenCode OAuth session is intentionally not copied into
OCR configuration.