### PR TITLE
docs(configuration): document openai-responses protocol

### DIFF
--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -62,8 +62,8 @@ environment variable.
 ### Custom providers
 
 Any provider name not in the table above is treated as custom and must
-supply at least `url` and `protocol` (`protocol` is either `anthropic` or
-`openai`):
+supply at least `url` and `protocol` (`protocol` is `anthropic`,
+`openai`, or `openai-responses`):
 
 ```bash
 ocr config set provider                             my-gateway
@@ -71,6 +71,17 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+
+Use `openai-responses` when a provider or model requires the OpenAI
+Responses API (`/v1/responses`):
+
+```bash
+ocr config set provider                                               openai-responses-gateway
+ocr config set custom_providers.openai-responses-gateway.url          https://api.openai.com/v1
+ocr config set custom_providers.openai-responses-gateway.protocol     openai-responses
+ocr config set custom_providers.openai-responses-gateway.model        gpt-5
+ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
 A local model served by Ollama is just a custom provider pointing at the

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -60,8 +60,8 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 ### カスタム provider
 
 上記の表にない provider 名はすべてカスタムとみなされ、少なくとも `url` と
-`protocol` を指定する必要があります（`protocol` は `anthropic` または
-`openai`）。
+`protocol` を指定する必要があります（`protocol` は `anthropic`、`openai`、
+または `openai-responses`）。
 
 ```bash
 ocr config set provider                             my-gateway
@@ -69,6 +69,17 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+
+provider またはモデルが OpenAI Responses API（`/v1/responses`）を必要とする場合は、
+`openai-responses` プロトコルを使用します。
+
+```bash
+ocr config set provider                                               openai-responses-gateway
+ocr config set custom_providers.openai-responses-gateway.url          https://api.openai.com/v1
+ocr config set custom_providers.openai-responses-gateway.protocol     openai-responses
+ocr config set custom_providers.openai-responses-gateway.model        gpt-5
+ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
 Ollama で動かすローカルモデルは、ローカルの OpenAI 互換エンドポイントを

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -59,7 +59,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 ### 自定义 provider
 
 任何不在上表中的 provider 名都视为自定义，至少要提供 `url` 和 `protocol`
-（`protocol` 取 `anthropic` 或 `openai`）：
+（`protocol` 取 `anthropic`、`openai` 或 `openai-responses`）：
 
 ```bash
 ocr config set provider                             my-gateway
@@ -67,6 +67,17 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+
+当 provider 或模型要求使用 OpenAI Responses API（`/v1/responses`）时，使用
+`openai-responses` 协议：
+
+```bash
+ocr config set provider                                               openai-responses-gateway
+ocr config set custom_providers.openai-responses-gateway.url          https://api.openai.com/v1
+ocr config set custom_providers.openai-responses-gateway.protocol     openai-responses
+ocr config set custom_providers.openai-responses-gateway.model        gpt-5
+ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
 用 Ollama 跑本地模型，就是一个指向本地 OpenAI 兼容端点的自定义 provider：


### PR DESCRIPTION
## Summary

This PR updates the custom provider configuration docs to document the `openai-responses` protocol supported by OCR.

Fixes #556.

## Changes

- Lists `anthropic`, `openai`, and `openai-responses` as valid custom provider protocol values.
- Adds an OpenAI Responses API (`/v1/responses`) custom provider example.
- Keeps the English, Chinese, and Japanese configuration docs consistent.

## Non-goals

- This does not change provider resolution or LLM client behavior.
- This does not add or modify built-in providers.

## Validation

- `git diff --check origin/main...HEAD`
- `cd pages && npm run typecheck`
- `cd pages && npm run build`
