### PR TITLE
fix(actions): clarify ambiguous batch review log

### DIFF
--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -403,7 +403,8 @@ async function publishBatch({
       succeeded = chunk.length - toRetry.length;
       reconciled = succeeded > 0;
       log(
-        `A batch review already exists on the server (review_id=${existingReview.review.id}). ` +
+        `A batch review with this run's tag exists on the server ` +
+          `(review_id=${existingReview.review.id}, may belong to an earlier batch). ` +
           `${succeeded}/${chunk.length} of this batch's inline comments already posted. ` +
           `${toRetry.length} missing, will retry only those.`
       );

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -289,10 +289,12 @@ function makeGithub(opts = {}) {
 
 function mockCore() {
   const outputs = {};
+  const logs = [];
   return {
     outputs,
+    logs,
     setOutput(name, value) { outputs[name] = value; },
-    info() {},
+    info(message) { logs.push(message); },
   };
 }
 
@@ -1458,7 +1460,7 @@ async function testBatchSizeLargerThanToSend() {
 // double-post). Requires the per-batch error spec.
 async function testBatchPartialSuccessReconcilesPerBatch() {
   const result = { comments: makeComments(4), warnings: [] };
-  const { github, outputs } = await run({
+  const { github, core, outputs } = await run({
     result,
     githubOpts: {
       // Fail ONLY batch #2 (index 1) with a 5xx; batch #1 (index 0) succeeds.
@@ -1496,6 +1498,10 @@ async function testBatchPartialSuccessReconcilesPerBatch() {
   assert.strictEqual(outputs.comments_failed, "0");
   assert.strictEqual(outputs.batches_total, "2");
   assert.strictEqual(outputs.batches_reconciled, "1", "batch #2 reconciled");
+  assert.ok(
+    core.logs.some((message) => message.includes("may belong to an earlier batch")),
+    "reconciliation log clarifies that the matched review may belong to an earlier batch"
+  );
 }
 
 // B4: 71 comments, one batch partially fails irrecoverably ->


### PR DESCRIPTION
## Description

When a later comment batch fails with a 5xx response,
`findExistingBatchReview` searches for a review using the run-level
`REVIEW_TAG`. Because this tag is shared by all batches in the same run, the
matched review may belong to an earlier successful batch rather than the
current failed batch.

The reconciliation logic remains correct because `getPostedCommentIds`
returns a server-global set of posted comment IDs. However, the existing log
message implies that the matched review necessarily belongs to the current
batch, which can be misleading while debugging partial failures.

This change:

- clarifies that the matched review may belong to an earlier batch;
- preserves the existing reconciliation and retry behavior;
- captures `core.info` output in the test mock;
- adds a regression assertion to the existing multi-batch reconciliation test.

Closes #518.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `npm run test:github-actions`
- [x] `node --check scripts/github-actions/post-review-comments.js`
- [x] `node --check scripts/github-actions/post-review-comments.test.js`
- [x] `go vet ./...`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the change is effective
- [x] New and existing GitHub Actions tests pass locally
- [x] I have updated the documentation accordingly (not applicable: log-only change)
- [x] I have signed the CLA

## Related Issues

Closes #518.