### PR TITLE
fix(vscode): pin linkify-it below v6 to fix vsce package failure

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "open-code-review-vscode",
   "displayName": "Open Code Review",
   "description": "%ocr.description%",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "open-code-review",
   "license": "Apache-2.0",
   "repository": {
@@ -115,7 +115,7 @@
     "@typescript-eslint/typescript-estree/minimatch": "^9.0.7",
     "brace-expansion": ">=2.1.2 <3",
     "fast-uri": ">=3.1.4",
-    "linkify-it": ">=5.0.2"
+    "linkify-it": ">=5.0.2 <6"
   },
   "dependencies": {
     "preact": "^10.29.7"

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -3547,10 +3547,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@>=5.0.2, linkify-it@^5.0.1:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-6.0.0.tgz#f4b22004fb7f7bd96f9ac079ecdf01719fd2bdc6"
-  integrity sha512-YXaVuD1L9iL52IsWy5WsfHbzJjjDL5VzbW7ARliFbB+oHxHXb+fh2qjYl34PGhyy06x3LCvuAuvWdaSFte0P1w==
+"linkify-it@>=5.0.2 <6", linkify-it@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
     uc.micro "^2.0.0"
 


### PR DESCRIPTION
## Summary

- Pin `linkify-it` resolution to `>=5.0.2 <6` to avoid the breaking ESM named-export change in v6
- Fixes `ERROR LinkifyIt is not a constructor` when running `vsce package`
- Bumps extension version to 0.1.2

## Context

`linkify-it` v6 switched from a default export to named exports (`{ LinkifyIt }`). The `markdown-it` library bundled in `@vscode/vsce` still calls `new LinkifyIt()` via the default import, causing the packaging step to fail after README markdown processing.

## Test plan

- [x] `corepack yarn package` succeeds and produces a valid `.vsix`