### PR TITLE
feat(viewer): add review comments display to session detail page

### DIFF
--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -75,6 +75,20 @@ func formatTime(t time.Time) string {
 	return t.In(cstZone).Format("2006-01-02 15:04")
 }
 
+// CommentFileGroup groups review comments by file path for template rendering.
+type CommentFileGroup struct {
+	FilePath string
+	Comments []*ReviewComment
+}
+
+// SeverityCount holds counts for each severity level.
+type SeverityCount struct {
+	Critical int
+	High     int
+	Medium   int
+	Low      int
+}
+
 func parseTemplate(name string) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"formatDuration": formatDuration,
@@ -129,6 +143,62 @@ func parseTemplate(name string) (*template.Template, error) {
 				}
 			}
 			return result
+		},
+		"groupCommentsByFile": func(comments []*ReviewComment) []CommentFileGroup {
+			index := make(map[string]int)
+			var groups []CommentFileGroup
+			for _, c := range comments {
+				idx, ok := index[c.FilePath]
+				if !ok {
+					idx = len(groups)
+					index[c.FilePath] = idx
+					groups = append(groups, CommentFileGroup{FilePath: c.FilePath})
+				}
+				groups[idx].Comments = append(groups[idx].Comments, c)
+			}
+			return groups
+		},
+		"severityCounts": func(comments []*ReviewComment) SeverityCount {
+			var sc SeverityCount
+			for _, c := range comments {
+				switch c.Severity {
+				case "critical":
+					sc.Critical++
+				case "high":
+					sc.High++
+				case "medium":
+					sc.Medium++
+				case "low":
+					sc.Low++
+				}
+			}
+			return sc
+		},
+		"severityClass": func(s string) string {
+			switch s {
+			case "critical":
+				return "severity-critical"
+			case "high":
+				return "severity-high"
+			case "medium":
+				return "severity-medium"
+			case "low":
+				return "severity-low"
+			default:
+				return "severity-default"
+			}
+		},
+		"categoryClass": func(s string) string {
+			switch s {
+			case "bug":
+				return "cat-bug"
+			case "security":
+				return "cat-security"
+			case "performance":
+				return "cat-performance"
+			default:
+				return "cat-default"
+			}
 		},
 	}
 	content, err := assets.ReadFile("templates/" + name)

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -809,6 +809,195 @@ p {
     font-size: 0.95rem;
 }
 
+/* ── Review Comments Section ── */
+.comments-section {
+    background: var(--surface);
+    border-radius: var(--radius);
+    padding: 1.75rem;
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--border);
+}
+.comments-section h3 {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+}
+
+.severity-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+.severity-badge {
+    padding: 0.3em 0.75em;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+.severity-critical { background: #fef2f2; color: #dc2626; }
+.severity-high { background: #fff7ed; color: #ea580c; }
+.severity-medium { background: #fefce8; color: #a16207; }
+.severity-low { background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); }
+
+@media (prefers-color-scheme: dark) {
+    .severity-critical { background: rgba(220, 38, 38, 0.12); color: #fca5a5; }
+    .severity-high { background: rgba(234, 88, 12, 0.12); color: #fdba74; }
+    .severity-medium { background: rgba(251, 191, 36, 0.12); color: #fcd34d; }
+    .severity-low { background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); }
+}
+
+.comment-groups { margin-top: 0.5rem; }
+
+.comment-file-group {
+    background: var(--surface-alt);
+    border-radius: var(--radius-sm);
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--border-subtle);
+    overflow: hidden;
+}
+.comment-file-header {
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+    color: var(--text-strong);
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    transition: background var(--transition);
+    list-style: none;
+}
+.comment-file-header::-webkit-details-marker { display: none; }
+.comment-file-header::marker { content: none; }
+.comment-file-header:hover { background: var(--accent-soft); }
+.comment-file-group[open] > .comment-file-header {
+    border-bottom: 1px solid var(--border-subtle);
+}
+.comment-file-group[open] > .comment-file-header .chevron::after {
+    transform: rotate(45deg);
+    margin-top: -2px;
+}
+
+.comment-file-body {
+    padding: 0.75rem 1rem;
+}
+
+.comment-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    transition: box-shadow var(--transition);
+}
+.comment-card:last-child { margin-bottom: 0; }
+.comment-card:hover { box-shadow: var(--shadow-md); }
+
+.comment-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.comment-badge {
+    padding: 0.15em 0.55em;
+    border-radius: 20px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.cat-bug { background: #fef2f2; color: #dc2626; }
+.cat-security { background: #fdf2f8; color: #be185d; }
+.cat-performance { background: #fff7ed; color: #ea580c; }
+.cat-default { background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); }
+.severity-default { background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); }
+
+@media (prefers-color-scheme: dark) {
+    .cat-bug { background: rgba(220, 38, 38, 0.12); color: #fca5a5; }
+    .cat-security { background: rgba(190, 24, 93, 0.12); color: #f9a8d4; }
+    .cat-performance { background: rgba(234, 88, 12, 0.12); color: #fdba74; }
+    .cat-default { background: var(--badge-neutral-bg); color: var(--badge-neutral-fg); }
+}
+
+.comment-lines {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    background: var(--code-bg);
+    padding: 0.15em 0.5em;
+    border-radius: var(--radius-xs);
+}
+
+.comment-content {
+    font-size: 0.85rem;
+    line-height: 1.7;
+    color: var(--text-strong);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.comment-code-diff {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-top: 0.85rem;
+}
+
+.code-panel {
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+}
+.code-panel-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--border-subtle);
+}
+.code-panel pre {
+    margin: 0;
+    padding: 0.65rem 0.75rem;
+    font-size: 0.76rem;
+    line-height: 1.55;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.code-panel code {
+    font-size: inherit;
+    background: none;
+}
+
+.code-existing .code-panel-label {
+    background: #fef2f2;
+    color: #dc2626;
+}
+.code-existing pre {
+    background: #fef8f8;
+}
+.code-suggestion .code-panel-label {
+    background: #ecfdf5;
+    color: #065f46;
+}
+.code-suggestion pre {
+    background: #f8fdfb;
+}
+
+@media (prefers-color-scheme: dark) {
+    .code-existing .code-panel-label { background: rgba(220, 38, 38, 0.12); color: #fca5a5; }
+    .code-existing pre { background: rgba(220, 38, 38, 0.05); }
+    .code-suggestion .code-panel-label { background: rgba(52, 211, 153, 0.12); color: #6ee7b7; }
+    .code-suggestion pre { background: rgba(52, 211, 153, 0.05); }
+}
+
 /* ── Responsive ── */
 @media (max-width: 768px) {
     main { padding: 0 1rem; margin: 1.25rem auto; }
@@ -817,6 +1006,7 @@ p {
     .token-stats { grid-template-columns: repeat(2, 1fr); }
     .meta { gap: 0.5rem 1rem; font-size: 0.8rem; }
     .table th, .table td { padding: 0.6rem 0.75rem; font-size: 0.82rem; }
+    .comment-code-diff { grid-template-columns: 1fr; }
 }
 
 /* ── Accessibility: reduced motion ── */

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -5,6 +5,7 @@ package viewer
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -88,6 +89,7 @@ type SessionSummary struct {
 	DurationSec   float64
 	FileCount     int
 	LLMFailures   int
+	CommentCount  int
 }
 
 // ListSessions returns lightweight summaries for all sessions in a repo subdir.
@@ -118,7 +120,8 @@ func ListSessions(root, encodedRepo string) ([]SessionSummary, error) {
 	return summaries, nil
 }
 
-// peekSession reads only the first and last record of a JSONL file.
+// peekSession reads the first record, all review_item records (for comment
+// count), and the last record of a JSONL file.
 func peekSession(path string) (SessionSummary, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -165,6 +168,17 @@ func peekSession(path string) (SessionSummary, error) {
 			if v, ok := rec["diffCommit"].(string); ok {
 				summary.DiffCommit = v
 			}
+			continue
+		}
+
+		// Count comments from review_item_done/reused records
+		if len(line) > 0 && (bytes.Contains(line, []byte(`"review_item_done"`)) || bytes.Contains(line, []byte(`"review_item_reused"`))) {
+			var rec map[string]any
+			if err := json.Unmarshal(line, &rec); err == nil {
+				if comments, ok := rec["comments"].([]any); ok {
+					summary.CommentCount += len(comments)
+				}
+			}
 		}
 	}
 
@@ -193,11 +207,24 @@ func peekSession(path string) (SessionSummary, error) {
 	return summary, scanner.Err()
 }
 
+// ReviewComment represents a single code review finding from a session.
+type ReviewComment struct {
+	FilePath       string
+	Content        string
+	SuggestionCode string
+	ExistingCode   string
+	StartLine      int
+	EndLine        int
+	Category       string // bug, security, performance, maintainability, test, style, documentation, other
+	Severity       string // critical, high, medium, low
+}
+
 // ViewSession holds fully parsed records for one session.
 type ViewSession struct {
 	Summary    SessionSummary
 	TokenUsage TokenUsageSummary
-	Files      []*FileGroup // ordered by file path
+	Files      []*FileGroup     // ordered by file path
+	Comments   []*ReviewComment // review findings from review_item_done/reused records
 }
 
 // TokenUsageSummary aggregates token counts across the session.
@@ -442,6 +469,43 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 				}
 			}
 
+		case "review_item_done", "review_item_reused":
+			fp, _ := rec["filePath"].(string)
+			if comments, ok := rec["comments"].([]any); ok {
+				for _, c := range comments {
+					cm, ok := c.(map[string]any)
+					if !ok {
+						continue
+					}
+					rc := &ReviewComment{FilePath: fp}
+					if v, ok := cm["path"].(string); ok && v != "" {
+						rc.FilePath = v
+					}
+					if v, ok := cm["content"].(string); ok {
+						rc.Content = v
+					}
+					if v, ok := cm["suggestion_code"].(string); ok {
+						rc.SuggestionCode = v
+					}
+					if v, ok := cm["existing_code"].(string); ok {
+						rc.ExistingCode = v
+					}
+					if v, ok := cm["start_line"].(float64); ok {
+						rc.StartLine = int(v)
+					}
+					if v, ok := cm["end_line"].(float64); ok {
+						rc.EndLine = int(v)
+					}
+					if v, ok := cm["category"].(string); ok {
+						rc.Category = v
+					}
+					if v, ok := cm["severity"].(string); ok {
+						rc.Severity = v
+					}
+					vs.Comments = append(vs.Comments, rc)
+				}
+			}
+
 		case "session_end":
 			if dur, ok := rec["duration_seconds"].(float64); ok {
 				vs.Summary.DurationSec = dur
@@ -492,5 +556,6 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 	})
 
 	vs.Summary.SessionID = sessionID
+	vs.Summary.CommentCount = len(vs.Comments)
 	return vs, scanner.Err()
 }

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -83,6 +83,59 @@
     {{end}}
 </div>
 
+{{if .Session.Comments}}
+<div class="comments-section">
+    <h3>Review Comments ({{len .Session.Comments}} findings)</h3>
+    {{with severityCounts .Session.Comments}}
+    <div class="severity-bar">
+        {{if .Critical}}<span class="severity-badge severity-critical">Critical: {{.Critical}}</span>{{end}}
+        {{if .High}}<span class="severity-badge severity-high">High: {{.High}}</span>{{end}}
+        {{if .Medium}}<span class="severity-badge severity-medium">Medium: {{.Medium}}</span>{{end}}
+        {{if .Low}}<span class="severity-badge severity-low">Low: {{.Low}}</span>{{end}}
+    </div>
+    {{end}}
+    <div class="comment-groups">
+    {{range groupCommentsByFile .Session.Comments}}
+    <details class="comment-file-group" open>
+        <summary class="comment-file-header">
+            <span class="chevron"></span>
+            <span class="file-path">{{.FilePath}}</span>
+            <span class="file-count-badge">{{len .Comments}} comments</span>
+        </summary>
+        <div class="comment-file-body">
+        {{range .Comments}}
+            <div class="comment-card">
+                <div class="comment-meta">
+                    {{if .Category}}<span class="comment-badge {{categoryClass .Category}}">{{.Category}}</span>{{end}}
+                    {{if .Severity}}<span class="comment-badge {{severityClass .Severity}}">{{.Severity}}</span>{{end}}
+                    {{if .StartLine}}<span class="comment-lines">L{{.StartLine}}{{if and .EndLine (ne .EndLine .StartLine)}}-L{{.EndLine}}{{end}}</span>{{end}}
+                </div>
+                <div class="comment-content">{{.Content}}</div>
+                {{if or .ExistingCode .SuggestionCode}}
+                <div class="comment-code-diff">
+                    {{if .ExistingCode}}
+                    <div class="code-panel code-existing">
+                        <div class="code-panel-label">Existing Code</div>
+                        <pre><code>{{.ExistingCode}}</code></pre>
+                    </div>
+                    {{end}}
+                    {{if .SuggestionCode}}
+                    <div class="code-panel code-suggestion">
+                        <div class="code-panel-label">Suggested Change</div>
+                        <pre><code>{{.SuggestionCode}}</code></pre>
+                    </div>
+                    {{end}}
+                </div>
+                {{end}}
+            </div>
+        {{end}}
+        </div>
+    </details>
+    {{end}}
+    </div>
+</div>
+{{end}}
+
 {{if .Session.Summary.FilesReviewed}}
 <h3>Files Reviewed</h3>
 <ul class="file-list">

--- a/internal/viewer/templates/sessions.html
+++ b/internal/viewer/templates/sessions.html
@@ -13,7 +13,7 @@
 <h2>Sessions: {{.RepoName}}</h2>
 {{if .Sessions}}
 <table class="table">
-    <thead><tr><th>Session ID</th><th>Branch</th><th>Mode</th><th>Model</th><th>Files</th><th>Duration</th><th>Started At</th></tr></thead>
+    <thead><tr><th>Session ID</th><th>Branch</th><th>Mode</th><th>Model</th><th>Files</th><th>Comments</th><th>Duration</th><th>Started At</th></tr></thead>
     <tbody>
     {{range .Sessions}}
         <tr>
@@ -22,6 +22,7 @@
             <td>{{if .ReviewMode}}{{.ReviewMode}}{{else}}-{{end}}</td>
             <td><code>{{.Model}}</code></td>
             <td>{{.FileCount}}</td>
+            <td>{{if .CommentCount}}{{.CommentCount}}{{else}}-{{end}}</td>
             <td>{{formatDuration .DurationSec}}</td>
             <td>{{formatTime .Timestamp}}</td>
         </tr>


### PR DESCRIPTION
## Summary

- Parse `review_item_done` and `review_item_reused` JSONL records in the viewer's `LoadSession` to extract structured review comments (`model.LlmComment`)
- Display comments in the session detail page as a dedicated section between Token Usage and Files Reviewed, grouped by file path
- Each comment card shows severity/category badges, line range, content, and a side-by-side code diff panel (existing code vs suggested change)
- Add comment count to `SessionSummary` and display it in the sessions list page
- Full dark mode support and responsive layout for the new UI components

## Test plan

- [x] `make check` passes (format + vet)
- [x] `make test` — all existing viewer tests pass
- [ ] Manual: run `ocr viewer` on a session that has review comments, verify comments render correctly
- [ ] Manual: verify dark mode styling
- [ ] Manual: verify responsive layout on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)