### PR TITLE
fix(llm): drop extra_body.stream from non-streaming requests (#647)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -346,6 +346,15 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 
 	var opts []openaiopt.RequestOption
 	for k, v := range c.cfg.ExtraBody {
+		// Skip the "stream" key here. The streaming decision below uses a
+		// dedicated boolean check, and when streaming is enabled the SDK's
+		// NewStreaming method sets stream=true on the wire itself. When
+		// streaming is NOT enabled, leaving the key in the body would make
+		// the API answer with text/event-stream and the non-streaming path
+		// fails to decode (see issue #647).
+		if k == "stream" {
+			continue
+		}
 		opts = append(opts, openaiopt.WithJSONSet(k, v))
 	}
 	if stream, ok := c.cfg.ExtraBody["stream"].(bool); ok && stream {
@@ -632,6 +641,13 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 
 	var opts []option.RequestOption
 	for k, v := range c.cfg.ExtraBody {
+		// This client is non-streaming: it calls Messages.New, which expects a
+		// single JSON body. If a provider config sets extra_body.stream=true,
+		// forwarding it here makes the API answer with SSE and every call fails
+		// to decode. Drop the key rather than forward it.
+		if k == "stream" {
+			continue
+		}
 		opts = append(opts, option.WithJSONSet(k, v))
 	}
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -603,15 +604,22 @@ func TestOpenAIClient_StreamOnlyGateway(t *testing.T) {
 	}
 }
 
-func TestOpenAIClient_StreamingRequiresBooleanTrue(t *testing.T) {
+// TestOpenAIClient_NonStreamingRequestDropsStreamField verifies that the
+// "stream" key in extra_body is NOT forwarded to the non-streaming Chat
+// Completions request. Forwarding it makes the API answer with
+// text/event-stream (SSE) while Chat.Completions.New expects a JSON body,
+// breaking every call (see issue #647). Only extra_body.stream=true as a
+// boolean triggers the streaming path; other types (string "true", bool
+// false) must be dropped from the wire body entirely so the server returns
+// JSON. Other extra_body keys are still forwarded.
+func TestOpenAIClient_NonStreamingRequestDropsStreamField(t *testing.T) {
 	tests := []struct {
-		name       string
-		configured bool
-		value      any
+		name  string
+		value any
 	}{
 		{name: "missing"},
-		{name: "boolean false", configured: true, value: false},
-		{name: "string true", configured: true, value: "true"},
+		{name: "boolean false", value: false},
+		{name: "string true", value: "true"},
 	}
 
 	for _, tt := range tests {
@@ -624,23 +632,8 @@ func TestOpenAIClient_StreamingRequiresBooleanTrue(t *testing.T) {
 					return
 				}
 
-				got, exists := body["stream"]
-				if exists != tt.configured {
-					t.Errorf("stream presence = %t, want %t", exists, tt.configured)
-				}
-				if tt.configured {
-					switch want := tt.value.(type) {
-					case bool:
-						gotBool, ok := got.(bool)
-						if !ok || gotBool != want {
-							t.Errorf("stream = %#v, want boolean %t", got, want)
-						}
-					case string:
-						gotString, ok := got.(string)
-						if !ok || gotString != want {
-							t.Errorf("stream = %#v, want string %q", got, want)
-						}
-					}
+				if _, exists := body["stream"]; exists {
+					t.Errorf("stream field should NOT be present in non-streaming request body, got %v", body["stream"])
 				}
 
 				w.Header().Set("Content-Type", "application/json")
@@ -654,7 +647,7 @@ func TestOpenAIClient_StreamingRequiresBooleanTrue(t *testing.T) {
 			defer server.Close()
 
 			var extraBody map[string]any
-			if tt.configured {
+			if tt.value != nil {
 				extraBody = map[string]any{"stream": tt.value}
 			}
 			client := NewOpenAIClient(ClientConfig{
@@ -1038,6 +1031,60 @@ func TestAnthropicClient_NoExtraHeadersWhenEmpty(t *testing.T) {
 		if k == "X-Custom-Header" || k == "X-Org-Id" {
 			t.Errorf("unexpected custom header %q sent", k)
 		}
+	}
+}
+
+// TestAnthropicClient_ExtraBodyStreamDropped verifies that an
+// extra_body.stream=true is NOT forwarded to the Messages API. Forwarding it
+// makes the API answer with text/event-stream (SSE) while Messages.New expects
+// a JSON body, breaking every call (see issue #647). Other extra_body keys
+// must still be forwarded.
+func TestAnthropicClient_ExtraBodyStreamDropped(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"msg_stream_test",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-test",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient(ClientConfig{
+		URL:    server.URL + "/v1/messages",
+		APIKey: "test-key",
+		Model:  "claude-test",
+		ExtraBody: map[string]any{
+			"stream":               true,
+			"keep_me":              "yes",
+			"temperature_override": 0.1,
+		},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		MaxTokens: 64,
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+
+	if _, present := gotBody["stream"]; present {
+		t.Errorf("request body should NOT contain a stream field, got %v", gotBody["stream"])
+	}
+	if gotBody["keep_me"] != "yes" {
+		t.Errorf("other extra_body keys must still be forwarded; keep_me = %v", gotBody["keep_me"])
+	}
+	if resp.Content() != "ok" {
+		t.Errorf("Content() = %q, want %q", resp.Content(), "ok")
 	}
 }
 


### PR DESCRIPTION
## Description

When `extra_body.stream` is configured, every LLM call fails with:

```
expected destination type of 'string' or '[]byte' for responses with content-type 'text/event-stream;charset=utf-8' that is not 'application/json'
```

### Root cause

The error originates from the SDK's response decoder (both `openai-go/v3` and `anthropic-sdk-go` share this code via Stainless generation). It surfaces when a non-streaming SDK call (`*.New()`, which expects `application/json`) receives an SSE body (`text/event-stream`).

`OpenAIClient` and `AnthropicClient` forwarded every `extra_body` key straight into the wire request body via `WithJSONSet`, including `stream`. The server therefore answered with SSE, but the client invoked the non-streaming `New()` path that expects JSON → decode fails.

This was already fixed for `OpenAIResponsesClient` — it drops the `stream` key in `CompletionsWithCtx` (see `responses_client.go:82-93`, with a detailed comment explaining why). This PR applies the same pattern to the other two non-streaming clients so all three behave consistently.

### Changes

- **`internal/llm/client.go`**:
  - `OpenAIClient.CompletionsWithCtx`: skip the `stream` key when merging `extra_body` into the request body. The streaming decision is preserved — only `stream: true` as a `bool` triggers the streaming path (`NewStreaming` sets `stream=true` itself on the wire); other value types (`"true"` string, `false` bool) now have the key dropped entirely so the server returns JSON instead of SSE.
  - `AnthropicClient.CompletionsWithCtx`: skip the `stream` key (mirrors `OpenAIResponsesClient` — this client has no streaming path at all, so any `stream` value would break the call).

- **`internal/llm/client_test.go`**:
  - Refactored `TestOpenAIClient_StreamingRequiresBooleanTrue` → `TestOpenAIClient_NonStreamingRequestDropsStreamField`: now verifies `stream` is absent from the non-streaming request body across three value types (missing / `false` / `"true"`).
  - Added `TestAnthropicClient_ExtraBodyStreamDropped`: verifies `stream` is dropped while other `extra_body` keys (`keep_me`, `temperature_override`) are still forwarded (mirrors `TestOpenAIResponsesClient_ExtraBodyStreamDropped`).

### End-to-end verification

Using the reporter's exact setup (DashScope-compatible Anthropic endpoint, `model: glm-5.2`):

| Version | `extra_body.stream` | `ocr llm test` result |
|----------|:---:|------|
| v1.8.3 (`80a5794`) | `true` | ❌ Fails — reproduces #647 exactly |
| This PR (`85fccde`) | `true` | ✅ `Connection test successful` |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (see the end-to-end comparison table above — reproduced the bug on v1.8.3 and verified the fix on this branch, using the reporter's exact setup: DashScope Anthropic-compatible endpoint with `model: glm-5.2` and `extra_body: {"stream": true}`)

Additional test coverage:
- All existing `TestOpenAIClient_Streaming*` tests (tool call, cancellation, error, usage, reasoning content, etc.) pass unchanged — the streaming path for `stream: true` (bool) is preserved.
- Full `internal/llm` package test suite passes (`go test -race -count=1 ./internal/llm/...`, ~89s).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly *(not applicable — the fix restores correct non-streaming behavior; the existing `extra_body` docs in `README.md` already accurately describe that `extra_body.stream=true` enables streaming for the Chat Completions client, and that remains unchanged)*
- [x] I have signed the CLA

## Related Issues

Relates to #647 — this PR addresses the same error, but the issue is intentionally left open for a short observation period to confirm this fix resolves the underlying problem for all affected users.
