### PR TITLE
fix(pages): simplify error boundary reload

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -33,6 +33,10 @@ jobs:
         working-directory: pages
         run: npm run typecheck
 
+      - name: Test
+        working-directory: pages
+        run: npm test
+
       - name: Build
         working-directory: pages
         run: npm run build

--- a/pages/package.json
+++ b/pages/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "webpack serve",
     "build": "NODE_ENV=production webpack --mode production",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.3.2",
+    "vitest": "^4.1.10",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4"

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -18,7 +18,7 @@ const ScrollToTop: React.FC = () => {
   return null;
 };
 
-const RouteErrorFallback: React.FC<{ reset: () => void }> = ({ reset }) => {
+const RouteErrorFallback: React.FC<{ reload: () => void }> = ({ reload }) => {
   const { t } = useTranslation();
 
   return (
@@ -47,7 +47,7 @@ const RouteErrorFallback: React.FC<{ reset: () => void }> = ({ reset }) => {
         <p style={{ margin: '0 0 16px', fontSize: 16 }}>{t('error.pageLoadFailed')}</p>
         <button
           type="button"
-          onClick={reset}
+          onClick={reload}
           style={{
             border: 0,
             borderRadius: 6,
@@ -70,7 +70,7 @@ const App: React.FC = () => {
   return (
     <>
       <ScrollToTop />
-      <ErrorBoundary reloadOnChunkError fallback={(_error, reset) => <RouteErrorFallback reset={reset} />}>
+      <ErrorBoundary reloadOnChunkError fallback={(_error, reload) => <RouteErrorFallback reload={reload} />}>
         <Suspense fallback={<div style={{ minHeight: '100vh', background: '#000000' }} />}>
           <Routes>
             <Route path="/" element={<LandingPage><FeaturesPage /></LandingPage>} />

--- a/pages/src/components/ErrorBoundary.test.tsx
+++ b/pages/src/components/ErrorBoundary.test.tsx
@@ -72,21 +72,21 @@ describe('ErrorBoundary', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('clears the guard and reloads directly when reset', () => {
+  it('clears the guard and reloads directly from the fallback', () => {
     storage.set(STORAGE_KEY, 'true');
-    let reset: (() => void) | undefined;
+    let reloadBoundary: (() => void) | undefined;
     const boundary = new ErrorBoundary({
       children: null,
-      fallback: (_error, retry) => {
-        reset = retry;
+      fallback: (_error, reload) => {
+        reloadBoundary = reload;
         return null;
       },
     });
     boundary.state = ErrorBoundary.getDerivedStateFromError(new Error('render failed'));
     boundary.render();
 
-    expect(reset).toBeDefined();
-    reset?.();
+    expect(reloadBoundary).toBeDefined();
+    reloadBoundary?.();
 
     expect(storage.has(STORAGE_KEY)).toBe(false);
     expect(reload).toHaveBeenCalledOnce();

--- a/pages/src/components/ErrorBoundary.test.tsx
+++ b/pages/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,94 @@
+import type { ErrorInfo } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+const STORAGE_KEY = 'ocr-chunk-reload-attempted';
+const errorInfo = {} as ErrorInfo;
+
+describe('ErrorBoundary', () => {
+  let reload: ReturnType<typeof vi.fn>;
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    reload = vi.fn();
+    storage = new Map();
+    vi.stubGlobal('window', {
+      location: { reload },
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('reloads once after a chunk load error', () => {
+    const boundary = new ErrorBoundary({
+      children: null,
+      fallback: null,
+      reloadOnChunkError: true,
+    });
+
+    boundary.componentDidCatch(
+      new Error('Failed to fetch dynamically imported module'),
+      errorInfo,
+    );
+
+    expect(storage.get(STORAGE_KEY)).toBe('true');
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('does not reload again when the session guard is set', () => {
+    storage.set(STORAGE_KEY, 'true');
+    const boundary = new ErrorBoundary({
+      children: null,
+      fallback: null,
+      reloadOnChunkError: true,
+    });
+
+    boundary.componentDidCatch(new Error('Loading chunk 42 failed'), errorInfo);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('renders the fallback for non-chunk errors without reloading', () => {
+    const error = new Error('render failed');
+    const fallback = vi.fn(() => 'fallback');
+    const boundary = new ErrorBoundary({
+      children: null,
+      fallback,
+      reloadOnChunkError: true,
+    });
+    boundary.state = ErrorBoundary.getDerivedStateFromError(error);
+
+    expect(boundary.render()).toBe('fallback');
+    expect(fallback).toHaveBeenCalledWith(error, expect.any(Function));
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('clears the guard and reloads directly when reset', () => {
+    storage.set(STORAGE_KEY, 'true');
+    let reset: (() => void) | undefined;
+    const boundary = new ErrorBoundary({
+      children: null,
+      fallback: (_error, retry) => {
+        reset = retry;
+        return null;
+      },
+    });
+    boundary.state = ErrorBoundary.getDerivedStateFromError(new Error('render failed'));
+    boundary.render();
+
+    expect(reset).toBeDefined();
+    reset?.();
+
+    expect(storage.has(STORAGE_KEY)).toBe(false);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/pages/src/components/ErrorBoundary.tsx
+++ b/pages/src/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const CHUNK_RELOAD_STORAGE_KEY = 'ocr-chunk-reload-attempted';
 
-type FallbackRender = (error: Error, reset: () => void) => React.ReactNode;
+type FallbackRender = (error: Error, reload: () => void) => React.ReactNode;
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -46,7 +46,7 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
     }
   }
 
-  private reset = (): void => {
+  private reload = (): void => {
     try {
       window.sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);
     } catch {}
@@ -58,6 +58,6 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
     if (!error) return this.props.children;
 
     const { fallback } = this.props;
-    return typeof fallback === 'function' ? fallback(error, this.reset) : fallback;
+    return typeof fallback === 'function' ? fallback(error, this.reload) : fallback;
   }
 }

--- a/pages/src/components/ErrorBoundary.tsx
+++ b/pages/src/components/ErrorBoundary.tsx
@@ -50,7 +50,7 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
     try {
       window.sessionStorage.removeItem(CHUNK_RELOAD_STORAGE_KEY);
     } catch {}
-    this.setState({ error: null });
+    window.location.reload();
   };
 
   render(): React.ReactNode {


### PR DESCRIPTION
## Description

Make the route fallback reload action direct and predictable: it clears the one-reload session guard and immediately reloads the page instead of resetting React state and waiting for the lazy import to fail again.

Add focused unit coverage for the automatic chunk-error reload, the session guard, non-chunk fallbacks, and the manual reset path. The Pages CI job now runs these tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] npm test (4 tests passed)
- [x] npm run typecheck
- [x] Production webpack build

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing frontend checks pass locally
- [x] Documentation is not required for this internal behavior change
- [ ] I have signed the CLA

## Related Issues

Closes #544