### PR TITLE
fix: honor per-file review terminal states

### DIFF
--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -25,11 +25,15 @@ func outputText(comments []model.LlmComment) {
 
 func hasSubtaskErrors(warnings []agent.AgentWarning) bool {
 	for _, w := range warnings {
-		if w.Type == "subtask_error" {
+		if isSubtaskErrorType(w.Type) {
 			return true
 		}
 	}
 	return false
+}
+
+func isSubtaskErrorType(warningType string) bool {
+	return warningType == "subtask_error" || warningType == "scan_subtask_error"
 }
 
 func outputTextWithWarnings(comments []model.LlmComment, warnings []agent.AgentWarning) {
@@ -45,7 +49,7 @@ func outputTextWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 		}
 	}
 	for _, w := range warnings {
-		if w.Type == "subtask_error" {
+		if isSubtaskErrorType(w.Type) {
 			continue
 		}
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING [%s] %s: %s\n", w.Type, sanitizeTerminal(w.File), sanitizeTerminal(w.Message))

--- a/cmd/opencodereview/output_helpers_test.go
+++ b/cmd/opencodereview/output_helpers_test.go
@@ -22,6 +22,7 @@ func TestHasSubtaskErrors(t *testing.T) {
 		{"empty", []agent.AgentWarning{}, false},
 		{"no subtask errors", []agent.AgentWarning{{Type: "other", Message: "msg"}}, false},
 		{"has subtask error", []agent.AgentWarning{{Type: "subtask_error", Message: "fail"}}, true},
+		{"has scan subtask error", []agent.AgentWarning{{Type: "scan_subtask_error", Message: "fail"}}, true},
 		{"mixed", []agent.AgentWarning{{Type: "warn"}, {Type: "subtask_error"}}, true},
 	}
 	for _, tc := range tests {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -631,7 +631,7 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, string,
 		return false, "", err
 	}
 	if !mainCompleted {
-		return false, "main_task did not complete before stopping", nil
+		return false, "", fmt.Errorf("main_task did not complete before stopping")
 	}
 	return true, "", nil
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -695,11 +695,15 @@ func TestDispatchSubtasks_MainTaskWithoutTaskDoneIsNotReusableCheckpoint(t *test
 	a.currentDate = "2025-06-26 10:00"
 
 	_, err := a.dispatchSubtasks(context.Background())
-	if err != nil {
-		t.Fatalf("dispatchSubtasks: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "all 1 file review(s) failed") {
+		t.Fatalf("expected all-failed error, got %v", err)
 	}
 	if client.calls != 1 {
 		t.Fatalf("LLM calls = %d, want 1", client.calls)
+	}
+	warnings := a.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "subtask_error" || warnings[0].File != diff.NewPath {
+		t.Fatalf("warnings = %+v, want one subtask_error for %s", warnings, diff.NewPath)
 	}
 	sess.Finalize()
 
@@ -723,6 +727,46 @@ func TestDispatchSubtasks_MainTaskWithoutTaskDoneIsNotReusableCheckpoint(t *test
 	}
 	if len(items) != 1 || items[0].Type != "failed" || !strings.Contains(items[0].Error, "main_task did not complete") {
 		t.Fatalf("items = %+v, want one incomplete-main failed item", items)
+	}
+}
+
+func TestDispatchSubtasks_IncompleteMainTaskMarksPartialFailure(t *testing.T) {
+	emptyContent := ""
+	client := &fakeAgentClient{responses: []*llm.ChatResponse{
+		agentTaskDoneResponse(),
+		{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &emptyContent}}},
+			Model:   "fake",
+			Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 1},
+		},
+	}}
+	a := New(Args{
+		From:           "main",
+		To:             "feature",
+		LLMClient:      client,
+		Model:          "fake",
+		MaxConcurrency: 1,
+		Template: template.Template{
+			MaxTokens:           100000,
+			MaxToolRequestTimes: 1,
+			MainTask: template.LlmConversation{
+				Messages: []template.ChatMessage{{Role: "user", Content: "Review {{diff}}"}},
+			},
+		},
+	})
+	a.diffs = []model.Diff{
+		{NewPath: "complete.go", OldPath: "complete.go", Diff: "+x", Insertions: 1},
+		{NewPath: "incomplete.go", OldPath: "incomplete.go", Diff: "+y", Insertions: 1},
+	}
+	a.currentDate = "2025-06-26 10:00"
+
+	_, err := a.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("one completed file should keep the review partial, got %v", err)
+	}
+	warnings := a.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "subtask_error" || warnings[0].File != "incomplete.go" {
+		t.Fatalf("warnings = %+v, want one subtask_error for incomplete.go", warnings)
 	}
 }
 

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -145,7 +145,7 @@ func (r *Runner) CollectPendingComments() []model.LlmComment {
 // tool calls returned by the model, and collects review comments until
 // task_done is called or limits are reached. Token usage and warnings
 // are aggregated on the Runner across all files. The returned bool is true
-// only when the model explicitly calls task_done.
+// only when the model explicitly calls task_done with a successful state.
 func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath string) (bool, error) {
 	toolReqCount := r.deps.Template.MaxToolRequestTimes
 	const maxConsecutiveEmptyRounds = 3
@@ -217,7 +217,9 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 
 		for _, call := range calls {
 			cp := r.executeToolCall(ctx, newPath, call, rec)
-			if cp.Completed {
+			if cp.Failed {
+				return false, fmt.Errorf("task failed: %s", cp.Data)
+			} else if cp.Completed {
 				results = append(results, tool.ToolCallResult{
 					ToolCallID: call.ID,
 					Name:       call.Function.Name,
@@ -307,7 +309,26 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 	}
 
 	if t == tool.TaskDone {
-		return tool.Complete()
+		args, err := parseToolArgs(call.Function.Arguments)
+		if err != nil {
+			return tool.Of(fmt.Sprintf("Error parsing tool arguments for %s: %v", t.Name(), err))
+		}
+		rawState, hasState := args["state"]
+		if !hasState {
+			return tool.Complete()
+		}
+		state, ok := rawState.(string)
+		if !ok {
+			return tool.Of("Error: task_done state must be DONE or FAILED.")
+		}
+		switch state {
+		case "DONE":
+			return tool.Complete()
+		case "FAILED":
+			return tool.Fail("task_done reported FAILED")
+		default:
+			return tool.Of(fmt.Sprintf("Error: invalid task_done state %q; expected DONE or FAILED.", state))
+		}
 	}
 
 	p := lookupTool(r.deps.Tools, t)

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -30,7 +30,7 @@ func (f *fakeClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*
 	return resp, nil
 }
 
-func taskDoneResponse() *llm.ChatResponse {
+func taskDoneResponseWithArguments(arguments string) *llm.ChatResponse {
 	content := ""
 	return &llm.ChatResponse{
 		Choices: []llm.Choice{{
@@ -41,7 +41,7 @@ func taskDoneResponse() *llm.ChatResponse {
 					Type: "function",
 					Function: llm.FunctionCall{
 						Name:      "task_done",
-						Arguments: `{}`,
+						Arguments: arguments,
 					},
 				}},
 			},
@@ -49,6 +49,10 @@ func taskDoneResponse() *llm.ChatResponse {
 		Model: "fake",
 		Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
 	}
+}
+
+func taskDoneResponse() *llm.ChatResponse {
+	return taskDoneResponseWithArguments(`{}`)
 }
 
 func fileReadToolCallResponse(callID, args string) *llm.ChatResponse {
@@ -115,6 +119,84 @@ func TestRunPerFile_TaskDoneImmediately(t *testing.T) {
 	}
 	if runner.TotalOutputTokens() != 5 {
 		t.Errorf("TotalOutputTokens = %d, want 5", runner.TotalOutputTokens())
+	}
+}
+
+func TestRunPerFile_TaskDoneExplicitDone(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		taskDoneResponseWithArguments(`{"state":"DONE"}`),
+	}}
+	runner := NewRunner(newTestDeps(client))
+
+	completed, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review this file")},
+		"main.go",
+	)
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	if !completed {
+		t.Fatal("expected task_done DONE to complete RunPerFile")
+	}
+}
+
+func TestRunPerFile_TaskDoneFailed(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		taskDoneResponseWithArguments(`{"state":"FAILED"}`),
+	}}
+	runner := NewRunner(newTestDeps(client))
+
+	completed, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review this file")},
+		"main.go",
+	)
+	if err == nil || !strings.Contains(err.Error(), "task_done reported FAILED") {
+		t.Fatalf("expected task_done FAILED error, got %v", err)
+	}
+	if completed {
+		t.Fatal("task_done FAILED must not complete RunPerFile")
+	}
+	if client.calls != 1 {
+		t.Fatalf("expected terminal failure after 1 LLM call, got %d", client.calls)
+	}
+}
+
+func TestRunPerFile_InvalidTaskDoneStateRetries(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+	}{
+		{name: "unknown state", arguments: `{"state":"UNKNOWN"}`},
+		{name: "empty state", arguments: `{"state":""}`},
+		{name: "non-string state", arguments: `{"state":1}`},
+		{name: "malformed arguments", arguments: `{"state":`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeClient{responses: []*llm.ChatResponse{
+				taskDoneResponseWithArguments(tt.arguments),
+				taskDoneResponseWithArguments(`{"state":"DONE"}`),
+			}}
+			runner := NewRunner(newTestDeps(client))
+
+			completed, err := runner.RunPerFile(
+				context.Background(),
+				[]llm.Message{llm.NewTextMessage("user", "review this file")},
+				"main.go",
+			)
+			if err != nil {
+				t.Fatalf("RunPerFile: %v", err)
+			}
+			if !completed {
+				t.Fatal("expected retry to complete with task_done DONE")
+			}
+			if client.calls != 2 {
+				t.Fatalf("expected invalid state to be retried, got %d LLM calls", client.calls)
+			}
+		})
 	}
 }
 

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -564,8 +564,14 @@ func (a *Agent) executeSubtask(ctx context.Context, it model.ScanItem) error {
 		return nil
 	}
 
-	_, err := a.runner.RunPerFile(ctx, messages, it.Path)
-	return err
+	completed, err := a.runner.RunPerFile(ctx, messages, it.Path)
+	if err != nil {
+		return err
+	}
+	if !completed {
+		return fmt.Errorf("main_task did not complete before stopping")
+	}
+	return nil
 }
 
 // maybeRunPlan invokes PLAN_TASK on the file and returns a human-readable

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -648,6 +648,47 @@ func TestDispatchSubtasks_AllFailed(t *testing.T) {
 	}
 }
 
+func TestDispatchSubtasks_WithoutTaskDoneIsAllFailed(t *testing.T) {
+	empty := ""
+	client := &fakeScanClient{responses: []*llm.ChatResponse{{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &empty}}},
+		Model:   "test",
+		Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 1},
+	}}}
+
+	tpl := makeTemplateWithFullScan()
+	tpl.MaxTokens = 100000
+	tpl.MaxToolRequestTimes = 1
+
+	a := NewAgent(Args{
+		Template:         tpl,
+		LLMClient:        client,
+		Model:            "test",
+		CommentCollector: tool.NewCommentCollector(),
+		Tools:            tool.NewRegistry(),
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipDedup:        true,
+		SkipSummary:      true,
+		Session: session.New(t.TempDir(), "main", "test", session.SessionOptions{
+			ReviewMode: session.ReviewModeFullScan,
+		}),
+	})
+	a.items = []model.ScanItem{{Path: "a.go", Content: "x", LineCount: 1}}
+	a.currentDate = "2026-06-26"
+	a.args.Tools.Freeze()
+
+	_, err := a.dispatchSubtasks(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "all 1 file scan(s) failed") {
+		t.Fatalf("expected all-failed error, got %v", err)
+	}
+	warnings := a.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "scan_subtask_error" ||
+		!strings.Contains(warnings[0].Message, "main_task did not complete") {
+		t.Fatalf("warnings = %+v, want one incomplete scan subtask error", warnings)
+	}
+}
+
 func TestPhaseEnabled(t *testing.T) {
 	tpl := makeTemplateWithFullScan()
 	a := newAgentForTest(t, tpl)

--- a/internal/tool/response_message.go
+++ b/internal/tool/response_message.go
@@ -7,14 +7,18 @@ type ToolCallResult struct {
 	Result     string // output from the tool
 }
 
-// TaskCheckpoint mirrors the Java TaskCheckPoint — signals completion or carries data back to the LLM.
+// TaskCheckpoint signals terminal completion or failure, or carries data back to the LLM.
 type TaskCheckpoint struct {
 	Data      string
 	Completed bool
+	Failed    bool
 }
 
 // Complete returns a checkpoint signaling task completion.
 func Complete() TaskCheckpoint { return TaskCheckpoint{Completed: true} }
+
+// Fail returns a checkpoint signaling terminal task failure.
+func Fail(data string) TaskCheckpoint { return TaskCheckpoint{Data: data, Failed: true} }
 
 // Of returns a checkpoint with data.
 func Of(data string) TaskCheckpoint { return TaskCheckpoint{Data: data, Completed: false} }

--- a/internal/tool/response_message_test.go
+++ b/internal/tool/response_message_test.go
@@ -7,8 +7,24 @@ func TestComplete(t *testing.T) {
 	if !cp.Completed {
 		t.Error("Complete() should set Completed=true")
 	}
+	if cp.Failed {
+		t.Error("Complete() should set Failed=false")
+	}
 	if cp.Data != "" {
 		t.Errorf("Complete() Data = %q, want empty", cp.Data)
+	}
+}
+
+func TestFail(t *testing.T) {
+	cp := Fail("task failed")
+	if cp.Completed {
+		t.Error("Fail() should set Completed=false")
+	}
+	if !cp.Failed {
+		t.Error("Fail() should set Failed=true")
+	}
+	if cp.Data != "task failed" {
+		t.Errorf("Fail() Data = %q, want %q", cp.Data, "task failed")
 	}
 }
 
@@ -16,6 +32,9 @@ func TestOf(t *testing.T) {
 	cp := Of("hello")
 	if cp.Completed {
 		t.Error("Of() should set Completed=false")
+	}
+	if cp.Failed {
+		t.Error("Of() should set Failed=false")
 	}
 	if cp.Data != "hello" {
 		t.Errorf("Of() Data = %q, want %q", cp.Data, "hello")

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -386,7 +386,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 							args, _ := tm["arguments"].(string)
 							info := ToolCallInfo{Name: name, Arguments: args}
 							if name == "task_done" {
-								info.Ok = true
+								info.Ok = taskDoneSucceeded(args)
 							}
 							card.ToolCalls = append(card.ToolCalls, info)
 						}
@@ -414,6 +414,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 			}
 
 		case "tool_call":
+			toolName, _ := rec["tool_name"].(string)
 			result, _ := rec["result"].(string)
 			okVal := true
 			if b, hasOk := rec["ok"].(bool); hasOk {
@@ -432,7 +433,10 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 				if len(cards) > 0 {
 					card := cards[len(cards)-1]
 					for ti := range card.ToolCalls {
-						if card.ToolCalls[ti].Result == "" && !card.ToolCalls[ti].Ok {
+						// Older session records omitted tool_name, so retain
+						// positional matching only for those records.
+						if (toolName == "" || card.ToolCalls[ti].Name == toolName) &&
+							card.ToolCalls[ti].Result == "" && !card.ToolCalls[ti].Ok {
 							card.ToolCalls[ti].Result = result
 							card.ToolCalls[ti].Ok = okVal
 							card.ToolCalls[ti].DurationMs = durationMs
@@ -493,4 +497,17 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 
 	vs.Summary.SessionID = sessionID
 	return vs, scanner.Err()
+}
+
+func taskDoneSucceeded(arguments string) bool {
+	var args map[string]any
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return false
+	}
+	state, hasState := args["state"]
+	if !hasState {
+		return true
+	}
+	stateString, ok := state.(string)
+	return ok && stateString == "DONE"
 }

--- a/internal/viewer/store_load_test.go
+++ b/internal/viewer/store_load_test.go
@@ -162,6 +162,58 @@ func TestLoadSession_FullParse(t *testing.T) {
 	}
 }
 
+func TestLoadSession_TaskDoneStates(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeJSONL(t, filepath.Join(repoDir, "terminal-states.jsonl"),
+		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":1,"messages":[]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","tool_calls":[{"name":"task_done","arguments":"{}"}]}`,
+		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":2,"messages":[]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","tool_calls":[{"name":"task_done","arguments":"{\"state\":\"DONE\"}"}]}`,
+		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":3,"messages":[]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","tool_calls":[{"name":"task_done","arguments":"{\"state\":\"FAILED\"}"}]}`,
+		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":4,"messages":[]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","tool_calls":[{"name":"task_done","arguments":"{\"state\":\"\"}"}]}`,
+		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":5,"messages":[]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","tool_calls":[{"name":"task_done","arguments":"{\"state\":\"\"}"},{"name":"file_read","arguments":"{\"path\":\"main.go\"}"}]}`,
+		`{"type":"tool_call","filePath":"main.go","taskType":"main_task","tool_name":"file_read","result":"package main","ok":true,"duration_ms":20}`,
+	)
+
+	vs, err := LoadSession(root, "repo", "terminal-states")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(vs.Files))
+	}
+	cards := vs.Files[0].Tasks[MainTask]
+	if len(cards) != 5 {
+		t.Fatalf("main_task cards = %d, want 5", len(cards))
+	}
+	wantOK := []bool{true, true, false, false}
+	for i, want := range wantOK {
+		if len(cards[i].ToolCalls) != 1 {
+			t.Fatalf("card %d tool calls = %d, want 1", i, len(cards[i].ToolCalls))
+		}
+		if got := cards[i].ToolCalls[0].Ok; got != want {
+			t.Errorf("card %d task_done Ok = %v, want %v", i, got, want)
+		}
+	}
+	if len(cards[4].ToolCalls) != 2 {
+		t.Fatalf("card 4 tool calls = %d, want 2", len(cards[4].ToolCalls))
+	}
+	if cards[4].ToolCalls[0].Ok || cards[4].ToolCalls[0].Result != "" {
+		t.Errorf("invalid task_done received another tool's result: %+v", cards[4].ToolCalls[0])
+	}
+	if !cards[4].ToolCalls[1].Ok || cards[4].ToolCalls[1].Result != "package main" {
+		t.Errorf("file_read result was not matched by name: %+v", cards[4].ToolCalls[1])
+	}
+}
+
 func TestLoadSession_MissingFile(t *testing.T) {
 	root := t.TempDir()
 	repoDir := filepath.Join(root, "repo")


### PR DESCRIPTION
Treat FAILED and missing completion as review failures, and retry invalid task_done states instead of accepting them as success.

Keep partial scan output and session history aligned with those states.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
