### PR TITLE
fix: TOCTOU race in resolveWorkspacePath allows symlink-based path traversal

### DIFF
--- a/internal/tool/filereader.go
+++ b/internal/tool/filereader.go
@@ -101,9 +101,11 @@ func (fr *FileReader) resolveWorkspacePath(path string) (string, error) {
 
 	resolvedPath, err := filepath.EvalSymlinks(fullPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fullPath, nil
-		}
+		// Do NOT return fullPath for non-existent paths. Returning the
+		// unresolved path opens a TOCTOU window: between this check and
+		// the subsequent os.ReadFile/os.Open, a symlink could be placed
+		// at fullPath pointing outside the repo, and it would be
+		// followed without any WithinBase verification.
 		return "", fmt.Errorf("resolve file %q: %w", path, err)
 	}
 	if !pathutil.WithinBase(repoRoot, resolvedPath) {


### PR DESCRIPTION
## Summary

**Security Fix**: TOCTOU (Time-of-Check-to-Time-of-Use) race condition in `resolveWorkspacePath()` (`internal/tool/filereader.go`) allows symlink-based path traversal to read arbitrary files outside the repository.

### Root Cause

When `filepath.EvalSymlinks(fullPath)` returns `os.IsNotExist`, the function returns the **unresolved** `fullPath` directly:

```go
resolvedPath, err := filepath.EvalSymlinks(fullPath)
if err != nil {
    if os.IsNotExist(err) {
        return fullPath, nil  // ← returned without symlink validation
    }
}
```

The caller (`readFromDisk` / `readLinesFromDisk`) then calls `os.ReadFile(fullPath)` or `os.Open(fullPath)`. Between the `EvalSymlinks` check and the actual file read, an attacker can:

1. Create a symlink at `fullPath` pointing to a sensitive file outside the repo (e.g., `/etc/shadow`, `~/.ssh/id_rsa`)
2. The symlink itself lives inside the repo (passes `WithinBase`), but its target is outside
3. `os.ReadFile` follows the symlink and reads the target — **no `WithinBase` re-check happens**

### Impact

An attacker with the ability to create symlinks within the repository (e.g., via a malicious commit in a PR being reviewed) could cause OCR to read and leak arbitrary file contents from the host system into the LLM conversation. This is particularly dangerous in CI/CD environments where the runner may have access to secrets, SSH keys, or cloud credentials.

### Fix

Remove the `os.IsNotExist` special-case that returns the unvalidated path. Instead, propagate the error to the caller. All callers (`readFromDisk`, `readLinesFromDisk`) already handle file-not-found errors gracefully by returning an error message to the LLM, so no behavioral change for legitimate use cases.

### Attack Scenario

```
1. Attacker creates PR with file: malicious/exploit → (normal file)
2. OCR starts reviewing, LLM requests file_read("malicious/exploit")
3. resolveWorkspacePath → EvalSymlinks finds the file, all checks pass ✓
4. Between reviews, attacker replaces malicious/exploit with symlink → /etc/shadow
5. LLM requests file_read("malicious/exploit") again
6. resolveWorkspacePath → EvalSymlinks fails (IsNotExist for intermediate dir)
7. Old code: returns fullPath → os.ReadFile follows symlink → LEAK
8. New code: returns error → safe
```
