### PR TITLE
fix(llm): retry once when a chat completion is truncated

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -8,7 +8,9 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -362,6 +364,23 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 	}
 
 	sdkResp, err := c.sdk.Chat.Completions.New(ctx, params, opts...)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		retryResp, retryErr := c.sdk.Chat.Completions.New(ctx, params, opts...)
+		if retryErr == nil {
+			sdkResp = retryResp
+			err = nil
+		} else {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if !errors.Is(retryErr, io.ErrUnexpectedEOF) {
+				err = retryErr
+			}
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -506,6 +507,161 @@ func TestOpenAIClient_ExtraHeadersSent(t *testing.T) {
 	}
 	if gotOrgID != "org-abc" {
 		t.Errorf("X-Org-ID = %q, want %q", gotOrgID, "org-abc")
+	}
+}
+
+func TestOpenAIClient_RetriesTruncatedResponse(t *testing.T) {
+	const responseBody = `{
+		"id":"chatcmpl-retry",
+		"object":"chat.completion",
+		"model":"gpt-retry",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"recovered"},"finish_reason":"stop"}]
+	}`
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if request == 1 {
+			w.Header().Set("Content-Length", fmt.Sprint(len(responseBody)))
+			_, _ = fmt.Fprint(w, responseBody[:len(responseBody)/2])
+			return
+		}
+		_, _ = fmt.Fprint(w, responseBody)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-retry",
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+	if got := resp.Content(); got != "recovered" {
+		t.Errorf("Content() = %q, want %q", got, "recovered")
+	}
+}
+
+func TestOpenAIClient_StopsAfterSecondTruncatedResponse(t *testing.T) {
+	const responseBody = `{
+		"id":"chatcmpl-truncated",
+		"object":"chat.completion",
+		"model":"gpt-retry",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"incomplete"},"finish_reason":"stop"}]
+	}`
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", fmt.Sprint(len(responseBody)))
+		_, _ = fmt.Fprint(w, responseBody[:len(responseBody)/2])
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-retry",
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("error = %v, want io.ErrUnexpectedEOF", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestOpenAIClient_DoesNotRetryNonRetryableError(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"invalid request","type":"invalid_request_error"}}`)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-test",
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if err == nil {
+		t.Fatal("error = nil, want API error")
+	}
+	if !strings.Contains(err.Error(), "invalid request") {
+		t.Fatalf("error = %v, want error containing %q", err, "invalid request")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+}
+
+func TestOpenAIClient_DoesNotRetryTruncatedResponseAfterCancellation(t *testing.T) {
+	const responseBody = `{
+		"id":"chatcmpl-canceled",
+		"object":"chat.completion",
+		"model":"gpt-retry",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"incomplete"},"finish_reason":"stop"}]
+	}`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", fmt.Sprint(len(responseBody)))
+		_, _ = fmt.Fprint(w, responseBody[:len(responseBody)/2])
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		cancel()
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gpt-retry",
+	})
+
+	resp, err := client.CompletionsWithCtx(ctx, ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if resp != nil {
+		t.Fatalf("response = %#v, want nil", resp)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Description

A truncated LLM response body surfaces from the SDK as `io.ErrUnexpectedEOF`, and the client returned it straight to the caller. A single truncated stream therefore failed the whole review run even though a retry would usually succeed.

This retries the completion exactly once when the error is `io.ErrUnexpectedEOF`, and otherwise leaves behavior unchanged.

Closes #664

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

Added four table-free unit tests in `internal/llm/client_test.go` that drive the client against a stub server, then verified they actually pin the new behavior by reverting the implementation and re-running them.

Retry semantics covered by the tests:

- `TestOpenAIClient_RetriesTruncatedResponse` - one truncated response then a good one succeeds.
- `TestOpenAIClient_StopsAfterSecondTruncatedResponse` - two consecutive truncations give up and return the error (exactly 2 requests, no unbounded retry loop).
- `TestOpenAIClient_DoesNotRetryNonRetryableError` - a non-EOF error is returned immediately without a second request.
- `TestOpenAIClient_DoesNotRetryTruncatedResponseAfterCancellation` - a cancelled context returns the context error instead of retrying.

Regression proof, so these are not vacuous. With `internal/llm/client.go` reverted to `main` and only the tests applied:

```
--- FAIL: TestOpenAIClient_RetriesTruncatedResponse (0.00s)
    client_test.go:544: CompletionsWithCtx: error reading response body: unexpected EOF
--- FAIL: TestOpenAIClient_StopsAfterSecondTruncatedResponse (0.00s)
    client_test.go:587: requests = 1, want 2
FAIL
```

With the fix applied, `go test -count=1 ./internal/llm/...` is `ok`.

- [ ] `make test` passes locally
  Not run: I ran the package directly (`go test -count=1 ./internal/llm/...`, ok) rather than the full `make test` target, which reaches beyond this package.
- [x] Manual testing (describe below)
  The revert-and-rerun regression proof above was done by hand.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
  `gofmt -l internal/llm/` is empty and `go vet ./internal/llm/...` is clean.
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
  See the regression proof above; the tests fail against `main` and pass with the change.

## Related Issues

Closes #664. No other open issue or PR touches `internal/llm/client.go` retry behavior as far as I can see.

## Implementation notes

The retry is deliberately narrow:

- It triggers only on `errors.Is(err, io.ErrUnexpectedEOF)`, so ordinary API errors, rate limits, and auth failures are untouched.
- It retries at most once. A second truncation returns the error rather than looping.
- It checks `ctx.Err()` before retrying and again after a failed retry, so a cancelled or timed-out context returns the context error and never issues an extra request.
- On a failed retry that is itself an unexpected EOF, the original error is preserved rather than replaced, so the caller sees the same error class as before.

## Notes for reviewers

Two things worth your judgment:

1. Retry count is fixed at one, with no backoff. For a truncated stream an immediate retry is usually right, but if you would prefer this to go through a shared retry/backoff helper, point me at it and I will rework it.
2. I scoped this strictly to `internal/llm`. While testing I noticed the Python example suites under `examples/*_ci/` do not collect cleanly without `__init__.py` files, which is unrelated to this issue; I left it alone rather than widen the PR. Happy to file that separately if it is news to you.
