### PR TITLE
docs(pages): fix .po catalog descriptions

### DIFF
--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -170,7 +170,7 @@ matching order:
 | `**/*.py` | `python.md` — Python source. |
 | `**/*.{php,phtml}` | `php.md` — PHP source and PHP templates. |
 | `**/*.proto` | `protobuf.md` — Protocol Buffers wire compatibility. |
-| `**/*.po` | `po.md` — gettext compiled catalogs. |
+| `**/*.po` | `po.md` — gettext translation source catalogs. |
 | `**/*.pot` | `pot.md` — gettext template files. |
 | `**/*.{graphql,gql}` | `graphql.md` — GraphQL schema and operations. |
 | `**/*.prisma` | `prisma.md` — Prisma schema. |

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -132,7 +132,7 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.py` | `python.md`: Python ソースコード。 |
 | `**/*.{php,phtml}` | `php.md`: PHP ソースと PHP テンプレート。 |
 | `**/*.proto` | `protobuf.md`: Protocol Buffers のワイヤ互換性。 |
-| `**/*.po` | `po.md`: gettext コンパイル済みカタログ。 |
+| `**/*.po` | `po.md`: gettext 翻訳ソースカタログ。 |
 | `**/*.pot` | `pot.md`: gettext テンプレートファイル。 |
 | `**/*.{graphql,gql}` | `graphql.md`: GraphQL スキーマと操作。 |
 | `**/*.prisma` | `prisma.md`: Prisma スキーマ。 |

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -172,7 +172,7 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.py` | `python.md` — исходный код Python. |
 | `**/*.{php,phtml}` | `php.md` — исходный код PHP и шаблоны PHP. |
 | `**/*.proto` | `protobuf.md` — совместимость Protocol Buffers на уровне wire. |
-| `**/*.po` | `po.md` — скомпилированные каталоги gettext. |
+| `**/*.po` | `po.md` — исходные каталоги переводов gettext. |
 | `**/*.pot` | `pot.md` — файлы шаблонов gettext. |
 | `**/*.{graphql,gql}` | `graphql.md` — схема и операции GraphQL. |
 | `**/*.prisma` | `prisma.md` — схема Prisma. |

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -153,7 +153,7 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.py` | `python.md`——Python 源代码。 |
 | `**/*.{php,phtml}` | `php.md`——PHP 源代码和 PHP 模板。 |
 | `**/*.proto` | `protobuf.md`——Protocol Buffers 线协议兼容性。 |
-| `**/*.po` | `po.md`——gettext 编译后的翻译目录。 |
+| `**/*.po` | `po.md`——gettext 翻译源目录。 |
 | `**/*.pot` | `pot.md`——gettext 模板文件。 |
 | `**/*.{graphql,gql}` | `graphql.md`——GraphQL schema 与操作。 |
 | `**/*.prisma` | `prisma.md`——Prisma schema。 |


### PR DESCRIPTION
## Description

Updates the `review-rules.md` tables in English, Japanese, Chinese, and Russian so `.po` files are described as gettext translation source catalogs rather than compiled catalogs. The compiled gettext format is `.mo`, so the previous wording was inaccurate.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Validated with:

- `git diff --check`
- `cd pages && npm run typecheck`

Note: `npm ci` could not be used locally because `pages/package-lock.json` is not currently in sync with `pages/package.json` on `main`; I installed dependencies locally without updating the lockfile to run the requested typecheck.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #618