### PR TITLE
ci(test): add binary smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,17 @@ jobs:
         run: |
           ./opencodereview --version
           ./opencodereview --version | grep -q "open-code-review"
-          ./opencodereview --help
-          ./opencodereview --help | grep -q "Commands:"
+          HELP=$(./opencodereview --help)
+          echo "$HELP" | grep -q "Commands:"
+          echo "$HELP" | grep -q "review"
+          echo "$HELP" | grep -q "scan"
+          echo "$HELP" | grep -q "delegate"
+          echo "$HELP" | grep -q "config"
+          echo "$HELP" | grep -q "llm"
+          echo "$HELP" | grep -q "viewer"
+          echo "$HELP" | grep -q "session"
+          echo "$HELP" | grep -q "rules"
+          rm -f ./opencodereview
 
   cross-compile:
     runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,14 @@ jobs:
           echo "PASS: Coverage ${COVERAGE}% meets 80% threshold"
 
       - name: Build
-        run: go build -o /dev/null ./cmd/opencodereview
+        run: go build -o ./opencodereview ./cmd/opencodereview
+
+      - name: Smoke test
+        run: |
+          ./opencodereview --version
+          ./opencodereview --version | grep -q "open-code-review"
+          ./opencodereview --help
+          ./opencodereview --help | grep -q "Commands:"
 
   cross-compile:
     runs-on: self-hosted


### PR DESCRIPTION
## Description

Adds a native binary smoke test to the existing CI `test` job.

Previously, CI built the CLI binary to `/dev/null`, which verified compilation only. This change builds a real `./opencodereview` executable and verifies that it starts successfully, prints version information, and renders CLI help correctly.

The cross-compile job remains unchanged because its target binaries cannot run on the Linux CI runner.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

- Verified the workflow builds `./opencodereview` rather than writing the binary to `/dev/null`.
- Added smoke checks for `./opencodereview --version` containing `open-code-review`.
- Added smoke checks for `./opencodereview --help` containing `Commands:`.
- Verified the workflow diff with `git diff --check`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #554