### PR TITLE
refactor(config): extract supported config keys into a single source of truth

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -346,6 +346,30 @@ func LoadAppConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// supportedConfigKeys is the single source of truth for the top-level config
+// keys accepted by setConfigValue. The unknown-key error message is generated
+// from this list so the two cannot drift apart when a new key is added.
+var supportedConfigKeys = []string{
+	"provider",
+	"model",
+	"providers.<name>.<field>",
+	"custom_providers.<name>.<field>",
+	"mcp_servers.<name>.<field>",
+	"llm.url",
+	"llm.auth_token",
+	"llm.auth_header",
+	"llm.model",
+	"llm.protocol",
+	"llm.use_anthropic",
+	"llm.extra_body",
+	"llm.extra_headers",
+	"language",
+	"telemetry.enabled",
+	"telemetry.exporter",
+	"telemetry.otlp_endpoint",
+	"telemetry.content_logging",
+}
+
 func setConfigValue(cfg *Config, key, value string) error {
 	// Handle providers.<name>.<field> paths.
 	if strings.HasPrefix(key, "providers.") {
@@ -477,7 +501,7 @@ func setConfigValue(cfg *Config, key, value string) error {
 		}
 		cfg.Llm.ExtraBody = m
 	default:
-		return fmt.Errorf("unknown config key: %s\nSupported keys: provider, model, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\nProtocol values: anthropic, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key)
+		return fmt.Errorf("unknown config key: %s\nSupported keys: %s\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\nProtocol values: anthropic, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key, strings.Join(supportedConfigKeys, ", "))
 	}
 	return nil
 }

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -941,6 +941,26 @@ func TestSetConfigValueUnknownKey(t *testing.T) {
 	}
 }
 
+func TestSetConfigValueUnknownKeyMessage(t *testing.T) {
+	// The unknown-key error message must stay byte-identical after extracting
+	// supportedConfigKeys, and must be generated from that list.
+	err := setConfigValue(&Config{}, "bogus.key", "val")
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	want := "unknown config key: bogus.key\n" +
+		"Supported keys: provider, model, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
+		"Provider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\n" +
+		"Protocol values: anthropic, openai, openai-responses\n" +
+		"MCP server fields: type, command, args, env, url, headers, tools, setup"
+	if err.Error() != want {
+		t.Errorf("unknown-key message drifted:\n got: %q\nwant: %q", err.Error(), want)
+	}
+	if !strings.Contains(err.Error(), strings.Join(supportedConfigKeys, ", ")) {
+		t.Error("message should be generated from supportedConfigKeys")
+	}
+}
+
 func TestSetConfigValueProviderClearsModel(t *testing.T) {
 	cfg := &Config{Provider: "old-provider", Model: "old-model"}
 	if err := setConfigValue(cfg, "provider", "new-provider"); err != nil {


### PR DESCRIPTION
`setConfigValue` kept the list of supported top-level config keys in two places — the `switch`/`case` branches and, hardcoded again, the "Supported keys:" line of the unknown-key error. Adding a key meant updating both, and it was easy to forget the error text.

This moves the keys into a `supportedConfigKeys` slice and builds the "Supported keys:" part of the message from it with `strings.Join`, so the two can't drift. The message content is byte-for-byte unchanged.

Added `TestSetConfigValueUnknownKeyMessage`, which pins the full message and checks it is generated from `supportedConfigKeys`. `go test ./...` and `make check` pass.

Closes #637

---
<sub>Disclosure: prepared with AI assistance.</sub>
