### PR TITLE
fix(telemetry): honour a base path in the OTLP HTTP endpoint

### DIFF
--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -46,6 +46,39 @@ func parseOTLPEndpoint(endpoint string) (addr string, insecure bool) {
 	}
 }
 
+// otlpSignalURL builds the URL for one signal from the configured endpoint.
+//
+// OTEL_EXPORTER_OTLP_ENDPOINT is defined by the OpenTelemetry specification as a BASE
+// URL for the HTTP protocols, to which the per-signal path is appended: an endpoint of
+// "https://backend.example.com" sends traces to "https://backend.example.com/v1/traces".
+// WithEndpointURL, by contrast, takes the full signal URL — it assigns u.Path straight
+// to URLPath — so the signal path has to be appended here rather than left to the SDK.
+//
+// Two details this has to get right:
+//
+//   - A bare host:port keeps the meaning parseOTLPEndpoint gave it, TLS, by gaining an
+//     https:// scheme. WithEndpointURL derives Insecure from the scheme
+//     (`u.Scheme != "https"`), which is what the explicit WithInsecure call used to do,
+//     so an existing configuration behaves identically after this change.
+//   - An endpoint that already names the signal path is left alone. Someone who worked
+//     around the missing path support by writing it out in full should not end up with
+//     "/v1/traces/v1/traces".
+func otlpSignalURL(endpoint, signalPath string) string {
+	base := endpoint
+	switch {
+	case len(base) >= 7 && strings.EqualFold(base[:7], "http://"):
+	case len(base) >= 8 && strings.EqualFold(base[:8], "https://"):
+	default:
+		base = "https://" + base
+	}
+
+	base = strings.TrimRight(base, "/")
+	if strings.HasSuffix(base, signalPath) {
+		return base
+	}
+	return base + signalPath
+}
+
 // initOTLPProviders dispatches to the gRPC or HTTP exporter based on cfg.OTLPProtocol.
 func initOTLPProviders(ctx context.Context, res *resource.Resource, cfg Config) {
 	switch cfg.OTLPProtocol {
@@ -99,14 +132,24 @@ func initOTLPGRPCProviders(ctx context.Context, res *resource.Resource, cfg Conf
 }
 
 // initOTLPHTTPProviders sets up OTLP HTTP exporters for traces and metrics.
+//
+// Unlike the gRPC path this uses WithEndpointURL rather than WithEndpoint, so that a
+// base path in OTEL_EXPORTER_OTLP_ENDPOINT is honoured. WithEndpoint takes a bare
+// host:port and cannot express a path, so every request went to /v1/traces at the root
+// of the host regardless of what the endpoint said.
+//
+// That silently excludes any backend reached through a path prefix. Langfuse receives
+// OTLP at /api/public/otel, for instance, so an endpoint of
+// "http://langfuse:3000/api/public/otel" produced requests to
+// "http://langfuse:3000/v1/traces" and every span was dropped with a 404.
+//
+// The signal path is appended by otlpSignalURL rather than by the SDK: WithEndpointURL
+// assigns the URL's path straight to URLPath, so it expects the full signal URL, while
+// OTEL_EXPORTER_OTLP_ENDPOINT is specified as a base. It also derives TLS from the
+// scheme, which is what the separate WithInsecure call was doing by hand.
 func initOTLPHTTPProviders(ctx context.Context, res *resource.Resource, cfg Config) {
-	addr, insecure := parseOTLPEndpoint(cfg.OTLPEndpoint)
-
-	traceOpts := []otlptracehttp.Option{otlptracehttp.WithEndpoint(addr)}
-	if insecure {
-		traceOpts = append(traceOpts, otlptracehttp.WithInsecure())
-	}
-	traceExp, err := otlptracehttp.New(ctx, traceOpts...)
+	traceExp, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpointURL(otlpSignalURL(cfg.OTLPEndpoint, "/v1/traces")))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to create OTLP HTTP trace exporter: %v\n", err)
 		return
@@ -119,11 +162,8 @@ func initOTLPHTTPProviders(ctx context.Context, res *resource.Resource, cfg Conf
 	tracerProvider = tp
 	shutdownFuncs = append(shutdownFuncs, func(ctx context.Context) error { return tp.Shutdown(ctx) })
 
-	metricOpts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpoint(addr)}
-	if insecure {
-		metricOpts = append(metricOpts, otlpmetrichttp.WithInsecure())
-	}
-	metricExp, err := otlpmetrichttp.New(ctx, metricOpts...)
+	metricExp, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithEndpointURL(otlpSignalURL(cfg.OTLPEndpoint, "/v1/metrics")))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to create OTLP HTTP metric exporter: %v\n", err)
 		return

--- a/internal/telemetry/exporter_test.go
+++ b/internal/telemetry/exporter_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -200,5 +203,95 @@ func TestInitOTLPProviders_ProtocolRouting(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestOTLPSignalURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		signal   string
+		want     string
+	}{
+		{"http scheme keeps its scheme", "http://192.0.2.1:4318", "/v1/traces", "http://192.0.2.1:4318/v1/traces"},
+		{"https scheme keeps its scheme", "https://otel.example.com:4318", "/v1/traces", "https://otel.example.com:4318/v1/traces"},
+		{"bare host:port gains https to keep TLS", "localhost:4318", "/v1/traces", "https://localhost:4318/v1/traces"},
+		{"a base path is preserved", "http://langfuse:3000/api/public/otel", "/v1/traces", "http://langfuse:3000/api/public/otel/v1/traces"},
+		{"a trailing slash does not double up", "http://192.0.2.1:4318/", "/v1/traces", "http://192.0.2.1:4318/v1/traces"},
+		{"an endpoint already naming the signal is left alone", "http://192.0.2.1:4318/v1/traces", "/v1/traces", "http://192.0.2.1:4318/v1/traces"},
+		{"metrics get their own path", "http://192.0.2.1:4318", "/v1/metrics", "http://192.0.2.1:4318/v1/metrics"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := otlpSignalURL(tc.endpoint, tc.signal); got != tc.want {
+				t.Errorf("otlpSignalURL(%q, %q) = %q, want %q", tc.endpoint, tc.signal, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInitOTLPHTTPProviders_HonoursBasePath is the regression test for the bug this
+// exporter had: WithEndpoint takes a bare host:port, so a base path in
+// OTEL_EXPORTER_OTLP_ENDPOINT was discarded and every span went to /v1/traces at the
+// root of the host. Backends addressed through a path prefix therefore answered 404
+// and no telemetry arrived, with nothing in the exporter to say why.
+//
+// The assertion is on the request path the collector actually receives, because that is
+// the thing that was wrong — a unit test of the URL helper alone would not have caught
+// it, since the helper did not exist and the discarding happened in the exporter option.
+//
+// It also covers the TLS decision that moved into WithEndpointURL. httptest.NewServer
+// speaks plaintext and its URL carries an http:// scheme, so the request only arrives if
+// Insecure was resolved to true from that scheme — which is what the explicit
+// WithInsecure call used to do. A regression there shows up here as a timeout rather
+// than as a wrong path.
+func TestInitOTLPHTTPProviders_HonoursBasePath(t *testing.T) {
+	const basePath = "/api/public/otel"
+
+	gotPath := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotPath <- r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tracerProvider = nil
+	meterProvider = nil
+	shutdownFuncs = nil
+	defer func() {
+		for _, fn := range shutdownFuncs {
+			_ = fn(context.Background())
+		}
+		tracerProvider = nil
+		meterProvider = nil
+		shutdownFuncs = nil
+	}()
+
+	cfg := Config{
+		Exporter:     "otlp",
+		OTLPEndpoint: srv.URL + basePath,
+		OTLPProtocol: "http/protobuf",
+	}
+	initOTLPHTTPProviders(context.Background(), resource.Default(), cfg)
+	if tracerProvider == nil {
+		t.Fatal("tracerProvider was not set")
+	}
+
+	_, span := tracerProvider.Tracer("test").Start(context.Background(), "probe")
+	span.End()
+	if err := tracerProvider.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush() = %v", err)
+	}
+
+	select {
+	case path := <-gotPath:
+		if want := basePath + "/v1/traces"; path != want {
+			t.Errorf("collector received %q, want %q", path, want)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the collector was never called; the endpoint's base path was discarded")
 	}
 }

--- a/pages/src/content/docs/en/telemetry.md
+++ b/pages/src/content/docs/en/telemetry.md
@@ -61,15 +61,45 @@ The result in `~/.opencodereview/config.json`:
 ```bash
 export OCR_ENABLE_TELEMETRY=1
 export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317   # implies exporter=otlp
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default. NOTE: only grpc is currently
-                                                    # implemented; http/protobuf and http/json
-                                                    # are accepted but not yet wired up.
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default; http/protobuf and http/json
+                                                    # are also supported
 export OTEL_SERVICE_NAME=open-code-review-prod      # optional; default: open-code-review
 export OCR_CONTENT_LOGGING=0                        # reserved / currently a no-op (see Content logging)
 ```
 
 Setting `OTEL_EXPORTER_OTLP_ENDPOINT` also forces `exporter=otlp` —
 useful for one-off `OTEL_EXPORTER_OTLP_ENDPOINT=… ocr review` runs.
+
+### Endpoint format
+
+The endpoint may be a bare `host:port` or carry a scheme. With a scheme, the
+scheme decides the transport security: `http://` is plaintext, `https://` uses
+TLS. A bare `host:port` uses TLS.
+
+Note that the default port differs by protocol — `4317` for gRPC, `4318` for
+HTTP:
+
+```bash
+# gRPC (default)
+export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+
+# HTTP
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+For the HTTP protocols the endpoint is a **base URL**, and the per-signal path
+is appended to it — so `http://localhost:4318` sends traces to
+`http://localhost:4318/v1/traces`. A base path is preserved, which is what
+backends served under a prefix require:
+
+```bash
+# traces go to http://collector:3000/api/public/otel/v1/traces
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:3000/api/public/otel
+```
+
+gRPC has no URL path, so this applies to the HTTP protocols only.
 
 ## What gets exported
 
@@ -267,7 +297,8 @@ and continues; the review still produces its normal output.
 | Symptom | Likely cause |
 |---|---|
 | Nothing exported | `OCR_ENABLE_TELEMETRY` / `telemetry.enabled` is unset. The default is **off**. |
-| OTLP works locally, fails in prod | OCR currently only implements OTLP/gRPC — `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or `http/json`) is accepted but not yet wired up, so switching it won't help. Verify the endpoint and that the collector is listening for gRPC. |
+| OTLP works locally, fails in prod | Check that the protocol matches the collector. The default is gRPC, and many managed backends accept OTLP over HTTP only — set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` and use the HTTP port (`4318`, not `4317`). |
+| Nothing arrives, no error | The exporter is created lazily, so a wrong endpoint fails silently at export time rather than at startup. Check the collector's access log for the path being requested: for the HTTP protocols the endpoint is a base URL and the signal path is appended, so `http://host:4318` posts to `http://host:4318/v1/traces`. |
 | Spans show but no metrics | Some collectors only enable the traces pipeline by default; add a `metrics` pipeline in the config. |
 | Prompts missing from spans | OCR never attaches prompt content to telemetry — see [Content logging](#content-logging). Inspect transcripts via [Session Viewer](../viewer/) instead. |
 

--- a/pages/src/content/docs/ja/telemetry.md
+++ b/pages/src/content/docs/ja/telemetry.md
@@ -57,9 +57,8 @@ ocr config set telemetry.content_logging false
 ```bash
 export OCR_ENABLE_TELEMETRY=1
 export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317   # implies exporter=otlp
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default. NOTE: only grpc is currently
-                                                    # implemented; http/protobuf and http/json
-                                                    # are accepted but not yet wired up.
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default; http/protobuf and http/json
+                                                    # are also supported
 export OTEL_SERVICE_NAME=open-code-review-prod      # optional; default: open-code-review
 export OCR_CONTENT_LOGGING=0                        # reserved / currently a no-op (see Content logging)
 ```

--- a/pages/src/content/docs/zh/telemetry.md
+++ b/pages/src/content/docs/zh/telemetry.md
@@ -57,9 +57,8 @@ ocr config set telemetry.content_logging false
 ```bash
 export OCR_ENABLE_TELEMETRY=1
 export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317   # implies exporter=otlp
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default. NOTE: only grpc is currently
-                                                    # implemented; http/protobuf and http/json
-                                                    # are accepted but not yet wired up.
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc             # default; http/protobuf and http/json
+                                                    # are also supported
 export OTEL_SERVICE_NAME=open-code-review-prod      # optional; default: open-code-review
 export OCR_CONTENT_LOGGING=0                        # reserved / currently a no-op (see Content logging)
 ```


### PR DESCRIPTION
## Description

The OTLP **HTTP** exporters were configured with `WithEndpoint`, which takes a bare `host:port` and cannot express a path, and `WithURLPath` is never called. Any path in `OTEL_EXPORTER_OTLP_ENDPOINT` was therefore discarded and every request went to `/v1/traces` (or `/v1/metrics`) at the **root** of the host.

That silently excludes any backend addressed through a path prefix. Langfuse, for example, receives OTLP at `/api/public/otel`, so:

```
OTEL_EXPORTER_OTLP_ENDPOINT=http://langfuse:3000/api/public/otel
OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
```

produced requests to `http://langfuse:3000/v1/traces`. The backend answered `404` and every span was dropped. Nothing surfaced the problem: exporter creation is lazy, so telemetry appears to initialise correctly and the failure only shows up as missing data.

### The change

The HTTP path now uses `WithEndpointURL`, which accepts a scheme and a path and derives TLS from the scheme — replacing the explicit `WithInsecure` call so the decision is made from one source rather than two.

The signal path is appended by a new `otlpSignalURL` helper rather than left to the SDK, because `WithEndpointURL` assigns the URL's path straight to `URLPath` and so expects the *full* signal URL, while `OTEL_EXPORTER_OTLP_ENDPOINT` is specified as a *base*.

Existing behaviour is preserved in both directions:

| Endpoint | Before | After |
|---|---|---|
| `http://host:4318` | plaintext, `/v1/traces` | plaintext, `/v1/traces` |
| `https://host:4318` | TLS, `/v1/traces` | TLS, `/v1/traces` |
| `host:4318` (no scheme) | TLS, `/v1/traces` | TLS, `/v1/traces` |
| `http://host:3000/base` | plaintext, `/v1/traces` ❌ | plaintext, `/base/v1/traces` ✅ |
| `http://host:4318/v1/traces` | plaintext, `/v1/traces` | plaintext, `/v1/traces` (not doubled) |

The last row matters: anyone who worked around this by writing the signal path out in full keeps working.

`parseOTLPEndpoint` is unchanged and still used by the **gRPC** path, where `WithEndpoint` genuinely does take a bare `host:port` — gRPC has no URL path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (described below)

Two tests were added:

- **`TestInitOTLPHTTPProviders_HonoursBasePath`** stands up an `httptest` collector under a `/api/public/otel` prefix, exports a span, and asserts on the request path the collector actually receives. This is the regression test: it **fails against the previous implementation** (receives `/v1/traces`, wants `/api/public/otel/v1/traces`), which I verified by reverting the fix with the test in place. It also covers the TLS decision that moved into `WithEndpointURL` — `httptest.NewServer` speaks plaintext, so the request only arrives if `Insecure` was resolved to `true` from the `http://` scheme.
- **`TestOTLPSignalURL`** covers the normalisation table above, including the trailing-slash and already-has-the-signal-path cases.

Existing tests are unchanged and pass, including `TestParseOTLPEndpoint` (that function keeps its behaviour for gRPC).

Verified with the project's own targets: `gofmt -s` clean, `go vet` clean, `go test -race -count=1 ./internal/telemetry/` green.

Manual verification of the real-world case that prompted this: with `OTEL_ENABLE_TELEMETRY=1` and an endpoint carrying a base path, requests now reach `<base>/v1/traces` instead of `/v1/traces`.

## Documentation

`pages/src/content/docs/*/telemetry.md` claimed in two places that the HTTP protocols were "accepted but not yet wired up". They are — `initOTLPProviders` routes both to `initOTLPHTTPProviders`, and `TestInitOTLPProviders_ProtocolRouting` covers it.

The troubleshooting row was the more costly of the two, because it surfaces exactly when someone is debugging this and points the wrong way ("switching it won't help ... verify the collector is listening for gRPC"). Replaced with the check that does help, plus a row for the failure mode that produces no error at all: exporter creation is lazy, so a wrong endpoint fails silently at export time.

Also added an **Endpoint format** section covering three things that were undocumented and are each easy to get wrong:

- the scheme decides transport security (`http://` plaintext, `https://` and bare `host:port` TLS);
- the default port differs by protocol — `4317` for gRPC, `4318` for HTTP — while every example used `4317`;
- for the HTTP protocols the endpoint is a base URL to which the signal path is appended, and a base path is preserved.

**Translations:** the `ja` and `zh` code blocks carry that note in English, so they are corrected here. Their **troubleshooting rows are translated prose** and I have deliberately left them alone rather than guess at Japanese and Chinese I cannot review — they still carry the outdated claim and would need a translator:

- `pages/src/content/docs/ja/telemetry.md:249`
- `pages/src/content/docs/zh/telemetry.md:249`

Happy to take a suggested wording in either language and apply it here.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

closes #668
