### PR TITLE
docs(configuration): document openai responses protocol

### DIFF
--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -62,8 +62,8 @@ environment variable.
 ### Custom providers
 
 Any provider name not in the table above is treated as custom and must
-supply at least `url` and `protocol` (`protocol` is either `anthropic` or
-`openai`):
+supply at least `url` and `protocol` (`protocol` is `anthropic`, `openai`,
+or `openai-responses`):
 
 ```bash
 ocr config set provider                             my-gateway
@@ -71,6 +71,16 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+For a provider that uses the OpenAI Responses API (`/v1/responses`), set
+`protocol` to `openai-responses`. OCR accepts either the API base URL or
+the full `/responses` endpoint:
+```bash
+ocr config set provider                                   my-responses-gateway
+ocr config set custom_providers.my-responses-gateway.url  https://api.example.com/v1
+ocr config set custom_providers.my-responses-gateway.protocol openai-responses
+ocr config set custom_providers.my-responses-gateway.model    my-model
+ocr config set custom_providers.my-responses-gateway.api_key  "$MY_API_KEY"
 ```
 
 A local model served by Ollama is just a custom provider pointing at the

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -60,8 +60,8 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 ### カスタム provider
 
 上記の表にない provider 名はすべてカスタムとみなされ、少なくとも `url` と
-`protocol` を指定する必要があります（`protocol` は `anthropic` または
-`openai`）。
+`protocol` を指定する必要があります（`protocol` は `anthropic`、`openai`、
+または `openai-responses`）。
 
 ```bash
 ocr config set provider                             my-gateway
@@ -69,6 +69,16 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+provider が OpenAI Responses API（`/v1/responses`）を使用する場合は、
+`protocol` を `openai-responses` に設定します。`url` には API の Base URL
+または完全な `/responses` エンドポイントを指定できます。
+```bash
+ocr config set provider                                   my-responses-gateway
+ocr config set custom_providers.my-responses-gateway.url  https://api.example.com/v1
+ocr config set custom_providers.my-responses-gateway.protocol openai-responses
+ocr config set custom_providers.my-responses-gateway.model    my-model
+ocr config set custom_providers.my-responses-gateway.api_key  "$MY_API_KEY"
 ```
 
 Ollama で動かすローカルモデルは、ローカルの OpenAI 互換エンドポイントを

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -59,7 +59,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 ### 自定义 provider
 
 任何不在上表中的 provider 名都视为自定义，至少要提供 `url` 和 `protocol`
-（`protocol` 取 `anthropic` 或 `openai`）：
+（`protocol` 取 `anthropic`、`openai` 或 `openai-responses`）：
 
 ```bash
 ocr config set provider                             my-gateway
@@ -67,6 +67,16 @@ ocr config set custom_providers.my-gateway.url      https://gateway.internal.com
 ocr config set custom_providers.my-gateway.protocol openai
 ocr config set custom_providers.my-gateway.model    llama-3-70b
 ocr config set custom_providers.my-gateway.api_key  "$MY_API_KEY"
+```
+如果 provider 使用 OpenAI Responses API（`/v1/responses`），请将 `protocol`
+设为 `openai-responses`。`url` 可以填写 API Base URL，也可以填写完整的
+`/responses` 端点：
+```bash
+ocr config set provider                                   my-responses-gateway
+ocr config set custom_providers.my-responses-gateway.url  https://api.example.com/v1
+ocr config set custom_providers.my-responses-gateway.protocol openai-responses
+ocr config set custom_providers.my-responses-gateway.model    my-model
+ocr config set custom_providers.my-responses-gateway.api_key  "$MY_API_KEY"
 ```
 
 用 Ollama 跑本地模型，就是一个指向本地 OpenAI 兼容端点的自定义 provider：


### PR DESCRIPTION
## Summary

- document `openai-responses` as the third supported custom-provider protocol
- add an OpenAI Responses API configuration example
- keep the English, Chinese, and Japanese configuration docs aligned

## Why

The Responses API has been supported since v1.7.10, but the custom-provider docs still listed only `anthropic` and `openai`. This closes the documentation gap reported in #556.

## Validation

- `git diff --check`
- verified the example against `internal/llm/responses_client.go` URL normalization
- local site build not run because `pages/node_modules` is not installed; the repository build script also uses Unix-style `NODE_ENV=...`

Closes #556.

Contributed as a member of the iFLYTEK Astron community.