### PR TITLE
refactor(diff): strip index headers from review prompts

### DIFF
--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -65,6 +65,11 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 		switch {
 		case strings.HasPrefix(line, "@@"):
 			inHunk = true
+		// The object IDs and mode in Git's extended "index" header are not
+		// useful review context. Keep index text in hunks, where it is file
+		// content and therefore carries a diff prefix.
+		case !inHunk && strings.HasPrefix(line, "index "):
+			continue
 		case !inHunk && binaryRe.MatchString(line):
 			current.IsBinary = true
 		// Extended header lines (unambiguous: content lines always carry a

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -2,8 +2,50 @@ package diff
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
+
+func TestParseDiffText_StripsIndexHeadersFromPromptDiff(t *testing.T) {
+	diffText := `diff --git a/first.go b/first.go
+index 1234567..89abcde 100644
+--- a/first.go
++++ b/first.go
+@@ -1,1 +1,2 @@
+ first
++index added-content
+diff --git a/second.go b/second.go
+new file mode 100644
+index 0000000..7654321
+--- /dev/null
++++ b/second.go
+@@ -0,0 +1 @@
++package second
+`
+
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
+	}
+
+	for _, d := range diffs {
+		if strings.Contains(d.Diff, "\nindex ") {
+			t.Errorf("prompt diff contains index header:\n%s", d.Diff)
+		}
+	}
+	if !strings.Contains(diffs[0].Diff, "diff --git a/first.go b/first.go") {
+		t.Errorf("prompt diff lost git header:\n%s", diffs[0].Diff)
+	}
+	if !strings.Contains(diffs[0].Diff, "+index added-content") {
+		t.Errorf("prompt diff lost index-prefixed hunk content:\n%s", diffs[0].Diff)
+	}
+	if !diffs[1].IsNew {
+		t.Error("new-file metadata was not preserved")
+	}
+}
 
 // TestParseDiffText_Rename guards against issue #99: a renamed file must be
 // recognized via the "rename from"/"rename to" extended header lines so that


### PR DESCRIPTION

## Description

Removes Git `index <old-hash>..<new-hash> <mode>` headers from per-file diffs embedded in LLM review prompts.

These headers contain Git object IDs and file modes that do not provide useful code-review context. The parser removes them only outside diff hunks, preserving all actual code content and existing diff metadata behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

Additional focused verification:

```bash
go test ./internal/diff
go test ./internal/diff -run TestParseDiffText_StripsIndexHeadersFromPromptDiff
make check
```

Added regression coverage verifying that:

- `index` headers are removed for multiple files.
- Git diff headers remain.
- `+index ...` source content inside a hunk remains intact.
- New-file metadata still parses correctly.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #606
