### PR TITLE
fix(pages): keep code block copy button anchored during horizontal scroll

### DIFF
--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -108,7 +108,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       // Create copy button matching reference HTML
       const btn = document.createElement('div');
       btn.className = 'code-copy-btn';
-      btn.style.cssText = 'display:flex;flex-shrink:0;justify-content:flex-start;align-items:flex-start;flex-direction:column;padding-top:4px;padding-bottom:4px;cursor:pointer;';
+      btn.style.cssText = 'position:absolute;top:4px;right:12px;display:flex;padding:4px;cursor:pointer;';
       btn.innerHTML = `<img src="${copyIcon}" alt="copy" style="width:16px;height:16px;" />`;
       btn.addEventListener('click', () => {
         const text = codeEl.textContent || '';

--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -85,9 +85,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       const trimmed = text.replace(/^\n+|\n+$/g, '');
       const content = escaped ? trimmed : trimmed.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
       const langClass = lang ? ` class="language-${lang}"` : '';
-      const isMultiline = trimmed.includes('\n');
-      const alignItems = isMultiline ? 'flex-start' : 'center';
-      return `<pre style="align-items:${alignItems};"><code${langClass}>${content}</code></pre>\n`;
+      return `<pre><code${langClass}>${content}</code></pre>\n`;
     };
     const instance = new Marked({ gfm: true, breaks: false, renderer });
     return DOMPurify.sanitize(instance.parse(content) as string);
@@ -105,10 +103,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       if (!codeEl || codeEl.classList.contains('language-mermaid')) return;
       if (pre.querySelector('.code-copy-btn')) return; // already added
 
-      // Create copy button matching reference HTML
+      // Create copy button; visual styles live in docs-markdown.css
       const btn = document.createElement('div');
       btn.className = 'code-copy-btn';
-      btn.style.cssText = 'position:absolute;top:4px;right:12px;display:flex;padding:4px;cursor:pointer;';
       btn.innerHTML = `<img src="${copyIcon}" alt="copy" style="width:16px;height:16px;" />`;
       btn.addEventListener('click', () => {
         const text = codeEl.textContent || '';

--- a/pages/src/styles/docs-markdown.css
+++ b/pages/src/styles/docs-markdown.css
@@ -73,10 +73,6 @@
   border-radius: 6px;
   padding: 4px 0;
   margin: 0 0 16px 0;
-  display: flex;
-  align-self: stretch;
-  justify-content: space-between;
-  align-items: center;
   position: relative;
 }
 
@@ -89,9 +85,41 @@
   color: rgba(255, 255, 255, 0.8);
   white-space: pre;
   display: block;
-  flex: 1;
-  min-width: 0;
   overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+/* Copy button: revealed on hover so it never obscures code while reading;
+   the translucent background keeps it legible over long lines. */
+.docs-markdown pre .code-copy-btn {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  display: flex;
+  padding: 4px;
+  cursor: pointer;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.docs-markdown pre:hover .code-copy-btn {
+  opacity: 1;
+}
+
+/* The generic content-image rule below must not inflate the icon. */
+.docs-markdown pre .code-copy-btn img {
+  margin: 0;
+  border-radius: 0;
+}
+
+/* Touch devices have no hover: keep the button always visible. */
+@media (hover: none) {
+  .docs-markdown pre .code-copy-btn {
+    opacity: 1;
+  }
 }
 
 /* Lists */

--- a/pages/src/styles/docs-markdown.css
+++ b/pages/src/styles/docs-markdown.css
@@ -71,19 +71,19 @@
   background: #000000;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 6px;
-  padding: 4px 16px;
+  padding: 4px 0;
   margin: 0 0 16px 0;
-  overflow-x: auto;
   display: flex;
   align-self: stretch;
   justify-content: space-between;
   align-items: center;
+  position: relative;
 }
 
 .docs-markdown pre code {
   background: none;
   border: none;
-  padding: 0;
+  padding: 0 16px;
   font-size: 13px;
   line-height: 22px;
   color: rgba(255, 255, 255, 0.8);
@@ -91,6 +91,7 @@
   display: block;
   flex: 1;
   min-width: 0;
+  overflow-x: auto;
 }
 
 /* Lists */
@@ -236,15 +237,15 @@
 }
 
 /* Scrollbar styling for code blocks */
-.docs-markdown pre::-webkit-scrollbar {
+.docs-markdown pre code::-webkit-scrollbar {
   height: 6px;
 }
 
-.docs-markdown pre::-webkit-scrollbar-track {
+.docs-markdown pre code::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.docs-markdown pre::-webkit-scrollbar-thumb {
+.docs-markdown pre code::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.15);
   border-radius: 3px;
 }


### PR DESCRIPTION
## Description

On the docs site (e.g. /docs/architecture), the copy icon of a code block
scrolled away together with overflowing code and could even end up out of
view, because the icon was a normal flex child inside the horizontally
scrolling `<pre>`.

This change moves horizontal scrolling from the `<pre>` to the inner `<code>`
element and floats the copy icon over the top-right corner. The horizontal
padding now lives inside the scrollport, so code text still appears and
disappears exactly at the box borders, and the icon stays anchored at the
top-right corner at any scroll position.

**Before** — the copy icon scrolls away with the code:
<img width="2484" height="1108" alt="image" src="https://github.com/user-attachments/assets/abae281f-f9b6-4a7e-a19a-51bcd02d93b7" />

**After** — the icon stays anchored at the top-right corner:
<img width="1472" height="618" alt="image" src="https://github.com/user-attachments/assets/cf3c8a39-b739-4d72-9754-515e3a5f7da7" />



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Frontend-only change under `pages/`, so `make test` (Go) is not applicable.
`npm run typecheck` and `npm run build` both pass (the same steps pages-ci
runs). Manually verified in Chrome on /docs/architecture with a horizontally
overflowing code block: the icon stays at the top-right corner at scroll
positions start/middle/end; text clips exactly at both box borders; copy
still works while scrolled; single-line blocks and mermaid diagrams are
unaffected.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`) — N/A (frontend-only)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works — N/A (pages/ has no test framework)
- [ ] New and existing unit tests pass locally with my changes — N/A
- [x] I have updated the documentation accordingly (if applicable) — no docs affected
- [ ] I have signed the CLA

## Related Issues

None.