### PR TITLE
docs(license): update copyright holder to project contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       "printed page" as the copyright notice for easier identification within
       third-party archives.
 
-   Copyright 2026 Alibaba
+   Copyright 2026 alibaba/open-code-review Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/extensions/vscode/LICENSE
+++ b/extensions/vscode/LICENSE
@@ -186,7 +186,7 @@
       "printed page" as the copyright notice for easier identification within
       third-party archives.
 
-   Copyright 2026 Alibaba
+   Copyright 2026 alibaba/open-code-review Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Updated the copyright holder in both `LICENSE` and `extensions/vscode/LICENSE` from "Alibaba" to "alibaba/open-code-review Contributors" to better reflect the open-source community ownership of this project.