### PR TITLE
feat(allowlist): add HCL/Terraform (.hcl, .tfvars) support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -32,6 +32,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".GRAPHQL", true},
 		{".gql", true},
 		{".GQL", true},
+		{".jl", true},
+		{".JL", true},
 		{".hcl", true},
 		{".HCL", true},
 		{".tfvars", true},
@@ -109,6 +111,11 @@ func TestIsExcludedPath(t *testing.T) {
 		{"oh_modules nested", "entry/oh_modules/lib/index.ets", true},
 		{"ets test file", "entry/src/test/Component.test.ets", true},
 		{"ets non-test", "entry/src/main/Component.ets", false},
+
+		// Julia test files
+		{"julia test file", "test/runtests.jl", true},
+		{"julia test nested", "MyPkg/test/unit/foo.jl", true},
+		{"julia non-test", "src/model.jl", false},
 
 		// Case insensitive
 		{"case insensitive go", "Foo/Bar_Test.go", true},

--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -32,8 +32,10 @@ func TestIsAllowedExt(t *testing.T) {
 		{".GRAPHQL", true},
 		{".gql", true},
 		{".GQL", true},
-		{".jl", true},
-		{".JL", true},
+		{".hcl", true},
+		{".HCL", true},
+		{".tfvars", true},
+		{".TFVARS", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -107,11 +109,6 @@ func TestIsExcludedPath(t *testing.T) {
 		{"oh_modules nested", "entry/oh_modules/lib/index.ets", true},
 		{"ets test file", "entry/src/test/Component.test.ets", true},
 		{"ets non-test", "entry/src/main/Component.ets", false},
-
-		// Julia test files
-		{"julia test file", "test/runtests.jl", true},
-		{"julia test nested", "MyPkg/test/unit/foo.jl", true},
-		{"julia non-test", "src/model.jl", false},
 
 		// Case insensitive
 		{"case insensitive go", "Foo/Bar_Test.go", true},

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -72,6 +72,7 @@
   ".tf",
   ".graphql",
   ".gql",
+  ".jl",
   ".hcl",
   ".tfvars"
 ]

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -72,5 +72,6 @@
   ".tf",
   ".graphql",
   ".gql",
-  ".jl"
+  ".hcl",
+  ".tfvars"
 ]

--- a/internal/config/rules/rule_docs/terraform.md
+++ b/internal/config/rules/rule_docs/terraform.md
@@ -1,0 +1,29 @@
+> Favor precision over recall: only raise an issue when you are confident it is a real defect, and stay silent when the surrounding context is unclear — a false alarm costs more reviewer trust than a missed minor issue. Treat security and correctness findings as blocking, and style or idiom suggestions as non-blocking. Review only what is observable in the HCL under review; do not infer runtime provider behavior, cloud account configuration, or state stored outside this file.
+
+#### Obvious Typos or Spelling Errors
+- Spelling errors in resource/module/variable/output names at their declaration sites; do not report spelling errors at reference sites
+- Typos in `description` fields that affect readability of the module's public interface
+
+#### Hardcoded Secrets and Credentials
+- A literal password, API key, access key/secret pair, private key, or connection string assigned directly to a resource argument or a `variable`/`locals` default instead of coming from a secret manager, `sensitive` input, or environment-backed data source
+- A `.tfvars` file (this file type is the conventional home for real input values, and is frequently committed by accident with production secrets in it) assigning a real-looking secret value rather than a placeholder
+- A `variable` block that clearly holds a credential (name/description implies password, token, key, or secret) missing `sensitive = true`
+
+#### Overly Permissive Access
+- A security group / firewall / network ACL rule with an unrestricted source (`0.0.0.0/0`, `::/0`, or `"*"`) on a sensitive port (SSH/22, RDP/3389, database ports) or on all ports
+- An IAM policy, role, or resource policy granting a wildcard action (`"Action": "*"`) or wildcard resource (`"Resource": "*"`) instead of a scoped permission set
+- Public read/write ACLs or public access settings enabled on a storage resource (bucket, blob container) that has no clear public-content purpose stated in the diff
+
+#### State and Lifecycle
+- A `terraform.tfstate` or `*.tfstate.backup` file included in the diff — state files can contain resource attributes and secrets in plaintext and should never be committed
+- Removing or weakening a `lifecycle { prevent_destroy = true }` block on a resource that looks stateful/critical (database, persistent volume, KMS key) without an explanation in the diff
+- A stateful resource (database, storage bucket, KMS key) newly created without any `lifecycle` protection, when sibling resources of the same kind in the diff do have one — an inconsistency worth flagging, not an absolute rule
+
+#### Versioning and Reproducibility
+- A `required_providers`/module `source` version constraint left fully unbounded (e.g. no version argument at all, or `>= 0.0.0`) where sibling entries in the same file pin a version — inconsistent, not universally wrong, since some root modules intentionally float
+- Do not flag a deliberately wide constraint (e.g. `~>`, a documented range) that is clearly intentional from the surrounding code
+
+#### Style and Structure
+- Duplicate resource/data-source labels within the same module (would fail `terraform validate`, if not already caught by other tooling)
+- Variables declared but never referenced anywhere in the diff's module, or referenced variables never declared in the diff's scope
+- Do not flag formatting/whitespace that `terraform fmt` would silently fix — focus on structural and semantic issues

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -24,6 +24,6 @@
     "**/*.po": "po.md",
     "**/*.pot": "pot.md",
     "**/*.{graphql,gql}": "graphql.md",
-    "**/*.jl": "julia.md"
+    "**/*.{tf,hcl,tfvars}": "terraform.md"
   }
 }

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -24,6 +24,7 @@
     "**/*.po": "po.md",
     "**/*.pot": "pot.md",
     "**/*.{graphql,gql}": "graphql.md",
+    "**/*.jl": "julia.md",
     "**/*.{tf,hcl,tfvars}": "terraform.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -92,8 +92,9 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"i18n/app.pot", "Header Integrity"},
 		{"api/schema.graphql", "Breaking Changes"},
 		{"queries/user.gql", "Breaking Changes"},
-		{"src/model.jl", "Type Stability"},
-		{"MyPkg/src/solver.jl", "Type Stability"},
+		{"main.tf", "Hardcoded Secrets"},
+		{"modules/network/vpc.hcl", "Overly Permissive Access"},
+		{"envs/prod.tfvars", "Hardcoded Secrets"},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -92,6 +92,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"i18n/app.pot", "Header Integrity"},
 		{"api/schema.graphql", "Breaking Changes"},
 		{"queries/user.gql", "Breaking Changes"},
+		{"src/model.jl", "Type Stability"},
+		{"MyPkg/src/solver.jl", "Type Stability"},
 		{"main.tf", "Hardcoded Secrets"},
 		{"modules/network/vpc.hcl", "Overly Permissive Access"},
 		{"envs/prod.tfvars", "Hardcoded Secrets"},


### PR DESCRIPTION
Closes #522. Part of #470.

## What
Adds `.hcl` and `.tfvars` to the code-review allowlist and maps them, along with the already-supported `.tf`, to a new dedicated `terraform.md` review-rule doc.

`.tf` was already allowlisted but had no dedicated rule doc — it fell through to the generic `default.md` rule set. Since `.tf`/`.hcl`/`.tfvars` are all the same HCL syntax family, this brings all three under one consistent, language-specific ruleset rather than adding rules only for the two new extensions and leaving `.tf` behind.

## Rule doc coverage
`terraform.md` follows the same structure as the existing `graphql.md` (precision-over-recall framing, security findings blocking / style non-blocking):
- Hardcoded secrets/credentials in resource arguments or `.tfvars` values, and credential-looking variables missing `sensitive = true`
- Overly permissive network rules (`0.0.0.0/0` on sensitive ports) and wildcard IAM policies
- Committed `.tfstate`/`.tfstate.backup` files (state can contain secrets in plaintext)
- Weakened/missing `lifecycle { prevent_destroy = true }` on stateful resources
- Unbounded provider/module version constraints, inconsistent with sibling pinned versions
- Structural issues (duplicate resource labels, unused/undeclared variables)

## Tests
- `allowed_ext_test.go`: `.hcl`/`.HCL`/`.tfvars`/`.TFVARS` allowlist cases
- `system_rules_test.go`: rule-resolution cases for `.tf`, `.hcl`, `.tfvars` all resolving to `terraform.md`
- Every new assertion confirmed to fail against pre-fix code before the corresponding change landed

## Verification
- `go vet`, `go build`, `go test` on the two touched packages (`internal/config/allowlist`, `internal/config/rules`): clean, all passing
- `gofmt -l`: clean