### PR TITLE
feat(allowlist): add Bicep (.bicep) support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -114,6 +114,11 @@ func TestIsExcludedPath(t *testing.T) {
 		{"ets test file", "entry/src/test/Component.test.ets", true},
 		{"ets non-test", "entry/src/main/Component.ets", false},
 
+		// Julia test files
+		{"julia test file", "test/runtests.jl", true},
+		{"julia test nested", "MyPkg/test/unit/foo.jl", true},
+		{"julia non-test", "src/model.jl", false},
+
 		// Case insensitive
 		{"case insensitive go", "Foo/Bar_Test.go", true},
 		{"case insensitive java", "com/FooTEST.java", true}, // lowercase → "com/footest.java" matches "**/*test.java"

--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -38,6 +38,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".HCL", true},
 		{".tfvars", true},
 		{".TFVARS", true},
+		{".bicep", true},
+		{".BICEP", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -111,11 +113,6 @@ func TestIsExcludedPath(t *testing.T) {
 		{"oh_modules nested", "entry/oh_modules/lib/index.ets", true},
 		{"ets test file", "entry/src/test/Component.test.ets", true},
 		{"ets non-test", "entry/src/main/Component.ets", false},
-
-		// Julia test files
-		{"julia test file", "test/runtests.jl", true},
-		{"julia test nested", "MyPkg/test/unit/foo.jl", true},
-		{"julia non-test", "src/model.jl", false},
 
 		// Case insensitive
 		{"case insensitive go", "Foo/Bar_Test.go", true},

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -74,5 +74,6 @@
   ".gql",
   ".jl",
   ".hcl",
-  ".tfvars"
+  ".tfvars",
+  ".bicep"
 ]

--- a/internal/config/rules/rule_docs/bicep.md
+++ b/internal/config/rules/rule_docs/bicep.md
@@ -10,7 +10,7 @@
 
 #### Overly Permissive Access
 - A `Microsoft.Authorization/roleAssignments` resource granting a broad built-in role (`Owner`, `Contributor`) at subscription or resource-group scope where a narrower, resource-scoped or custom role would suffice, especially when sibling assignments in the same file use narrower scopes
-- A network security group rule (`Microsoft.Network/networkSecurityGroups/securityRules`) with `sourceAddressPrefix` set to `*`/`Internet`/`0.0.0.0/0` on a sensitive port (SSH/22, RDP/3389, database ports) or on all ports (`destinationPortRange: '*'`)
+- A network security group rule (`Microsoft.Network/networkSecurityGroups/securityRules`) with `sourceAddressPrefix` set to `*`/`Internet`/`0.0.0.0/0` on a sensitive port (SSH/22, RDP/3389, or a database port such as MySQL/3306, PostgreSQL/5432, SQL Server/1433, MongoDB/27017) or on all ports (`destinationPortRange: '*'`)
 - A storage account, key vault, or SQL server resource with `publicNetworkAccess` explicitly set to `'Enabled'` (or left at a default that resolves to public) alongside no compensating `networkAcls`/private-endpoint configuration elsewhere in the same file
 
 #### Insecure Resource Defaults

--- a/internal/config/rules/rule_docs/bicep.md
+++ b/internal/config/rules/rule_docs/bicep.md
@@ -1,0 +1,28 @@
+> Favor precision over recall: only raise an issue when you are confident it is a real defect, and stay silent when the surrounding context is unclear — a false alarm costs more reviewer trust than a missed minor issue. Treat security and correctness findings as blocking, and style or idiom suggestions as non-blocking. Review only what is observable in the Bicep under review; do not infer Azure subscription/tenant configuration, deployed resource state, or policy assignments that live outside this file.
+
+#### Obvious Typos or Spelling Errors
+- Spelling errors in resource/module/parameter/variable/output names at their declaration sites; do not report spelling errors at reference sites
+- Typos in `@description()` text that affect readability of the module's public interface
+
+#### Hardcoded Secrets and Credentials
+- A literal password, connection string, API key, or access token assigned directly to a resource property, parameter default, or variable instead of coming from a Key Vault reference (`getSecret()` / `Microsoft.KeyVault/vaults/secrets` resource) or a secure parameter supplied at deployment time
+- A parameter whose name or description clearly indicates a credential (password, secret, token, connectionString, apiKey) declared without the `@secure()` decorator, which is what prevents the value from being logged or shown in deployment history
+
+#### Overly Permissive Access
+- A `Microsoft.Authorization/roleAssignments` resource granting a broad built-in role (`Owner`, `Contributor`) at subscription or resource-group scope where a narrower, resource-scoped or custom role would suffice, especially when sibling assignments in the same file use narrower scopes
+- A network security group rule (`Microsoft.Network/networkSecurityGroups/securityRules`) with `sourceAddressPrefix` set to `*`/`Internet`/`0.0.0.0/0` on a sensitive port (SSH/22, RDP/3389, database ports) or on all ports (`destinationPortRange: '*'`)
+- A storage account, key vault, or SQL server resource with `publicNetworkAccess` explicitly set to `'Enabled'` (or left at a default that resolves to public) alongside no compensating `networkAcls`/private-endpoint configuration elsewhere in the same file
+
+#### Insecure Resource Defaults
+- A storage account without `minimumTlsVersion` set to a current version, or with `supportsHttpsTrafficOnly` explicitly set to `false`
+- A resource property that disables encryption-at-rest or transparent data encryption where the resource type supports enabling it
+- Do not flag a resource for merely omitting an optional hardening property when the diff gives no indication either way — only flag an explicit insecure value or an explicit disabling of a secure default
+
+#### Versioning and Reproducibility
+- An `api-version` in a resource's type string that is unusually old relative to sibling resources of the same provider in the same diff — inconsistency worth flagging, not an absolute "must be latest" rule
+- A module reference (`module ... 'path/to/module.bicep'` or a registry reference) with no version/tag pinning where the surrounding file otherwise pins versions
+
+#### Style and Structure
+- Parameters declared but never referenced anywhere in the diff's scope, or referenced parameters/variables never declared in the diff's scope
+- Duplicate resource symbolic names within the same file (would fail compilation, if not already caught by other tooling)
+- Do not flag formatting/whitespace that the Bicep formatter would silently fix — focus on structural and semantic issues

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -25,6 +25,7 @@
     "**/*.pot": "pot.md",
     "**/*.{graphql,gql}": "graphql.md",
     "**/*.jl": "julia.md",
-    "**/*.{tf,hcl,tfvars}": "terraform.md"
+    "**/*.{tf,hcl,tfvars}": "terraform.md",
+    "**/*.bicep": "bicep.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -92,7 +92,7 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"i18n/app.pot", "Header Integrity"},
 		{"api/schema.graphql", "Breaking Changes"},
 		{"queries/user.gql", "Breaking Changes"},
-{"src/model.jl", "Type Stability"},
+		{"src/model.jl", "Type Stability"},
 		{"MyPkg/src/solver.jl", "Type Stability"},
 		{"main.tf", "Hardcoded Secrets"},
 		{"modules/network/vpc.hcl", "Overly Permissive Access"},

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -92,11 +92,12 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"i18n/app.pot", "Header Integrity"},
 		{"api/schema.graphql", "Breaking Changes"},
 		{"queries/user.gql", "Breaking Changes"},
-		{"src/model.jl", "Type Stability"},
+{"src/model.jl", "Type Stability"},
 		{"MyPkg/src/solver.jl", "Type Stability"},
 		{"main.tf", "Hardcoded Secrets"},
 		{"modules/network/vpc.hcl", "Overly Permissive Access"},
 		{"envs/prod.tfvars", "Hardcoded Secrets"},
+		{"infra/main.bicep", "Hardcoded Secrets"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #523. Part of #470.

## What
Adds `.bicep` to the code-review allowlist and maps it to a new dedicated `bicep.md` review-rule doc.

## Rule doc coverage
`bicep.md` follows the same structure as the existing `graphql.md`/`terraform.md` (precision-over-recall framing, security findings blocking / style non-blocking):
- Hardcoded secrets/connection strings instead of Key Vault references, and credential-looking parameters missing `@secure()`
- Overly permissive RBAC role assignments (broad built-in roles at wide scope where sibling assignments use narrower scope) and network security group rules open to `*`/`Internet` on sensitive ports
- Insecure resource defaults — public network access enabled with no compensating network ACLs, outdated `minimumTlsVersion`, disabled `supportsHttpsTrafficOnly`
- Unpinned module references and inconsistent `api-version` usage relative to sibling resources
- Structural issues (unused/undeclared parameters, duplicate resource symbolic names)

## Tests
- `allowed_ext_test.go`: `.bicep`/`.BICEP` allowlist cases
- `system_rules_test.go`: rule-resolution case for `.bicep` resolving to `bicep.md`
- Every new assertion confirmed to fail against pre-fix code before the corresponding change landed

## Verification
- `go vet`, `go build`, `go test` on the two touched packages (`internal/config/allowlist`, `internal/config/rules`): clean, all passing
- `gofmt -l`: clean