### PR TITLE
fix(vscode): select Git roots with platform-aware paths

### DIFF
--- a/extensions/vscode/src/extension/services/__tests__/gitMap.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/gitMap.test.ts
@@ -215,6 +215,11 @@ describe('pickRepoRoot', () => {
     const roots = ['C:\\repo', 'C:\\repository'];
     expect(pickRepoRoot(roots, 'C:\\repository\\src')).toBe('C:\\repository');
   });
+
+  it('handles mixed separators between a UNC root and workspace path', () => {
+    const roots = ['//server/share/other', '//server/share/repo'];
+    expect(pickRepoRoot(roots, '\\\\server\\share\\repo\\src')).toBe('//server/share/repo');
+  });
 });
 
 describe('getCommitFiles: git show revision placement', () => {

--- a/extensions/vscode/src/extension/services/__tests__/gitMap.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/gitMap.test.ts
@@ -205,6 +205,16 @@ describe('pickRepoRoot', () => {
     const roots = ['/a/repo', '/b/repo'];
     expect(pickRepoRoot(roots, undefined)).toBe('/a/repo');
   });
+
+  it('selects a Windows repository containing the workspace subdirectory', () => {
+    const roots = ['C:\\other', 'C:\\repo'];
+    expect(pickRepoRoot(roots, 'C:\\repo\\packages\\app')).toBe('C:\\repo');
+  });
+
+  it('does not treat a Windows path with the same prefix as an ancestor', () => {
+    const roots = ['C:\\repo', 'C:\\repository'];
+    expect(pickRepoRoot(roots, 'C:\\repository\\src')).toBe('C:\\repository');
+  });
 });
 
 describe('getCommitFiles: git show revision placement', () => {

--- a/extensions/vscode/src/extension/services/gitMap.ts
+++ b/extensions/vscode/src/extension/services/gitMap.ts
@@ -89,7 +89,8 @@ export function pickRepoRoot(roots: string[], workspacePath?: string): string | 
   if (!workspacePath) return roots[0];
 
   const candidates = roots.map((root) => {
-    const pathApi = /^[a-z]:[\\/]/i.test(root) || root.includes('\\') ? path.win32 : path.posix;
+    const isWindowsPath = [root, workspacePath].some((p) => /^[a-z]:[\\/]/i.test(p) || p.includes('\\'));
+    const pathApi = isWindowsPath ? path.win32 : path.posix;
     return { root, relative: pathApi.relative(root, workspacePath), pathApi };
   });
 

--- a/extensions/vscode/src/extension/services/gitMap.ts
+++ b/extensions/vscode/src/extension/services/gitMap.ts
@@ -1,4 +1,5 @@
 import { FileChange } from '../../shared/types';
+import path from 'path';
 
 export function mapStatusCode(code: string): FileChange['status'] {
   switch (code) {
@@ -87,12 +88,19 @@ export function pickRepoRoot(roots: string[], workspacePath?: string): string | 
   if (roots.length === 0) return null;
   if (!workspacePath) return roots[0];
 
-  const exact = roots.find((r) => r === workspacePath);
-  if (exact) return exact;
+  const candidates = roots.map((root) => {
+    const pathApi = /^[a-z]:[\\/]/i.test(root) || root.includes('\\') ? path.win32 : path.posix;
+    return { root, relative: pathApi.relative(root, workspacePath), pathApi };
+  });
 
-  const ancestors = roots.filter((r) => workspacePath.startsWith(r.endsWith('/') ? r : r + '/'));
+  const exact = candidates.find(({ relative }) => relative === '');
+  if (exact) return exact.root;
+
+  const ancestors = candidates.filter(({ relative, pathApi }) =>
+    relative !== '..' && !relative.startsWith(`..${pathApi.sep}`) && !pathApi.isAbsolute(relative));
   if (ancestors.length > 0) {
-    return ancestors.reduce((deepest, r) => (r.length > deepest.length ? r : deepest));
+    return ancestors.reduce((deepest, candidate) =>
+      candidate.relative.length < deepest.relative.length ? candidate : deepest).root;
   }
 
   return roots[0];


### PR DESCRIPTION
## Description

The VS Code extension selects the repository associated with the first workspace folder. `pickRepoRoot` previously compared paths using raw string equality and a `/`-only prefix check.

On Windows, VS Code repository paths normally use `\`. When a repository subdirectory is opened as the workspace, the ancestor check therefore fails and the extension falls back to the first repository returned by the Git extension, which may be an unrelated or nested repository.

This change uses Node's platform-aware POSIX/Windows path utilities to:

- recognize exact repository matches using native path semantics;
- select the deepest repository containing the workspace;
- avoid treating similarly prefixed sibling paths as ancestors.

The change is limited to repository selection and its focused regression tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- `corepack yarn test --runInBand src/extension/services/__tests__/gitMap.test.ts` - 30 tests passed
- `corepack yarn lint`
- `corepack yarn compile`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] The focused unit tests for the changed behavior pass locally
- [x] Documentation changes are not required for this internal path-resolution fix
- [x] I have signed the CLA