### PR TITLE
feat(cli): add 'ocr session comments' to display saved review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ ocr review --commit abc123
 ocr session list
 ocr review --from main --to feature-branch --resume <session-id>
 
+# Print the review comments recorded in a saved session
+ocr session comments <session-id>
+ocr session comments --severity critical,high --json <session-id>
+
 # Full-file scan — review whole files instead of a diff (no git history needed)
 ocr scan                          # scan the entire repository
 ocr scan --path internal/agent    # scan a directory or specific files

--- a/cmd/opencodereview/compat_test.go
+++ b/cmd/opencodereview/compat_test.go
@@ -106,6 +106,25 @@ func runSessionShowCompat(args []string) error {
 	return cmd.Execute()
 }
 
+// runSessionCommentsCompat provides test compatibility for old-style runSessionComments([]string{...}) calls.
+func runSessionCommentsCompat(args []string) error {
+	cmd := &cobra.Command{
+		Use:           "comments",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, a []string) error {
+			return runSessionComments(a[0])
+		},
+	}
+	cmd.Flags().StringVar(&sessionCommentsRepoDir, "repo", "", "")
+	cmd.Flags().BoolVar(&sessionCommentsJSON, "json", false, "")
+	cmd.Flags().StringVar(&sessionCommentsSeverity, "severity", "", "")
+	cmd.Flags().StringVar(&sessionCommentsCategory, "category", "", "")
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
 // runSession provides test compatibility for the old dispatch function.
 func runSession(args []string) error {
 	cmd := &cobra.Command{Use: "session", SilenceUsage: true, SilenceErrors: true}

--- a/cmd/opencodereview/session_cmd.go
+++ b/cmd/opencodereview/session_cmd.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -37,12 +38,56 @@ var sessionShowRepoDir string
 var sessionShowJSON bool
 
 var sessionShowCmd = &cobra.Command{
-	Use:   "show [flags] <session-id>",
-	Short: "Show one session's metadata and per-file items",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show [flags] <session-id>",
+	Short:             "Show one session's metadata and per-file items",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeSessionIDs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSessionShow(args[0])
 	},
+}
+
+var sessionCommentsRepoDir string
+var sessionCommentsJSON bool
+var sessionCommentsSeverity string
+var sessionCommentsCategory string
+
+var sessionCommentsCmd = &cobra.Command{
+	Use:               "comments [flags] <session-id>",
+	Short:             "Show the review comments recorded in one session",
+	Long:              "Print every review comment persisted in a session, formatted like 'ocr review' terminal output.\nUse --json for machine-readable output and --severity/--category to filter findings.",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeSessionIDs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSessionComments(args[0])
+	},
+}
+
+// completeSessionIDs offers the persisted session ids for the current repo
+// (or --repo, when already typed) as shell completions, newest first, with a
+// short summary as the completion description.
+func completeSessionIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	repo, _ := cmd.Flags().GetString("repo")
+	resolvedRepo, err := resolveWorkingDirForSession(repo)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	summaries, err := session.ListSessions(resolvedRepo)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	completions := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		if !strings.HasPrefix(s.SessionID, toComplete) {
+			continue
+		}
+		desc := fmt.Sprintf("%s · %d comments · %s", describeStart(s), s.TotalComments, describeStatus(s))
+		completions = append(completions, s.SessionID+"\t"+desc)
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
 func init() {
@@ -53,8 +98,16 @@ func init() {
 	sessionShowCmd.Flags().StringVar(&sessionShowRepoDir, "repo", "", "root directory of the git repository (default: current dir)")
 	sessionShowCmd.Flags().BoolVar(&sessionShowJSON, "json", false, "emit JSON instead of a table")
 
+	sessionCommentsCmd.Flags().StringVar(&sessionCommentsRepoDir, "repo", "", "root directory of the git repository (default: current dir)")
+	sessionCommentsCmd.Flags().BoolVar(&sessionCommentsJSON, "json", false, "emit the comments as a JSON array")
+	sessionCommentsCmd.Flags().StringVar(&sessionCommentsSeverity, "severity", "", "comma-separated severities to include (critical, high, medium, low)")
+	sessionCommentsCmd.Flags().StringVar(&sessionCommentsCategory, "category", "", "comma-separated categories to include (e.g. bug, security)")
+	sessionCommentsCmd.RegisterFlagCompletionFunc("severity", completeEnum("critical", "high", "medium", "low"))
+	sessionCommentsCmd.RegisterFlagCompletionFunc("category", completeEnum("bug", "security", "performance", "maintainability", "test", "style", "documentation", "other"))
+
 	sessionCmd.AddCommand(sessionListCmd)
 	sessionCmd.AddCommand(sessionShowCmd)
+	sessionCmd.AddCommand(sessionCommentsCmd)
 }
 
 func runSessionList() error {
@@ -106,6 +159,75 @@ func runSessionShow(sessionID string) error {
 
 	printSessionDetail(os.Stdout, summary, items)
 	return nil
+}
+
+func runSessionComments(sessionID string) error {
+	resolvedRepo, err := resolveWorkingDirForSession(sessionCommentsRepoDir)
+	if err != nil {
+		return err
+	}
+	comments, err := session.LoadComments(resolvedRepo, sessionID)
+	if err != nil {
+		return fmt.Errorf("load session %q: %w", sessionID, err)
+	}
+	filtered := filterComments(comments, sessionCommentsSeverity, sessionCommentsCategory)
+
+	if sessionCommentsJSON {
+		if filtered == nil {
+			filtered = []model.LlmComment{}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(filtered)
+	}
+
+	if len(filtered) == 0 {
+		if len(comments) == 0 {
+			fmt.Printf("No comments recorded in session %s.\n", sessionID)
+		} else {
+			fmt.Printf("No comments match the given filters (%d recorded in session %s).\n", len(comments), sessionID)
+		}
+		return nil
+	}
+	for _, c := range filtered {
+		renderComment(c)
+	}
+	return nil
+}
+
+// filterComments keeps comments whose severity and category are in the given
+// comma-separated, case-insensitive filter lists. Empty filters keep everything.
+func filterComments(comments []model.LlmComment, severities, categories string) []model.LlmComment {
+	sevSet := parseFilterSet(severities)
+	catSet := parseFilterSet(categories)
+	if sevSet == nil && catSet == nil {
+		return comments
+	}
+	var out []model.LlmComment
+	for _, c := range comments {
+		if sevSet != nil && !sevSet[strings.ToLower(c.Severity)] {
+			continue
+		}
+		if catSet != nil && !catSet[strings.ToLower(c.Category)] {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func parseFilterSet(s string) map[string]bool {
+	set := map[string]bool{}
+	for _, part := range strings.Split(s, ",") {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part != "" {
+			set[part] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 // resolveWorkingDirForSession accepts an explicit --repo flag value and falls

--- a/cmd/opencodereview/session_cmd_test.go
+++ b/cmd/opencodereview/session_cmd_test.go
@@ -139,6 +139,140 @@ func TestRunSessionShow_JSON(t *testing.T) {
 	}
 }
 
+func TestRunSessionComments_TextRendersLikeReview(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "possible nil deref", StartLine: 3, EndLine: 5, Severity: "high", Category: "bug"},
+	})
+	sh.Finalize()
+
+	got := captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+
+	for _, want := range []string{"a.go:3-5", "[bug · high]", "possible nil deref"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestRunSessionComments_SeverityFilter(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "keep me", Severity: "high"},
+		{Path: "a.go", Content: "drop me", Severity: "low"},
+	})
+	sh.Finalize()
+
+	got := captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, "--severity", "HIGH", sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+	if !strings.Contains(got, "keep me") || strings.Contains(got, "drop me") {
+		t.Errorf("severity filter not applied, got %q", got)
+	}
+
+	got = captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, "--severity", "critical", sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+	if !strings.Contains(got, "No comments match the given filters") {
+		t.Errorf("expected filter-miss message, got %q", got)
+	}
+}
+
+func TestRunSessionComments_JSON(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "note", Severity: "medium", Category: "style"},
+	})
+	sh.Finalize()
+
+	got := captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, "--json", sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+
+	var decoded []model.LlmComment
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v (out=%q)", err, got)
+	}
+	if len(decoded) != 1 || decoded[0].Content != "note" || decoded[0].Severity != "medium" {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+}
+
+func TestRunSessionComments_JSONEmptyIsArray(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", nil)
+	sh.Finalize()
+
+	got := captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, "--json", sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+	if strings.TrimSpace(got) != "[]" {
+		t.Errorf("expected empty JSON array, got %q", got)
+	}
+}
+
+func TestRunSessionComments_NoCommentsMessage(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", nil)
+	sh.Finalize()
+
+	got := captureStdout(t, func() {
+		if err := runSessionCommentsCompat([]string{"--repo", repoDir, sh.SessionID}); err != nil {
+			t.Fatalf("runSessionComments: %v", err)
+		}
+	})
+	if !strings.Contains(got, "No comments recorded in session") {
+		t.Errorf("expected no-comments message, got %q", got)
+	}
+}
+
 func TestRunSessionShow_MissingID(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -148,6 +148,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	addRepoFlag(cmd, &opts.repoDir)
 	addDiffFlags(cmd, &opts.from, &opts.to, &opts.commit)
 	cmd.Flags().StringVar(&opts.resume, "resume", "", "resume from a previous review session id")
+	cmd.RegisterFlagCompletionFunc("resume", completeSessionIDs)
 	addExcludeFlag(cmd, &opts.excludes)
 	addOutputFlags(cmd, &opts.outputFormat, &opts.audience)
 	addConcurrencyFlags(cmd, &opts.concurrency, &opts.perFileTimeout, &opts.maxTools, &opts.maxGitProcs, &opts.maxTokensBudget)

--- a/internal/session/comments.go
+++ b/internal/session/comments.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"encoding/json"
+
+	"github.com/alibaba/open-code-review/internal/model"
+)
+
+// LoadComments replays one session's JSONL and returns every review comment
+// recorded in it, in file-completion order. It mirrors resume replay
+// semantics: a later checkpoint for the same fingerprint supersedes the
+// earlier one, and a subsequent review_item_failed drops it. Comments that
+// were persisted without a path inherit the record's file path.
+func LoadComments(repoDir, sessionID string) ([]model.LlmComment, error) {
+	path, err := SessionFilePath(repoDir, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	type group struct {
+		comments []model.LlmComment
+	}
+	var order []*group
+	byFingerprint := map[string]*group{}
+	err = walkSessionFile(path, func(rec summaryRecord) {
+		switch rec.Type {
+		case "review_item_done", "review_item_reused":
+			var comments []model.LlmComment
+			if len(rec.Comments) > 0 {
+				if err := json.Unmarshal(rec.Comments, &comments); err != nil {
+					return
+				}
+			}
+			filePath := rec.FilePath
+			if filePath == "" {
+				filePath = rec.NewPath
+			}
+			for i := range comments {
+				if comments[i].Path == "" {
+					comments[i].Path = filePath
+				}
+			}
+			if rec.Fingerprint != "" {
+				if g, ok := byFingerprint[rec.Fingerprint]; ok {
+					g.comments = comments
+					return
+				}
+			}
+			g := &group{comments: comments}
+			order = append(order, g)
+			if rec.Fingerprint != "" {
+				byFingerprint[rec.Fingerprint] = g
+			}
+		case "review_item_failed":
+			if g, ok := byFingerprint[rec.Fingerprint]; ok {
+				g.comments = nil
+			}
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	var out []model.LlmComment
+	for _, g := range order {
+		out = append(out, g.comments...)
+	}
+	return out, nil
+}

--- a/internal/session/comments_test.go
+++ b/internal/session/comments_test.go
@@ -1,0 +1,79 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/model"
+)
+
+func TestLoadComments_ReturnsCommentsInOrder(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := New(repoDir, "main", "test-model", SessionOptions{
+		ReviewMode: ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "first", Severity: "high", Category: "bug"},
+		{Content: "second, no path", Severity: "low"},
+	})
+	sh.RecordReviewItemReused("b.go", "b.go", "b.go", "fp-b", "prior-session", []model.LlmComment{
+		{Path: "b.go", Content: "cached", Severity: "medium"},
+	})
+	sh.RecordReviewItemFailed("c.go", "c.go", "c.go", "fp-c", "boom")
+	sh.Finalize()
+
+	got, err := LoadComments(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadComments: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 comments, got %d: %+v", len(got), got)
+	}
+	if got[0].Content != "first" || got[1].Content != "second, no path" || got[2].Content != "cached" {
+		t.Errorf("unexpected order: %+v", got)
+	}
+	if got[1].Path != "a.go" {
+		t.Errorf("comment without path should inherit record file path, got %q", got[1].Path)
+	}
+}
+
+func TestLoadComments_LaterCheckpointSupersedes(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := New(repoDir, "main", "test-model", SessionOptions{
+		ReviewMode: ReviewModeCommit,
+		DiffCommit: "abc123",
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "stale"},
+	})
+	sh.RecordReviewItemDone("a.go", "a.go", "a.go", "fp-a", []model.LlmComment{
+		{Path: "a.go", Content: "fresh"},
+	})
+	sh.RecordReviewItemDone("b.go", "b.go", "b.go", "fp-b", []model.LlmComment{
+		{Path: "b.go", Content: "kept"},
+	})
+	sh.RecordReviewItemFailed("b.go", "b.go", "b.go", "fp-b", "boom")
+	sh.Finalize()
+
+	got, err := LoadComments(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadComments: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != "fresh" {
+		t.Fatalf("expected only the superseding comment, got %+v", got)
+	}
+}
+
+func TestLoadComments_MissingSession(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if _, err := LoadComments(t.TempDir(), "nonexistent"); err == nil {
+		t.Fatal("expected error for missing session")
+	}
+}

--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -58,6 +58,7 @@ GitHub: https://github.com/alibaba/open-code-review
 | `ocr llm providers` | — | List all built-in LLM providers. |
 | `ocr session list` | `ocr sessions list`, `ocr session ls` | List saved review sessions. |
 | `ocr session show <id>` | `ocr sessions show <id>` | Inspect one session and its per-file checkpoints. |
+| `ocr session comments <id>` | `ocr sessions comments <id>` | Print the review comments recorded in one session. |
 | `ocr viewer` | — | Launch the local web UI for past review sessions (`localhost:5483`). |
 | `ocr version` | — | Print version, commit, platform, build date, and GitHub URL. |
 
@@ -155,6 +156,7 @@ resume from one that matches the same review target:
 ```bash
 ocr session list
 ocr session show <session-id>
+ocr session comments <session-id>
 ocr review --from main --to feature-branch --resume <session-id>
 ocr review --commit abc123 --resume <session-id>
 ```
@@ -275,8 +277,9 @@ ocr session <sub-command>
 ocr sessions <sub-command>   (alias)
 
 Sub-commands:
-  list, ls    List recent review sessions for the current repo
-  show <id>   Show one session's metadata and per-file items
+  list, ls        List recent review sessions for the current repo
+  show <id>       Show one session's metadata and per-file items
+  comments <id>   Show the review comments recorded in one session
 ```
 
 ### `ocr session list`
@@ -305,6 +308,26 @@ ocr session show --repo /path/to/repo <session-id>
 |---|---|---|
 | `--repo <path>` | current dir | Repository whose session should be inspected. |
 | `--json` | `false` | Emit session metadata and per-file items as JSON. |
+
+### `ocr session comments`
+
+Prints every review comment persisted in a session, rendered in the same
+style as `ocr review` terminal output (path, line range, severity badge,
+suggestion diff).
+
+```bash
+ocr session comments <session-id>
+ocr session comments --json <session-id>
+ocr session comments --severity high <session-id>
+ocr session comments --severity critical,high --category bug,security <session-id>
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--repo <path>` | current dir | Repository whose session should be inspected. |
+| `--json` | `false` | Emit the comments as a JSON array. |
+| `--severity <list>` | all | Comma-separated severities to include (`critical`, `high`, `medium`, `low`). |
+| `--category <list>` | all | Comma-separated categories to include (e.g. `bug`, `security`). |
 
 ## `ocr rules`
 

--- a/pages/src/content/docs/ja/cli-reference.md
+++ b/pages/src/content/docs/ja/cli-reference.md
@@ -57,6 +57,7 @@ GitHub: https://github.com/alibaba/open-code-review
 | `ocr llm providers` | — | 組み込みの LLM プロバイダーをすべて一覧表示します。 |
 | `ocr session list` | `ocr sessions list`, `ocr session ls` | 保存されたレビューセッションを一覧表示します。 |
 | `ocr session show <id>` | `ocr sessions show <id>` | 1つのセッションとファイル単位のチェックポイントを表示します。 |
+| `ocr session comments <id>` | `ocr sessions comments <id>` | 1つのセッションに記録されたレビューコメントを表示します。 |
 | `ocr viewer` | — | 過去のレビューセッション用のローカル Web UI を起動します（`localhost:5483`）。 |
 | `ocr version` | — | バージョン、commit、プラットフォーム、ビルド日、GitHub URL を出力します。 |
 
@@ -143,6 +144,7 @@ ocr review -c abc123
 ```bash
 ocr session list
 ocr session show <session-id>
+ocr session comments <session-id>
 ocr review --from main --to feature-branch --resume <session-id>
 ocr review --commit abc123 --resume <session-id>
 ```
@@ -255,8 +257,9 @@ ocr session <sub-command>
 ocr sessions <sub-command>   (alias)
 
 Sub-commands:
-  list, ls    List recent review sessions for the current repo
-  show <id>   Show one session's metadata and per-file items
+  list, ls        List recent review sessions for the current repo
+  show <id>       Show one session's metadata and per-file items
+  comments <id>   Show the review comments recorded in one session
 ```
 
 ### `ocr session list`
@@ -285,6 +288,25 @@ ocr session show --repo /path/to/repo <session-id>
 |---|---|---|
 | `--repo <path>` | カレントディレクトリ | セッションを確認するリポジトリ。 |
 | `--json` | `false` | セッションのメタデータとファイル単位の項目を JSON として出力します。 |
+
+### `ocr session comments`
+
+セッションに保存されたすべてのレビューコメントを、`ocr review` のターミナル出力と
+同じスタイル（パス、行範囲、重要度バッジ、提案 diff）で表示します。
+
+```bash
+ocr session comments <session-id>
+ocr session comments --json <session-id>
+ocr session comments --severity high <session-id>
+ocr session comments --severity critical,high --category bug,security <session-id>
+```
+
+| 引数 | デフォルト | 説明 |
+|---|---|---|
+| `--repo <path>` | カレントディレクトリ | セッションを確認するリポジトリ。 |
+| `--json` | `false` | コメントを JSON 配列として出力します。 |
+| `--severity <list>` | すべて | 含める重要度をカンマ区切りで指定します（`critical`、`high`、`medium`、`low`）。 |
+| `--category <list>` | すべて | 含めるカテゴリをカンマ区切りで指定します（例: `bug`、`security`）。 |
 
 ## `ocr rules`
 

--- a/pages/src/content/docs/zh/cli-reference.md
+++ b/pages/src/content/docs/zh/cli-reference.md
@@ -57,6 +57,7 @@ GitHub: https://github.com/alibaba/open-code-review
 | `ocr llm providers` | — | 列出所有内置 LLM provider。 |
 | `ocr session list` | `ocr sessions list`, `ocr session ls` | 列出已保存的评审会话。 |
 | `ocr session show <id>` | `ocr sessions show <id>` | 查看单个会话及其逐文件检查点。 |
+| `ocr session comments <id>` | `ocr sessions comments <id>` | 输出单个会话中记录的评审评论。 |
 | `ocr viewer` | — | 启动用于历史评审会话的本地 Web UI（`localhost:5483`）。 |
 | `ocr version` | — | 打印版本、commit、平台、构建日期与 GitHub URL。 |
 
@@ -146,6 +147,7 @@ ocr review -c abc123
 ```bash
 ocr session list
 ocr session show <session-id>
+ocr session comments <session-id>
 ocr review --from main --to feature-branch --resume <session-id>
 ocr review --commit abc123 --resume <session-id>
 ```
@@ -263,8 +265,9 @@ ocr session <sub-command>
 ocr sessions <sub-command>   (alias)
 
 Sub-commands:
-  list, ls    List recent review sessions for the current repo
-  show <id>   Show one session's metadata and per-file items
+  list, ls        List recent review sessions for the current repo
+  show <id>       Show one session's metadata and per-file items
+  comments <id>   Show the review comments recorded in one session
 ```
 
 ### `ocr session list`
@@ -293,6 +296,25 @@ ocr session show --repo /path/to/repo <session-id>
 |---|---|---|
 | `--repo <path>` | 当前目录 | 要查看会话的仓库。 |
 | `--json` | `false` | 以 JSON 输出会话元数据和逐文件条目。 |
+
+### `ocr session comments`
+
+输出会话中保存的所有评审评论，渲染风格与 `ocr review` 的终端输出一致
+（路径、行范围、严重程度标签、建议 diff）。
+
+```bash
+ocr session comments <session-id>
+ocr session comments --json <session-id>
+ocr session comments --severity high <session-id>
+ocr session comments --severity critical,high --category bug,security <session-id>
+```
+
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `--repo <path>` | 当前目录 | 要查看会话的仓库。 |
+| `--json` | `false` | 以 JSON 数组输出评论。 |
+| `--severity <list>` | 全部 | 逗号分隔的要包含的严重程度（`critical`、`high`、`medium`、`low`）。 |
+| `--category <list>` | 全部 | 逗号分隔的要包含的类别（如 `bug`、`security`）。 |
 
 ## `ocr rules`
 


### PR DESCRIPTION
## Description

`ocr session show <id>` only surfaces per-file comment **counts**, not the actual review feedback — retrieving it after a session completes meant manually parsing the `.jsonl` file. This PR adds a dedicated subcommand:

```bash
ocr session comments <session-id>                        # formatted, matches `ocr review` output style
ocr session comments --json <session-id>                 # raw JSON array (jq-friendly, [] when empty)
ocr session comments --severity critical,high <id>       # filter by severity
ocr session comments --category bug,security <id>        # filter by category
```

Formatted output reuses the exact `ocr review` rendering (path:line header, colored `[category · severity]` badge, suggestion diff).

Implementation notes:

- Comments are read from the `review_item_done` / `review_item_reused` checkpoint records (which already persist the full comment objects) via a new `session.LoadComments`, rather than mining `llm_response` tool calls. Replay mirrors resume semantics: a later checkpoint for the same fingerprint supersedes the earlier one, and a subsequent `review_item_failed` drops it. Comments persisted without a path inherit the record's file path.
- Shell tab completion: session ids (newest first, with start time / comment count / status as description) for `session show`, `session comments`, and `review --resume`; enum completion for `--severity` and `--category`.
- Docs updated: README + English/Japanese/Chinese CLI references.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

- New unit tests: `session.LoadComments` (ordering, path inheritance, supersede/failure semantics) and CLI-level tests for review-style rendering, severity filtering, `--json` output, empty-array JSON, and the no-comments message.
- `go test ./internal/session ./cmd/opencodereview` passes (118 tests in `cmd/opencodereview`), except pre-existing tests that don't work in my sandboxed environment (`TestGetCommitMessage` hangs on a git subprocess there and the config/provider connectivity tests hit a real endpoint) — unrelated to this change.
- Manually verified against real saved sessions: formatted output, filters (including filter-miss message), JSON output, and `__complete`-based session-id completion.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
