### PR TITLE
refactor: extract duplicated command palette, heading parser, and copy-toast into shared hooks

### DIFF
--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useEffect, useRef, useState, useCallback, useId } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { Marked, Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import mermaid from 'mermaid';
 import { useTranslation } from '../i18n';
+import { useCopyToast } from '../hooks/useCopyToast';
 import copyIcon from '../assets/icons/icon-copy.svg';
 import { generateHeadingId } from '../utils/headingId';
 
@@ -47,35 +48,7 @@ interface MarkdownRendererProps {
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
-  const [toastVisible, setToastVisible] = useState(false);
-
-  const handleCopy = useCallback((text: string) => {
-    if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(text).then(() => {
-        setToastVisible(true);
-      }).catch(() => fallbackCopy(text));
-    } else {
-      fallbackCopy(text);
-    }
-  }, []);
-
-  const fallbackCopy = (text: string) => {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    const success = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    if (success) setToastVisible(true);
-  };
-
-  useEffect(() => {
-    if (!toastVisible) return;
-    const timer = setTimeout(() => setToastVisible(false), 1200);
-    return () => clearTimeout(timer);
-  }, [toastVisible]);
+  const { toastVisible, handleCopy } = useCopyToast();
 
   const html = useMemo(() => {
     // Custom renderer to generate heading IDs matching the TOC extraction logic

--- a/pages/src/components/QuickStartSection.tsx
+++ b/pages/src/components/QuickStartSection.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from '../i18n';
 import { useResponsive } from '../hooks/useResponsive';
 import { useSectionTitleStyle } from '../hooks/useResponsiveStyle';
+import { useCopyToast } from '../hooks/useCopyToast';
 import copyIcon from '../assets/icons/icon-copy.svg';
 import chevronDown from '../assets/icons/icon-chevron-down.svg';
 import chevronRight from '../assets/icons/icon-chevron-right.svg';
@@ -67,37 +68,7 @@ const QuickStartSection: React.FC = () => {
   const { t } = useTranslation();
   const { isMobile, isTablet } = useResponsive();
   const titleStyle = useSectionTitleStyle();
-  const [toastVisible, setToastVisible] = useState(false);
-
-  const handleCopy = useCallback((text: string) => {
-    if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(text).then(() => {
-        setToastVisible(true);
-      }).catch(() => {
-        fallbackCopy(text);
-      });
-    } else {
-      fallbackCopy(text);
-    }
-  }, []);
-
-  const fallbackCopy = (text: string) => {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    const success = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    if (success) setToastVisible(true);
-  };
-
-  useEffect(() => {
-    if (!toastVisible) return;
-    const timer = setTimeout(() => setToastVisible(false), 1200);
-    return () => clearTimeout(timer);
-  }, [toastVisible]);
+  const { toastVisible, handleCopy } = useCopyToast();
 
   return (
     <section

--- a/pages/src/hooks/useCommandSearch.ts
+++ b/pages/src/hooks/useCommandSearch.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Dispatch, KeyboardEvent as ReactKeyboardEvent, SetStateAction } from 'react';
+
+interface SearchResult<S extends string> {
+  slug: S;
+  title: string;
+  snippet: string;
+}
+
+export function useCommandSearch<S extends string>(
+  runSearch: (query: string, language: string) => SearchResult<S>[],
+  language: string,
+) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchSelectedIdx, setSearchSelectedIdx] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const searchResults = useMemo(
+    () => runSearch(searchQuery, language),
+    [runSearch, searchQuery, language],
+  );
+
+  /* Reset selection when results change */
+  useEffect(() => {
+    setSearchSelectedIdx(0);
+  }, [searchResults]);
+
+  /* ⌘K / Ctrl+K keyboard shortcut */
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        // Don't intercept when focused in other input/textarea (unless search is already open)
+        const activeEl = document.activeElement;
+        if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA') && !searchOpen) return;
+        e.preventDefault();
+        setSearchOpen(prev => !prev);
+      }
+      if (e.key === 'Escape') {
+        setSearchOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [searchOpen]);
+
+  /* Focus input when search opens */
+  useEffect(() => {
+    if (searchOpen) {
+      setTimeout(() => searchInputRef.current?.focus(), 50);
+    } else {
+      setSearchQuery('');
+    }
+  }, [searchOpen]);
+
+  return {
+    searchOpen,
+    setSearchOpen,
+    searchQuery,
+    setSearchQuery,
+    searchSelectedIdx,
+    setSearchSelectedIdx,
+    searchInputRef,
+    searchResults,
+  };
+}
+
+export function useSearchKeyboardNav<S extends string>(
+  searchResults: readonly SearchResult<S>[],
+  searchSelectedIdx: number,
+  setSearchSelectedIdx: Dispatch<SetStateAction<number>>,
+  onSelect: (slug: S) => void,
+) {
+  return useCallback(
+    (e: ReactKeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSearchSelectedIdx(prev => Math.min(prev + 1, searchResults.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSearchSelectedIdx(prev => Math.max(prev - 1, 0));
+      } else if (e.key === 'Enter' && searchResults.length > 0) {
+        e.preventDefault();
+        onSelect(searchResults[searchSelectedIdx].slug);
+      }
+    },
+    [searchResults, searchSelectedIdx, setSearchSelectedIdx, onSelect],
+  );
+}

--- a/pages/src/hooks/useCopyToast.ts
+++ b/pages/src/hooks/useCopyToast.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useCopyToast(duration = 1200) {
+  const [toastVisible, setToastVisible] = useState(false);
+
+  const handleCopy = useCallback((text: string) => {
+    const fallbackCopy = (value: string) => {
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const success = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      if (success) setToastVisible(true);
+    };
+
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text)
+        .then(() => setToastVisible(true))
+        .catch(() => fallbackCopy(text));
+    } else {
+      fallbackCopy(text);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!toastVisible) return;
+    const timer = setTimeout(() => setToastVisible(false), duration);
+    return () => clearTimeout(timer);
+  }, [toastVisible, duration]);
+
+  return { toastVisible, handleCopy };
+}

--- a/pages/src/pages/BlogPage.tsx
+++ b/pages/src/pages/BlogPage.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import { useResponsive } from '../hooks/useResponsive';
+import { useCommandSearch, useSearchKeyboardNav } from '../hooks/useCommandSearch';
 import {
   getBlogContent,
   getBlogMeta,
@@ -13,7 +14,7 @@ import {
   searchBlog,
   BlogSlug,
 } from '../content/blog';
-import { generateHeadingId } from '../utils/headingId';
+import { extractHeadings } from '../utils/extractHeadings';
 import docContentsIcon from '../assets/icons/doc-contents.svg';
 import searchIcon from '../assets/icons/icon-search.svg';
 import '../styles/docs-markdown.css';
@@ -21,30 +22,6 @@ import '../styles/blog.css';
 
 const fontFamily = 'PingFang SC, -apple-system, BlinkMacSystemFont, sans-serif';
 
-/* ─── Extract headings from markdown for right TOC ─── */
-function extractHeadings(markdown: string): { id: string; text: string; level: number }[] {
-  const headings: { id: string; text: string; level: number }[] = [];
-  const lines = markdown.split('\n');
-  let inCodeBlock = false;
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-    const match = line.match(/^(#{2,3})\s+(.+)$/);
-    if (match) {
-      const level = match[1].length;
-      const text = match[2]
-        .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-        .replace(/[`*_\[\]()]/g, '')
-        .trim();
-      const id = generateHeadingId(text);
-      headings.push({ id, text, level });
-    }
-  }
-  return headings;
-}
 
 /* ─── Build valid slug set from blog posts ─── */
 function getValidSlugs(language: string): Set<BlogSlug> {
@@ -59,10 +36,13 @@ const BlogPage: React.FC = () => {
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [activeHeadingId, setActiveHeadingId] = useState<string>('');
   const [hoveredHeadingId, setHoveredHeadingId] = useState<string>('');
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchSelectedIdx, setSearchSelectedIdx] = useState(0);
-  const searchInputRef = useRef<HTMLInputElement>(null);
+  const {
+    searchOpen, setSearchOpen,
+    searchQuery, setSearchQuery,
+    searchSelectedIdx, setSearchSelectedIdx,
+    searchInputRef,
+    searchResults,
+  } = useCommandSearch(searchBlog, language);
 
   const validSlugs = useMemo(() => getValidSlugs(language), [language]);
   const isDetailView = !!(slugParam && validSlugs.has(slugParam as BlogSlug));
@@ -117,56 +97,15 @@ const BlogPage: React.FC = () => {
     return () => observer.disconnect();
   }, [headings, isDetailView]);
 
-  /* Search results */
-  const searchResults = useMemo(() => searchBlog(searchQuery, language), [searchQuery, language]);
-
-  useEffect(() => {
-    setSearchSelectedIdx(0);
-  }, [searchResults]);
-
-  /* Cmd+K keyboard shortcut */
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        const activeEl = document.activeElement;
-        if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA') && !searchOpen) return;
-        e.preventDefault();
-        setSearchOpen(prev => !prev);
-      }
-      if (e.key === 'Escape') {
-        setSearchOpen(false);
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [searchOpen]);
-
-  useEffect(() => {
-    if (searchOpen) {
-      setTimeout(() => searchInputRef.current?.focus(), 50);
-    } else {
-      setSearchQuery('');
-    }
-  }, [searchOpen]);
-
   const handleSearchSelect = useCallback((slug: BlogSlug) => {
     navigate(`/blog/${slug}`);
     setSearchOpen(false);
     window.scrollTo(0, 0);
-  }, [navigate]);
+  }, [navigate, setSearchOpen]);
 
-  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setSearchSelectedIdx(prev => Math.min(prev + 1, searchResults.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setSearchSelectedIdx(prev => Math.max(prev - 1, 0));
-    } else if (e.key === 'Enter' && searchResults.length > 0) {
-      e.preventDefault();
-      handleSearchSelect(searchResults[searchSelectedIdx].slug);
-    }
-  }, [searchResults, searchSelectedIdx, handleSearchSelect]);
+  const handleSearchKeyDown = useSearchKeyboardNav(
+    searchResults, searchSelectedIdx, setSearchSelectedIdx, handleSearchSelect,
+  );
 
   const scrollToHeading = useCallback((id: string) => {
     const el = document.getElementById(id);

--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -5,8 +5,9 @@ import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import { useResponsive } from '../hooks/useResponsive';
+import { useCommandSearch, useSearchKeyboardNav } from '../hooks/useCommandSearch';
 import { getDocContent, getDocTitle, DocSlug, searchDocs } from '../content/docs';
-import { generateHeadingId } from '../utils/headingId';
+import { extractHeadings } from '../utils/extractHeadings';
 import docContentsIcon from '../assets/icons/doc-contents.svg';
 import searchIcon from '../assets/icons/icon-search.svg';
 import '../styles/docs-markdown.css';
@@ -98,32 +99,6 @@ const ChevronIcon: React.FC<{ expanded: boolean }> = ({ expanded }) => (
   </svg>
 );
 
-/* ─── Extract headings from markdown for right TOC ─── */
-function extractHeadings(markdown: string): { id: string; text: string; level: number }[] {
-  const headings: { id: string; text: string; level: number }[] = [];
-  const lines = markdown.split('\n');
-  let inCodeBlock = false;
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-    const match = line.match(/^(#{2,3})\s+(.+)$/);
-    if (match) {
-      const level = match[1].length;
-      // Strip markdown link syntax [text](url) → text, then strip other formatting
-      const text = match[2]
-        .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-        .replace(/[`*_\[\]()]/g, '')
-        .trim();
-      const id = generateHeadingId(text);
-      headings.push({ id, text, level });
-    }
-  }
-  return headings;
-}
-
 /* ─── Flat ordered list of all doc slugs for prev/next navigation ─── */
 function buildFlatDocList(): { slug: DocSlug; labelKey: string }[] {
   const list: { slug: DocSlug; labelKey: string }[] = [];
@@ -167,14 +142,17 @@ const DocsPage: React.FC = () => {
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({ 'sb-integrations': true });
   const [activeHeadingId, setActiveHeadingId] = useState<string>('');
   const [hoveredHeadingId, setHoveredHeadingId] = useState<string>('');
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchSelectedIdx, setSearchSelectedIdx] = useState(0);
-  const searchInputRef = useRef<HTMLInputElement>(null);
   /* Cancels an in-flight click-triggered scroll when a newer one starts */
   const cancelPendingScroll = useRef<(() => void) | null>(null);
   const { t, language } = useTranslation();
   const { isMobile } = useResponsive();
+  const {
+    searchOpen, setSearchOpen,
+    searchQuery, setSearchQuery,
+    searchSelectedIdx, setSearchSelectedIdx,
+    searchInputRef,
+    searchResults,
+  } = useCommandSearch(searchDocs, language);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
   const fontFamily = 'PingFang SC, -apple-system, BlinkMacSystemFont, sans-serif';
@@ -276,15 +254,6 @@ const DocsPage: React.FC = () => {
     }
   }, []);
 
-  /* Check if a sidebar item or its children is active */
-  const isItemActive = useCallback((item: SidebarItem): boolean => {
-    if (item.slug === activeSlug) return true;
-    if (item.children) {
-      return item.children.some(child => child.slug === activeSlug);
-    }
-    return false;
-  }, [activeSlug]);
-
   /* Auto-expand parent when a child is active */
   useEffect(() => {
     for (const group of sidebarTree) {
@@ -296,60 +265,16 @@ const DocsPage: React.FC = () => {
     }
   }, [activeSlug]);
 
-  /* Search results */
-  const searchResults = useMemo(() => searchDocs(searchQuery, language), [searchQuery, language]);
-
-  /* Reset selection when results change */
-  useEffect(() => {
-    setSearchSelectedIdx(0);
-  }, [searchResults]);
-
-  /* ⌘K / Ctrl+K keyboard shortcut */
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        // Don't intercept when focused in other input/textarea (unless search is already open)
-        const activeEl = document.activeElement;
-        if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA') && !searchOpen) return;
-        e.preventDefault();
-        setSearchOpen(prev => !prev);
-      }
-      if (e.key === 'Escape') {
-        setSearchOpen(false);
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [searchOpen]);
-
-  /* Focus input when search opens */
-  useEffect(() => {
-    if (searchOpen) {
-      setTimeout(() => searchInputRef.current?.focus(), 50);
-    } else {
-      setSearchQuery('');
-    }
-  }, [searchOpen]);
-
   /* Handle search result selection */
   const handleSearchSelect = useCallback((slug: DocSlug) => {
     navigateToDoc(slug);
     setSearchOpen(false);
-  }, [navigateToDoc]);
+  }, [navigateToDoc, setSearchOpen]);
 
   /* Keyboard navigation in search modal */
-  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setSearchSelectedIdx(prev => Math.min(prev + 1, searchResults.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setSearchSelectedIdx(prev => Math.max(prev - 1, 0));
-    } else if (e.key === 'Enter' && searchResults.length > 0) {
-      e.preventDefault();
-      handleSearchSelect(searchResults[searchSelectedIdx].slug);
-    }
-  }, [searchResults, searchSelectedIdx, handleSearchSelect]);
+  const handleSearchKeyDown = useSearchKeyboardNav(
+    searchResults, searchSelectedIdx, setSearchSelectedIdx, handleSearchSelect,
+  );
 
   return (
     <div style={{ minHeight: '100vh', background: '#000000', paddingTop: 72, fontFamily }}>

--- a/pages/src/utils/extractHeadings.ts
+++ b/pages/src/utils/extractHeadings.ts
@@ -1,0 +1,27 @@
+/* ─── Extract headings from markdown for right TOC ─── */
+import { generateHeadingId } from './headingId';
+
+export function extractHeadings(markdown: string): { id: string; text: string; level: number }[] {
+  const headings: { id: string; text: string; level: number }[] = [];
+  const lines = markdown.split('\n');
+  let inCodeBlock = false;
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    const match = line.match(/^(#{2,3})\s+(.+)$/);
+    if (match) {
+      const level = match[1].length;
+      // Strip markdown link syntax [text](url) → text, then strip other formatting
+      const text = match[2]
+        .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+        .replace(/[`*_\[\]()]/g, '')
+        .trim();
+      const id = generateHeadingId(text);
+      headings.push({ id, text, level });
+    }
+  }
+  return headings;
+}


### PR DESCRIPTION
## What

Removes three sets of duplicated logic in the landing/docs pages by extracting them into shared hooks and a util. No behavior change — pure refactor.

### 1. `useCommandSearch` + `useSearchKeyboardNav` (`src/hooks/useCommandSearch.ts`)

`DocsPage` and `BlogPage` each carried an identical copy of the ⌘K command palette:

- open/close + query + selected-index state and the input ref
- the ⌘K / Ctrl+K / Escape global shortcut
- focus-on-open (and query reset on close)
- reset-selection-when-results-change
- arrow-up / arrow-down / Enter result navigation

`useCommandSearch(runSearch, language)` owns the state, the memoized results, and the effects; `useSearchKeyboardNav(...)` returns the keydown handler. Each page still supplies its own search function (`searchDocs` / `searchBlog`) and select handler (docs vs blog navigation), which are the only genuinely page-specific parts.

### 2. `extractHeadings` util (`src/utils/extractHeadings.ts`)

The markdown-heading parser was defined as a local function inside **both** `DocsPage` and `BlogPage`. Moved to a single shared util that both import.

### 3. `useCopyToast` (`src/hooks/useCopyToast.ts`)

`QuickStartSection` and `MarkdownRenderer` had byte-identical clipboard-copy logic — a `navigator.clipboard` path, a `textarea` + `execCommand` fallback, and an auto-hiding confirmation toast. Extracted into `useCopyToast()` returning `{ toastVisible, handleCopy }`.

## Notes

- Removed a dead `isItemActive` `useCallback` in `DocsPage`. Confirmed genuinely dead: on `main` its only occurrence is the definition itself (no call sites), and there are zero references to it anywhere in `pages/src`. The sidebar highlights via `item.slug === activeSlug` directly, so this is a safe dead-code removal with no behavior change.
- `HeroSection` has a superficially similar copy-toast block but is intentionally **left as-is**: it also tracks a toast *message* and shows distinct success/failure i18n strings, so folding it into the boolean `useCopyToast` would have changed its behavior. Can generalize the hook in a follow-up if desired.
- `tsc --noEmit` passes.

## Net

7 files, ~200 fewer lines of duplication, behavior unchanged.
