### PR TITLE
fix(cli): align help text and aliases with actual behavior

### DIFF
--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -224,6 +224,9 @@ Examples:
   ocr review --preview
   ocr review -c abc123 -p
 
+  # Exclude generated files / fixtures
+  ocr review --exclude '**/generated/*,**/testdata/*'
+
   # Provide requirement/business context inline, from a Markdown file, or both
   ocr review --background "Adding rate limiting to the login API"
   ocr review --background-file ./docs/requirements.md
@@ -236,6 +239,7 @@ Flags:
   -c, --commit string           single commit hash or tag to review (vs its parent)
   -f, --format string           output format: text or json (default "text")
   --concurrency int             max concurrent file reviews (default 8)
+  --exclude string              comma-separated gitignore-style patterns to exclude (merged with rule.json)
   --max-git-procs int           max concurrent git subprocesses (default 16)
   --from string                 source ref to start diff from (e.g., 'main')
   --max-tools int               max tool call rounds per file (0 = template default; min 10)
@@ -275,7 +279,7 @@ func parseConfigArgs(args []string) (configAction, error) {
 		}, nil
 	case "unset":
 		if len(args) < 2 {
-			return configAction{}, fmt.Errorf("usage: ocr config unset custom_providers.<name>\ne.g., ocr config unset custom_providers.my-gateway")
+			return configAction{}, fmt.Errorf("usage: ocr config unset custom_providers.<name> | mcp_servers.<name>\ne.g., ocr config unset custom_providers.my-gateway\ne.g., ocr config unset mcp_servers.codegraph")
 		}
 		return configAction{
 			subCmd: "unset",

--- a/cmd/opencodereview/main.go
+++ b/cmd/opencodereview/main.go
@@ -54,7 +54,7 @@ func dispatch() error {
 		return runLLM(args[1:])
 	case "rules":
 		return runRules(args[1:])
-	case "viewer":
+	case "viewer", "v":
 		return runViewer(args[1:])
 	case "delegate", "d":
 		return runDelegate(args[1:])
@@ -81,7 +81,7 @@ Commands:
   rules        Inspect and debug review rules
   config       Manage configuration settings
   llm          LLM utility commands
-  viewer       Start the WebUI session viewer
+  viewer, v    Start the WebUI session viewer
   session, sessions  List and inspect saved review sessions
   version      Show version information
 
@@ -100,9 +100,11 @@ Examples:
 
 Use "ocr review -h" for more information about review.
 Use "ocr scan -h" for more information about scan.
+Use "ocr delegate -h" for more information about delegation mode.
 Use "ocr rules -h" for more information about rules.
 Use "ocr config" for more information about config.
 Use "ocr llm" for more information about LLM utilities.
+Use "ocr viewer -h" for more information about the session viewer.
 Use "ocr session -h" for more information about session inspection.
 
 GitHub: https://github.com/alibaba/open-code-review`)

--- a/cmd/opencodereview/viewer_cmd.go
+++ b/cmd/opencodereview/viewer_cmd.go
@@ -35,7 +35,7 @@ func runViewer(args []string) error {
 		return nil
 	}
 
-	fmt.Printf("Open Code Review Viewer starting on http://%s\n", opts.addr)
+	fmt.Printf("Open Code Review Viewer starting on http://%s\n", viewer.DisplayAddr(opts.addr))
 	return viewer.StartServer(opts.addr)
 }
 

--- a/internal/viewer/hostguard.go
+++ b/internal/viewer/hostguard.go
@@ -113,6 +113,21 @@ func splitBindHost(addr string) string {
 	return addr
 }
 
+// DisplayAddr rewrites a wildcard listen address (empty host, 0.0.0.0, or ::)
+// to a localhost form so printed URLs are always openable in a browser.
+// Non-wildcard addresses are returned unchanged.
+func DisplayAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		return net.JoinHostPort("localhost", port)
+	}
+	return addr
+}
+
 // resolveAllowedHostsFromEnv reads the OCR_VIEWER_ALLOWED_HOSTS environment
 // variable and combines it with the bind host to produce the active allowlist.
 func resolveAllowedHostsFromEnv(bindAddr string) map[string]struct{} {

--- a/internal/viewer/hostguard_test.go
+++ b/internal/viewer/hostguard_test.go
@@ -159,3 +159,27 @@ func TestHostGuard(t *testing.T) {
 		})
 	}
 }
+
+func TestDisplayAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{"empty-host", ":3000", "localhost:3000"},
+		{"ipv4-wildcard", "0.0.0.0:3000", "localhost:3000"},
+		{"ipv6-wildcard", "[::]:8080", "localhost:8080"},
+		{"loopback-default", "127.0.0.1:5483", "127.0.0.1:5483"},
+		{"lan-host", "192.168.1.10:5483", "192.168.1.10:5483"},
+		{"hostname", "localhost:5483", "localhost:5483"},
+		{"no-port", "localhost", "localhost"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DisplayAddr(c.addr); got != c.want {
+				t.Errorf("DisplayAddr(%q) = %q, want %q", c.addr, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -59,7 +59,7 @@ func StartServer(addr string) error {
 		Handler: guarded,
 	}
 
-	fmt.Printf("\nOpen browser: http://%s\n", addr)
+	fmt.Printf("\nOpen browser: http://%s\n", DisplayAddr(addr))
 	return srv.ListenAndServe()
 }
 


### PR DESCRIPTION


### Description

This PR fixes five small mismatches between CLI help text and actual behavior. No review semantics are changed — the only behavioral additions are an alias that the help already promised and a display-only URL fix.

1. **`ocr v` alias now works.** `ocr viewer -h` documents `ocr v [flags] (alias)`, but the top-level dispatch had no `"v"` case, so `ocr v` failed with `unknown command: v`. Added the case (matching the existing `review|r`, `scan|s`, `delegate|d` convention) and listed `viewer, v` in the top-level command list.
2. **`ocr review -h` now lists `--exclude`.** The flag is registered and works, but it was the only one of review's 18 flags missing from the usage text (scan and delegate both document theirs). Added the flag line and an example, wording aligned with `ocr scan -h`.
3. **`ocr config unset` usage error now mentions `mcp_servers.<name>`.** The implementation supports unsetting both `custom_providers.<name>` and `mcp_servers.<name>`, and the other two usage strings in the codebase list both — only this error message omitted the MCP form.
4. **Top-level usage hint block now covers delegate and viewer.** The `Use "ocr X -h" ...` block listed six subcommands but skipped `delegate` and `viewer`, both of which appear in the Commands list and support `-h`.
5. **Viewer banner prints an openable URL for wildcard binds.** `ocr viewer --addr :3000` (the help's own example) printed `http://:3000`, which browsers cannot open; `0.0.0.0`/`::` binds printed similarly unusable URLs. Added a small `viewer.DisplayAddr` helper that rewrites wildcard hosts to `localhost` for display only (loopback is always allowed by the host guard); non-wildcard addresses are unchanged, and the actual listen address is untouched.

### Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

### How Has This Been Tested?

- [X] `make test` passes locally
- [X] Manual testing (describe below)

- `make check` and `make test` (race detector) pass; added a table-driven unit test for `DisplayAddr` covering empty-host, `0.0.0.0`, `[::]`, loopback, LAN IP, hostname, and no-port forms.
- Manual verification with a locally built binary:
  - `ocr v -h` prints the viewer usage (previously `unknown command: v`).
  - `ocr` top-level usage shows `viewer, v` and the new delegate/viewer `-h` hint lines.
  - `ocr review -h` lists `--exclude` with an example.
  - `ocr config unset` error output mentions both `custom_providers.<name>` and `mcp_servers.<name>`.
  - `ocr viewer --addr :3199` and `ocr v --addr 0.0.0.0:3198` both print `http://localhost:<port>`; the default `127.0.0.1:5483` output is unchanged.

### Checklist

- [X] My code follows the project's coding style (`go fmt`, `go vet`)
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have updated the documentation accordingly (if applicable)
- [X] I have signed the CLA

### Related Issues

None.