### PR TITLE
fix(vscode): support workspace review before first commit

### DIFF
--- a/extensions/vscode/src/extension/services/GitService.ts
+++ b/extensions/vscode/src/extension/services/GitService.ts
@@ -149,7 +149,8 @@ export class GitService {
 
     try {
       const [diffHeadOut, untrackedOut] = await Promise.all([
-        runGit(root, ['diff', '--name-status', 'HEAD']),
+        // HEAD does not exist before the first commit; fall back to the index below.
+        runGit(root, ['diff', '--name-status', 'HEAD']).catch(() => ''),
         runGit(root, ['ls-files', '--others', '--exclude-standard']),
       ]);
       let diffCachedOut = '';

--- a/extensions/vscode/src/extension/services/__tests__/GitService.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/GitService.test.ts
@@ -1,0 +1,39 @@
+import { execFile } from 'child_process';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import * as vscode from 'vscode';
+import { ReviewMode } from '../../../shared/types';
+import { GitService } from '../GitService';
+
+const execFileAsync = promisify(execFile);
+
+describe('GitService workspace files', () => {
+  let repoRoot: string;
+  const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(path.join(tmpdir(), 'ocr-vscode-git-'));
+    await execFileAsync('git', ['init', '-q'], { cwd: repoRoot });
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: repoRoot } }];
+  });
+
+  afterEach(async () => {
+    (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it('includes staged and untracked files before the first commit', async () => {
+    await writeFile(path.join(repoRoot, 'staged.ts'), 'export const staged = true;\n');
+    await execFileAsync('git', ['add', 'staged.ts'], { cwd: repoRoot });
+    await writeFile(path.join(repoRoot, 'untracked.ts'), 'export const untracked = true;\n');
+
+    const state = await new GitService().getState(ReviewMode.Workspace);
+
+    expect(state.workspaceFiles).toEqual([
+      { path: 'staged.ts', status: 'added' },
+      { path: 'untracked.ts', status: 'added' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Workspace review currently fails in a newly initialized Git repository before its first commit. `git diff --name-status HEAD` cannot resolve an unborn `HEAD`; because it runs inside `Promise.all`, the rejection also discards the successfully collected untracked files and clears `workspaceFiles`. As a result, the VS Code extension disables starting a review even when the repository contains staged or untracked changes.

This change:

- treats a failed `HEAD` diff as unavailable and reuses the existing cached diff fallback;
- continues to include untracked files in workspace review;
- preserves the existing behavior for repositories with commits;
- aligns VS Code workspace discovery with the CLI's existing fallback semantics;
- adds regression coverage using a real Git repository without any commits.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)

Automated checks:

- [x] `yarn install --frozen-lockfile`
- [x] `yarn lint`
- [x] `yarn compile`
- [x] `yarn build`
- [x] Regression test for staged and untracked files before the first commit
- [x] All other VS Code test suites pass locally

The full test run on Windows has one pre-existing failure in
`CliService.isAvailable` related to spawning `npm`; this is unrelated to this
change and is being addressed by #490. The new regression test passes, and the
remaining 88 tests pass locally.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] I have updated the documentation accordingly (not applicable: no user-facing API or workflow change)
- [x] I have signed the CLA

## Related Issues

N/A. Follow-up to #334.