### PR TITLE
ci: pin govulncheck to v1.6.0, narrow release.yml permissions to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
           govulncheck ./...
 
       - name: Test with coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Two one-line CI changes, split out of #473 so that PR stays single-purpose.

**`ci.yml:51` installed govulncheck with `@latest`.** Not a supply-chain hole: `golang.org/x/vuln` is the Go team's own module and `go install` verifies it through GOSUMDB. What `@latest` actually costs is a govulncheck release turning CI red on an unchanged tree, and two runs of the same commit scanning with different binaries. This gate is load-bearing — e6e5da0 bumped the Go image to fix GO-2026-5856 because govulncheck caught it — so it's worth protecting from unrelated churn. Pinned to `v1.6.0`.

The pin does not make the scan stale. The vulnerability database is fetched at runtime, independent of the binary version:

```
$ govulncheck -show version ./...
Scanner: govulncheck@v1.6.0
DB updated: 2026-07-27 20:14:16 +0000 UTC
No vulnerabilities found.
```

**`release.yml:8` requested workflow-level `contents: write`.** `contents: read` covers it. Only the `build` job inherits the workflow-level set, and it checks out, builds, and uploads artifacts — `upload-artifact` authenticates with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`. `release` declares its own `contents: write` / `id-token: write` / `attestations: write` and `npm-publish` declares `contents: read`; job-level permissions replace the inherited set rather than adding to it, so neither job changes behaviour.

## Limitations

A pin needs a manual bump; `@latest` did not. `release.yml` only triggers on `v*` tags, so this can't be exercised before the next release — that `build` doesn't need write access is read off the job definition, not observed on a real run.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally (three consecutive `-race` runs)
- [x] Manual testing: ran `govulncheck ./...` at the pinned `v1.6.0` — exit 0, no vulnerabilities; confirmed `yaml.safe_load` parses both changed workflows; read `release.yml` to confirm `build` is the only job inheriting the workflow-level permissions

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — n/a, workflow config
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable)
- [x] I have signed the CLA

## Related Issues

Split out of #473.

AI assistance: Claude Code helped research and verify this change. I reviewed the full diff and take responsibility for it.
