### PR TITLE
docs(README.ja-JP): fix Contributing link to point to Japanese version

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -181,7 +181,7 @@ ocr delegate rule src/main.go src/handler.go
 
 ## コントリビューション
 
-このプロジェクトは、貢献してくださるすべての方々のおかげで成り立っています。開発環境のセットアップ、コーディングガイドライン、プルリクエストの提出方法については[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+このプロジェクトは、貢献してくださるすべての方々のおかげで成り立っています。開発環境のセットアップ、コーディングガイドライン、プルリクエストの提出方法については[CONTRIBUTING.ja-JP.md](CONTRIBUTING.ja-JP.md)を参照してください。
 
 <a href="https://github.com/alibaba/open-code-review/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=alibaba/open-code-review" />


### PR DESCRIPTION
## Description

Fix the Contributing link in `README.ja-JP.md` to point to the Japanese version (`CONTRIBUTING.ja-JP.md`) instead of the English version (`CONTRIBUTING.md`).

Other localized README files (`zh-CN`, `ko-KR`, `ru-RU`) already link to their respective localized CONTRIBUTING files, but the Japanese version was missed.

## Changes

- `README.ja-JP.md:184` — `[CONTRIBUTING.md](CONTRIBUTING.md)` → `[CONTRIBUTING.ja-JP.md](CONTRIBUTING.ja-JP.md)`

## Type of Change

- [x] Documentation fix
