### PR TITLE
docs: add shell completion setup guide for CLI Reference and Installation (#639)

### DIFF
--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -449,6 +449,80 @@ Prints the version stamped at build time, the short Git commit (when
 present), the platform (`<GOOS>/<GOARCH>`), the build date (when present),
 and the GitHub URL (`https://github.com/alibaba/open-code-review`).
 
+
+## ocr completion
+
+Generate shell completion scripts for `ocr`, so command names, flags,
+and arguments can be tab-completed in your shell.
+
+### Bash
+
+One-shot, current session only:
+
+```bash
+source <(ocr completion bash)
+```
+
+Persistent (Linux):
+
+```bash
+ocr completion bash > /etc/bash_completion.d/ocr
+```
+
+Persistent (macOS):
+
+```bash
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+```
+
+### Zsh
+
+If shell completion isn't already enabled in your environment, enable
+it once:
+
+```bash
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+Then load completions persistently:
+
+```bash
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+Start a new shell for this to take effect.
+
+### Fish
+
+One-shot, current session only:
+
+```bash
+ocr completion fish | source
+```
+
+Persistent:
+
+```bash
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+### PowerShell
+
+One-shot, current session only:
+
+```powershell
+ocr completion powershell | Out-String | Invoke-Expression
+```
+
+Persistent — generate the script once, then source it from your profile:
+
+```powershell
+ocr completion powershell > ocr.ps1
+```
+
+Add a line to your PowerShell profile that dot-sources `ocr.ps1`.
+
+
 ## Tips & gotchas
 
 - `--audience agent` does **not** imply `--format json`. They control

--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -168,6 +168,22 @@ which ocr
 echo $PATH
 ```
 
+## Enable Shell Completion (optional)
+
+`ocr` supports tab-completion for bash, zsh, fish, and PowerShell.
+
+```bash
+# bash
+source <(ocr completion bash)
+
+# zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+See the [CLI Reference](./cli-reference.md#ocr-completion) for fish,
+PowerShell, and persistent setup instructions.
+
+
 ## Where OCR stores state
 
 | Path | What it holds |

--- a/pages/src/content/docs/ja/cli-reference.md
+++ b/pages/src/content/docs/ja/cli-reference.md
@@ -408,6 +408,76 @@ ocr -V
 
 ビルド時に書き込まれたバージョン情報、短い Git commit（存在する場合）、プラットフォーム（`<GOOS>/<GOARCH>`）、ビルド日（存在する場合）、そして GitHub URL（`https://github.com/alibaba/open-code-review`）を出力します。
 
+## ocr completion
+
+`ocr` のシェル補完スクリプトを生成し、シェル内でコマンド名・フラグ・引数を Tab 補完できるようにします。
+
+### Bash
+
+現在のセッションのみ：
+
+```bash
+source <(ocr completion bash)
+```
+
+永続化（Linux）：
+
+```bash
+ocr completion bash > /etc/bash_completion.d/ocr
+```
+
+永続化（macOS）：
+
+```bash
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+```
+
+### Zsh
+
+シェル補完がまだ有効になっていない場合は、一度だけ実行してください：
+
+```bash
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+その後、補完を永続的に読み込みます：
+
+```bash
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+反映させるには新しいシェルを開始する必要があります。
+
+### Fish
+
+現在のセッションのみ：
+
+```bash
+ocr completion fish | source
+```
+
+永続化：
+
+```bash
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+### PowerShell
+
+現在のセッションのみ：
+
+```powershell
+ocr completion powershell | Out-String | Invoke-Expression
+```
+
+永続化 —— スクリプトを生成し、PowerShell プロファイルから読み込みます：
+
+```powershell
+ocr completion powershell > ocr.ps1
+```
+
+その後、`ocr.ps1` を読み込む行を PowerShell プロファイルに追加してください。
+
 ## ヒントと注意点
 
 - `--audience agent` は `--format json` を**含意しません**。両者は異なることを制御します。UI の抑制 vs 構造化されたペイロードです。両方が必要な場合は組み合わせて使用してください。

--- a/pages/src/content/docs/ja/installation.md
+++ b/pages/src/content/docs/ja/installation.md
@@ -163,6 +163,21 @@ which ocr
 echo $PATH
 ```
 
+## シェル補完を有効にする（任意）
+
+`ocr` は bash、zsh、fish、PowerShell の Tab 補完に対応しています。
+
+```bash
+# bash
+source <(ocr completion bash)
+
+# zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+fish、PowerShell、および永続化の詳しい設定方法は [CLI リファレンス](./cli-reference.md#ocr-completion) を参照してください。
+
+
 ## OCR が状態を保存する場所
 
 | パス | 保存内容 |

--- a/pages/src/content/docs/ru/installation.md
+++ b/pages/src/content/docs/ru/installation.md
@@ -165,6 +165,22 @@ which ocr
 echo $PATH
 ```
 
+## Включение автодополнения оболочки (опционально)
+
+`ocr` поддерживает автодополнение по Tab для bash, zsh, fish и PowerShell.
+
+```bash
+# bash
+source <(ocr completion bash)
+
+# zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+Подробности по fish, PowerShell и постоянной настройке см. в
+[CLI Reference](./cli-reference.md#ocr-completion).
+
+
 ## Где OCR хранит состояние
 
 | Путь | Содержимое |

--- a/pages/src/content/docs/zh/cli-reference.md
+++ b/pages/src/content/docs/zh/cli-reference.md
@@ -428,6 +428,78 @@ ocr -V
 （`<GOOS>/<GOARCH>`）、构建日期（存在时），以及 GitHub URL
 （`https://github.com/alibaba/open-code-review`）。
 
+
+## ocr completion
+
+为 `ocr` 生成 shell 补全脚本，以便在 shell 中对命令名、参数和标志进行 Tab 补全。
+
+### Bash
+
+仅当前会话生效：
+
+```bash
+source <(ocr completion bash)
+```
+
+持久生效（Linux）：
+
+```bash
+ocr completion bash > /etc/bash_completion.d/ocr
+```
+
+持久生效（macOS）：
+
+```bash
+ocr completion bash > $(brew --prefix)/etc/bash_completion.d/ocr
+```
+
+### Zsh
+
+如果 shell 补全尚未启用，请先执行一次：
+
+```bash
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+然后持久加载补全：
+
+```bash
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+需要打开一个新的 shell 才能生效。
+
+### Fish
+
+仅当前会话生效：
+
+```bash
+ocr completion fish | source
+```
+
+持久生效：
+
+```bash
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
+### PowerShell
+
+仅当前会话生效：
+
+```powershell
+ocr completion powershell | Out-String | Invoke-Expression
+```
+
+持久生效 —— 先生成脚本，再从 PowerShell 配置文件中加载：
+
+```powershell
+ocr completion powershell > ocr.ps1
+```
+
+然后在 PowerShell 配置文件中添加一行以加载 `ocr.ps1`。
+
+
 ## 提示与注意
 
 - `--audience agent` **并不**隐含 `--format json`。两者控制不同的事——屏蔽 UI

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -160,6 +160,22 @@ which ocr
 echo $PATH
 ```
 
+
+## 启用 Shell 补全（可选）
+
+`ocr` 支持 bash、zsh、fish 和 PowerShell 的 Tab 补全。
+
+```bash
+# bash
+source <(ocr completion bash)
+
+# zsh
+ocr completion zsh > "${fpath[1]}/_ocr"
+```
+
+完整的 fish、PowerShell 及持久化配置说明，请参见 [CLI 参考](./cli-reference.md#ocr-completion)。
+
+
 ## OCR 在哪里存放状态
 
 | 路径 | 存放内容 |


### PR DESCRIPTION
Documents the `ocr completion` command (bash/zsh/fish/powershell), which is implemented but has zero documentation.

## CLI Reference (en, zh, ja)

- New `## ocr completion` section alongside the existing command sections
- Command format: `ocr completion [bash|zsh|fish|powershell]`
- Per-shell one-shot and persistent setup instructions, matching the help text in `cmd/opencodereview/completion.go`

## Installation (en, zh, ja, ru)

- New "Enable Shell Completion" section after "Verifying the install"
- One-line explanation, quick shell example, and a link to the CLI Reference for full details

Content verified against the shells and setup steps in `cmd/opencodereview/completion.go`. Docs site renders correctly locally via `cd pages && npm run dev`.
