### PR TITLE
docs: state merge-base range in --from/--to examples

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -135,7 +135,7 @@ cd your-project
 # ワークスペースモード — ステージ済み・未ステージ・未追跡のすべての変更をレビュー
 ocr review
 
-# ブランチ範囲 — 2つのrefを比較
+# ブランチ範囲 — merge-base(main, feature-branch)..feature-branch をレビュー
 ocr review --from main --to feature-branch
 
 # 単一コミット

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -135,7 +135,7 @@ cd your-project
 # Workspace mode: staged, unstaged, untracked 변경을 모두 리뷰
 ocr review
 
-# Branch range: 두 ref 비교
+# Branch range: merge-base(main, feature-branch)..feature-branch 리뷰
 ocr review --from main --to feature-branch
 
 # 단일 commit

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ cd your-project
 # Workspace mode — review all staged, unstaged, and untracked changes
 ocr review
 
-# Branch range — compare two refs
+# Branch range — reviews merge-base(main, feature-branch)..feature-branch
 ocr review --from main --to feature-branch
 
 # Single commit

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -135,7 +135,7 @@ cd your-project
 # Режим рабочей копии — ревью всех staged, unstaged и untracked изменений
 ocr review
 
-# Диапазон веток — сравнение двух ref'ов
+# Диапазон веток — ревью merge-base(main, feature-branch)..feature-branch
 ocr review --from main --to feature-branch
 
 # Один коммит

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,7 +135,7 @@ cd your-project
 # 工作区模式 —— 审查所有暂存、未暂存和未跟踪的变更
 ocr review
 
-# 分支范围 —— 比较两个引用
+# 分支范围 —— 审查 merge-base(main, feature-branch)..feature-branch
 ocr review --from main --to feature-branch
 
 # 单个提交

--- a/cmd/opencodereview/flags.go
+++ b/cmd/opencodereview/flags.go
@@ -208,7 +208,7 @@ Examples:
   # Review staged + unstaged + untracked changes in current workspace
   ocr review
 
-  # Review a branch against its base (merge-base mode)
+  # Review a branch range: merge-base(master, dev-ref)..dev-ref
   ocr review --from master --to dev-ref
 
   # Review a specific commit

--- a/pages/src/content/docs/en/quickstart.md
+++ b/pages/src/content/docs/en/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # Workspace mode — reviews staged + unstaged + untracked changes (default)
 ocr review
 
-# Branch range — reviews `main..feature-branch`
+# Branch range — reviews `merge-base(main, feature-branch)..feature-branch`
 ocr review --from main --to feature-branch
 
 # Single commit — reviews the diff that commit introduced

--- a/pages/src/content/docs/ja/quickstart.md
+++ b/pages/src/content/docs/ja/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # ワークスペースモード —— staged + unstaged + untracked の変更をレビュー（デフォルト）
 ocr review
 
-# ブランチ区間 —— `main..feature-branch` をレビュー
+# ブランチ区間 —— `merge-base(main, feature-branch)..feature-branch` をレビュー
 ocr review --from main --to feature-branch
 
 # 単一 commit —— その commit が導入した diff をレビュー

--- a/pages/src/content/docs/ru/quickstart.md
+++ b/pages/src/content/docs/ru/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # Все локальные изменения, включая новые файлы
 ocr review
 
-# Изменения в feature-branch относительно main
+# Изменения в feature-branch относительно merge-base(main, feature-branch)
 ocr review --from main --to feature-branch
 
 # Изменения, внесённые коммитом abc123

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # 工作区模式 —— 评审 staged + unstaged + untracked 变更（默认）
 ocr review
 
-# 分支区间 —— 评审 `main..feature-branch`
+# 分支区间 —— 评审 `merge-base(main, feature-branch)..feature-branch`
 ocr review --from main --to feature-branch
 
 # 单个 commit —— 评审该 commit 引入的 diff


### PR DESCRIPTION
Fixes #579.

Range mode reviews `merge-base(from, to)..to`, but the README examples only said "compare two refs" and the quickstart docs claimed `main..feature-branch`, which contradicted both the CLI help and the CLI reference. I updated the branch-range example comments in the READMEs and the quickstart pages (all locales) to state the merge-base range explicitly, and made the `ocr review --help` example spell out the same range instead of only naming "merge-base mode".

I could not run the full suite in my environment, but the file-level lint and checks I could run on the changed files pass; CI should confirm the rest.
