### PR TITLE
docs: clarify --from/--to merge-base semantics (#579)

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -135,7 +135,7 @@ cd your-project
 # ワークスペースモード — ステージ済み・未ステージ・未追跡のすべての変更をレビュー
 ocr review
 
-# ブランチ範囲 — 2つのrefを比較
+# ブランチ範囲 — main から分岐した後の feature-branch の変更をレビュー（マージベースモード）
 ocr review --from main --to feature-branch
 
 # 単一コミット

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -135,7 +135,7 @@ cd your-project
 # Workspace mode: staged, unstaged, untracked 변경을 모두 리뷰
 ocr review
 
-# Branch range: 두 ref 비교
+# 브랜치 범위 — main에서 분기된 이후 feature-branch의 변경 사항을 리뷰합니다 (머지베이스 모드)
 ocr review --from main --to feature-branch
 
 # 단일 commit

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ cd your-project
 # Workspace mode — review all staged, unstaged, and untracked changes
 ocr review
 
-# Branch range — compare two refs
+# Branch range — reviews feature-branch's changes since it diverged from main (merge-base mode)
 ocr review --from main --to feature-branch
 
 # Single commit

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -135,7 +135,7 @@ cd your-project
 # Режим рабочей копии — ревью всех staged, unstaged и untracked изменений
 ocr review
 
-# Диапазон веток — сравнение двух ref'ов
+# Диапазон веток — просматривает изменения feature-branch с момента её отделения от main (режим merge-base)
 ocr review --from main --to feature-branch
 
 # Один коммит

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,7 +135,7 @@ cd your-project
 # 工作区模式 —— 审查所有暂存、未暂存和未跟踪的变更
 ocr review
 
-# 分支范围 —— 比较两个引用
+# 分支范围 —— 评审 feature-branch 自与 main 分叉以来的变更（合并基准模式）
 ocr review --from main --to feature-branch
 
 # 单个提交

--- a/pages/src/content/docs/en/quickstart.md
+++ b/pages/src/content/docs/en/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # Workspace mode — reviews staged + unstaged + untracked changes (default)
 ocr review
 
-# Branch range — reviews `main..feature-branch`
+# Branch range — reviews feature-branch's changes since it diverged from main (merge-base mode)
 ocr review --from main --to feature-branch
 
 # Single commit — reviews the diff that commit introduced

--- a/pages/src/content/docs/ja/quickstart.md
+++ b/pages/src/content/docs/ja/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # ワークスペースモード —— staged + unstaged + untracked の変更をレビュー（デフォルト）
 ocr review
 
-# ブランチ区間 —— `main..feature-branch` をレビュー
+# ブランチ区間 —— main から分岐した後の feature-branch の変更をレビュー（マージベースモード）
 ocr review --from main --to feature-branch
 
 # 単一 commit —— その commit が導入した diff をレビュー

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # 工作区模式 —— 评审 staged + unstaged + untracked 变更（默认）
 ocr review
 
-# 分支区间 —— 评审 `main..feature-branch`
+# 分支区间 —— 评审 feature-branch 自与 main 分叉以来的变更（合并基准模式）
 ocr review --from main --to feature-branch
 
 # 单个 commit —— 评审该 commit 引入的 diff


### PR DESCRIPTION
## Problem

Three sources documented `ocr review --from x --to y` inconsistently:

- **README.md** — didn't specify two-dot (`a..b`) vs three-dot (`a...b`)
  semantics at all.
- **Website Quickstart** (en/ja/zh) — explicitly described it as
  `main..feature-branch` (two-dot), which is wrong.
- **CLI `--help`** (`cmd/opencodereview/flags.go:206`) — correctly
  describes it as "merge-base mode" (three-dot semantics).

## Root cause confirmed

`internal/diff/git.go`'s `ModeRange` computes the range via the two
refs' common ancestor (merge-base) — i.e. three-dot semantics, matching
the CLI help text. The Quickstart pages contradicted this.

## Fix

Updated the single-line comment above `ocr review --from main --to
feature-branch` in all four affected files to describe the actual
behavior in plain language, rather than relying on git's `..`/`...`
notation (which was the source of the original ambiguity):

- `README.md`
- `pages/src/content/docs/en/quickstart.md`
- `pages/src/content/docs/ja/quickstart.md`
- `pages/src/content/docs/zh/quickstart.md`

No behavior change — documentation only. `flags.go`'s help text was
already correct and untouched.

## Note on translations

I'm not a native Japanese or Chinese speaker; I'd appreciate a quick
sanity check on the ja/zh wording from a maintainer or native speaker
before merge.