### PR TITLE
fix: path traversal bypass via backslash separators on Windows in code_search

### DIFF
--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -89,7 +90,9 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 }
 
 func hasTraversalPathComponent(pathspec string) bool {
-	for _, part := range strings.Split(pathspec, "/") {
+	// Normalize backslash separators (Windows) so "..\..\.." is caught too.
+	normalized := filepath.ToSlash(filepath.Clean(pathspec))
+	for _, part := range strings.Split(normalized, "/") {
 		if part == ".." {
 			return true
 		}

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -462,6 +462,34 @@ func TestCodeSearchProvider_Execute_RejectsTraversalPattern(t *testing.T) {
 	}
 }
 
+func TestCodeSearchProvider_Execute_RejectsBackslashTraversal(t *testing.T) {
+	dir := setupTestRepo(t)
+	p := NewCodeSearch(&FileReader{RepoDir: dir, Mode: ModeWorkspace})
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "backslash leading parent", pattern: `..\..\etc`},
+		{name: "backslash middle parent", pattern: `pkg\..\internal`},
+		{name: "mixed separators", pattern: `pkg\../..\secret`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := p.Execute(context.Background(), map[string]any{
+				"search_text":   "Hello",
+				"file_patterns": []any{test.pattern},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "Error: file_patterns must not contain .." {
+				t.Errorf("Execute() = %q, want traversal rejection", got)
+			}
+		})
+	}
+}
+
 func TestCodeSearchProvider_Execute_AllowsDoubleDotInFilename(t *testing.T) {
 	dir := setupTestRepo(t)
 	if err := os.WriteFile(filepath.Join(dir, "foo..bar.go"), []byte("package main\n\nfunc DoubleDotName() {}\n"), 0644); err != nil {


### PR DESCRIPTION
## Summary

**Security Fix**: `hasTraversalPathComponent()` in `internal/tool/code_search.go` only splits on `'/'` to detect `..` path traversal components in `file_patterns`. On Windows (an explicitly supported platform), backslash `\` is a valid path separator, so patterns like `..\..\etc\passwd` bypass the traversal check entirely.

### Root Cause

The function splits the pathspec on `'/'` only. When a backslash-separated path like `..\..\..\etc` is provided, `strings.Split(s, "/")` produces a single component `..\..\..\etc` which does NOT equal `..`, so the traversal is not detected.

### Impact

An LLM (potentially via prompt injection in reviewed code) could craft `file_patterns` arguments to `code_search` using backslash path separators to search files outside the repository root when OCR runs on Windows.

### Fix

Normalize the pathspec via `filepath.ToSlash()` (converts `\` to `/`) and `filepath.Clean()` (collapses redundant separators and `..` segments) before splitting to check for traversal components.

### Testing

Added `TestCodeSearchProvider_Execute_RejectsBackslashTraversal` with test cases for:
- Pure backslash traversal: `..\..\\etc`
- Backslash mid-path: `pkg\..\internal`
- Mixed separators: `pkg\../..\secret`

All existing tests continue to pass.
