### PR TITLE
feat(allowlist): exclude snapshots, testdata, fixtures, and generated code from review

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -130,6 +130,33 @@ func TestIsExcludedPath(t *testing.T) {
 		{"julia test nested", "MyPkg/test/unit/foo.jl", true},
 		{"julia non-test", "src/model.jl", false},
 
+		// Snapshot files
+		{"jest snapshot dir", "src/__snapshots__/App.test.js.snap", true},
+		{"snap file", "src/components/Button.snap", true},
+		{"snap deeply nested", "packages/ui/src/__snapshots__/util.snap", true},
+
+		// Test data directories
+		{"testdata go", "internal/parser/testdata/input.json", true},
+		{"testdata nested", "pkg/a/b/testdata/golden.txt", true},
+		{"fixtures dir", "test/fixtures/sample.json", true},
+		{"fixtures nested", "spec/fixtures/users.yml", true},
+
+		// Generated code
+		{"generated go", "api/types.generated.go", true},
+		{"generated ts", "src/graphql/schema.generated.ts", true},
+		{"gen go", "proto/message.gen.go", true},
+		{"pb go", "api/v1/service.pb.go", true},
+		{"pb cc", "proto/message.pb.cc", true},
+		{"pb h", "proto/message.pb.h", true},
+
+		// Non-matches for new patterns
+		{"snapshots in name", "src/snapshots/util.ts", false},
+		{"testdata in filename", "src/testdata.go", false},
+		{"fixtures in filename", "src/fixtures.ts", false},
+		{"generated not dotted", "src/generated/code.go", false},
+		{"gen not suffix", "src/gen/util.go", false},
+		{"pb not suffix", "src/pb/client.go", false},
+
 		// Case insensitive
 		{"case insensitive go", "Foo/Bar_Test.go", true},
 		{"case insensitive java", "com/FooTEST.java", true}, // lowercase → "com/footest.java" matches "**/*test.java"

--- a/internal/config/allowlist/default_exclude_patterns.json
+++ b/internal/config/allowlist/default_exclude_patterns.json
@@ -15,5 +15,15 @@
   "**/*_test.rs",
   "**/oh_modules/**",
   "**/*.test.ets",
-  "**/test/**/*.jl"
+  "**/test/**/*.jl",
+
+  "**/__snapshots__/**",
+  "**/*.snap",
+  "**/testdata/**",
+  "**/fixtures/**",
+  "**/*.generated.*",
+  "**/*.gen.go",
+  "**/*.pb.go",
+  "**/*.pb.cc",
+  "**/*.pb.h"
 ]


### PR DESCRIPTION
## Summary

- Add 9 new patterns to `default_exclude_patterns.json` to skip files that pass existing filters but have low review value:
  - **Snapshot files**: `__snapshots__/**`, `*.snap` (Jest/Vitest auto-generated)
  - **Test data directories**: `testdata/**`, `fixtures/**` (fixture data, not manually authored logic)
  - **Generated code**: `*.generated.*`, `*.gen.go`, `*.pb.go`, `*.pb.cc`, `*.pb.h` (protobuf/codegen output)
- Add 16 test cases covering both positive matches and negative (non-match) assertions to prevent false positives

## Rationale

These files are tracked by Git and have allowed extensions, so they reach the review stage. However, reviewing auto-generated protobuf stubs or golden-file test fixtures yields no actionable feedback. This change reduces noise without affecting user-authored code.

## Test plan

- [x] `make test` — all tests pass including new `TestIsExcludedPath` cases
- [x] `make check` — formatting and vet clean
- [x] `ocr review` — no comments on the change itself