### PR TITLE
feat(llm): add GPT-5.6 models to OpenAI provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -46,6 +46,9 @@ var registry = []Provider{
 		BaseURL:     "https://api.openai.com/v1",
 		EnvVar:      "OPENAI_API_KEY",
 		Models: []string{
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
 			"gpt-5.5",
 			"gpt-5.4",
 			"gpt-5.4-mini",

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -125,6 +125,22 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 	if p.AuthHeader != "" {
 		t.Errorf("AuthHeader = %q, want empty", p.AuthHeader)
 	}
+	expectedModels := []string{
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.6-luna",
+		"gpt-5.5",
+		"gpt-5.4",
+		"gpt-5.4-mini",
+	}
+	if len(p.Models) != len(expectedModels) {
+		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))
+	}
+	for i, model := range expectedModels {
+		if p.Models[i] != model {
+			t.Errorf("Models[%d] = %q, want %q", i, p.Models[i], model)
+		}
+	}
 }
 
 func TestLookupProvider_OllamaCloudDetails(t *testing.T) {


### PR DESCRIPTION

## Description

Adds the OpenAI GPT-5.6 model tiers to the built-in provider registry:

- `gpt-5.6-sol`
- `gpt-5.6-terra`
- `gpt-5.6-luna`

Existing OpenAI models remain available. The OpenAI provider test now verifies the complete ordered model list.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing

```bash
go test ./internal/llm -run TestLookupProvider_OpenAIDetails -count=1 -v
go test ./internal/llm/...
make test
make check
git diff --check
```

Manually verified that the OpenAI model picker exposes the new model IDs. No API key or LLM request was required.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Part of the provider registry update issue #632 
