### PR TITLE
refactor(test): remove config migration comments

### DIFF
--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -369,10 +369,6 @@ func TestSetConfigValueCustomProviderExtraHeaders(t *testing.T) {
 
 // --- unset tests ---
 
-// parseConfigArgs unset tests were removed with the helper; unset dispatch is
-// covered by the TestRunConfigUnset_* tests and config_dispatch_test.go, and the
-// deeper unset behavior by the TestDeleteCustomProvider / provider tests below.
-
 func TestUnsetCustomProvider(t *testing.T) {
 	dir := t.TempDir()
 	configPath := dir + "/config.json"

--- a/cmd/opencodereview/flags_test.go
+++ b/cmd/opencodereview/flags_test.go
@@ -146,6 +146,3 @@ func TestParseReviewFlags_ShortFlags(t *testing.T) {
 		t.Error("expected preview=true")
 	}
 }
-
-// Config argument parsing is exercised through runConfig (see
-// config_dispatch_test.go), which now routes via the production cobra tree.


### PR DESCRIPTION
## Summary

- remove the historical `parseConfigArgs` migration comment from `config_cmd_test.go`
- remove the historical config parsing migration comment from `flags_test.go`
- keep source comments focused on current behavior rather than refactor history

Closes #662

## Testing

- `LC_ALL=C go test -v -race -count=1 ./cmd/opencodereview` (Go 1.25.12)
- `make check` (Go 1.25.12)

The affected package and static checks pass. A full local `make test` run on macOS with Go 1.26.5 reached an unrelated existing stress test in `internal/llmloop` and the race runtime aborted with `too many address space collisions`; no changed code is in that package.
