### PR TITLE
fix(vscode): upgrade js-yaml resolution to >=5.2.2 for GHSA DoS

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -110,7 +110,7 @@
   "resolutions": {
     "undici": ">=7.28.0",
     "form-data": ">=4.0.6",
-    "js-yaml": ">=4.3.0",
+    "js-yaml": ">=5.2.2",
     "minimatch": "^9.0.7",
     "@typescript-eslint/typescript-estree/minimatch": "^9.0.7",
     "brace-expansion": ">=2.1.2 <3",

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -3420,10 +3420,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@>=4.3.0, js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.1.tgz#bb3f2e87295ebfe6ef0a75e17c62834daeff9ce2"
-  integrity sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==
+js-yaml@>=5.2.2, js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.2.tgz#497bfe63f0b0db11c7bbc5ce8bc568e836c8b08c"
+  integrity sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

Bump the `js-yaml` yarn resolution floor from `>=4.3.0` to `>=5.2.2` to remediate a high-severity DoS vulnerability (CVSS 7.5).

js-yaml 5.0.0–5.2.1 is vulnerable to exponential parsing time when processing crafted YAML flow collections — a sub-200-byte payload can hang any `load()`/`loadAll()` call indefinitely.

## Changes

- `extensions/vscode/package.json`: update resolution `"js-yaml": ">=5.2.2"`
- `extensions/vscode/yarn.lock`: regenerated — all js-yaml consumers now resolve to 5.2.2

## References

- Dependabot alert: https://github.com/alibaba/open-code-review/security/dependabot/27
- Fix: https://github.com/nodeca/js-yaml/releases/tag/5.2.2