### PR TITLE
docs(configuration): note url accepts base URL or full /responses endpoint

### DIFF
--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -84,6 +84,8 @@ ocr config set custom_providers.openai-responses-gateway.model        gpt-5
 ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
+The `url` can be either the API base URL or the full `/responses` endpoint — OCR normalizes it either way.
+
 A local model served by Ollama is just a custom provider pointing at the
 local OpenAI-compatible endpoint:
 

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -82,6 +82,8 @@ ocr config set custom_providers.openai-responses-gateway.model        gpt-5
 ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
+`url` には API の Base URL または完全な `/responses` エンドポイントのどちらを指定してもよく、OCR がどちらの形式も正規化します。
+
 Ollama で動かすローカルモデルは、ローカルの OpenAI 互換エンドポイントを
 指すカスタム provider にすぎません。
 

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -80,6 +80,8 @@ ocr config set custom_providers.openai-responses-gateway.model        gpt-5
 ocr config set custom_providers.openai-responses-gateway.api_key      "$OPENAI_API_KEY"
 ```
 
+`url` 既可以填 API 的 Base URL，也可以填完整的 `/responses` 端点，OCR 会自动归一化处理。
+
 用 Ollama 跑本地模型，就是一个指向本地 OpenAI 兼容端点的自定义 provider：
 
 ```bash


### PR DESCRIPTION
## What

Follow-up to #562 as suggested by @lizhengfeng101 in #563.

#562 already documented the `openai-responses` protocol across all three locales. This adds the one incremental clarification #563 had that #562 lacked: for `openai-responses`, the `url` field accepts **either** the API base URL **or** the full `/responses` endpoint.

Added one sentence right after the `openai-responses` example in `en`, `zh`, and `ja`.

## Why it's accurate

`internal/llm/responses_client.go` → `ensureResponsesEndpoint` normalizes both forms. Its own contract comment states:

```
https://api.openai.com/v1             -> https://api.openai.com/v1/responses
https://api.openai.com/v1/            -> https://api.openai.com/v1/responses
https://api.openai.com/v1/responses   -> https://api.openai.com/v1/responses
```

So a user can supply either shape and it resolves the same way — worth stating so people don't guess.

## Scope

Docs-only, +2 lines per locale (the sentence + a blank line), no other changes. Rebased on current `main` so it sits cleanly on top of #562.

Refs #556, #563
