### PR TITLE
feat(examples/gitlab): add fail-open category/severity publication controls

### DIFF
--- a/examples/gitlab_ci/.gitlab-ci.yml
+++ b/examples/gitlab_ci/.gitlab-ci.yml
@@ -22,6 +22,10 @@
 #   OCR_FAILURE_DELAY       - Delay (ms) after a non-rate-limit failure to pace subsequent requests (default: 1000)
 #   OCR_RATE_LIMIT_THRESHOLD - Proactively slow down when GitLab RateLimit-Remaining is at/below this value (default: 10, set 0 to disable)
 #
+# Optional CI/CD Variables (for category/severity publication routing):
+#   OCR_ROUTE_SEVERITY_BELOW  - Route findings at-or-below this severity (critical/high/medium/low) to summary notes instead of inline (fail-open; empty disables)
+#   OCR_ROUTE_CATEGORIES      - Comma-separated categories to route to summary (bug, security, performance, maintainability, test, style, documentation, other)
+#
 # Note: The pipeline also configures llm.extra_body to '{"thinking": {"type": "disabled"}}'
 #   to disable thinking mode for compatibility with various LLM providers.
 #

--- a/examples/gitlab_ci/README.md
+++ b/examples/gitlab_ci/README.md
@@ -62,8 +62,8 @@ You need a token with `api` scope to post discussions on MRs. Options:
 When an MR is reviewed, comments appear as:
 
 - **Inline discussions**: Directly on the changed lines in the MR diff view
-- **Summary note**: A final note summarizing the total number of issues found
-- **Fallback notes**: If inline posting fails for specific comments, they appear as regular MR notes with file/line references
+- **Summary note**: A final note summarizing the total number of issues found and how they were posted (inline, no line info, routed by policy, or failed)
+- **Fallback notes**: Comments without line info, routed by category/severity policy, or failed inline posts appear as separate MR notes
 
 ### Inline Discussion Example
 
@@ -110,6 +110,8 @@ When posting review discussions, the script includes rate-limit handling with ex
 | `OCR_SUCCESS_DELAY` | `2000` | Delay (ms) after a successful discussion post to pace subsequent requests |
 | `OCR_FAILURE_DELAY` | `1000` | Delay (ms) after a non-rate-limit failure to pace subsequent requests |
 | `OCR_RATE_LIMIT_THRESHOLD` | `10` | Proactively slow down when GitLab `RateLimit-Remaining` is at/below this value (set `0` to disable) |
+| `OCR_ROUTE_SEVERITY_BELOW` | _(empty)_ | Optional severity threshold (`critical`, `high`, `medium`, `low`) that routes findings at-or-below it from inline comments to summary notes (fail-open: never drops a finding). Empty or unknown values disable severity routing. |
+| `OCR_ROUTE_CATEGORIES` | _(empty)_ | Optional comma-separated categories (`bug`, `security`, `performance`, `maintainability`, `test`, `style`, `documentation`, `other`) routed from inline to summary notes. Unknown tokens are ignored. Combine with `OCR_ROUTE_SEVERITY_BELOW` to route on either condition. |
 
 These variables are optional — if not configured, sensible defaults are used. Consider increasing delays for self-hosted GitLab instances with aggressive rate-limit configurations or for large MRs that generate numerous review comments. The `OCR_RATE_LIMIT_THRESHOLD` variable enables proactive throttling: when GitLab reports low remaining quota in the `RateLimit-Remaining` response header, the script automatically doubles the pacing delay to avoid hitting 429 errors.
 

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -121,12 +121,10 @@ def route_comment(comment, policy):
     if not policy or (not policy.get("route_by_severity") and not policy.get("route_by_category")):
         return {"routed": False}
 
-    cat_raw = ""
-    if comment and comment.get("category") is not None:
-        cat_raw = str(comment["category"]).strip().lower()
-    sev_raw = ""
-    if comment and comment.get("severity") is not None:
-        sev_raw = str(comment["severity"]).strip().lower()
+    # Match build_badge: strip control chars before enum matching so badge
+    # labels and routing decisions stay consistent for malformed LLM output.
+    cat_raw = sanitize_metadata(comment.get("category") if comment else None).strip().lower()
+    sev_raw = sanitize_metadata(comment.get("severity") if comment else None).strip().lower()
 
     cat_known = cat_raw != "" and cat_raw in CATEGORIES
     sev_known = sev_raw != "" and sev_raw in SEVERITY_RANK

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -8,14 +8,17 @@ binary and lives entirely in the pipeline.  It reads the JSON emitted by
 discussions:
 
   - one inline discussion per comment that maps onto the diff,
-  - a single fallback note collecting comments that could not be placed inline,
+  - optional fail-open category/severity routing (``OCR_ROUTE_SEVERITY_BELOW``,
+    ``OCR_ROUTE_CATEGORIES``) that moves matching findings to summary notes,
+  - separate summary notes for comments without line info, routed-by-policy,
+    and failed inline posts,
   - a final summary note.
 
 The script separates a transport-agnostic :func:`publish` (driven by an
 injectable ``post`` callable) from the GitLab REST transport
-:func:`make_poster`, so the full posting flow — including retry/backoff and
-rate-limit throttling — can be unit-tested with no network access and no
-wall-clock sleep cost.
+:func:`make_poster`, so the full posting flow — including retry/backoff,
+rate-limit throttling, and publication routing — can be unit-tested with no
+network access and no wall-clock sleep cost.
 
 Standard library only (json, urllib) so it runs on any stock python3 image.
 """
@@ -39,6 +42,113 @@ def log(msg):
 
 
 # --------------------------------------------------------------------------- #
+# Category/severity badge + publication routing (fail-open)
+# --------------------------------------------------------------------------- #
+
+# Enumerations from the LLM output schema (internal/config/toolsconfig/tools.json).
+CATEGORIES = [
+    "bug",
+    "security",
+    "performance",
+    "maintainability",
+    "test",
+    "style",
+    "documentation",
+    "other",
+]
+SEVERITIES = ["critical", "high", "medium", "low"]
+SEVERITY_RANK = {s: len(SEVERITIES) - i for i, s in enumerate(SEVERITIES)}
+
+NO_ROUTING = {"route_by_severity": False, "route_by_category": False}
+NO_LINE_REASON = "No line information provided"
+
+
+def sanitize_metadata(value):
+    """Strip C0/C1 control characters from a metadata value."""
+    text = "" if value is None else str(value)
+    return "".join(ch for ch in text if not (("\x00" <= ch <= "\x1f") or ("\x7f" <= ch <= "\x9f")))
+
+
+def build_badge(comment):
+    """Build the category/severity badge for a comment."""
+    category = sanitize_metadata(comment.get("category") if comment else None)
+    severity = sanitize_metadata(comment.get("severity") if comment else None)
+    if category and severity:
+        return "[%s · %s]" % (category, severity)
+    if category:
+        return "[%s]" % category
+    if severity:
+        return "[%s]" % severity
+    return ""
+
+
+def build_policy(severity_threshold=None, categories=None):
+    """Parse fail-open publication policy from raw opt-in inputs."""
+    route_by_severity = False
+    severity_rank = -1
+    if severity_threshold is not None:
+        norm = str(severity_threshold).strip().lower()
+        if norm in SEVERITY_RANK:
+            route_by_severity = True
+            severity_rank = SEVERITY_RANK[norm]
+
+    route_by_category = False
+    category_set = set()
+    if categories is not None:
+        tokens = [
+            t.strip().lower()
+            for t in str(categories).split(",")
+            if t.strip()
+        ]
+        for token in tokens:
+            if token in CATEGORIES:
+                category_set.add(token)
+        if category_set:
+            route_by_category = True
+
+    if not route_by_severity and not route_by_category:
+        return NO_ROUTING
+    return {
+        "route_by_severity": route_by_severity,
+        "severity_rank": severity_rank,
+        "route_by_category": route_by_category,
+        "categories": category_set,
+    }
+
+
+def route_comment(comment, policy):
+    """Decide whether a comment routes to the summary per the policy."""
+    if not policy or (not policy.get("route_by_severity") and not policy.get("route_by_category")):
+        return {"routed": False}
+
+    cat_raw = ""
+    if comment and comment.get("category") is not None:
+        cat_raw = str(comment["category"]).strip().lower()
+    sev_raw = ""
+    if comment and comment.get("severity") is not None:
+        sev_raw = str(comment["severity"]).strip().lower()
+
+    cat_known = cat_raw != "" and cat_raw in CATEGORIES
+    sev_known = sev_raw != "" and sev_raw in SEVERITY_RANK
+
+    if policy.get("route_by_severity") and sev_known and SEVERITY_RANK[sev_raw] <= policy["severity_rank"]:
+        reason = "Routed to summary (severity %s" % sev_raw
+        if cat_known:
+            reason += " · category %s" % cat_raw
+        reason += ")"
+        return {"routed": True, "reason": reason}
+
+    if policy.get("route_by_category") and cat_known and cat_raw in policy.get("categories", set()):
+        reason = "Routed to summary (category %s" % cat_raw
+        if sev_known:
+            reason += " · severity %s" % sev_raw
+        reason += ")"
+        return {"routed": True, "reason": reason}
+
+    return {"routed": False}
+
+
+# --------------------------------------------------------------------------- #
 # Comment formatting (pure)
 # --------------------------------------------------------------------------- #
 
@@ -49,7 +159,11 @@ def format_comment(comment):
     Uses GitLab's ``suggestion:-0+0`` syntax so the suggestion renders as a
     one-click "Apply suggestion" button in the MR diff.
     """
-    body = comment.get("content", "")
+    body = ""
+    badge = build_badge(comment)
+    if badge:
+        body += badge + "\n"
+    body += comment.get("content", "")
 
     existing = comment.get("existing_code", "")
     suggestion = comment.get("suggestion_code", "")
@@ -60,18 +174,24 @@ def format_comment(comment):
     return body
 
 
-def format_comment_fallback(comment):
+def format_comment_fallback(comment, reason=None):
     """Format a comment for fallback (non-inline) display in a note.
 
     Uses ``<details><summary>`` HTML so the suggested change is collapsible
-    in the MR comment thread.
+    in the MR comment thread.  When ``reason`` is provided it is appended as
+    an italic line at the end (routing or posting failure context).
     """
+    md = ""
+    badge = build_badge(comment)
+    if badge:
+        md += badge + "\n"
+
     path = comment.get("path", "unknown")
     start_line = comment.get("start_line", 0)
     end_line = comment.get("end_line", 0)
     content = comment.get("content", "")
 
-    md = "### 📄 `%s`" % path
+    md += "### 📄 `%s`" % path
     if start_line and end_line:
         md += " (L%d-L%d)" % (start_line, end_line)
     md += "\n\n%s" % content
@@ -84,7 +204,26 @@ def format_comment_fallback(comment):
         md += "**After:**\n```\n%s\n```\n\n" % suggestion
         md += "</details>"
 
+    if reason:
+        md += "\n\n*%s*" % reason
+
     return md
+
+
+def build_summary_body(total, inline, summary, routed, failed, warnings):
+    """Merged summary header mirroring the GitHub Action breakdown."""
+    body = "🔍 **OpenCodeReview** found **%d** issue(s) in this MR." % total
+    if total > 0:
+        body += "\n- ✅ Successfully posted inline: %d comment(s)" % inline
+        if summary > 0:
+            body += "\n- 📝 In summary (no line info): %d comment(s)" % summary
+        if routed > 0:
+            body += "\n- 📋 Routed to summary by policy: %d comment(s)" % routed
+        if failed > 0:
+            body += "\n- ❌ Failed to post inline: %d comment(s)" % failed
+    if warnings:
+        body += "\n\n⚠️ %d warning(s) occurred during review." % len(warnings)
+    return body
 
 
 # --------------------------------------------------------------------------- #
@@ -105,29 +244,39 @@ def publish(result, diff_refs, post, config, sleep=_sleep):
     ``config`` provides pacing values (``success_delay``, ``failure_delay``,
     ``rate_limit_threshold``).
 
-    Returns ``{"inline": int, "fallback": int}``.
+    Returns ``{"inline": int, "fallback": int, "routed": int, "failed": int}``.
     """
     success_delay = config["success_delay"]
     failure_delay = config["failure_delay"]
     rate_limit_threshold = config["rate_limit_threshold"]
+    policy = build_policy(
+        severity_threshold=config.get("route_severity_below", ""),
+        categories=config.get("route_categories", ""),
+    )
 
     comments = result.get("comments") or []
     if not comments:
         message = result.get("message", "No comments generated. Looks good to me.")
         post({"body": "✅ **OpenCodeReview**: %s" % message})
-        return {"inline": 0, "fallback": 0}
+        return {"inline": 0, "fallback": 0, "routed": 0, "failed": 0}
 
     success_count = 0
+    no_line_comments = []
+    routed_comments = []
     failed_comments = []
 
     for comment in comments:
         path = comment.get("path", "")
         end_line = comment.get("end_line", 0)
-        start_line = comment.get("start_line", end_line)
         body = format_comment(comment)
 
         if not path or not end_line or not diff_refs:
-            failed_comments.append(comment)
+            no_line_comments.append({"comment": comment, "reason": NO_LINE_REASON})
+            continue
+
+        route = route_comment(comment, policy)
+        if route.get("routed"):
+            routed_comments.append({"comment": comment, "reason": route["reason"]})
             continue
 
         discussion = {
@@ -155,7 +304,10 @@ def publish(result, diff_refs, post, config, sleep=_sleep):
             else:
                 sleep(success_delay)
         else:
-            failed_comments.append(comment)
+            failed_comments.append({
+                "comment": comment,
+                "reason": "Failed to post inline comment",
+            })
             # Failure pacing: rate-limit-exhausted failures get the longer
             # success_delay; other failures get the shorter failure_delay.
             is_rate_limit_exhausted = (
@@ -167,26 +319,42 @@ def publish(result, diff_refs, post, config, sleep=_sleep):
 
     log("Successfully posted %d/%d inline comments." % (success_count, len(comments)))
 
-    # Post fallback for any failed inline comments
-    if failed_comments:
-        fallback_body = "🔍 **OpenCodeReview** found issues that could not be posted inline:\n\n---\n\n"
-        for comment in failed_comments:
-            fallback_body += format_comment_fallback(comment) + "\n\n---\n\n"
-        post({"body": fallback_body})
+    if no_line_comments:
+        note_body = "🔍 **OpenCodeReview** found issues that could not be posted inline:\n\n---\n\n"
+        for item in no_line_comments:
+            note_body += format_comment_fallback(item["comment"], item["reason"]) + "\n\n---\n\n"
+        post({"body": note_body})
 
-    # Post summary last
+    if routed_comments:
+        note_body = "📋 **OpenCodeReview** findings routed to summary by policy:\n\n---\n\n"
+        for item in routed_comments:
+            note_body += format_comment_fallback(item["comment"], item["reason"]) + "\n\n---\n\n"
+        post({"body": note_body})
+
+    if failed_comments:
+        note_body = "❌ **OpenCodeReview** findings that failed to post inline:\n\n---\n\n"
+        for item in failed_comments:
+            note_body += format_comment_fallback(item["comment"], item["reason"]) + "\n\n---\n\n"
+        post({"body": note_body})
+
     total_count = len(comments)
-    failed_count = len(failed_comments)
-    summary = "🔍 **OpenCodeReview** found **%d** issue(s) in this MR." % total_count
-    if total_count > 0:
-        summary += "\n- ✅ %d posted as inline comment(s)" % success_count
-        summary += "\n- 📝 %d posted as summary (missing line info)" % failed_count
     warnings = result.get("warnings") or []
-    if warnings:
-        summary += "\n\n⚠️ %d warning(s) occurred during review." % len(warnings)
+    summary = build_summary_body(
+        total_count,
+        success_count,
+        len(no_line_comments),
+        len(routed_comments),
+        len(failed_comments),
+        warnings,
+    )
     post({"body": summary})
 
-    return {"inline": success_count, "fallback": failed_count}
+    return {
+        "inline": success_count,
+        "fallback": len(no_line_comments),
+        "routed": len(routed_comments),
+        "failed": len(failed_comments),
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -423,6 +591,9 @@ def build_config(env):
         "max_retries": int(env.get("OCR_MAX_RETRIES", "3")),
         "max_retry_delay": int(env.get("OCR_MAX_RETRY_DELAY", "60000")) / 1000,
         "transient_base_delay": 2.0,  # hardcoded, matches heredoc
+        # Publication routing (fail-open; empty = no routing)
+        "route_severity_below": env.get("OCR_ROUTE_SEVERITY_BELOW", ""),
+        "route_categories": env.get("OCR_ROUTE_CATEGORIES", ""),
     }
 
 

--- a/examples/gitlab_ci/post_review_test.py
+++ b/examples/gitlab_ci/post_review_test.py
@@ -64,6 +64,8 @@ DEFAULT_CONFIG = {
     "max_retries": 3,
     "max_retry_delay": 60.0,
     "transient_base_delay": 2.0,
+    "route_severity_below": "",
+    "route_categories": "",
 }
 
 
@@ -103,6 +105,11 @@ class FormatCommentTest(unittest.TestCase):
     def test_plain_content(self):
         body = pr.format_comment({"content": "hello world"})
         self.assertEqual(body, "hello world")
+
+    def test_badge_prefix(self):
+        body = pr.format_comment(comment(content="issue", category="bug", severity="high"))
+        self.assertTrue(body.startswith("[bug · high]\n"))
+        self.assertIn("issue", body)
 
     def test_with_suggestion(self):
         body = pr.format_comment(comment(
@@ -155,12 +162,94 @@ class FormatCommentFallbackTest(unittest.TestCase):
         self.assertIn("**After:**\n```\nx = 2\n```", md)
         self.assertIn("</details>", md)
 
+    def test_badge_prefix(self):
+        md = pr.format_comment_fallback(comment(
+            content="issue",
+            category="style",
+            severity="low",
+        ))
+        self.assertTrue(md.startswith("[style · low]\n"))
+
+    def test_reason_appended(self):
+        md = pr.format_comment_fallback(comment(content="issue"), reason="Routed to summary (severity low)")
+        self.assertIn("*Routed to summary (severity low)*", md)
+
     def test_suggestion_without_existing(self):
         md = pr.format_comment_fallback(comment(
             content="fix this",
             suggestion_code="x = 2",
         ))
         self.assertNotIn("<details>", md)
+
+
+# --------------------------------------------------------------------------- #
+# Badge + publication policy
+# --------------------------------------------------------------------------- #
+
+
+class BuildBadgeTest(unittest.TestCase):
+    def test_both(self):
+        self.assertEqual(pr.build_badge({"category": "bug", "severity": "high"}), "[bug · high]")
+
+    def test_category_only(self):
+        self.assertEqual(pr.build_badge({"category": "style"}), "[style]")
+
+    def test_severity_only(self):
+        self.assertEqual(pr.build_badge({"severity": "low"}), "[low]")
+
+    def test_neither(self):
+        self.assertEqual(pr.build_badge({}), "")
+
+    def test_preserves_case(self):
+        self.assertEqual(pr.build_badge({"category": "Bug", "severity": "High"}), "[Bug · High]")
+
+    def test_strips_control_chars(self):
+        self.assertEqual(pr.build_badge({"category": "bu\ng", "severity": "high"}), "[bug · high]")
+
+
+class BuildPolicyTest(unittest.TestCase):
+    def test_empty_is_no_routing(self):
+        self.assertEqual(pr.build_policy(), pr.NO_ROUTING)
+        self.assertEqual(pr.build_policy(severity_threshold="", categories=""), pr.NO_ROUTING)
+
+    def test_unknown_severity_fails_open(self):
+        self.assertEqual(pr.build_policy(severity_threshold="trivial"), pr.NO_ROUTING)
+
+    def test_medium_threshold(self):
+        policy = pr.build_policy(severity_threshold="medium")
+        self.assertTrue(policy["route_by_severity"])
+        self.assertEqual(policy["severity_rank"], pr.SEVERITY_RANK["medium"])
+
+    def test_known_categories(self):
+        policy = pr.build_policy(categories="style, UNKNOWN, documentation")
+        self.assertTrue(policy["route_by_category"])
+        self.assertIn("style", policy["categories"])
+        self.assertIn("documentation", policy["categories"])
+        self.assertNotIn("unknown", policy["categories"])
+
+
+class RouteCommentTest(unittest.TestCase):
+    def setUp(self):
+        self.policy = pr.build_policy(severity_threshold="medium", categories="style,documentation")
+
+    def test_severity_at_or_below_threshold(self):
+        self.assertTrue(pr.route_comment({"severity": "medium"}, self.policy)["routed"])
+        self.assertTrue(pr.route_comment({"severity": "low"}, self.policy)["routed"])
+        self.assertFalse(pr.route_comment({"severity": "high"}, self.policy)["routed"])
+
+    def test_unknown_severity_stays_inline(self):
+        self.assertFalse(pr.route_comment({"severity": "trivial"}, self.policy)["routed"])
+        self.assertFalse(pr.route_comment({"severity": ""}, self.policy)["routed"])
+
+    def test_category_routing(self):
+        self.assertTrue(pr.route_comment({"category": "style"}, self.policy)["routed"])
+        self.assertFalse(pr.route_comment({"category": "bug"}, self.policy)["routed"])
+
+    def test_unknown_category_stays_inline(self):
+        self.assertFalse(pr.route_comment({"category": "unknown"}, self.policy)["routed"])
+
+    def test_no_routing_sentinel(self):
+        self.assertFalse(pr.route_comment({"severity": "low", "category": "style"}, pr.NO_ROUTING)["routed"])
 
 
 # --------------------------------------------------------------------------- #
@@ -203,7 +292,7 @@ class PublishTest(unittest.TestCase):
         result = {"comments": [comment()]}
         stats, rec = run_publish(result)
 
-        self.assertEqual(stats, {"inline": 1, "fallback": 0})
+        self.assertEqual(stats, {"inline": 1, "fallback": 0, "routed": 0, "failed": 0})
         # 2 calls: inline discussion + summary note
         self.assertEqual(len(rec.calls), 2)
 
@@ -217,32 +306,33 @@ class PublishTest(unittest.TestCase):
         summary = rec.calls[1]
         self.assertNotIn("position", summary)
         self.assertIn("**1** issue(s)", summary["body"])
-        self.assertIn("✅ 1 posted as inline", summary["body"])
+        self.assertIn("Successfully posted inline: 1", summary["body"])
 
     def test_fallback_when_diff_refs_none(self):
         result = {"comments": [comment()]}
         stats, rec = run_publish(result, diff_refs=None)
 
-        self.assertEqual(stats, {"inline": 0, "fallback": 1})
-        # 2 calls: fallback note + summary
+        self.assertEqual(stats, {"inline": 0, "fallback": 1, "routed": 0, "failed": 0})
+        # 2 calls: no-line note + summary
         self.assertEqual(len(rec.calls), 2)
         self.assertIn("could not be posted inline", rec.calls[0]["body"])
-        self.assertIn("📝 1 posted as summary", rec.calls[1]["body"])
+        self.assertIn("In summary (no line info): 1", rec.calls[1]["body"])
 
     def test_inline_error_falls_back(self):
         result = {"comments": [comment()]}
         outcomes = [{"success": False, "rate_limit_remaining": None, "is_rate_limit_exhausted": False}]
         stats, rec = run_publish(result, outcomes=outcomes)
 
-        self.assertEqual(stats, {"inline": 0, "fallback": 1})
-        # 3 calls: failed inline attempt + fallback note + summary
+        self.assertEqual(stats, {"inline": 0, "fallback": 0, "routed": 0, "failed": 1})
+        # 3 calls: failed inline attempt + failed note + summary
         self.assertEqual(len(rec.calls), 3)
+        self.assertIn("failed to post inline", rec.calls[1]["body"].lower())
 
     def test_no_comments_lgtm(self):
         result = {"message": "Looks good to me."}
         stats, rec = run_publish(result)
 
-        self.assertEqual(stats, {"inline": 0, "fallback": 0})
+        self.assertEqual(stats, {"inline": 0, "fallback": 0, "routed": 0, "failed": 0})
         self.assertEqual(len(rec.calls), 1)
         self.assertIn("Looks good to me", rec.calls[0]["body"])
         self.assertIn("✅", rec.calls[0]["body"])
@@ -305,20 +395,50 @@ class PublishTest(unittest.TestCase):
             {"success": True, "rate_limit_remaining": 100, "is_rate_limit_exhausted": False},
         ]
         stats, rec = run_publish(result, outcomes=outcomes)
-        self.assertEqual(stats, {"inline": 2, "fallback": 1})
-        # 4 calls: 3 inline attempts + fallback note + summary = 5 calls
-        # Wait: 3 inline posts + 1 fallback + 1 summary = 5
+        self.assertEqual(stats, {"inline": 2, "fallback": 0, "routed": 0, "failed": 1})
+        # 5 calls: 3 inline attempts + failed note + summary
         self.assertEqual(len(rec.calls), 5)
 
     def test_comment_without_path_falls_back(self):
         result = {"comments": [comment(path="", end_line=0)]}
         stats, rec = run_publish(result)
-        self.assertEqual(stats, {"inline": 0, "fallback": 1})
+        self.assertEqual(stats, {"inline": 0, "fallback": 1, "routed": 0, "failed": 0})
 
     def test_comment_without_end_line_falls_back(self):
         result = {"comments": [comment(end_line=0)]}
         stats, rec = run_publish(result)
-        self.assertEqual(stats, {"inline": 0, "fallback": 1})
+        self.assertEqual(stats, {"inline": 0, "fallback": 1, "routed": 0, "failed": 0})
+
+    def test_severity_routing_to_summary(self):
+        config = dict(DEFAULT_CONFIG)
+        config["route_severity_below"] = "medium"
+        result = {"comments": [comment(severity="low", category="bug")]}
+        stats, rec = run_publish(result, config=config)
+
+        self.assertEqual(stats, {"inline": 0, "fallback": 0, "routed": 1, "failed": 0})
+        self.assertEqual(len(rec.calls), 2)
+        self.assertIn("routed to summary by policy", rec.calls[0]["body"].lower())
+        self.assertIn("Routed to summary (severity low", rec.calls[0]["body"])
+        self.assertIn("Routed to summary by policy: 1", rec.calls[1]["body"])
+
+    def test_category_routing_to_summary(self):
+        config = dict(DEFAULT_CONFIG)
+        config["route_categories"] = "style"
+        result = {"comments": [comment(category="style", severity="high")]}
+        stats, rec = run_publish(result, config=config)
+
+        self.assertEqual(stats, {"inline": 0, "fallback": 0, "routed": 1, "failed": 0})
+        self.assertIn("Routed to summary (category style", rec.calls[0]["body"])
+
+    def test_unknown_metadata_stays_inline(self):
+        config = dict(DEFAULT_CONFIG)
+        config["route_severity_below"] = "medium"
+        config["route_categories"] = "style"
+        result = {"comments": [comment(severity="trivial", category="unknown")]}
+        stats, rec = run_publish(result, config=config)
+
+        self.assertEqual(stats, {"inline": 1, "fallback": 0, "routed": 0, "failed": 0})
+        self.assertIn("position", rec.calls[0])
 
 
 # --------------------------------------------------------------------------- #
@@ -756,6 +876,8 @@ class BuildConfigTest(unittest.TestCase):
         self.assertEqual(config["max_retries"], 3)
         self.assertEqual(config["max_retry_delay"], 60.0)
         self.assertEqual(config["transient_base_delay"], 2)
+        self.assertEqual(config["route_severity_below"], "")
+        self.assertEqual(config["route_categories"], "")
 
     def test_env_overrides(self):
         env = {
@@ -765,6 +887,8 @@ class BuildConfigTest(unittest.TestCase):
             "OCR_RETRY_BASE_DELAY": "3000",
             "OCR_MAX_RETRIES": "5",
             "OCR_MAX_RETRY_DELAY": "120000",
+            "OCR_ROUTE_SEVERITY_BELOW": "low",
+            "OCR_ROUTE_CATEGORIES": "style,documentation",
         }
         config = pr.build_config(env)
         self.assertEqual(config["success_delay"], 5.0)
@@ -773,6 +897,8 @@ class BuildConfigTest(unittest.TestCase):
         self.assertEqual(config["retry_base_delay"], 3.0)
         self.assertEqual(config["max_retries"], 5)
         self.assertEqual(config["max_retry_delay"], 120.0)
+        self.assertEqual(config["route_severity_below"], "low")
+        self.assertEqual(config["route_categories"], "style,documentation")
         # transient_base_delay is always hardcoded
         self.assertEqual(config["transient_base_delay"], 2)
 

--- a/examples/gitlab_ci/post_review_test.py
+++ b/examples/gitlab_ci/post_review_test.py
@@ -251,6 +251,14 @@ class RouteCommentTest(unittest.TestCase):
     def test_no_routing_sentinel(self):
         self.assertFalse(pr.route_comment({"severity": "low", "category": "style"}, pr.NO_ROUTING)["routed"])
 
+    def test_sanitizes_control_chars_for_matching(self):
+        decision = pr.route_comment({"category": "sty\nle"}, self.policy)
+        self.assertTrue(decision["routed"])
+        self.assertIn("category style", decision["reason"])
+        decision = pr.route_comment({"severity": "med\nium"}, self.policy)
+        self.assertTrue(decision["routed"])
+        self.assertIn("severity medium", decision["reason"])
+
 
 # --------------------------------------------------------------------------- #
 # publish() with Recorder fake poster (Seam 1)


### PR DESCRIPTION
## Summary
- Port GitHub Action fail-open category/severity publication controls (#478 / #529) to the GitLab CI example (`examples/gitlab_ci/post_review.py`).
- Add `[category · severity]` badges on inline and summary findings, plus optional `OCR_ROUTE_SEVERITY_BELOW` / `OCR_ROUTE_CATEGORIES` routing that moves matching findings to summary notes without dropping them.
- Split destination accounting into inline / no-line fallback / routed / failed, and document the new CI variables in the GitLab example README and workflow comments.

## Test plan
- [x] `python3 examples/gitlab_ci/post_review_test.py` (78 tests)
- [x] Smoke on a GitLab MR with `OCR_ROUTE_SEVERITY_BELOW=medium` and `OCR_ROUTE_CATEGORIES=style,documentation,test`
- [x] Confirm `security`/`high` findings still land as inline discussions with `suggestion:-0+0`
- [x] Confirm routed findings appear in a summary note with `Routed to summary…` reason and Before/After details


Made with [Cursor](https://cursor.com)