### PR TITLE
[WIP] feat: add ACP support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,12 @@ OpenCodeReview currently provides:
   PyCharm, and other JetBrains IDEs with the same capabilities as the
   existing VSCode extension.
 
+### Agent Client Protocol (ACP)
+
+- **ACP server adapter** — Expose OpenCodeReview as a specialized review
+  agent for Paseo and other ACP-compatible clients, while keeping the
+  protocol integration decoupled from the core review engine.
+
 ### Delegate Mode
 
 - **Subscription-friendly review** — An opt-in mode where `ocr` no longer


### PR DESCRIPTION
## Description

Add Agent Client Protocol (ACP) support to the H2 2026 roadmap.

This draft PR serves as a planning placeholder while the implementation approach is evaluated. The current direction is to expose OpenCodeReview as a specialized review agent for Paseo and other ACP-compatible clients through a decoupled ACP server adapter.

This PR does not implement ACP support yet.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

Documentation-only change; verified with `git diff --check`.

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Tracks #674.
