### PR TITLE
fix(vscode): patch brace-expansion DoS via minimatch 10.2.6 (CVE-2026-14257)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -111,9 +111,9 @@
     "undici": ">=7.28.0",
     "form-data": ">=4.0.6",
     "js-yaml": ">=5.2.2",
-    "minimatch": "^9.0.7",
-    "@typescript-eslint/typescript-estree/minimatch": "^9.0.7",
-    "brace-expansion": ">=2.1.2 <3",
+    "minimatch": "^10.2.6",
+    "@typescript-eslint/typescript-estree/minimatch": "^10.2.6",
+    "brace-expansion": ">=5.0.8 <6",
     "fast-uri": ">=3.1.4",
     "linkify-it": ">=5.0.2 <6"
   },

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -1724,10 +1724,10 @@ babel-preset-jest@30.4.0:
     babel-plugin-jest-hoist "30.4.0"
     babel-preset-current-node-syntax "^1.2.0"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -1765,12 +1765,12 @@ boundary@^2.0.0:
   resolved "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz#169c8b1f0d44cf2c25938967a328f37e0a4e5efc"
   integrity sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==
 
-"brace-expansion@>=2.1.2 <3", brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+"brace-expansion@>=5.0.8 <6", brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
-    balanced-match "^1.0.0"
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -3743,12 +3743,12 @@ mimic-response@^3.1.0:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-minimatch@9.0.3, minimatch@^10.2.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^9.0.4, minimatch@^9.0.7:
-  version "9.0.9"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+minimatch@9.0.3, minimatch@^10.2.2, minimatch@^10.2.6, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^9.0.4:
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
   dependencies:
-    brace-expansion "^2.0.2"
+    brace-expansion "^5.0.8"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.8"


### PR DESCRIPTION
## Description

Found via an automated dependency scan: `extensions/vscode`'s `resolutions` pins `minimatch` to `^9.0.7`, which yarn resolves to `9.0.9` — still pulling `brace-expansion@2.1.2`, inside the vulnerable range of [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257 (unbounded brace expansion can OOM the process — `expand()` bounds result *count* but not result *length*).

The `resolutions` block also caps `brace-expansion` below 3.0 (`>=2.1.2 <3`), which looks intentional rather than an oversight: `minimatch@9.0.9` imports brace-expansion via `__importDefault(...).default`, a shape `brace-expansion@5.0.8`'s CJS build doesn't provide (named `expand` export only — no `module.exports = expand`, no `__esModule` marker). A naive override straight to `5.0.8` would throw `TypeError` at runtime.

`minimatch@10.2.6` calls brace-expansion via the compatible named-export form instead, so the actual fix is bumping minimatch itself, not just widening the brace-expansion range in isolation. No application code imports `minimatch` directly (grepped `src/`) — it's purely a transitive dependency of the eslint/typescript-eslint toolchain here, which lowers the risk of the major-version bump surfacing elsewhere.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `yarn install` — clean
- [x] `yarn lint` — 0 errors (1 pre-existing warning, unrelated to this change)
- [x] `yarn build` — all three webpack bundles (extension/webview/configPanel) compile successfully
- [x] `yarn test` — 11/11 suites, 96/96 tests pass

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA (will complete if prompted)

## Related Issues

None — found via automated dependency scan (OSV database), not a filed issue.