### PR TITLE
docs: remove stale Java-implementation references from code comments

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -73,7 +73,7 @@ type Args struct {
 	Tools *tool.Registry
 
 	// PlanToolDefs holds llm.ToolDef entries enabled in plan_task, built once at startup.
-	// When nil, plan phase sends no tool definitions (same as Java behavior when plan_task is false).
+	// When nil, plan phase sends no tool definitions.
 	PlanToolDefs []llm.ToolDef
 
 	// MainToolDefs holds llm.ToolDef entries enabled in main_task, built once at startup.
@@ -81,10 +81,9 @@ type Args struct {
 
 	// CommentWorkerPool — separate goroutine pool for running asynchronous
 	// comment post-processing tasks (tracking, re-tracking, reflection,
-	// suggestion validation). This mirrors the Java side's subtaskExecutor
-	// which executes the CODE_COMMENT tool off the critical path so that the
-	// main LLM tool-use loop can continue issuing requests while comments are
-	// being processed in the background.
+	// suggestion validation). It executes the CODE_COMMENT tool off the
+	// critical path so that the main LLM tool-use loop can continue issuing
+	// requests while comments are being processed in the background.
 	//
 	// When nil (the default), comment processing happens synchronously inside
 	// executeToolCall instead of via a separate worker pool.

--- a/internal/config/template/template.go
+++ b/internal/config/template/template.go
@@ -212,7 +212,7 @@ func (t *ScanTemplate) Validate() error {
 	return nil
 }
 
-// LlmConversation mirrors LlmConversation from the Java side — a preset prompt with settings.
+// LlmConversation is a preset prompt with settings.
 type LlmConversation struct {
 	Timeout  int           `json:"timeout"`
 	Messages []ChatMessage `json:"messages"`

--- a/internal/diff/resolver.go
+++ b/internal/diff/resolver.go
@@ -228,7 +228,7 @@ func splitAndNormalize(code string) []string {
 }
 
 // normalizeLine removes leading/trailing whitespace and strips any leading
-// '+' or '-' diff marker (mirrors Java's processTargetLineCode).
+// '+' or '-' diff marker.
 func normalizeLine(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "+")

--- a/internal/llmloop/pool.go
+++ b/internal/llmloop/pool.go
@@ -30,8 +30,7 @@ type AgentWarning struct {
 // re-tracking, reflection, suggestion validation) asynchronously.
 //
 // Offloading them to a worker pool keeps the main LLM tool-use loop
-// unblocked, reducing overall latency — mirroring the Java side's dedicated
-// subtaskExecutor for the CODE_COMMENT tool.
+// unblocked, reducing overall latency.
 type CommentWorkerPool struct {
 	semaphore chan struct{}
 	wg        sync.WaitGroup

--- a/internal/tool/response_message.go
+++ b/internal/tool/response_message.go
@@ -7,7 +7,7 @@ type ToolCallResult struct {
 	Result     string // output from the tool
 }
 
-// TaskCheckpoint mirrors the Java TaskCheckPoint — signals completion or carries data back to the LLM.
+// TaskCheckpoint signals completion or carries data back to the LLM.
 type TaskCheckpoint struct {
 	Data      string
 	Completed bool


### PR DESCRIPTION
## Description

Removes six stale "mirrors the Java ..." style comments left over from the original Java-to-Go migration. The referenced Java implementation (`processTargetLineCode`, `TaskCheckPoint`, `subtaskExecutor`, Java-side `LlmConversation`) does not exist in this repository, so these cross-references can no longer be verified and only add noise for new contributors.

Each comment is trimmed or reworded to keep the useful behavioral explanation while dropping the unverifiable Java reference:

- `internal/diff/resolver.go` — `normalizeLine`: drop `(mirrors Java's processTargetLineCode)`.
- `internal/tool/response_message.go` — `TaskCheckpoint`: drop `mirrors the Java TaskCheckPoint`, keep the semantic description.
- `internal/llmloop/pool.go` — `CommentWorkerPool`: drop the `mirroring the Java side's dedicated subtaskExecutor` clause, keep the latency rationale.
- `internal/config/template/template.go` — `LlmConversation`: reword to a direct description.
- `internal/agent/agent.go` — `Args.PlanToolDefs`: drop `(same as Java behavior when plan_task is false)`; `Args.CommentWorkerPool`: reword `This mirrors the Java side's subtaskExecutor which executes ...` to `It executes ...`, keeping the full explanation of the off-critical-path design.

Comment-only change; no behavior is affected.

## Type of Change

- [X] Documentation update

## How Has This Been Tested?

- [X] `make test` passes locally (23 packages, 1394 tests, race detector on)
- [ ] Manual testing (not applicable — comment-only change)

`make check` (go mod tidy + go fmt + go vet) also passes with no diffs.

## Checklist

- [X] My code follows the project's coding style (`go fmt`, `go vet`)
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works (not applicable — comment-only change)
- [X] New and existing unit tests pass locally with my changes
- [X] I have updated the documentation accordingly (if applicable)
- [X] I have signed the CLA

## Related Issues

None.