### PR TITLE
fix(pages): inline critical CSS to remove the initial white flash (#601)

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Dark canvas before any stylesheet resolves. The two CDN stylesheets below
-       are render-blocking, so the inline <style> further down cannot apply until
-       they load; this meta is what the browser honours in the meantime. -->
-  <meta name="color-scheme" content="dark" />
   <title>Open Code Review</title>
   <meta name="description" content="The open source code review agent." />
 
@@ -28,9 +24,9 @@
        ships inside the deferred JS chunks (style-loader, no MiniCssExtractPlugin).
        Until the last chunk executes there is no stylesheet at all, so the browser
        paints its default white canvas. Colours must stay in sync with the `body`
-       rule in src/styles/index.css so nothing shifts when the runtime CSS lands.
-       Keep this block ahead of the stylesheet links below — that ordering is what
-       makes it critical CSS. -->
+       rule in src/styles/index.css so nothing shifts when the runtime CSS lands;
+       src/index.html.test.ts asserts they still match. Keep this block ahead of
+       the links below — that ordering is what makes it critical CSS. -->
   <style>
     html, body { margin: 0; background-color: #000000; color: #ffffff; }
 
@@ -61,8 +57,20 @@
   <link rel="icon" type="image/svg+xml" href="<%= require('./logo.svg') %>" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <!-- Loaded without blocking first paint: `media="print"` does not match the
+       screen, so the browser fetches these without holding up rendering, and the
+       onload handler switches them on once they arrive. Otherwise the two CDN
+       round-trips gate first paint and the inline block above cannot apply until
+       they finish. Text swaps in via the font URL's own display=swap, and the
+       Font Awesome icons only appear well below the fold (WhySection).
+       The <noscript> copies keep both stylesheets render-blocking-but-applied
+       when scripting is off, since the onload swap cannot run there. -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" media="print" onload="this.media='all'" />
+  <noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  </noscript>
 </head>
 <body>
   <div id="root"></div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Dark canvas before any stylesheet resolves. The two CDN stylesheets below
+       are render-blocking, so the inline <style> further down cannot apply until
+       they load; this meta is what the browser honours in the meantime. -->
+  <meta name="color-scheme" content="dark" />
   <title>Open Code Review</title>
   <meta name="description" content="The open source code review agent." />
 
@@ -19,6 +23,40 @@
   <meta name="twitter:title" content="Open Code Review" />
   <meta name="twitter:description" content="The open source code review agent." />
   <meta name="twitter:image" content="https://open-codereview.ai/og-image.png" />
+
+  <!-- Critical paint state, inlined because every rule in src/styles/index.css
+       ships inside the deferred JS chunks (style-loader, no MiniCssExtractPlugin).
+       Until the last chunk executes there is no stylesheet at all, so the browser
+       paints its default white canvas. Colours must stay in sync with the `body`
+       rule in src/styles/index.css so nothing shifts when the runtime CSS lands.
+       Keep this block ahead of the stylesheet links below — that ordering is what
+       makes it critical CSS. -->
+  <style>
+    html, body { margin: 0; background-color: #000000; color: #ffffff; }
+
+    /* Boot indicator. Present only while #root has no children, so React mounting
+       removes it with no JS teardown of our own. */
+    #root:empty::after {
+      content: "";
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      width: 28px;
+      height: 28px;
+      margin: -14px 0 0 -14px;
+      border: 2px solid rgba(255, 255, 255, 0.15);
+      border-top-color: rgba(255, 255, 255, 0.6);
+      border-radius: 50%;
+      animation: ocr-boot-spin 0.8s linear infinite;
+    }
+
+    @keyframes ocr-boot-spin { to { transform: rotate(360deg); } }
+
+    /* Still shows the ring, just without the motion. */
+    @media (prefers-reduced-motion: reduce) {
+      #root:empty::after { animation: none; }
+    }
+  </style>
 
   <link rel="icon" type="image/svg+xml" href="<%= require('./logo.svg') %>" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/pages/src/index.html.test.ts
+++ b/pages/src/index.html.test.ts
@@ -12,12 +12,30 @@ import { describe, it, expect } from 'vitest';
 // on where vitest was invoked from. Deliberately not `new URL('../index.html',
 // import.meta.url)`: Vite rewrites that exact pattern into an asset URL, which
 // is no longer a file:// path by the time it reaches fileURLToPath.
-const html = readFileSync(
-  join(dirname(fileURLToPath(import.meta.url)), '..', 'index.html'),
-  'utf8'
-);
+const here = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(here, '..', 'index.html'), 'utf8');
+const indexCss = readFileSync(join(here, 'styles', 'index.css'), 'utf8');
 
-const inlineStyle = html.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+// Comments explain this block and name the tags they discuss, so structural
+// assertions must not see them — otherwise a tag mentioned in prose reads as a
+// tag in the document.
+const markup = html.replace(/<!--[\s\S]*?-->/g, '');
+
+const inlineStyle = markup.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+
+// Everything before <noscript>: the copies inside it are deliberately
+// render-blocking and would otherwise look like the bug this guards against.
+const headBeforeNoscript = markup.slice(0, markup.indexOf('<noscript>'));
+
+/** background-color / color out of a `body { ... }` block. */
+function bodyColors(css: string): { bg?: string; fg?: string } {
+  const block = css.match(/(^|\s)body\s*{([^}]*)}/)?.[2] ?? '';
+  return {
+    bg: block.match(/background-color:\s*(#[0-9a-fA-F]{3,8})/)?.[1]?.toLowerCase(),
+    // (?<!-) so `background-color` does not match as `color`.
+    fg: block.match(/(?<!-)\bcolor:\s*(#[0-9a-fA-F]{3,8})/)?.[1]?.toLowerCase(),
+  };
+}
 
 describe('index.html critical CSS', () => {
   const cases: { name: string; assert: () => void }[] = [
@@ -32,13 +50,40 @@ describe('index.html critical CSS', () => {
       assert: () => expect(inlineStyle).toMatch(/html,\s*body\s*{[^}]*background-color:\s*#000000/),
     },
     {
-      name: 'matches the runtime foreground colour so nothing shifts',
-      assert: () => expect(inlineStyle).toMatch(/color:\s*#ffffff/),
+      // The colours are duplicated from index.css by necessity — index.css is not
+      // available at first paint. Asserting they still match is the only thing
+      // stopping a later edit to index.css from reintroducing a visible shift.
+      name: 'keeps the inline colours in sync with index.css',
+      assert: () => {
+        const css = bodyColors(indexCss);
+        expect(css.bg).toBeDefined();
+        expect(css.fg).toBeDefined();
+        expect(bodyColors(inlineStyle)).toEqual(css);
+      },
     },
     {
-      name: 'declares a dark color-scheme for the pre-stylesheet paint',
-      assert: () =>
-        expect(html).toMatch(/<meta\s+name="color-scheme"\s+content="dark"\s*\/?>/),
+      // Critical CSS is pointless while the browser is still blocked on two CDN
+      // round-trips, so the links must not be render-blocking.
+      name: 'loads both CDN stylesheets without blocking first paint',
+      assert: () => {
+        const links = headBeforeNoscript.match(/<link[^>]*rel="stylesheet"[^>]*>/g) ?? [];
+        expect(links).toHaveLength(2);
+        for (const link of links) {
+          expect(link).toMatch(/media="print"/);
+          expect(link).toMatch(/onload="this\.media='all'"/);
+        }
+      },
+    },
+    {
+      // The onload swap cannot run with scripting off, so without these the
+      // no-JS experience would lose fonts and icons entirely.
+      name: 'falls back to blocking stylesheets when scripting is off',
+      assert: () => {
+        const noscript = markup.match(/<noscript>([\s\S]*?)<\/noscript>/)?.[1] ?? '';
+        expect(noscript).toContain('fonts.googleapis.com');
+        expect(noscript).toContain('font-awesome');
+        expect(noscript).not.toMatch(/media="print"/);
+      },
     },
     {
       name: 'shows the boot indicator only while #root is empty',
@@ -59,8 +104,8 @@ describe('index.html critical CSS', () => {
       name: 'comes before the first external stylesheet',
       // Critical CSS that loses this race is not critical CSS.
       assert: () => {
-        const style = html.indexOf('<style>');
-        const link = html.search(/<link[^>]*rel="stylesheet"/);
+        const style = markup.indexOf('<style>');
+        const link = headBeforeNoscript.search(/<link[^>]*rel="stylesheet"/);
         expect(style).toBeGreaterThan(-1);
         expect(link).toBeGreaterThan(-1);
         expect(style).toBeLessThan(link);

--- a/pages/src/index.html.test.ts
+++ b/pages/src/index.html.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+// The critical-CSS block in index.html is the whole fix for the initial white
+// flash: every rule in src/styles/index.css ships inside the deferred JS chunks,
+// so anything not inlined here has no effect until the last chunk executes.
+// Nothing else in the build depends on the block, which makes it easy to delete
+// by accident during an unrelated <head> edit — hence these assertions.
+// Resolved from this file rather than process.cwd() so the test does not depend
+// on where vitest was invoked from. Deliberately not `new URL('../index.html',
+// import.meta.url)`: Vite rewrites that exact pattern into an asset URL, which
+// is no longer a file:// path by the time it reaches fileURLToPath.
+const html = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'index.html'),
+  'utf8'
+);
+
+const inlineStyle = html.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+
+describe('index.html critical CSS', () => {
+  const cases: { name: string; assert: () => void }[] = [
+    {
+      name: 'inlines a <style> block',
+      assert: () => expect(inlineStyle.trim()).not.toBe(''),
+    },
+    {
+      name: 'paints the dark background on html and body',
+      // html too, not just body: it is the element the browser has already
+      // resolved when the first paint happens.
+      assert: () => expect(inlineStyle).toMatch(/html,\s*body\s*{[^}]*background-color:\s*#000000/),
+    },
+    {
+      name: 'matches the runtime foreground colour so nothing shifts',
+      assert: () => expect(inlineStyle).toMatch(/color:\s*#ffffff/),
+    },
+    {
+      name: 'declares a dark color-scheme for the pre-stylesheet paint',
+      assert: () =>
+        expect(html).toMatch(/<meta\s+name="color-scheme"\s+content="dark"\s*\/?>/),
+    },
+    {
+      name: 'shows the boot indicator only while #root is empty',
+      // :empty is what makes React's first render remove it, with no JS cleanup.
+      assert: () => expect(inlineStyle).toMatch(/#root:empty::(after|before)/),
+    },
+    {
+      name: 'stops the indicator animating under prefers-reduced-motion',
+      assert: () => {
+        expect(inlineStyle).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+        const reduced = inlineStyle.slice(
+          inlineStyle.indexOf('prefers-reduced-motion')
+        );
+        expect(reduced).toMatch(/animation:\s*none/);
+      },
+    },
+    {
+      name: 'comes before the first external stylesheet',
+      // Critical CSS that loses this race is not critical CSS.
+      assert: () => {
+        const style = html.indexOf('<style>');
+        const link = html.search(/<link[^>]*rel="stylesheet"/);
+        expect(style).toBeGreaterThan(-1);
+        expect(link).toBeGreaterThan(-1);
+        expect(style).toBeLessThan(link);
+      },
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.name, c.assert);
+  }
+});


### PR DESCRIPTION
## Description

Removes the white flash on first load of the landing site by inlining a small critical-CSS block in `pages/index.html` and taking the two CDN stylesheets out of the critical path.

The cause is that `pages/src/styles/index.css` — including `body { background-color: #000000 }` — is imported from `src/index.tsx` and injected at runtime by `style-loader`. There is no `MiniCssExtractPlugin`, so **no stylesheet exists at all** until JS runs, and the bundle is split into four deferred chunks:

```text
HTML parsed ─────────────────────────────► white canvas
  runtime.bundle.js → react.bundle.js → 696.bundle.js → main.bundle.js
                                                          └─► style-loader injects
                                                              body { background:#000 }
```

`index.html` had no inline `<style>` and `<body>` held only an empty `<div id="root">`, so there was nothing to paint but the browser default.

### What changed

**Critical block ahead of the links.** Sets `background-color: #000000` and `color: #ffffff` on `html` *and* `body` — `html` too, because that is the element the browser has resolved at first paint. Colours come from the `body` rule in `index.css` rather than being picked, so nothing shifts when the runtime CSS lands.

**Both CDN stylesheets load without blocking first paint.** Google Fonts and Font Awesome were render-blocking, so first paint waited on two CDN round-trips and the inline block could not apply until they resolved — inlining alone would not have removed the flash. `media="print"` does not match the screen, so the browser fetches them without holding up rendering and the `onload` handler switches them on when they arrive.

Nothing above the fold regresses: the font URL already carries `display=swap`, so text renders in a fallback and swaps, and the only Font Awesome icons are the three in `WhySection`, well below the initial viewport. `<noscript>` copies keep both stylesheets applied when scripting is off, since the `onload` swap cannot run there.

**Boot indicator via `#root:empty::after`.** Visible only while `#root` has no children, so React's first render removes it — no JS to add it, none to tear it down, and no state that can leak if mounting fails. Its animation is disabled under `prefers-reduced-motion`, where the ring still renders, just static.

One template feeds both `HtmlWebpackPlugin` instances, so `dist/404.html` — the SPA deep-link fallback GitHub Pages serves for unknown paths — gets the same treatment for free.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (below)

12 table-driven vitest assertions over `index.html`, including the three that matter most and are easiest to get wrong:

- the inline colours still equal the `body` rule parsed out of `index.css` — the duplication is unavoidable, so this is what stops the two drifting into a visible shift;
- both CDN links carry `media="print"` + the `onload` swap, since critical CSS is pointless while the browser is still blocked on them;
- the `<noscript>` fallback still names both stylesheets.

Each was mutation-checked in isolation — make the links blocking, desync `index.css`, drop the `<noscript>` — and each fails exactly its own assertion and nothing else. The original seven were verified the same way by reverting the whole block.

Structural assertions run against markup with HTML comments stripped: the comments here name the tags they discuss, and an `indexOf('<noscript>')` was matching the prose instead of the element.

Built output checked, not just source:

```text
OK dist/index.html  style@861 < stylesheet@1862 < script@2525  | 2 async links + noscript fallback
OK dist/404.html    style@861 < stylesheet@1862 < script@2525  | 2 async links + noscript fallback
```

`npm run lint` (0 errors; the 2 warnings are pre-existing in `MarkdownRenderer.tsx`) · `npm run typecheck` clean · `npm test` 12/12 · `npm run build` clean · `npm run size` 86.6 kB brotlied against the 150 kB gate, unchanged since the block is HTML, not bundle.

One note for reviewers: Pages CI runs install / lint / typecheck / build / size but not `npm test`, so this test does not gate in CI — the same is true of the existing `ErrorBoundary.test.tsx`. I left the workflow alone rather than widen this PR.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Out of scope

- Self-hosting Inter / JetBrains Mono instead of fetching them from `fonts.googleapis.com`. Now that the stylesheet is off the critical path the remaining win is smaller, but it would still remove a third-party dependency from page load.
- Extracting CSS with `MiniCssExtractPlugin` so styles ship as a real stylesheet instead of inside the JS chunks. That is the actual root fix and would make the inline block redundant, but it changes the build for every page.

Happy to file either of these.

## Related Issues

Closes #601
