### PR TITLE
fix(action): group 422 fallback inline comments into a single review

### DIFF
--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -265,6 +265,10 @@ async function runPostReviewComments({
     // may have landed on the server even though we received a 5xx response).
     const reviewBody = REVIEW_TAG;
 
+    // Shared across batches so the PR's diff inventory is fetched at most once
+    // per run even if several batches trip the 422 line-resolution fallback.
+    const diffCache = {};
+
     for (const chunk of batches) {
       const r = await publishBatch({
         chunk,
@@ -276,6 +280,7 @@ async function runPostReviewComments({
         reviewBody,
         REVIEW_TAG,
         log,
+        diffCache,
       });
       successCount += r.succeeded;
       failedCount += r.failed;
@@ -367,6 +372,7 @@ async function publishBatch({
   reviewBody,
   REVIEW_TAG,
   log,
+  diffCache,
 }) {
   let succeeded = 0;
   let failed = 0;
@@ -407,68 +413,129 @@ async function publishBatch({
     // (findExistingBatchReview / getPostedCommentIds / isCommentAlreadyPosted),
     // so it is not read here — only the write-path pacing knobs are.
 
-    // Rate-limit cooldown: honor the batch error's retry/rate-limit headers
-    // BEFORE any further API call — including the idempotency reads below.
-    // Firing reads immediately after a rate-limit/5xx would further pressure
-    // the already-struggling API; this is the same cool-down-before-read
-    // discipline the per-comment loop applies before isCommentAlreadyPosted.
-    const batchRetry = computeRetryDelayMs(e, 0);
-    if (batchRetry != null) {
-      const secs = (batchRetry.delayMs / 1000).toFixed(1);
-      log(
-        `Batch createReview failed (HTTP ${e.status}). ` +
-          `Cooling down ${secs}s via '${batchRetry.source}' (${batchRetry.detail}) before any retry or read.`
-      );
-      await sleep(batchRetry.delayMs);
-    }
+    // Rate-limit cooldown + idempotency reconciliation, both handled by
+    // cooldownAndReconcile(). The SAME helper runs for the secondary filtered
+    // batch below, so the two write paths cannot drift apart: every batch-level
+    // failure honors the error's retry/rate-limit headers before any further API
+    // call, and every failure that MAY have reached the server is reconciled
+    // against what actually landed before we retry anything.
+    const primary = await cooldownAndReconcile({
+      github,
+      owner,
+      repo,
+      prNumber,
+      log,
+      error: e,
+      items: chunk,
+      tag: REVIEW_TAG,
+      label: "Batch",
+      labelLower: "batch",
+    });
+    let toRetry = primary.toRetry;
+    succeeded += primary.alreadyPosted;
+    reconciled = primary.reconciled;
+    const batchStatus = primary.status;
 
-    // The idempotency read ("did the batch land?") is only meaningful when the
-    // request MAY have reached the server: 5xx, 408 timeout, or a network
-    // error with no status. For a pure rate-limit (429 / 403 abuse) or a
-    // validation error (422), the request was rejected before the review was
-    // created, so the batch definitely did not land — querying would be both
-    // pointless AND an extra read fired during a rate-limit episode. Skip it
-    // and retry all comments. This mirrors the per-comment maybeReachedServer
-    // predicate so the two layers stay consistent.
-    const batchStatus = e.status;
-    const batchMaybeReachedServer =
-      (typeof batchStatus === "number" && (batchStatus >= 500 || batchStatus === 408)) ||
-      batchStatus == null; // network errors (ECONNRESET, ETIMEDOUT, ...)
-
-    let existingReview = null;
-    if (batchMaybeReachedServer) {
-      log("Checking whether the batch review actually landed on the server before retrying...");
+    // ---- HTTP 422 line-resolution fallback -------------------------------
+    // GitHub rejects a whole createReview batch when ANY inline comment points
+    // at a line outside the PR diff. Rather than degrading straight to N
+    // separate per-comment reviews (N timeline entries — the churn issue #624
+    // is about), drop the comments we can PROVE are unresolvable and re-send
+    // the survivors as one review.
+    //
+    // Two guards keep this from making things worse:
+    //   * isLineResolutionFailure() — a 422 from this endpoint means
+    //     "Validation failed, OR the endpoint has been spammed". Only a
+    //     confirmed line/diff validation error activates the fallback; an
+    //     unrecognized 422 (including spam/abuse detection) falls straight
+    //     through to the per-comment loop, which has its own retry discipline.
+    //     Re-sending a batch into a spam-throttled endpoint would deepen the
+    //     incident rather than fix it.
+    //   * classifyCommentAgainstDiff() is TRI-state. A comment is only dropped
+    //     when the diff inventory is complete AND proves the line is outside
+    //     it. "unknown" (incomplete file list, file present but patch omitted
+    //     for a binary/oversized diff, LEFT-side comment, no line info) keeps
+    //     the pre-existing per-comment behavior instead of silently voiding a
+    //     comment that might well post.
+    if (batchStatus === 422 && toRetry.length > 0 && isLineResolutionFailure(e)) {
+      log(`[422-fallback] Batch createReview rejected by line/diff validation (HTTP 422). Filtering unresolvable comments against PR diff hunks...`);
+      let diff = null;
       try {
-        existingReview = await findExistingBatchReview({ github, owner, repo, prNumber, tag: REVIEW_TAG, log });
-      } catch (checkErr) {
-        log(`Idempotency check failed (${checkErr.message}). Degrading to original fallback (accepting duplicate risk).`);
+        diff = await getPrDiffHunks({ github, owner, repo, prNumber, log, cache: diffCache });
+      } catch (hunkErr) {
+        log(`[422-fallback] Failed to fetch PR diff hunks (${hunkErr.message}); proceeding without diff hunk filter.`);
       }
-    } else {
-      log(`Batch did not reach the server (HTTP ${batchStatus || "n/a"}); skipping idempotency check and retrying all comments.`);
-    }
 
-    // Compute the list of inline comments that still need to be posted. If the
-    // batch review landed, only retry the missing ones; otherwise retry all of
-    // them. NOTE: REVIEW_TAG is shared across all batches, so
-    // findExistingBatchReview may match an EARLIER batch's review — harmless
-    // for correctness because getPostedCommentIds returns a server-global set
-    // of every fence ID across ALL reviews, and we filter this chunk's items
-    // against that global set (never the set against the chunk). The counts
-    // below therefore reflect only THIS chunk's members.
-    let toRetry = chunk;
-    if (existingReview && existingReview.found) {
-      const postedIds = await getPostedCommentIds({ github, owner, repo, prNumber, log });
-      toRetry = chunk.filter((item) => !postedIds.has(item.id));
-      succeeded = chunk.length - toRetry.length;
-      reconciled = succeeded > 0;
-      log(
-        `A batch review with this run's tag exists on the server ` +
-          `(review_id=${existingReview.review.id}, may belong to an earlier batch). ` +
-          `${succeeded}/${chunk.length} of this batch's inline comments already posted. ` +
-          `${toRetry.length} missing, will retry only those.`
-      );
-    } else {
-      log("Batch review not found on server. Falling back to per-comment posting...");
+      // valid   -> provably inside the diff, safe to re-batch
+      // unknown -> cannot prove either way, fall through to the per-comment loop
+      // invalid -> provably outside the diff, route to the summary
+      const validItems = [];
+      const unknownItems = [];
+      for (const item of toRetry) {
+        const verdict = classifyCommentAgainstDiff(item, diff);
+        if (verdict === "valid") {
+          validItems.push(item);
+        } else if (verdict === "unknown") {
+          unknownItems.push(item);
+        } else {
+          failed++;
+          failedComments.push({
+            comment: item.comment,
+            error: `${describeCommentLocation(item.reviewComment)} could not be resolved (outside PR diff hunks)`,
+          });
+          log(`[422-fallback] Comment for ${item.reviewComment.path}:${describeCommentLocation(item.reviewComment)} is outside PR diff hunks; routing to summary failure.`);
+        }
+      }
+      if (unknownItems.length > 0) {
+        log(`[422-fallback] ${unknownItems.length} comment(s) could not be checked against the diff (incomplete or unavailable patch data); posting them individually rather than discarding them.`);
+      }
+
+      if (validItems.length > 0) {
+        log(`[422-fallback] Attempting secondary filtered batch createReview with ${validItems.length} valid comment(s)...`);
+        try {
+          const secondaryRes = await github.rest.pulls.createReview({
+            owner,
+            repo,
+            pull_number: prNumber,
+            commit_id: commitSha,
+            body: reviewBody,
+            event: "COMMENT",
+            comments: validItems.map(({ reviewComment }) => reviewComment),
+          });
+          succeeded += validItems.length;
+          log(`Successfully posted secondary filtered review batch with ${validItems.length} inline comment(s).`);
+          logRateLimitQuota(secondaryRes, "after secondary batch createReview", log);
+          toRetry = unknownItems;
+        } catch (secondaryE) {
+          log(`Secondary filtered batch createReview failed (HTTP ${secondaryE.status || "n/a"}): ${secondaryE.message}. Falling back to per-comment loop.`);
+          // Same cooldown + idempotency discipline as the primary batch: a 5xx
+          // or network error can mean the secondary review LANDED and only the
+          // response was lost, in which case dropping straight into the
+          // per-comment loop would repost every surviving comment.
+          const secondary = await cooldownAndReconcile({
+            github,
+            owner,
+            repo,
+            prNumber,
+            log,
+            error: secondaryE,
+            items: validItems,
+            tag: REVIEW_TAG,
+            label: "Secondary filtered batch",
+            labelLower: "secondary filtered batch",
+          });
+          succeeded += secondary.alreadyPosted;
+          if (secondary.reconciled) reconciled = true;
+          toRetry = secondary.toRetry.concat(unknownItems);
+        }
+      } else {
+        toRetry = unknownItems;
+      }
+
+      if (toRetry.length === 0) {
+        log(`[422-fallback] No comments remain for the per-comment fallback.`);
+        return { succeeded, failed, failedComments, reconciled };
+      }
     }
 
     for (const { comment, reviewComment, id } of toRetry) {
@@ -1529,6 +1596,268 @@ function safeRead(fs, p) {
   }
 }
 
+// Rate-limit cooldown + idempotency reconciliation for a FAILED batch
+// createReview. Shared by the primary batch and the 422 secondary filtered
+// batch so the two can never drift apart.
+//
+// Order matters: cool down FIRST (honoring the error's retry/rate-limit
+// headers) before any further API call, including the idempotency reads.
+// Firing reads immediately after a rate-limit/5xx would further pressure an
+// already-struggling API; this is the same cool-down-before-read discipline
+// the per-comment loop applies before isCommentAlreadyPosted.
+//
+// The idempotency read ("did the review land?") is only meaningful when the
+// request MAY have reached the server: 5xx, 408 timeout, or a network error
+// with no status. For a pure rate-limit (429 / 403 abuse) or a validation
+// error (422), the request was rejected before the review was created, so it
+// definitely did not land — querying would be both pointless AND an extra read
+// fired during a rate-limit episode. This mirrors the per-comment
+// maybeReachedServer predicate so all layers stay consistent.
+//
+// Returns { toRetry, alreadyPosted, reconciled, status, maybeReachedServer }.
+async function cooldownAndReconcile({ github, owner, repo, prNumber, log, error, items, tag, label, labelLower }) {
+  const retry = computeRetryDelayMs(error, 0);
+  if (retry != null) {
+    const secs = (retry.delayMs / 1000).toFixed(1);
+    log(
+      `${label} createReview failed (HTTP ${error.status}). ` +
+        `Cooling down ${secs}s via '${retry.source}' (${retry.detail}) before any retry or read.`
+    );
+    await sleep(retry.delayMs);
+  }
+
+  const status = error.status;
+  const maybeReachedServer =
+    (typeof status === "number" && (status >= 500 || status === 408)) ||
+    status == null; // network errors (ECONNRESET, ETIMEDOUT, ...)
+
+  let existingReview = null;
+  if (maybeReachedServer) {
+    log(`Checking whether the ${labelLower} review actually landed on the server before retrying...`);
+    try {
+      existingReview = await findExistingBatchReview({ github, owner, repo, prNumber, tag, log });
+    } catch (checkErr) {
+      log(`Idempotency check failed (${checkErr.message}). Degrading to original fallback (accepting duplicate risk).`);
+    }
+  } else {
+    log(`${label} did not reach the server (HTTP ${status || "n/a"}); skipping idempotency check and retrying all comments.`);
+  }
+
+  // If the review landed, only retry the missing comments; otherwise retry all
+  // of them. NOTE: the run tag is shared across all batches, so
+  // findExistingBatchReview may match an EARLIER batch's review — harmless for
+  // correctness because getPostedCommentIds returns a server-global set of
+  // every fence ID across ALL reviews, and we filter these items against that
+  // global set (never the set against the items). The counts below therefore
+  // reflect only the items passed in.
+  if (existingReview && existingReview.found) {
+    const postedIds = await getPostedCommentIds({ github, owner, repo, prNumber, log });
+    const toRetry = items.filter((item) => !postedIds.has(item.id));
+    const alreadyPosted = items.length - toRetry.length;
+    log(
+      `A ${labelLower} review with this run's tag exists on the server ` +
+        `(review_id=${existingReview.review.id}, may belong to an earlier batch). ` +
+        `${alreadyPosted}/${items.length} of this batch's inline comments already posted. ` +
+        `${toRetry.length} missing, will retry only those.`
+    );
+    return { toRetry, alreadyPosted, reconciled: alreadyPosted > 0, status, maybeReachedServer };
+  }
+
+  log(`${label} review not found on server. Falling back to per-comment posting...`);
+  return { toRetry: items, alreadyPosted: 0, reconciled: false, status, maybeReachedServer };
+}
+
+// GitHub documents 422 on this endpoint as "Validation failed, OR the endpoint
+// has been spammed" — so a bare status code is NOT evidence that a comment
+// pointed at a line outside the diff. Only re-send a filtered batch when the
+// error body actually names a line/diff validation problem; anything else
+// (spam/abuse detection, an unrelated validation failure) falls through to the
+// per-comment loop, which paces and retries on its own.
+const LINE_RESOLUTION_PATTERNS = [
+  /must be part of the diff/i,
+  /not part of the diff/i,
+  /could not be resolved/i,
+  /outside the diff/i,
+  /diff hunk/i,
+];
+const LINE_RESOLUTION_FIELDS = new Set(["line", "start_line", "position", "original_line", "original_start_line"]);
+
+function isLineResolutionFailure(error) {
+  if (!error) return false;
+  const texts = [];
+  if (error.message) texts.push(String(error.message));
+
+  const errors =
+    (error.response && error.response.data && error.response.data.errors) ||
+    (error.data && error.data.errors) ||
+    error.errors;
+  if (Array.isArray(errors)) {
+    for (const entry of errors) {
+      if (!entry) continue;
+      if (typeof entry === "string") {
+        texts.push(entry);
+        continue;
+      }
+      // A structured validation error naming a line field is conclusive on its
+      // own, regardless of how the message happens to be worded.
+      if (entry.field && LINE_RESOLUTION_FIELDS.has(String(entry.field))) return true;
+      if (entry.message) texts.push(String(entry.message));
+    }
+  }
+
+  const text = texts.join(" | ");
+  if (!text) return false;
+  return LINE_RESOLUTION_PATTERNS.some((re) => re.test(text));
+}
+
+// Parse a unified-diff patch into the RIGHT-side (new file) line ranges it
+// covers, ONE RANGE PER HUNK. Ranges — not a flat set of line numbers — because
+// GitHub requires a multi-line comment's start_line and line to sit inside the
+// SAME hunk; a flat set cannot tell a legal span from one that straddles two
+// hunks, and the straddling span would 422 all over again.
+//
+// Within a hunk the new-file line numbers are contiguous from the hunk header's
+// start: additions and context lines advance the counter, deletions do not (they
+// exist only in the old file). So each hunk collapses to {start, end}.
+function parseDiffHunkRanges(patch) {
+  if (!patch) return [];
+  const ranges = [];
+  const hunkHeaderRegex = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+  const lines = String(patch).split("\n");
+  let current = null;
+
+  const flush = () => {
+    // A hunk with no RIGHT-side lines at all (a pure deletion, "+N,0") never
+    // advanced the counter, so end < start and there is nothing to comment on.
+    if (current && current.end >= current.start) ranges.push({ start: current.start, end: current.end });
+  };
+
+  for (const line of lines) {
+    const match = hunkHeaderRegex.exec(line);
+    if (match) {
+      flush();
+      const start = parseInt(match[1], 10);
+      current = { start, end: start - 1, next: start };
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith("\\")) continue; // "\ No newline at end of file"
+    if (line.startsWith("-")) continue; // deletion: old file only, does not advance
+    if (line.startsWith("+") || line.startsWith(" ")) {
+      current.end = current.next;
+      current.next++;
+    }
+    // Anything else (notably a bare "" produced by a trailing newline in the
+    // patch string) is not a diff body line and must not advance the counter.
+  }
+  flush();
+  return ranges;
+}
+
+// TRI-STATE classification: "valid" | "invalid" | "unknown".
+//
+// "invalid" is a claim we must be able to PROVE, because it permanently routes
+// a finding to the summary without ever attempting to post it. Missing or
+// partial diff metadata is "unknown", not "invalid" — it means we could not
+// check, and the caller keeps the pre-existing per-comment behavior.
+function classifyCommentAgainstDiff(item, diff) {
+  // No inventory at all, or one we know is truncated: we cannot prove anything.
+  if (!diff || !diff.complete) return "unknown";
+
+  const { reviewComment } = item;
+  const path = reviewComment.path;
+
+  // File is not among the PR's changed files at all — provably outside the diff.
+  if (!diff.known.has(path)) return "invalid";
+
+  // File IS in the PR but GitHub omitted its `patch` (binary, or a diff over
+  // the size limit). We know nothing about its lines.
+  const ranges = diff.files.get(path);
+  if (!ranges) return "unknown";
+
+  // We only model RIGHT-side (new file) lines. The producer builds RIGHT-side
+  // comments today; if that ever changes, decline to judge rather than drop.
+  if (reviewComment.side && reviewComment.side !== "RIGHT") return "unknown";
+
+  const endLine = reviewComment.line;
+  if (endLine == null) return "unknown";
+  const startLine = reviewComment.start_line != null ? reviewComment.start_line : endLine;
+
+  // A reversed span is malformed and GitHub will reject it.
+  if (startLine > endLine) return "invalid";
+
+  // Both endpoints must fall inside ONE hunk.
+  const withinOneHunk = ranges.some((r) => startLine >= r.start && endLine <= r.end);
+  return withinOneHunk ? "valid" : "invalid";
+}
+
+// Human-readable location for the failure summary. A multi-line comment reports
+// its full span, so a range that failed on start_line is not described by the
+// (perfectly valid) end line alone.
+function describeCommentLocation(reviewComment) {
+  const endLine = reviewComment.line;
+  const startLine = reviewComment.start_line;
+  if (endLine == null && startLine == null) return "Line n/a";
+  if (startLine != null && endLine != null && startLine !== endLine) {
+    return `Lines ${startLine}-${endLine}`;
+  }
+  return `Line ${endLine != null ? endLine : startLine}`;
+}
+
+// Build the PR's RIGHT-side diff inventory.
+//
+// Returns { files, known, complete }:
+//   files    Map<path, Array<{start,end}>> — paths whose patch we could parse
+//   known    Set<path>                     — every path in the PR's file list
+//   complete boolean                       — the file list was fully enumerated
+//
+// `complete` is the guard that makes "invalid" provable: a truncated walk means
+// an absent path proves nothing. Pagination goes through readWithPacing so this
+// read honors the same retry/pacing/quota discipline as every other read in
+// this file. GitHub caps listFiles at 3000 files, hence MAX_PAGES = 30.
+//
+// `cache` (optional) memoizes the result for the run: with several batches each
+// failing 422, the inventory would otherwise be refetched per batch.
+async function getPrDiffHunks({ github, owner, repo, prNumber, log, cache }) {
+  const logFn = typeof log === "function" ? log : () => {};
+  if (cache && cache.diff !== undefined) return cache.diff;
+
+  const files = new Map();
+  const known = new Set();
+  let complete = true;
+
+  const PER_PAGE = 100;
+  const MAX_PAGES = 30;
+  let page = 1;
+  while (page <= MAX_PAGES) {
+    const res = await readWithPacing(
+      `listFiles (page ${page})`,
+      () => github.rest.pulls.listFiles({ owner, repo, pull_number: prNumber, per_page: PER_PAGE, page }),
+      logFn
+    );
+    const batch = (res && res.data) || [];
+    for (const file of batch) {
+      if (!file || !file.filename) continue;
+      known.add(file.filename);
+      if (file.patch) files.set(file.filename, parseDiffHunkRanges(file.patch));
+    }
+    if (batch.length < PER_PAGE) break;
+    page++;
+  }
+  if (page > MAX_PAGES) {
+    complete = false;
+    logFn(
+      `[422-fallback] PR changed-file list exceeded ${MAX_PAGES * PER_PAGE} files; ` +
+        `diff inventory is incomplete, so no comment will be discarded as out-of-diff.`
+    );
+  }
+
+  const diff = { files, known, complete };
+  if (cache) cache.diff = diff;
+  return diff;
+}
+
 module.exports = {
   runPostReviewComments,
   postSummary,
@@ -1579,4 +1908,10 @@ module.exports = {
   CATEGORIES,
   SEVERITIES,
   SEVERITY_RANK,
+  parseDiffHunkRanges,
+  classifyCommentAgainstDiff,
+  describeCommentLocation,
+  isLineResolutionFailure,
+  cooldownAndReconcile,
+  getPrDiffHunks,
 };

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -12,7 +12,7 @@
 
 const assert = require("assert");
 const path = require("path");
-const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK } = require(path.join(__dirname, "post-review-comments.js"));
+const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks } = require(path.join(__dirname, "post-review-comments.js"));
 
 // REVIEW_TAG as the production code builds it for this test's hardcoded run
 // identity (context.runId=undefined -> 0, runAttempt=undefined -> 1). Used as
@@ -97,6 +97,7 @@ function makeGithub(opts = {}) {
   const listCommentsCalls = [];
   const listReviewCommentsCalls = [];
   const listReviewsCalls = [];
+  const listFilesCalls = [];
   // Interleaved log of write operations (createReview / createComment /
   // updateComment) in call order, so tests can assert positioning invariants
   // such as "summary created before review" without timing the calls.
@@ -153,6 +154,7 @@ function makeGithub(opts = {}) {
     listCommentsCalls,
     listReviewCommentsCalls,
     listReviewsCalls,
+    listFilesCalls,
     ops,
     rest: {
       users: {
@@ -231,6 +233,18 @@ function makeGithub(opts = {}) {
           }
           return { data: opts.reviews || [] };
         },
+        listFiles: async (params) => {
+          listFilesCalls.push(params);
+          if (opts.listFilesThrow) {
+            throw makeErr(opts.listFilesError || "listFiles unavailable", opts.listFilesStatus || 503);
+          }
+          // Honor page/per_page so tests can exercise the multi-page walk and
+          // the >MAX_PAGES truncation guard, not just a single short page.
+          const all = opts.files || [];
+          const perPage = params.per_page || 100;
+          const page = params.page || 1;
+          return { data: all.slice((page - 1) * perPage, page * perPage) };
+        },
         listReviewComments: async (params) => {
           listReviewCommentsCalls.push(params);
           if (opts.listReviewCommentsThrow) {
@@ -242,6 +256,34 @@ function makeGithub(opts = {}) {
           //   - landedKeys: per-comment calls (index >= 1) that landed despite
           //     a 5xx/network error — drives per-comment isCommentAlreadyPosted.
           // Deduping by embedded comment id keeps them composable.
+          // echoBatchIdx: echo ONLY the comments carried by batch call #N
+          // (0-based among batch calls). Needed to simulate "the SECONDARY
+          // filtered batch landed but its response was lost" without also
+          // marking the primary batch's comments as posted — echoPosted scans
+          // ALL batch calls, and the two calls share comment IDs.
+          if (opts.echoBatchIdx != null) {
+            let seen = -1;
+            for (const call of createReviewCalls) {
+              if ((call.body || "") !== REVIEW_TAG) continue;
+              seen++;
+              if (seen !== opts.echoBatchIdx) continue;
+              // postedCount echoes only the FIRST N of that batch's comments, so
+              // a test can simulate a partially-landed review: the reconciler
+              // must re-send exactly the comments the server never received.
+              const carried = call.comments || [];
+              const n = opts.postedCount != null ? opts.postedCount : carried.length;
+              return {
+                data: carried.slice(0, n).map((c) => ({
+                  path: c.path,
+                  body: c.body,
+                  side: c.side || "RIGHT",
+                  start_line: c.start_line,
+                  line: c.line,
+                })),
+              };
+            }
+            return { data: [] };
+          }
           if (opts.echoPosted || opts.landedKeys) {
             const byId = new Map();
             const add = (c) => {
@@ -2120,7 +2162,523 @@ async function main() {
   await testAccountingReconcilesToTotal();
   await testMalformedRoutingPolicyFailsOpen();
   await testRoutedFindingsCarryNoIdempotencyId();
+  // Diff hunk parsing & 422 line-resolution fallback
+  testParseDiffHunkRanges();
+  testClassifyCommentAgainstDiff();
+  testIsLineResolutionFailure();
+  testDescribeCommentLocation();
+  await testGetPrDiffHunks();
+  await testGetPrDiffHunksTruncationIsIncomplete();
+  await testHttp422SecondaryFilteredBatchFallback();
+  await testHttp422SecondaryFailureReconcilesInsteadOfDuplicating();
+  await testHttp422SecondaryFailureReconcilesPerCommentNotWholesale();
+  await testHttp422SecondaryFailureFallsBackWhenNothingLanded();
+  await testHttp422SecondaryRateLimitCoolsDownBeforeRetrying();
+  await testNonLineResolution422SkipsFilteredBatch();
+  await testUnknownDiffMetadataStillPostsComments();
+  await testDiffFetchFailureDegradesToPerComment();
+  await testAllCommentsFilteredOutAccounting();
+  await testCrossHunkRangeIsFilteredOut();
   console.log("All post-review-comments tests passed.");
+}
+function testParseDiffHunkRanges() {
+  const patch = `@@ -10,3 +10,4 @@
+ context line 10
+-deleted line 11
++added line 11
++added line 12
+ context line 13`;
+  const ranges = parseDiffHunkRanges(patch);
+  assert.deepStrictEqual(ranges, [{ start: 10, end: 13 }]);
+
+  // Two hunks stay SEPARATE ranges: the gap between them is not commentable,
+  // and a span straddling both is not a legal multi-line comment.
+  const twoHunks = `@@ -1,3 +1,3 @@
+ a
+ b
+ c
+@@ -50,3 +50,3 @@
+ x
+ y
+ z`;
+  assert.deepStrictEqual(parseDiffHunkRanges(twoHunks), [
+    { start: 1, end: 3 },
+    { start: 50, end: 52 },
+  ]);
+
+  // A pure-deletion hunk has no RIGHT-side lines at all.
+  assert.deepStrictEqual(parseDiffHunkRanges("@@ -5,2 +4,0 @@\n-gone\n-also gone"), []);
+
+  // "\\ No newline at end of file" must not advance the line counter.
+  const noNewline = `@@ -1,1 +1,2 @@
+ kept
++added
+\\ No newline at end of file`;
+  assert.deepStrictEqual(parseDiffHunkRanges(noNewline), [{ start: 1, end: 2 }]);
+
+  // A trailing newline in the patch string yields a bare "" after split; it is
+  // not a diff body line and must not extend the range.
+  assert.deepStrictEqual(parseDiffHunkRanges("@@ -1,1 +1,1 @@\n context\n"), [{ start: 1, end: 1 }]);
+
+  assert.deepStrictEqual(parseDiffHunkRanges(""), []);
+  assert.deepStrictEqual(parseDiffHunkRanges(null), []);
+}
+
+function testClassifyCommentAgainstDiff() {
+  const diff = {
+    complete: true,
+    known: new Set(["foo.js", "binary.png"]),
+    files: new Map([["foo.js", [{ start: 10, end: 12 }, { start: 50, end: 52 }]]]),
+  };
+  const at = (rc) => classifyCommentAgainstDiff({ reviewComment: rc }, diff);
+
+  // Single line inside a hunk.
+  assert.strictEqual(at({ path: "foo.js", line: 11 }), "valid");
+  // Single line outside every hunk.
+  assert.strictEqual(at({ path: "foo.js", line: 30 }), "invalid");
+  // File not in the PR at all.
+  assert.strictEqual(at({ path: "bar.js", line: 10 }), "invalid");
+
+  // Multi-line span wholly inside ONE hunk.
+  assert.strictEqual(at({ path: "foo.js", start_line: 10, line: 12 }), "valid");
+  // Span straddling two hunks: both endpoints exist, but not in the same hunk.
+  // A flat line-set would wrongly call this valid and 422 all over again.
+  assert.strictEqual(at({ path: "foo.js", start_line: 11, line: 51 }), "invalid");
+  // Reversed span.
+  assert.strictEqual(at({ path: "foo.js", start_line: 52, line: 11 }), "invalid");
+  // Span partially overhanging the end of a hunk.
+  assert.strictEqual(at({ path: "foo.js", start_line: 11, line: 13 }), "invalid");
+
+  // ---- "unknown" must never be reported as "invalid" ----
+  // File is in the PR but GitHub omitted its patch (binary / oversized diff).
+  assert.strictEqual(at({ path: "binary.png", line: 3 }), "unknown");
+  // No line information to check.
+  assert.strictEqual(at({ path: "foo.js", line: null }), "unknown");
+  // LEFT-side comment: we only model RIGHT-side lines.
+  assert.strictEqual(at({ path: "foo.js", line: 11, side: "LEFT" }), "unknown");
+  // A truncated inventory proves nothing about an absent path.
+  assert.strictEqual(
+    classifyCommentAgainstDiff({ reviewComment: { path: "bar.js", line: 1 } }, { ...diff, complete: false }),
+    "unknown"
+  );
+  // No inventory at all (the fetch failed).
+  assert.strictEqual(classifyCommentAgainstDiff({ reviewComment: { path: "foo.js", line: 11 } }, null), "unknown");
+}
+
+function testIsLineResolutionFailure() {
+  // GitHub's own wording for this failure.
+  assert.strictEqual(isLineResolutionFailure({ message: "Validation Failed: line must be part of the diff" }), true);
+  assert.strictEqual(isLineResolutionFailure({ message: "Line could not be resolved" }), true);
+  // Structured validation error naming a line field is conclusive regardless
+  // of how the message is worded.
+  assert.strictEqual(
+    isLineResolutionFailure({ message: "Validation Failed", response: { data: { errors: [{ field: "start_line", code: "invalid" }] } } }),
+    true
+  );
+  assert.strictEqual(
+    isLineResolutionFailure({ message: "Validation Failed", errors: [{ message: "pull_request_review_thread.line must be part of the diff" }] }),
+    true
+  );
+
+  // 422 on this endpoint also means "the endpoint has been spammed" — that must
+  // NOT be read as a line-resolution problem, or the fallback would re-send a
+  // batch into a throttled endpoint.
+  assert.strictEqual(isLineResolutionFailure({ message: "You have exceeded a secondary rate limit" }), false);
+  assert.strictEqual(isLineResolutionFailure({ message: "Validation Failed: body is too long" }), false);
+  assert.strictEqual(isLineResolutionFailure({ message: "Validation Failed" }), false);
+  assert.strictEqual(isLineResolutionFailure({}), false);
+  assert.strictEqual(isLineResolutionFailure(null), false);
+}
+
+function testDescribeCommentLocation() {
+  assert.strictEqual(describeCommentLocation({ line: 42 }), "Line 42");
+  // A range that failed on start_line must not be described by its (valid) end
+  // line alone.
+  assert.strictEqual(describeCommentLocation({ start_line: 40, line: 42 }), "Lines 40-42");
+  assert.strictEqual(describeCommentLocation({ start_line: 42, line: 42 }), "Line 42");
+  assert.strictEqual(describeCommentLocation({}), "Line n/a");
+}
+
+async function testGetPrDiffHunks() {
+  const files = [
+    { filename: "src/main.js", patch: "@@ -1,2 +1,2 @@\n context 1\n+added 2" },
+    { filename: "assets/logo.png" }, // no patch (binary)
+  ];
+  const gh = makeGithub({ files });
+  const diff = await getPrDiffHunks({ github: gh, owner: "owner", repo: "repo", prNumber: 123, log: () => {} });
+  assert.strictEqual(diff.complete, true);
+  assert.deepStrictEqual(diff.files.get("src/main.js"), [{ start: 1, end: 2 }]);
+  // A patchless file is KNOWN (so it is not "not in the PR") but has no ranges.
+  assert.strictEqual(diff.known.has("assets/logo.png"), true);
+  assert.strictEqual(diff.files.has("assets/logo.png"), false);
+
+  // Cache: a second call for the same run must not re-fetch.
+  const cache = {};
+  const gh2 = makeGithub({ files });
+  await getPrDiffHunks({ github: gh2, owner: "o", repo: "r", prNumber: 1, log: () => {}, cache });
+  const afterFirst = gh2.listFilesCalls.length;
+  await getPrDiffHunks({ github: gh2, owner: "o", repo: "r", prNumber: 1, log: () => {}, cache });
+  assert.strictEqual(gh2.listFilesCalls.length, afterFirst, "cached diff inventory must not re-fetch listFiles");
+}
+
+async function testGetPrDiffHunksTruncationIsIncomplete() {
+  // 30 pages x 100 files is the GitHub listFiles ceiling; a PR at or past it
+  // yields an inventory we must not treat as authoritative.
+  const files = [];
+  for (let i = 0; i < 3100; i++) files.push({ filename: `f${i}.js`, patch: "@@ -1,1 +1,1 @@\n a" });
+  const gh = makeGithub({ files });
+  const diff = await getPrDiffHunks({ github: gh, owner: "o", repo: "r", prNumber: 1, log: () => {} });
+  assert.strictEqual(diff.complete, false, "a truncated file walk must report complete=false");
+  // ...and an incomplete inventory must never condemn a comment.
+  assert.strictEqual(classifyCommentAgainstDiff({ reviewComment: { path: "nope.js", line: 1 } }, diff), "unknown");
+}
+
+async function testHttp422SecondaryFilteredBatchFallback() {
+  const files = [
+    { filename: "src/valid.js", patch: "@@ -1,2 +1,2 @@\n context 1\n+added 2" },
+  ];
+  const result = {
+    comments: [
+      { path: "src/valid.js", content: "valid comment", start_line: 2, end_line: 2, severity: "high", category: "bug" },
+      { path: "src/invalid.js", content: "out of diff comment", start_line: 99, end_line: 99, severity: "high", category: "bug" },
+    ],
+  };
+
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [{ message: "Line could not be resolved", status: 422 }],
+  });
+  const core = { setOutput() {} };
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core,
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  // Call #0: initial batch (body === REVIEW_TAG, 2 comments) -> threw 422.
+  // Call #1: secondary filtered batch (1 surviving comment) -> succeeded.
+  // No per-comment calls: the whole point of the fallback.
+  assert.strictEqual(gh.createReviewCalls.length, 2, "Expected 2 createReview calls (initial batch + secondary filtered batch)");
+  const secondaryCall = gh.createReviewCalls[1];
+  assert.strictEqual(secondaryCall.comments.length, 1, "Secondary batch should contain only 1 valid comment");
+  assert.strictEqual(secondaryCall.comments[0].path, "src/valid.js");
+
+  assert.strictEqual(gh.updatedComments.length, 1);
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 1 comment(s)"), true);
+  assert.strictEqual(summaryText.includes("Failed to post inline: 1 comment(s)"), true);
+  assert.strictEqual(summaryText.includes("Line 99 could not be resolved"), true);
+}
+
+// REGRESSION: a secondary batch that LANDS but whose response is lost (5xx /
+// network error) must be reconciled, not blindly re-posted. Without this, every
+// surviving comment is duplicated — reintroducing exactly the churn the 422
+// fallback exists to remove.
+async function testHttp422SecondaryFailureReconcilesInsteadOfDuplicating() {
+  const files = [{ filename: "src/valid.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c" }];
+  const result = {
+    comments: [
+      { path: "src/valid.js", content: "c1", start_line: 1, end_line: 1 },
+      { path: "src/valid.js", content: "c2", start_line: 2, end_line: 2 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [
+      { message: "Line could not be resolved", status: 422 },
+      { message: "Bad gateway", status: 502 },
+    ],
+    batchLanded: true, // listReviews reports a review carrying this run's tag
+    echoBatchIdx: 1, // ...and the SECONDARY batch's comments are on the server
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  assert.strictEqual(
+    gh.createReviewCalls.length,
+    2,
+    "secondary batch landed: no comment may be re-posted individually"
+  );
+  assert.strictEqual(gh.listReviewsCalls.length > 0, true, "secondary 5xx must trigger the idempotency read");
+  assert.strictEqual(gh.listReviewCommentsCalls.length > 0, true, "secondary 5xx must reconcile against posted comment IDs");
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 2 comment(s)"), true);
+  // buildSummaryBody omits the failed line entirely when the count is zero.
+  assert.strictEqual(summaryText.includes("Failed to post inline"), false);
+}
+
+// The mirror case: the secondary batch genuinely did NOT land, so the
+// per-comment loop must still run and post every surviving comment exactly once.
+async function testHttp422SecondaryFailureFallsBackWhenNothingLanded() {
+  const files = [{ filename: "src/valid.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c" }];
+  const result = {
+    comments: [
+      { path: "src/valid.js", content: "c1", start_line: 1, end_line: 1 },
+      { path: "src/valid.js", content: "c2", start_line: 2, end_line: 2 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [
+      { message: "Line could not be resolved", status: 422 },
+      { message: "Bad gateway", status: 502 },
+    ],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  // 2 batch calls + 2 per-comment calls.
+  assert.strictEqual(gh.createReviewCalls.length, 4);
+  assert.strictEqual(gh.listReviewsCalls.length > 0, true, "secondary 5xx must still check whether the review landed");
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 2 comment(s)"), true);
+}
+
+// REGRESSION: the reconciler must match INDIVIDUAL comment ids against what the
+// server actually holds, not treat "a review with this run's tag exists" as
+// proof that every comment in the batch landed. A fully-echoed batch cannot
+// tell those two implementations apart — both post nothing further — so echo
+// only PART of the secondary batch and require the remainder to be re-sent.
+// The primary batch path already has this coverage (see the postedCount: 1 case
+// in the multi-path recovery test); this is its secondary-batch mirror.
+async function testHttp422SecondaryFailureReconcilesPerCommentNotWholesale() {
+  const files = [{ filename: "src/valid.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c" }];
+  const result = {
+    comments: [
+      { path: "src/valid.js", content: "c1", start_line: 1, end_line: 1 },
+      { path: "src/valid.js", content: "c2", start_line: 2, end_line: 2 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [
+      { message: "Line could not be resolved", status: 422 },
+      { message: "Bad gateway", status: 502 },
+    ],
+    batchLanded: true, // listReviews reports a review carrying this run's tag
+    echoBatchIdx: 1, // ...and the SECONDARY batch is the one that landed...
+    postedCount: 1, // ...but only its FIRST comment actually made it.
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  // Call #0: initial batch -> 422. Call #1: secondary batch -> 502 (partly
+  // landed). Call #2: per-comment retry of ONLY the comment that never landed.
+  assert.strictEqual(gh.createReviewCalls.length, 3, "the un-posted comment must be retried individually");
+  assert.strictEqual(gh.createReviewCalls[2].body, "", "the retry must be a per-comment review, not another batch");
+  assert.strictEqual(gh.createReviewCalls[2].comments.length, 1, "only the missing comment may be re-sent");
+  assert.strictEqual(
+    gh.createReviewCalls[2].comments[0].line,
+    2,
+    "the retried comment must be the one the server never received, not the one it already has"
+  );
+
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 2 comment(s)"), true);
+  assert.strictEqual(summaryText.includes("Failed to post inline"), false);
+}
+
+// A 429/403 rate-limit error surfacing from the secondary batch must cool down
+// (honoring Retry-After) before the per-comment loop issues another write.
+async function testHttp422SecondaryRateLimitCoolsDownBeforeRetrying() {
+  const realBase = process.env.OCR_RETRY_BASE_DELAY;
+  process.env.OCR_RETRY_BASE_DELAY = "1";
+  const logs = [];
+  try {
+    const files = [{ filename: "src/valid.js", patch: "@@ -1,2 +1,2 @@\n a\n b" }];
+    const result = { comments: [{ path: "src/valid.js", content: "c1", start_line: 1, end_line: 1 }] };
+    const gh = makeGithub({
+      files,
+      batchErrorSpec: [
+        { message: "Line could not be resolved", status: 422 },
+        { message: "You have exceeded a secondary rate limit", status: 429, headers: { "retry-after": "0" } },
+      ],
+    });
+
+    await runPostReviewComments({
+      github: gh,
+      context,
+      // runPostReviewComments logs through core.info when available.
+      core: { setOutput() {}, info: (m) => logs.push(m) },
+      fs: mockFs(JSON.stringify(result), ""),
+      out: {},
+    });
+
+    const cooled = logs.some((m) => /Secondary filtered batch createReview failed \(HTTP 429\)\. Cooling down/.test(m));
+    assert.strictEqual(cooled, true, "secondary rate-limit must cool down before any further write");
+    // 429 cannot have created the review, so no idempotency read should fire.
+    assert.strictEqual(gh.listReviewsCalls.length, 0, "a 429 rejects before creation; no idempotency read needed");
+    // Asserting the cooldown alone would still pass if the code cooled down and
+    // then gave up: that proves "cool down" but not "before retrying". Pin the
+    // retry down too — initial batch + secondary batch + per-comment call.
+    assert.strictEqual(gh.createReviewCalls.length, 3, "secondary 429 must fall through to the per-comment loop, not abandon the comment");
+    assert.strictEqual(gh.createReviewCalls[2].body, "", "the third call must be a per-comment review (batches carry the run tag as body)");
+    assert.strictEqual(gh.createReviewCalls[2].comments.length, 1, "the per-comment retry carries exactly the surviving comment");
+    assert.strictEqual(gh.updatedComments[0].body.includes("Successfully posted inline: 1 comment(s)"), true);
+  } finally {
+    if (realBase === undefined) delete process.env.OCR_RETRY_BASE_DELAY;
+    else process.env.OCR_RETRY_BASE_DELAY = realBase;
+  }
+}
+
+// A 422 that is NOT a line-resolution failure (GitHub returns 422 for spam
+// detection too) must not activate the filter or re-send a batch.
+async function testNonLineResolution422SkipsFilteredBatch() {
+  const files = [{ filename: "src/valid.js", patch: "@@ -1,2 +1,2 @@\n a\n b" }];
+  const result = { comments: [{ path: "src/valid.js", content: "c1", start_line: 1, end_line: 1 }] };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [{ message: "Validation Failed: the endpoint has been spammed", status: 422 }],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  assert.strictEqual(gh.listFilesCalls.length, 0, "an unrecognized 422 must not fetch the diff inventory");
+  // Batch call + per-comment call only — no secondary batch.
+  assert.strictEqual(gh.createReviewCalls.length, 2);
+  assert.strictEqual(gh.createReviewCalls[1].body, "", "second call must be the per-comment fallback, not a batch");
+}
+
+// REGRESSION: a file whose patch GitHub omitted (binary / oversized diff) is
+// UNKNOWN, not out-of-diff. Its comments must still be attempted individually
+// rather than silently routed to the summary.
+async function testUnknownDiffMetadataStillPostsComments() {
+  const files = [{ filename: "src/huge.js" }]; // in the PR, but no `patch`
+  const result = {
+    comments: [
+      { path: "src/huge.js", content: "c1", start_line: 1, end_line: 1 },
+      { path: "src/huge.js", content: "c2", start_line: 2, end_line: 2 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [{ message: "Line could not be resolved", status: 422 }],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  // Batch (422) + 2 per-comment calls. No secondary batch (nothing was provably
+  // valid), and critically NOTHING was discarded.
+  assert.strictEqual(gh.createReviewCalls.length, 3);
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 2 comment(s)"), true);
+  // buildSummaryBody omits the failed line entirely when the count is zero.
+  assert.strictEqual(summaryText.includes("Failed to post inline"), false);
+}
+
+// When the diff inventory fetch itself fails, every comment is unknown and the
+// original per-comment behavior is preserved.
+async function testDiffFetchFailureDegradesToPerComment() {
+  const result = { comments: [{ path: "src/a.js", content: "c1", start_line: 1, end_line: 1 }] };
+  const gh = makeGithub({
+    listFilesThrow: true,
+    batchErrorSpec: [{ message: "Line could not be resolved", status: 422 }],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  assert.strictEqual(gh.createReviewCalls.length, 2, "batch + per-comment fallback");
+  assert.strictEqual(gh.updatedComments[0].body.includes("Successfully posted inline: 1 comment(s)"), true);
+}
+
+// All comments provably out of diff: nothing is posted, accounting still
+// reconciles, and no stray createReview is issued.
+async function testAllCommentsFilteredOutAccounting() {
+  const files = [{ filename: "src/a.js", patch: "@@ -1,2 +1,2 @@\n a\n b" }];
+  const result = {
+    comments: [
+      { path: "src/a.js", content: "c1", start_line: 90, end_line: 90 },
+      { path: "src/gone.js", content: "c2", start_line: 1, end_line: 1 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [{ message: "Line could not be resolved", status: 422 }],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  assert.strictEqual(gh.createReviewCalls.length, 1, "nothing survivable: only the original failed batch");
+  const summaryText = gh.updatedComments[0].body;
+  assert.strictEqual(summaryText.includes("Successfully posted inline: 0 comment(s)"), true);
+  assert.strictEqual(summaryText.includes("Failed to post inline: 2 comment(s)"), true);
+  assert.strictEqual(summaryText.includes("Line 90 could not be resolved"), true);
+}
+
+// A multi-line span straddling two hunks is provably invalid; the in-hunk span
+// beside it still goes out in the grouped secondary batch.
+async function testCrossHunkRangeIsFilteredOut() {
+  const files = [{ filename: "src/a.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c\n@@ -50,3 +50,3 @@\n x\n y\n z" }];
+  const result = {
+    comments: [
+      { path: "src/a.js", content: "straddles two hunks", start_line: 2, end_line: 51 },
+      { path: "src/a.js", content: "inside one hunk", start_line: 50, end_line: 52 },
+    ],
+  };
+  const gh = makeGithub({
+    files,
+    batchErrorSpec: [{ message: "Line could not be resolved", status: 422 }],
+  });
+
+  await runPostReviewComments({
+    github: gh,
+    context,
+    core: { setOutput() {} },
+    fs: mockFs(JSON.stringify(result), ""),
+    out: {},
+  });
+
+  assert.strictEqual(gh.createReviewCalls.length, 2);
+  assert.strictEqual(gh.createReviewCalls[1].comments.length, 1, "only the single-hunk span may be re-batched");
+  assert.strictEqual(gh.createReviewCalls[1].comments[0].start_line, 50);
+  const summaryText = gh.updatedComments[0].body;
+  // The failure names the whole span, not just its (valid) end line.
+  assert.strictEqual(summaryText.includes("Lines 2-51 could not be resolved"), true);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Description

Fixes the duplicate inline comments and the N separate "PR Review" timeline entries described in #624.

GitHub rejects an entire batch `createReview` with HTTP 422 when **any** one inline comment points at a line outside the PR diff. The existing fallback reacted by degrading to N separate per-comment reviews — so one logical review became N timeline entries, which is the churn #624 is about.

This change filters out the comments that can be **proven** unresolvable against the PR diff and re-sends the survivors as a **single** review. Dropped comments are reported in the summary with their original span. The design was discussed and approved by a maintainer in #624.

### Why the guards are shaped the way they are

The useful part of this change is not the filtering — it is the set of constraints that keep the filtering from making things *worse* than the behavior it replaces. Each of these is load-bearing:

**Classification is tri-state (`valid` / `invalid` / `unknown`), not boolean.** `invalid` is a claim that has to be proven, because it permanently routes a finding to the summary without ever attempting to post it. Missing diff metadata — a patchless binary or oversized file, or a truncated file walk — is `unknown`, not `invalid`. A boolean version of this treats "GitHub didn't give me a patch" as "this comment is out of diff", silently voids an entire batch with zero posting attempts, and is strictly worse than not having the feature. Only `valid` comments are re-batched; `unknown` keeps the pre-existing per-comment path.

**The 422 gate is deliberately conservative.** GitHub documents 422 on this endpoint as *"Validation failed, **or the endpoint has been spammed**"*, so the status code alone is not evidence of a line-resolution problem. The fallback activates only on a confirmed line/diff validation error; anything else — including spam/abuse detection — falls straight through to the per-comment loop, which has its own retry discipline. Re-sending a filtered batch into a spam-throttled endpoint would deepen the incident rather than resolve it.

**Both batch paths share one cooldown + idempotency reconciliation.** A secondary batch that fails with a 5xx or network error may still have **landed**, with only its response lost. Retrying it blindly reposts every surviving comment and recreates precisely the duplication this change exists to remove. `cooldownAndReconcile()` is shared by the primary and secondary paths so they cannot drift apart, and it reconciles per comment ID against what the server actually holds.

**Diff hunks are `{start, end}` ranges, one per hunk.** A multi-line span must satisfy `start_line <= line` within a *single* hunk. Testing membership against a flat per-file line set accepts cross-hunk and reversed spans, which GitHub then rejects with another 422.

The diff inventory is fetched once per run and paginated through the existing `readWithPacing` helper, so it honors the same retry, pacing, and quota discipline as every other read in the file rather than bypassing it.

### Known limitations

- **The 422 gate matches known line-resolution wordings.** A validation message outside those patterns falls through to the per-comment loop. That is never worse than the pre-existing behavior, but an unusual GitHub message would quietly disable the grouping rather than fail loudly. Flagging it explicitly because it is the most likely way this silently stops helping.
- **Only RIGHT-side comments are modeled.** A LEFT-side comment classifies as `unknown` and takes the per-comment path. The producer emits RIGHT-side comments today, so this is currently unreachable — but it is an assumption, not a guarantee.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Full gate, run on this branch against a fresh `upstream/main`:

```
go fmt ./...   # nothing reformatted
go vet ./...   # exit 0
make test      # all packages pass
make build     # OK
npm run test:github-actions
  All post-review-comments tests passed.
  All check-translation-sync tests passed.
```

Only `scripts/github-actions/` changes, so no Go behavior is affected; `make test` and `go vet` are included because CI runs them.

**Please read this part before trusting the rest.** Every GitHub response here is mocked. None of these failure paths — a secondary review that lands while its response is lost, a 422 on a PR with an oversized diff — has been exercised against live GitHub infrastructure. I would treat "tests pass" as weak evidence on its own, which is why the tests were themselves put under scrutiny (below).

### Failure modes reproduced

Both of the guards that carry real risk were verified by removing them and driving the real `runPostReviewComments` through the test mock:

| scenario | without the guard | with it |
|---|---|---|
| secondary batch returns 502 but the review landed | 4 `createReview` calls, 0 idempotency reads → **both comments duplicated** | 2 calls, 1 `listReviews` + 1 `listReviewComments` → posted 2, failed 0 |
| file present in the PR with `patch` omitted | 1 call → **both comments silently discarded** (failed 2) | 3 calls → posted 2, failed 0 |

### The tests were reviewed too, and two of them were blind

Because the mocked-only caveat above means the tests *are* the safety argument, I ran OpenCodeReview over the test file (locally, via an Ollama-hosted model) and it found two tests that could not fail on the defect they existed to catch. Both were confirmed by mutation — the mutant is listed, and in each case the original assertions passed against it:

| mutant | original test | after fix |
|---|---|---|
| replace the per-ID filter in `cooldownAndReconcile` with `toRetry = []` (assume the whole batch landed) | **passed** | fails `2 !== 3` |
| replace the secondary catch's `toRetry` assignment with `toRetry = []` (cool down, then give up) | **passed** | fails `2 !== 3` |

The first is the more serious of the two: the reconciliation test echoed *both* of the batch's comments back as posted, so "reconcile each comment ID against the server" and "assume everything landed because a tagged review exists" produced identical observable behavior. Asserting that `listReviewComments` was *called* proves the read happened, not that its result was used. There is now a partially-landed case where only the un-posted comment may be re-sent, identified by line rather than by count — mirroring coverage the primary batch path already had.

Test coverage overall: secondary landed-then-5xx reconciliation (fully and partially landed), secondary 5xx with nothing landed, secondary 429 cooldown followed by the per-comment retry, non-line 422, patchless-file `unknown`, diff-fetch failure, all-filtered accounting, cross-hunk and reversed spans, `listFiles` truncation → `complete: false`, and inventory caching.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable) — no user-facing behavior or documented interface changes
- [x] I have signed the CLA

## Related Issues

Refs #624 — design discussed and approved there. Leaving it to the maintainers whether merging should close it.
