### PR TITLE
docs: document ocr completion command

### DIFF
--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -449,6 +449,47 @@ Prints the version stamped at build time, the short Git commit (when
 present), the platform (`<GOOS>/<GOARCH>`), the build date (when present),
 and the GitHub URL (`https://github.com/alibaba/open-code-review`).
 
+## `ocr completion`
+
+```text
+ocr completion [bash|zsh|fish|powershell]
+```
+
+Generates a shell completion script so that `ocr` subcommands and flags
+auto-complete in your shell. Pass the target shell as an argument; any other
+value errors out.
+
+Per-shell one-shot and persistent setup:
+
+```bash
+# Bash (current session)
+source <(ocr completion bash)
+# Bash (persistent) — Linux:
+ocr completion bash > /etc/bash_completion.d/ocr
+# Bash (persistent) — macOS:
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+
+# Zsh — enable completion once if needed:
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+# Zsh (persistent):
+ocr completion zsh > "${fpath[1]}/_ocr"
+# Then start a new shell.
+
+# Fish:
+ocr completion fish | source
+# Fish (persistent):
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+PowerShell:
+
+```powershell
+PS> ocr completion powershell | Out-String | Invoke-Expression
+# For every new session:
+PS> ocr completion powershell > ocr.ps1
+# and source this file from your PowerShell profile.
+```
+
 ## Tips & gotchas
 
 - `--audience agent` does **not** imply `--format json`. They control

--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -168,6 +168,25 @@ which ocr
 echo $PATH
 ```
 
+## Enable shell completion
+
+Optional: generate a shell completion script so that `ocr` subcommands and
+flags auto-complete in your shell.
+
+```bash
+# Bash
+source <(ocr completion bash)
+
+# Zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+
+# Fish
+ocr completion fish | source
+```
+
+See the [`ocr completion`](../cli-reference/) section of the CLI reference
+for persistent setup and PowerShell instructions.
+
 ## Where OCR stores state
 
 | Path | What it holds |

--- a/pages/src/content/docs/ja/cli-reference.md
+++ b/pages/src/content/docs/ja/cli-reference.md
@@ -408,6 +408,45 @@ ocr -V
 
 ビルド時に書き込まれたバージョン情報、短い Git commit（存在する場合）、プラットフォーム（`<GOOS>/<GOARCH>`）、ビルド日（存在する場合）、そして GitHub URL（`https://github.com/alibaba/open-code-review`）を出力します。
 
+## `ocr completion`
+
+```text
+ocr completion [bash|zsh|fish|powershell]
+```
+
+`ocr` サブコマンドとフラグをシェル上で自動補完できるようにする補完スクリプトを生成します。対象のシェルを引数で指定します。それ以外の値はエラーになります。
+
+シェルごとの 1 回限り / 永続化のセットアップ：
+
+```bash
+# Bash（現在のセッション）
+source <(ocr completion bash)
+# Bash（永続化）—— Linux：
+ocr completion bash > /etc/bash_completion.d/ocr
+# Bash（永続化）—— macOS：
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+
+# Zsh —— 補完を一度だけ有効にする場合：
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+# Zsh（永続化）：
+ocr completion zsh > "${fpath[1]}/_ocr"
+# その後、新しいシェルを起動してください。
+
+# Fish：
+ocr completion fish | source
+# Fish（永続化）：
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+PowerShell：
+
+```powershell
+PS> ocr completion powershell | Out-String | Invoke-Expression
+# 新しいセッションごとに読み込む場合：
+PS> ocr completion powershell > ocr.ps1
+# このファイルを PowerShell プロファイルから source してください。
+```
+
 ## ヒントと注意点
 
 - `--audience agent` は `--format json` を**含意しません**。両者は異なることを制御します。UI の抑制 vs 構造化されたペイロードです。両方が必要な場合は組み合わせて使用してください。

--- a/pages/src/content/docs/ja/installation.md
+++ b/pages/src/content/docs/ja/installation.md
@@ -163,6 +163,23 @@ which ocr
 echo $PATH
 ```
 
+## シェル補完を有効にする
+
+任意：`ocr` サブコマンドとフラグをシェル上で自動補完できるようにする補完スクリプトを生成します。
+
+```bash
+# Bash
+source <(ocr completion bash)
+
+# Zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+
+# Fish
+ocr completion fish | source
+```
+
+永続化の設定と PowerShell での使い方は、CLI リファレンスの [`ocr completion`](../cli-reference/) を参照してください。
+
 ## OCR が状態を保存する場所
 
 | パス | 保存内容 |

--- a/pages/src/content/docs/ru/installation.md
+++ b/pages/src/content/docs/ru/installation.md
@@ -165,6 +165,23 @@ which ocr
 echo $PATH
 ```
 
+## Включение автодополнения в оболочке
+
+Необязательно: сгенерируйте скрипт автодополнения, чтобы подкоманды и флаги `ocr` дополнялись автоматически в вашей оболочке.
+
+```bash
+# Bash
+source <(ocr completion bash)
+
+# Zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+
+# Fish
+ocr completion fish | source
+```
+
+Постоянная настройка и инструкции для PowerShell — в разделе [`ocr completion`](../cli-reference/) справки по CLI.
+
 ## Где OCR хранит состояние
 
 | Путь | Содержимое |

--- a/pages/src/content/docs/zh/cli-reference.md
+++ b/pages/src/content/docs/zh/cli-reference.md
@@ -428,6 +428,45 @@ ocr -V
 （`<GOOS>/<GOARCH>`）、构建日期（存在时），以及 GitHub URL
 （`https://github.com/alibaba/open-code-review`）。
 
+## `ocr completion`
+
+```text
+ocr completion [bash|zsh|fish|powershell]
+```
+
+生成 shell 补全脚本，让 `ocr` 子命令和参数在你的 shell 中自动补全。将目标 shell 作为参数传入；其他值会报错。
+
+各 shell 的一次性与持久化配置：
+
+```bash
+# Bash（当前会话）
+source <(ocr completion bash)
+# Bash（持久化）—— Linux：
+ocr completion bash > /etc/bash_completion.d/ocr
+# Bash（持久化）—— macOS：
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+
+# Zsh —— 如需一次性启用补全：
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+# Zsh（持久化）：
+ocr completion zsh > "${fpath[1]}/_ocr"
+# 然后重新打开一个 shell。
+
+# Fish：
+ocr completion fish | source
+# Fish（持久化）：
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+PowerShell：
+
+```powershell
+PS> ocr completion powershell | Out-String | Invoke-Expression
+# 每次新会话都加载：
+PS> ocr completion powershell > ocr.ps1
+# 并在你的 PowerShell 配置文件中 source 此文件。
+```
+
 ## 提示与注意
 
 - `--audience agent` **并不**隐含 `--format json`。两者控制不同的事——屏蔽 UI

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -160,6 +160,23 @@ which ocr
 echo $PATH
 ```
 
+## 启用 shell 补全
+
+可选：生成 shell 补全脚本，让 `ocr` 子命令和参数在你的 shell 中自动补全。
+
+```bash
+# Bash
+source <(ocr completion bash)
+
+# Zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+
+# Fish
+ocr completion fish | source
+```
+
+持久化配置和 PowerShell 用法，见 CLI 参考中的 [`ocr completion`](../cli-reference/) 一节。
+
 ## OCR 在哪里存放状态
 
 | 路径 | 存放内容 |


### PR DESCRIPTION
Fixes #639

Documents the `ocr completion` command (bash/zsh/fish/powershell), which is implemented but has zero documentation.

### CLI Reference (en, zh, ja)
- New `## ocr completion` section alongside the existing command sections
- Command format: `ocr completion [bash|zsh|fish|powershell]`
- Per-shell one-shot and persistent setup instructions, mirroring the help text in `cmd/opencodereview/completion.go`

### Installation (en, zh, ja, ru)
- New "Enable shell completion" section after "Verifying the install"
- One-line explanation, quick bash/zsh/fish examples, and a link to the CLI Reference

Content matches the shells and setup steps in `cmd/opencodereview/completion.go`.