### PR TITLE
fix(config): warn when llm.* settings are silently ignored due to active provider

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -93,7 +93,7 @@ func runConfigSet(key, value string) error {
 
 	// Warn when llm.* settings are shadowed by an active provider.
 	if cfg.Provider != "" && strings.HasPrefix(key, "llm.") {
-		fmt.Fprintf(os.Stderr, "[ocr] WARNING: %q is ignored because provider %q is active. Unset the provider first if you want to use legacy llm config.\n", key, cfg.Provider)
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: %q will have no effect while provider %q is active. The value is saved but will not be used until the provider is unset.\n", key, cfg.Provider)
 	}
 	return nil
 }
@@ -112,6 +112,9 @@ func runConfigUnset(key string) error {
 		}
 		switch key {
 		case "provider":
+			if cfg.Model != "" {
+				fmt.Fprintf(os.Stderr, "[ocr] WARNING: 'model' has also been cleared because it is tied to the provider.\n")
+			}
 			cfg.Provider = ""
 			cfg.Model = ""
 		case "model":

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -90,18 +90,45 @@ func runConfigSet(key, value string) error {
 		displayValue = maskKey(value)
 	}
 	fmt.Printf("Set %s = %s\n", key, displayValue)
+
+	// Warn when llm.* settings are shadowed by an active provider.
+	if cfg.Provider != "" && strings.HasPrefix(key, "llm.") {
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: %q is ignored because provider %q is active. Unset the provider first if you want to use legacy llm config.\n", key, cfg.Provider)
+	}
 	return nil
 }
 
 func runConfigUnset(key string) error {
-	parts := strings.SplitN(key, ".", 2)
-	if len(parts) != 2 || parts[1] == "" {
-		return fmt.Errorf("unset supports custom_providers.<name> and mcp_servers.<name>")
-	}
-
 	configPath, err := defaultConfigPath()
 	if err != nil {
 		return err
+	}
+
+	// Top-level keys that do not contain a dot.
+	if !strings.Contains(key, ".") {
+		cfg, err := loadOrCreateConfig(configPath)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		switch key {
+		case "provider":
+			cfg.Provider = ""
+			cfg.Model = ""
+		case "model":
+			cfg.Model = ""
+		default:
+			return fmt.Errorf("unset supports provider, model, custom_providers.<name> and mcp_servers.<name>")
+		}
+		if err := saveConfig(configPath, cfg); err != nil {
+			return err
+		}
+		fmt.Printf("Unset %s\n", key)
+		return nil
+	}
+
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return fmt.Errorf("unset supports provider, model, custom_providers.<name> and mcp_servers.<name>")
 	}
 
 	switch parts[0] {
@@ -110,7 +137,7 @@ func runConfigUnset(key string) error {
 	case "mcp_servers":
 		return unsetMCPServer(configPath, parts[1])
 	default:
-		return fmt.Errorf("unset supports custom_providers.<name> and mcp_servers.<name>")
+		return fmt.Errorf("unset supports provider, model, custom_providers.<name> and mcp_servers.<name>")
 	}
 }
 

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -115,7 +115,21 @@ func runConfigUnset(key string) error {
 			cfg.Provider = ""
 			cfg.Model = ""
 		case "model":
-			cfg.Model = ""
+			if cfg.Provider != "" {
+				if _, isPreset := llm.LookupProvider(cfg.Provider); isPreset {
+					if entry, exists := cfg.Providers[cfg.Provider]; exists {
+						entry.Model = ""
+						cfg.Providers[cfg.Provider] = entry
+					}
+				} else {
+					if entry, exists := cfg.CustomProviders[cfg.Provider]; exists {
+						entry.Model = ""
+						cfg.CustomProviders[cfg.Provider] = entry
+					}
+				}
+			} else {
+				cfg.Model = ""
+			}
 		default:
 			return fmt.Errorf("unset supports provider, model, custom_providers.<name> and mcp_servers.<name>")
 		}

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -1385,11 +1385,29 @@ func TestRunConfigUnsetProvider(t *testing.T) {
 		t.Fatalf("saveConfig: %v", err)
 	}
 
-	if err := runConfigUnset("provider"); err != nil {
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := runConfigUnset("provider")
+
+	w.Close()
+	os.Stderr = oldStderr
+	if err != nil {
 		t.Fatalf("runConfigUnset: %v", err)
 	}
 
-	cfg, err := loadOrCreateConfig(configPath)
+	var buf strings.Builder
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	stderr := buf.String()
+
+	if !strings.Contains(stderr, "WARNING") {
+		t.Errorf("stderr = %q, want WARNING about cleared model", stderr)
+	}
+
+	cfg, err = loadOrCreateConfig(configPath)
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
@@ -1410,7 +1428,7 @@ func TestRunConfigUnsetModel(t *testing.T) {
 		Provider: "anthropic",
 		Model:    "claude-opus-4-6",
 		Providers: map[string]ProviderEntry{
-			"anthropic": {APIKey: "sk-test"},
+			"anthropic": {APIKey: "sk-test", Model: "claude-opus-4-6"},
 		},
 	}
 	if err := saveConfig(configPath, cfg); err != nil {
@@ -1429,7 +1447,10 @@ func TestRunConfigUnsetModel(t *testing.T) {
 		t.Errorf("Provider = %q, want anthropic", cfg.Provider)
 	}
 	if cfg.Model != "" {
-		t.Errorf("Model = %q, want empty", cfg.Model)
+		t.Errorf("top-level Model = %q, want empty", cfg.Model)
+	}
+	if cfg.Providers["anthropic"].Model != "" {
+		t.Errorf("provider entry Model = %q, want empty", cfg.Providers["anthropic"].Model)
 	}
 }
 

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/open-code-review/internal/llm"
@@ -1285,5 +1286,158 @@ func TestSetMCPServerValue_HeadersEmptyValue(t *testing.T) {
 	cfg := &Config{}
 	if err := setMCPServerValue(cfg, "mcp_servers.gh.headers", `{"Authorization":""}`); err == nil {
 		t.Fatal("expected error for empty header value, got nil")
+	}
+}
+
+// --- runConfigSet warning tests ---
+
+func TestRunConfigSetWarnsWhenLlmShadowedByProvider(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Create a config with an active provider.
+	configPath, _ := defaultConfigPath()
+	cfg := &Config{
+		Provider: "anthropic",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {APIKey: "sk-test"},
+		},
+	}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := runConfigSet("llm.url", "https://custom.example.com")
+
+	w.Close()
+	os.Stderr = oldStderr
+	if err != nil {
+		t.Fatalf("runConfigSet: %v", err)
+	}
+
+	var buf strings.Builder
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	stderr := buf.String()
+
+	if !strings.Contains(stderr, "WARNING") {
+		t.Errorf("stderr = %q, want WARNING about shadowed llm config", stderr)
+	}
+	if !strings.Contains(stderr, "anthropic") {
+		t.Errorf("stderr = %q, want provider name in warning", stderr)
+	}
+}
+
+func TestRunConfigSetNoWarningWhenProviderNotActive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configPath, _ := defaultConfigPath()
+	cfg := &Config{}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := runConfigSet("llm.url", "https://custom.example.com")
+
+	w.Close()
+	os.Stderr = oldStderr
+	if err != nil {
+		t.Fatalf("runConfigSet: %v", err)
+	}
+
+	var buf strings.Builder
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	stderr := buf.String()
+
+	if strings.Contains(stderr, "WARNING") {
+		t.Errorf("stderr = %q, should NOT contain WARNING when no provider is active", stderr)
+	}
+}
+
+// --- runConfigUnset tests ---
+
+func TestRunConfigUnsetProvider(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configPath, _ := defaultConfigPath()
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-6",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {APIKey: "sk-test"},
+		},
+	}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	if err := runConfigUnset("provider"); err != nil {
+		t.Fatalf("runConfigUnset: %v", err)
+	}
+
+	cfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if cfg.Provider != "" {
+		t.Errorf("Provider = %q, want empty", cfg.Provider)
+	}
+	if cfg.Model != "" {
+		t.Errorf("Model = %q, want empty", cfg.Model)
+	}
+}
+
+func TestRunConfigUnsetModel(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configPath, _ := defaultConfigPath()
+	cfg := &Config{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-6",
+		Providers: map[string]ProviderEntry{
+			"anthropic": {APIKey: "sk-test"},
+		},
+	}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	if err := runConfigUnset("model"); err != nil {
+		t.Fatalf("runConfigUnset: %v", err)
+	}
+
+	cfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if cfg.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic", cfg.Provider)
+	}
+	if cfg.Model != "" {
+		t.Errorf("Model = %q, want empty", cfg.Model)
+	}
+}
+
+func TestRunConfigUnsetInvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	if err := runConfigUnset("invalid_key"); err == nil {
+		t.Fatal("expected error for invalid key")
 	}
 }

--- a/extensions/vscode/src/extension/services/CliService.ts
+++ b/extensions/vscode/src/extension/services/CliService.ts
@@ -32,7 +32,7 @@ export class CliService {
 
   private probeCommand(bin: string, args: string[]): Promise<{ ok: boolean; version?: string }> {
     return new Promise((resolve) => {
-      const proc = spawn(resolveBin(bin), args, { env: getShellEnv() });
+      const proc = spawn(resolveBin(bin), args, { env: getShellEnv(), shell: process.platform === 'win32' });
       let stdout = '';
       let errored = false;
       proc.stdout?.on('data', (d) => { stdout += d.toString(); });
@@ -111,6 +111,7 @@ export class CliService {
       const proc = spawn(resolveBin(this.cliPath), args, {
         cwd,
         env: envExtra ? { ...getShellEnv(), ...envExtra } : getShellEnv(),
+        shell: process.platform === 'win32',
       });
       this.current = proc;
       let stdout = '';

--- a/extensions/vscode/src/extension/services/__tests__/CliService.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/CliService.test.ts
@@ -1,6 +1,9 @@
 // src/extension/services/__tests__/CliService.test.ts
 process.env.OCR_SKIP_SHELL_RESOLVE = '1';
 import { CliService } from '../CliService';
+import { spawn } from 'child_process';
+
+jest.mock('child_process');
 
 describe('CliService.isAvailable', () => {
   it('node 一定存在 → true', async () => {
@@ -10,6 +13,57 @@ describe('CliService.isAvailable', () => {
   it('不存在的命令 → false', async () => {
     const svc = new CliService('definitely-not-a-real-binary-xyz');
     expect(await svc.isAvailable()).toBe(false);
+  });
+});
+
+describe('CliService probe shell option', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('Windows 上 probeCommand 应传入 shell: true', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const mockProc = {
+      stdout: { on: jest.fn() },
+      on: jest.fn((event: string, cb: Function) => {
+        if (event === 'close') cb(0);
+      }),
+    };
+    (spawn as jest.Mock).mockReturnValue(mockProc);
+
+    const svc = new CliService('node');
+    await (svc as any).probeCommand('npm', ['--version']);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
+      ['--version'],
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it('非 Windows 上 probeCommand 不应传入 shell', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const mockProc = {
+      stdout: { on: jest.fn() },
+      on: jest.fn((event: string, cb: Function) => {
+        if (event === 'close') cb(0);
+      }),
+    };
+    (spawn as jest.Mock).mockReturnValue(mockProc);
+
+    const svc = new CliService('node');
+    await (svc as any).probeCommand('npm', ['--version']);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
+      ['--version'],
+      expect.not.objectContaining({ shell: true }),
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

When a provider is already active, writing an `llm.*` setting via the CLI succeeds without error but is discarded at runtime. The resolver checks `cfg.Provider != ""` and invokes `tryProviderConfig`, leaving `tryLegacyLlmConfig` as the fallback path. Users have no idea their setting was ignored.

### Reproduction

1. `ocr config provider` → select any provider (e.g. anthropic)
2. `ocr config set llm.url https://custom.example.com` → succeeds silently
3. At runtime, `llm.url` is ignored because the provider takes priority.

## Fix

- `runConfigSet`: issue a stderr warning when `llm.*` values are written while a provider is present.
- `runConfigUnset`: enable unsetting the `provider` and `model` fields so users can switch back to legacy llm config.

The resolver's priority ordering is intentional and remains untouched.

## Test

Added regression tests:
- `TestRunConfigSetWarnsWhenLlmShadowedByProvider`
- `TestRunConfigSetNoWarningWhenProviderNotActive`
- `TestRunConfigUnsetProvider`
- `TestRunConfigUnsetModel`
- `TestRunConfigUnsetInvalidKey`

Fixes #583