### PR TITLE
refactor(template): remove dead Timeout field from template structs

### DIFF
--- a/internal/config/template/template.go
+++ b/internal/config/template/template.go
@@ -54,7 +54,6 @@ type manifestMessage struct {
 }
 
 type manifestConversation struct {
-	Timeout  int               `json:"timeout"`
 	Messages []manifestMessage `json:"messages"`
 }
 
@@ -70,7 +69,7 @@ type templateManifest struct {
 }
 
 func resolveConversation(m manifestConversation) (LlmConversation, error) {
-	conv := LlmConversation{Timeout: m.Timeout}
+	conv := LlmConversation{}
 	conv.Messages = make([]ChatMessage, len(m.Messages))
 	for i, mm := range m.Messages {
 		data, err := templateFS.ReadFile("prompts/" + mm.PromptFile)
@@ -214,7 +213,6 @@ func (t *ScanTemplate) Validate() error {
 
 // LlmConversation mirrors LlmConversation from the Java side — a preset prompt with settings.
 type LlmConversation struct {
-	Timeout  int           `json:"timeout"`
 	Messages []ChatMessage `json:"messages"`
 }
 

--- a/internal/config/template/template_test.go
+++ b/internal/config/template/template_test.go
@@ -65,9 +65,6 @@ func TestLoadDefault_FieldsPopulated(t *testing.T) {
 			t.Errorf("MainTask.Messages[%d].Content is empty", i)
 		}
 	}
-	if tpl.MainTask.Timeout != 0 {
-		t.Errorf("MainTask.Timeout = %d, want 0 (unset in template JSON)", tpl.MainTask.Timeout)
-	}
 	if tpl.PlanTask == nil {
 		t.Fatal("PlanTask is nil, expected non-nil")
 	}


### PR DESCRIPTION
## Description

PR #474 removed the per-task timeout logic but left the `Timeout` struct fields and copy logic behind as dead code. This PR removes the unused `Timeout` field from `manifestConversation` and `LlmConversation` in `internal/config/template/template.go`, simplifies `resolveConversation` to no longer copy it, and removes the corresponding zero-value assertion in `template_test.go`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

Ran `go test ./internal/config/template/... -v` — all tests pass. Also ran `go fmt ./...` and `go vet ./...` with no issues.

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
