### PR TITLE
docs(agent): correct MaxConcurrency doc comment to match actual default

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -90,7 +90,7 @@ type Args struct {
 	// executeToolCall instead of via a separate worker pool.
 	CommentWorkerPool *CommentWorkerPool
 
-	// Concurrency limit for per-file subtasks. Defaults to number of CPUs.
+	// Concurrency limit for per-file subtasks. MaxConcurrency <= 0 defaults to 8.
 	MaxConcurrency int
 
 	// Concurrent task timeout in minutes. 0 means no timeout.


### PR DESCRIPTION
## Description

The doc comment on `Args.MaxConcurrency` in `internal/agent/agent.go` claims the
concurrency limit "Defaults to number of CPUs", but the actual fallback in
`dispatchSubtasks` is a fixed `8` when the value is `<= 0` — there is no
`runtime.NumCPU` call anywhere in the repository. The `--concurrency` CLI flag
default is also `8`, so the documented behavior never happens on any path.

This PR corrects the comment to `MaxConcurrency <= 0 defaults to 8.`, matching
both the implementation and the existing comment style used for the same
fallback pattern in `internal/llmloop/pool.go` (`workerCount <= 0 defaults to 8.`).

Comment-only change; no behavior is affected.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

`make check` (go mod tidy + gofmt + go vet) and `make test` (full suite with
`-race`) both pass locally: 23 packages ok, 0 failures. No test changes are
needed for a comment-only fix.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works (N/A — comment-only)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

None.