### PR TITLE
fix(cli): refocus previous input on esc in manual provider form

### DIFF
--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1642,7 +1642,7 @@ func (m *providerTUIModel) blurManualStep() {
 	}
 }
 
-func (m providerTUIModel) focusManualStep() tea.Cmd {
+func (m *providerTUIModel) focusManualStep() tea.Cmd {
 	switch m.manualStep {
 	case manualStepURL:
 		return m.manualURLInput.Focus()

--- a/cmd/opencodereview/provider_tui_test.go
+++ b/cmd/opencodereview/provider_tui_test.go
@@ -265,6 +265,62 @@ func TestProviderTUI_ManualFormEscFromURLExitsForm(t *testing.T) {
 	}
 }
 
+func TestProviderTUI_ManualFormEscRefocusesPreviousInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		fromStep manualStep
+		wantStep manualStep
+		focused  func(m providerTUIModel) bool
+		value    func(m providerTUIModel) string
+	}{
+		{
+			name:     "protocol back to url",
+			fromStep: manualStepProtocol,
+			wantStep: manualStepURL,
+			focused:  func(m providerTUIModel) bool { return m.manualURLInput.Focused() },
+			value:    func(m providerTUIModel) string { return m.manualURLInput.Value() },
+		},
+		{
+			name:     "auth token back to model",
+			fromStep: manualStepAuthToken,
+			wantStep: manualStepModel,
+			focused:  func(m providerTUIModel) bool { return m.manualModelInput.Focused() },
+			value:    func(m providerTUIModel) string { return m.manualModelInput.Value() },
+		},
+		{
+			name:     "auth header back to auth token",
+			fromStep: manualStepAuthHeader,
+			wantStep: manualStepAuthToken,
+			focused:  func(m providerTUIModel) bool { return m.manualTokenInput.Focused() },
+			value:    func(m providerTUIModel) string { return m.manualTokenInput.Value() },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newProviderTUI(&Config{}, "")
+			m.activeTab = tabManual
+			m.inManualForm = true
+			m.manualStep = tt.fromStep
+
+			result, _ := m.Update(escKey())
+			m2 := result.(providerTUIModel)
+			if m2.manualStep != tt.wantStep {
+				t.Fatalf("manualStep = %d, want %d", m2.manualStep, tt.wantStep)
+			}
+			if !tt.focused(m2) {
+				t.Fatal("previous step input should be focused after Esc")
+			}
+
+			result, _ = m2.Update(charKey('x'))
+			m3 := result.(providerTUIModel)
+			if got := tt.value(m3); !strings.Contains(got, "x") {
+				t.Errorf("input should accept typing after Esc: value = %q", got)
+			}
+		})
+	}
+}
+
 func TestProviderTUI_ManualFormEscRestoresOriginalValues(t *testing.T) {
 	cfg := &Config{
 		Llm: LlmConfig{


### PR DESCRIPTION
## Description

In `ocr config provider`, the Manual tab form loses input focus when the user presses <kbd>Esc</kbd> to go back to a previous field. For example: fill in the URL, press <kbd>Enter</kbd> to reach the Protocol step, then press <kbd>Esc</kbd> to go back and edit the URL — the URL field is rendered as active, but it has no cursor and ignores all typing. The same back-navigation works correctly in the Custom provider form.

Root cause: `focusManualStep` is declared with a value receiver, while `textinput.Model.Focus()` uses a pointer receiver. In the <kbd>Esc</kbd> branch of `updateManualForm` (`return m, m.focusManualStep()`), the method receives a copy of the model, so `Focus()` marks the input as focused only on that discarded copy — the model actually returned from `Update` still holds a blurred input, and bubbles' `textinput` ignores key messages while blurred.

The fix changes `focusManualStep` to a pointer receiver, matching its Custom-form counterpart `focusCPStep` (which is why the Custom form was unaffected). All back-navigation paths with a text input are covered: Protocol→URL, Auth Token→Model, Auth Header→Auth Token. (Model→Protocol was unaffected: the protocol step has no text input.)

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [X] `make test` passes locally
- [X] Manual testing (describe below)

- Added `TestProviderTUI_ManualFormEscRefocusesPreviousInput`, a table-driven regression test covering the three back-navigation paths that land on a text input. Each case asserts the previous step's input is focused after <kbd>Esc</kbd> and accepts subsequent typing. Verified the test fails on the unfixed code (all three cases) and passes with the fix.
- Full suite: `make check` and `make test` (with `-race`) pass locally.
- Manual testing with a locally built binary (`ocr config provider`, isolated `$HOME` sandbox): Manual tab → fill URL → Enter → Esc — the URL field regains the cursor and is editable again; same verified for the Auth Token and Auth Header back-navigation paths. Reproduced the broken behavior with an unfixed main binary as an A/B control.

## Checklist

- [X] My code follows the project's coding style (`go fmt`, `go vet`)
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable) — not applicable, no user-facing docs describe this interaction
- [X] I have signed the CLA

## Related Issues

Closes #628