### PR TITLE
refactor(search): extract shared SearchTrigger, fix platform-specific shortcut hint

### DIFF
--- a/pages/src/components/SearchTrigger.tsx
+++ b/pages/src/components/SearchTrigger.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import searchIcon from '../assets/icons/icon-search.svg';
+
+const fontFamily = 'PingFang SC, -apple-system, BlinkMacSystemFont, sans-serif';
+
+interface SearchTriggerProps {
+  placeholder: string;
+  onClick: () => void;
+  style?: React.CSSProperties;
+}
+
+export function SearchTrigger({ placeholder, onClick, style }: SearchTriggerProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px 12px',
+        background: 'rgba(255,255,255,0.04)',
+        border: '1px solid rgba(255,255,255,0.12)',
+        borderRadius: 8,
+        cursor: 'pointer',
+        color: 'rgba(255,255,255,0.4)',
+        fontSize: 14,
+        fontFamily,
+        outline: 'none',
+        transition: 'border-color 0.15s',
+        ...style,
+      }}
+      onMouseEnter={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.25)')}
+      onMouseLeave={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)')}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <img src={searchIcon} alt="" style={{ width: 16, height: 16, opacity: 0.6 }} />
+        {placeholder}
+      </span>
+      <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.3)', fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif', lineHeight: 1 }}>
+        {navigator.userAgent?.includes('Mac') ? '⌘K' : 'Ctrl+K'}
+      </span>
+    </button>
+  );
+}

--- a/pages/src/pages/BlogPage.tsx
+++ b/pages/src/pages/BlogPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../i18n';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import MarkdownRenderer from '../components/MarkdownRenderer';
+import { SearchTrigger } from '../components/SearchTrigger';
 import { useResponsive } from '../hooks/useResponsive';
 import { useCommandSearch, useSearchKeyboardNav } from '../hooks/useCommandSearch';
 import {
@@ -274,30 +275,11 @@ const BlogPage: React.FC = () => {
           </h1>
           {/* Search button */}
           {!isMobile && (
-            <button
+            <SearchTrigger
+              placeholder={t('blog.search.placeholder')}
               onClick={() => setSearchOpen(true)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                padding: '8px 12px',
-                background: 'rgba(255,255,255,0.04)',
-                border: '1px solid rgba(255,255,255,0.12)',
-                borderRadius: 8,
-                cursor: 'pointer',
-                color: 'rgba(255,255,255,0.4)',
-                fontSize: 14,
-                fontFamily,
-                outline: 'none',
-                transition: 'border-color 0.15s',
-              }}
-              onMouseEnter={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.25)')}
-              onMouseLeave={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)')}
-            >
-              <img src={searchIcon} alt="" style={{ width: 16, height: 16, opacity: 0.6 }} />
-              <span>{t('blog.search.placeholder')}</span>
-              <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.3)', fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif', lineHeight: 1, marginLeft: 8 }}>{navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K'}</span>
-            </button>
+              style={{ gap: 16 }}
+            />
           )}
         </div>
 

--- a/pages/src/pages/DocsPage.tsx
+++ b/pages/src/pages/DocsPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../i18n';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import MarkdownRenderer from '../components/MarkdownRenderer';
+import { SearchTrigger } from '../components/SearchTrigger';
 import { useResponsive } from '../hooks/useResponsive';
 import { useCommandSearch, useSearchKeyboardNav } from '../hooks/useCommandSearch';
 import { getDocContent, getDocTitle, DocSlug, searchDocs } from '../content/docs';
@@ -298,34 +299,11 @@ const DocsPage: React.FC = () => {
             borderRight: 'none',
           }}>
             {/* Search trigger button */}
-            <button
+            <SearchTrigger
+              placeholder={t('docs.search.placeholder')}
               onClick={() => setSearchOpen(true)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                width: '100%',
-                padding: '8px 12px',
-                marginBottom: 20,
-                background: 'rgba(255,255,255,0.04)',
-                border: '1px solid rgba(255,255,255,0.12)',
-                borderRadius: 8,
-                cursor: 'pointer',
-                color: 'rgba(255,255,255,0.4)',
-                fontSize: 14,
-                fontFamily,
-                outline: 'none',
-                transition: 'border-color 0.15s',
-              }}
-              onMouseEnter={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.25)')}
-              onMouseLeave={e => (e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)')}
-            >
-              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <img src={searchIcon} alt="" style={{ width: 16, height: 16, opacity: 0.6 }} />
-                {t('docs.search.placeholder')}
-              </span>
-              <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.3)', fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif', lineHeight: 1 }}>⌘K</span>
-            </button>
+              style={{ width: '100%', justifyContent: 'space-between', marginBottom: 20 }}
+            />
 
             {sidebarTree.map((group, gi) => (
               <div key={gi} style={{ display: 'flex', flexDirection: 'column', marginBottom: 16 }}>


### PR DESCRIPTION
## What

DocsPage and BlogPage each rendered a near-identical search-trigger button inline — same base styles, hover handlers, search icon, and ⌘K/Ctrl+K hint. This extracts a single `<SearchTrigger>` component and, in doing so, fixes two pre-existing issues in the keyboard-shortcut hint.

## Changes

### 1. Extract `SearchTrigger` (`src/components/SearchTrigger.tsx`)

One component with `{ placeholder, onClick, style? }`. The only real difference between the two call sites is layout, so that goes through the `style` prop:

- **Docs** (sidebar, full width): `style={{ width: '100%', justifyContent: 'space-between', marginBottom: 20 }}`
- **Blog** (inline): `style={{ gap: 16 }}` to preserve the existing placeholder→shortcut spacing

Everything else (button chrome, hover, icon, hint) lives in the component, so future style tweaks per page don't require forking the core.

### 2. Fix: Docs search button always showed `⌘K`

DocsPage hardcoded the hint to `⌘K`, so Windows/Linux users saw the Mac symbol. It now renders `Ctrl+K` / `⌘K` per platform — the behavior BlogPage already had. (macOS uses the bare `⌘K` symbol by convention; Windows/Linux use `Ctrl+K` — this matches VS Code, Slack, etc.)

### 3. Fix: replace deprecated `navigator.platform`

Blog's platform check used the deprecated [`navigator.platform`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform). The extracted component uses `navigator.userAgent` instead, so both pages get the non-deprecated path in one place.

## Notes

- Pure to the search button — no other component touched.
- `tsc --noEmit` passes.
- Visual output is unchanged on both pages (spacing verified in `pnpm dev`), except Docs now shows the correct platform hint.
