### PR TITLE
fix(pages): handle stale lazy-loaded chunks gracefully

### DIFF
--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { Suspense, useEffect } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import LandingPage from './components/LandingPage';
+import ErrorBoundary from './components/ErrorBoundary';
+import { useTranslation } from './i18n';
 import FeaturesPage from './pages/FeaturesPage';
 
 const BenchmarkPage = React.lazy(() => import(/* webpackChunkName: "benchmark-page" */ './pages/BenchmarkPage'));
@@ -16,21 +18,71 @@ const ScrollToTop: React.FC = () => {
   return null;
 };
 
+const RouteErrorFallback: React.FC<{ reset: () => void }> = ({ reset }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#000000',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 360,
+          padding: 24,
+          background: '#141414',
+          border: '1px solid rgba(255,255,255,0.16)',
+          borderRadius: 12,
+          color: '#ffffff',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ margin: '0 0 16px', fontSize: 16 }}>{t('error.pageLoadFailed')}</p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            border: 0,
+            borderRadius: 6,
+            padding: '10px 18px',
+            background: '#ffffff',
+            color: '#000000',
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {t('error.reload')}
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const App: React.FC = () => {
   return (
     <>
       <ScrollToTop />
-      <Suspense fallback={<div style={{ minHeight: '100vh', background: '#000000' }} />}>
-        <Routes>
-          <Route path="/" element={<LandingPage><FeaturesPage /></LandingPage>} />
-          <Route path="/benchmark" element={<LandingPage><BenchmarkPage /></LandingPage>} />
-          <Route path="/quickstart" element={<LandingPage><QuickStartPage /></LandingPage>} />
-          <Route path="/docs" element={<DocsPage />} />
-          <Route path="/docs/:slug" element={<DocsPage />} />
-          <Route path="/blog" element={<BlogPage />} />
-          <Route path="/blog/:slug" element={<BlogPage />} />
-        </Routes>
-      </Suspense>
+      <ErrorBoundary reloadOnChunkError fallback={(_error, reset) => <RouteErrorFallback reset={reset} />}>
+        <Suspense fallback={<div style={{ minHeight: '100vh', background: '#000000' }} />}>
+          <Routes>
+            <Route path="/" element={<LandingPage><FeaturesPage /></LandingPage>} />
+            <Route path="/benchmark" element={<LandingPage><BenchmarkPage /></LandingPage>} />
+            <Route path="/quickstart" element={<LandingPage><QuickStartPage /></LandingPage>} />
+            <Route path="/docs" element={<DocsPage />} />
+            <Route path="/docs/:slug" element={<DocsPage />} />
+            <Route path="/blog" element={<BlogPage />} />
+            <Route path="/blog/:slug" element={<BlogPage />} />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
     </>
   );
 };

--- a/pages/src/components/ErrorBoundary.tsx
+++ b/pages/src/components/ErrorBoundary.tsx
@@ -29,7 +29,8 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
     return { error };
   }
 
-  componentDidCatch(error: Error): void {
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, info);
     if (this.props.reloadOnChunkError && isChunkLoadError(error) && this.markChunkReloadAttempt()) {
       window.location.reload();
     }

--- a/pages/src/components/ErrorBoundary.tsx
+++ b/pages/src/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const CHUNK_RELOAD_STORAGE_KEY = 'ocr-chunk-reload-attempted';
+
+type FallbackRender = (error: Error, reset: () => void) => React.ReactNode;
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode | FallbackRender;
+  reloadOnChunkError?: boolean;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    /Loading( CSS)? chunk .* failed/i.test(error.message) ||
+    /failed to fetch dynamically imported module/i.test(error.message)
+  );
+}
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error): void {
+    if (this.props.reloadOnChunkError && isChunkLoadError(error) && this.markChunkReloadAttempt()) {
+      window.location.reload();
+    }
+  }
+
+  private markChunkReloadAttempt(): boolean {
+    try {
+      if (window.sessionStorage.getItem(CHUNK_RELOAD_STORAGE_KEY)) return false;
+      window.sessionStorage.setItem(CHUNK_RELOAD_STORAGE_KEY, 'true');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private reset = (): void => {
+    try {
+      window.sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);
+    } catch {}
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const { fallback } = this.props;
+    return typeof fallback === 'function' ? fallback(error, this.reset) : fallback;
+  }
+}

--- a/pages/src/components/HeroSection.tsx
+++ b/pages/src/components/HeroSection.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Link } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import { useResponsive } from '../hooks/useResponsive';
+import ErrorBoundary from './ErrorBoundary';
 import docDownloadIcon from '../assets/icons/doc-download-green.svg';
 import copyIcon from '../assets/icons/icon-copy.svg';
 
@@ -207,31 +208,33 @@ const HeroSection: React.FC = () => {
       {/* Shader Background */}
       {!showShaderBackground && shaderFallback}
       {showShaderBackground && (
-        <Suspense fallback={shaderFallback}>
-          <ColorBends
-            style={{
-              position: 'absolute',
-              left: 0,
-              top: 0,
-              width: '100%',
-              height: '100%',
-              zIndex: 0,
-            }}
-            colors={['#0d750d', '#042e04', '#066020']}
-            rotation={90}
-            speed={0.23}
-            scale={1.2}
-            frequency={1}
-            warpStrength={1}
-            mouseInfluence={1}
-            noise={0.33}
-            parallax={0.45}
-            iterations={1}
-            intensity={0.8}
-            bandWidth={6}
-            transparent
-          />
-        </Suspense>
+        <ErrorBoundary fallback={shaderFallback}>
+          <Suspense fallback={shaderFallback}>
+            <ColorBends
+              style={{
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: '100%',
+                height: '100%',
+                zIndex: 0,
+              }}
+              colors={['#0d750d', '#042e04', '#066020']}
+              rotation={90}
+              speed={0.23}
+              scale={1.2}
+              frequency={1}
+              warpStrength={1}
+              mouseInfluence={1}
+              noise={0.33}
+              parallax={0.45}
+              iterations={1}
+              intensity={0.8}
+              bandWidth={6}
+              transparent
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
 
       {/* Gradient overlay */}

--- a/pages/src/i18n/en.ts
+++ b/pages/src/i18n/en.ts
@@ -18,6 +18,10 @@ export const en: TranslationKeys = {
   'hero.copied': 'Copied!',
   'hero.copyFailed': 'Copy failed',
 
+  // Error boundary
+  'error.pageLoadFailed': 'Failed to load this page.',
+  'error.reload': 'Reload',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': 'ACTIVE USERS',

--- a/pages/src/i18n/ja.ts
+++ b/pages/src/i18n/ja.ts
@@ -18,6 +18,10 @@ export const ja: TranslationKeys = {
   'hero.copied': 'コピーしました',
   'hero.copyFailed': 'コピー失敗',
 
+  // Error boundary
+  'error.pageLoadFailed': 'ページの読み込みに失敗しました。',
+  'error.reload': '再読み込み',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': 'アクティブユーザー',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -18,6 +18,10 @@ export const zh: TranslationKeys = {
   'hero.copied': '已复制',
   'hero.copyFailed': '复制失败',
 
+  // Error boundary
+  'error.pageLoadFailed': '页面加载失败。',
+  'error.reload': '重新加载',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': '活跃用户',


### PR DESCRIPTION
Add error boundaries for rejected route and shader imports. Reload once for stale route chunks and show a localized fallback when the retry also fails, while preserving the shader gradient fallback.

## Description

This PR fixes blank pages caused by stale or unavailable lazy-loaded JavaScript chunks.

Route-level chunk failures now trigger one session-guarded page reload. If the chunk still cannot be loaded, users see a localized error card with a Reload button instead of a blank page.

The decorative `ColorBends` shader now fails gracefully and preserves its existing gradient fallback without reloading the page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Validation performed:

- `npm run typecheck` from `pages/`
- `npm run build` from `pages/`
- `git diff --check`
- Verified route lazy-load failures are caught by the error boundary.
- Verified route chunk failures reload only once per browser session.
- Verified repeated failures display the localized fallback card.
- Verified the Reload button clears the session guard and retries.
- Verified shader chunk failures preserve the gradient fallback without reloading the page.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of the code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing frontend checks pass locally
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues
Closes #521

<!-- Add the related issue number here, for example: closes #123 -->