### PR TITLE
feat(cli): select provider per run

### DIFF
--- a/cmd/opencodereview/flags_test.go
+++ b/cmd/opencodereview/flags_test.go
@@ -35,6 +35,16 @@ func TestParseReviewFlagsModelOverride(t *testing.T) {
 	}
 }
 
+func TestParseReviewFlagsProviderOverride(t *testing.T) {
+	opts, err := parseReviewFlags([]string{"--provider", "openai"})
+	if err != nil {
+		t.Fatalf("parseReviewFlags: %v", err)
+	}
+	if opts.provider != "openai" {
+		t.Errorf("provider = %q, want openai", opts.provider)
+	}
+}
+
 func TestParseReviewFlagsResume(t *testing.T) {
 	opts, err := parseReviewFlags([]string{"--from", "main", "--to", "feature", "--resume", "session-123"})
 	if err != nil {

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -33,6 +33,7 @@ type reviewOptions struct {
 	audience        string
 	background      string
 	backgroundFile  string
+	provider        string
 	model           string
 	concurrency     int
 	perFileTimeout  int
@@ -73,6 +74,9 @@ var reviewCmd = &cobra.Command{
   # Preview which files will be reviewed
   ocr review --preview
   ocr review -c abc123 -p
+
+  # Select a configured provider/model without changing config.json
+  ocr review --provider anthropic --model claude-opus-4-6
 
   # Exclude generated files / fixtures
   ocr review --exclude '**/generated/*,**/testdata/*'
@@ -134,7 +138,7 @@ func executeReview(opts reviewOptions) error {
 		return err
 	}
 
-	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, opts.model)
+	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, opts.provider, opts.model)
 	if err != nil {
 		return err
 	}

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -36,6 +36,7 @@ type scanOptions struct {
 	noSummary       bool
 	batch           string
 	maxTokensBudget int
+	provider        string
 	model           string
 }
 
@@ -63,7 +64,10 @@ var scanCmd = &cobra.Command{
   ocr scan --preview
 
   # Skip the per-file PLAN_TASK pre-pass
-  ocr scan --no-plan`,
+  ocr scan --no-plan
+
+  # Select a configured provider/model without changing config.json
+  ocr scan --provider openai --model gpt-5.4`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateScanOptions(&scanOpts); err != nil {
 			return err
@@ -128,7 +132,7 @@ func executeScan(opts scanOptions) error {
 		return runScanPreview(cc, scanTpl, scanPaths)
 	}
 
-	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, opts.model)
+	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, opts.provider, opts.model)
 	if err != nil {
 		return err
 	}

--- a/cmd/opencodereview/scan_cmd_test.go
+++ b/cmd/opencodereview/scan_cmd_test.go
@@ -178,6 +178,16 @@ func TestParseScanFlags_ModelOverride(t *testing.T) {
 	}
 }
 
+func TestParseScanFlags_ProviderOverride(t *testing.T) {
+	opts, err := parseScanFlags([]string{"--provider", "openai"})
+	if err != nil {
+		t.Fatalf("parseScanFlags: %v", err)
+	}
+	if opts.provider != "openai" {
+		t.Errorf("provider = %q, want openai", opts.provider)
+	}
+}
+
 func TestParseScanFlags_AllStringFlags(t *testing.T) {
 	opts, err := parseScanFlags([]string{
 		"--tools", "/tmp/tools.json",

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -147,9 +147,10 @@ type llmRuntime struct {
 // loadLLMRuntime loads tool defs from toolConfigPath, reads the app config
 // from the user's default config path (applying the configured language to
 // tpl — defaulting when the config file is absent), resolves the LLM
-// endpoint (honoring modelOverride from --model when non-empty), and
+// endpoint (honoring providerOverride and modelOverride from the CLI when
+// non-empty), and
 // returns the runtime bundle. tpl is mutated in place.
-func loadLLMRuntime(tpl *template.Template, toolConfigPath, modelOverride string) (*llmRuntime, error) {
+func loadLLMRuntime(tpl *template.Template, toolConfigPath, providerOverride, modelOverride string) (*llmRuntime, error) {
 	toolEntries, err := toolsconfig.Load(toolConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("load tools: %w", err)
@@ -174,9 +175,12 @@ func loadLLMRuntime(tpl *template.Template, toolConfigPath, modelOverride string
 	}
 	tpl.ApplyLanguage(lang)
 
-	ep, err := llm.ResolveEndpointWithModelOverride(cfgPath, modelOverride)
+	ep, err := llm.ResolveEndpointWithOverrides(cfgPath, providerOverride, modelOverride)
 	if err != nil {
 		return nil, fmt.Errorf("resolve LLM endpoint: %w", err)
+	}
+	if ep.Provider != "" {
+		provider = ep.Provider
 	}
 
 	return &llmRuntime{

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -49,6 +49,10 @@ func addModelFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVar(target, "model", "", "override LLM model for this run (e.g., claude-opus-4-6)")
 }
 
+func addProviderFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "provider", "", "override configured LLM provider for this run (e.g., anthropic or openai)")
+}
+
 func addToolsFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVar(target, "tools", "", "path to JSON tools config file (default: embedded)")
 }
@@ -153,6 +157,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	addOutputFlags(cmd, &opts.outputFormat, &opts.audience)
 	addConcurrencyFlags(cmd, &opts.concurrency, &opts.perFileTimeout, &opts.maxTools, &opts.maxGitProcs, &opts.maxTokensBudget)
 	addBackgroundFlags(cmd, &opts.background, &opts.backgroundFile)
+	addProviderFlag(cmd, &opts.provider)
 	addModelFlag(cmd, &opts.model)
 	addPreviewFlag(cmd, &opts.preview)
 }
@@ -176,6 +181,7 @@ func registerScanFlags(cmd *cobra.Command, opts *scanOptions) {
 	cmd.Flags().BoolVar(&opts.noDedup, "no-dedup", false, "skip the per-batch DEDUP_TASK")
 	cmd.Flags().BoolVar(&opts.noSummary, "no-summary", false, "skip the post-run PROJECT_SUMMARY_TASK")
 	cmd.Flags().StringVar(&opts.batch, "batch", "", "override BATCH_STRATEGY: none | by-language | by-directory")
+	addProviderFlag(cmd, &opts.provider)
 	addModelFlag(cmd, &opts.model)
 	cmd.RegisterFlagCompletionFunc("batch", completeEnum("none", "by-language", "by-directory"))
 }

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -17,6 +17,7 @@ type ResolvedEndpoint struct {
 	URL          string
 	Token        string
 	Model        string
+	Provider     string            // configured provider name; empty for environment-resolved endpoints
 	Protocol     string            // canonical protocol name (see protocol.go); resolver normalizes aliases
 	AuthHeader   string            // Anthropic auth header: "x-api-key" or "authorization"
 	Source       string            // human-readable config source label
@@ -59,23 +60,40 @@ const (
 // Each strategy requires all three fields (URL, Token, Model) to be non-empty.
 // Returns the first valid strategy's result.
 func ResolveEndpoint(configPath string) (ResolvedEndpoint, error) {
-	return ResolveEndpointWithModelOverride(configPath, "")
+	return ResolveEndpointWithOverrides(configPath, "", "")
 }
 
 // ResolveEndpointWithModelOverride resolves an endpoint like ResolveEndpoint,
 // but uses modelOverride as the request model when it is non-empty. The override
 // can also supply the otherwise required model for a configured endpoint.
 func ResolveEndpointWithModelOverride(configPath, modelOverride string) (ResolvedEndpoint, error) {
+	return ResolveEndpointWithOverrides(configPath, "", modelOverride)
+}
+
+// ResolveEndpointWithOverrides resolves an endpoint like ResolveEndpoint, but
+// applies providerOverride and modelOverride to this invocation only. Provider
+// overrides are resolved from the configured providers/custom_providers maps;
+// the config file is never modified.
+func ResolveEndpointWithOverrides(configPath, providerOverride, modelOverride string) (ResolvedEndpoint, error) {
+	providerOverride = strings.TrimSpace(providerOverride)
 	modelOverride = strings.TrimSpace(modelOverride)
 
 	strategies := []struct {
 		name string
 		fn   func() (ResolvedEndpoint, bool, error)
 	}{
-		{"OCR config file", func() (ResolvedEndpoint, bool, error) { return tryOCRConfig(configPath, modelOverride) }},
+		{"OCR config file", func() (ResolvedEndpoint, bool, error) {
+			return tryOCRConfig(configPath, providerOverride, modelOverride)
+		}},
 		{"OCR environment", func() (ResolvedEndpoint, bool, error) { return tryOCREnv(modelOverride) }},
 		{"Claude Code environment", func() (ResolvedEndpoint, bool, error) { return tryCCEnv(modelOverride) }},
 		{"Shell rc file", func() (ResolvedEndpoint, bool, error) { return tryShellRC(modelOverride) }},
+	}
+	if providerOverride != "" {
+		// A named provider must come from the user's provider map. Falling back to
+		// an unrelated URL/token environment endpoint would silently ignore the
+		// requested provider.
+		strategies = strategies[:1]
 	}
 
 	for _, s := range strategies {
@@ -118,6 +136,9 @@ func ResolveEndpointWithModelOverride(configPath, modelOverride string) (Resolve
 		}
 	}
 
+	if providerOverride != "" {
+		return ResolvedEndpoint{}, fmt.Errorf("provider override %q could not be resolved from %s", providerOverride, configPath)
+	}
 	return ResolvedEndpoint{}, fmt.Errorf("no valid LLM endpoint configured; one of OCR_LLM_URL/OCR_LLM_TOKEN/OCR_LLM_MODEL, ~/.opencodereview/config.json, or ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN/ANTHROPIC_MODEL must be set")
 }
 
@@ -241,7 +262,7 @@ type configFile struct {
 }
 
 // tryOCRConfig reads the OCR config file.
-func tryOCRConfig(path, modelOverride string) (ResolvedEndpoint, bool, error) {
+func tryOCRConfig(path, providerOverride, modelOverride string) (ResolvedEndpoint, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -255,6 +276,9 @@ func tryOCRConfig(path, modelOverride string) (ResolvedEndpoint, bool, error) {
 		return ResolvedEndpoint{}, false, fmt.Errorf("parse config: %w", err)
 	}
 
+	if providerOverride != "" {
+		cfg.Provider = providerOverride
+	}
 	if cfg.Provider != "" {
 		return tryProviderConfig(cfg, modelOverride)
 	}
@@ -393,6 +417,7 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		URL:          url,
 		Token:        apiKey,
 		Model:        model,
+		Provider:     cfg.Provider,
 		Protocol:     protocol,
 		AuthHeader:   authHeader,
 		Source:       "provider:" + cfg.Provider,

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -359,6 +359,71 @@ func TestResolveEndpoint_ProviderModelOverride(t *testing.T) {
 	}
 }
 
+func TestResolveEndpointWithOverrides_ProviderAndModelDoNotMutateConfig(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-6",
+		Providers: map[string]providerEntryConfig{
+			"anthropic": {APIKey: "sk-ant-test", Model: "claude-sonnet-4-6"},
+			"openai":    {APIKey: "sk-openai-test", Model: "gpt-5.4"},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	original, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read original config: %v", err)
+	}
+
+	ep, err := ResolveEndpointWithOverrides(cfgPath, "openai", "gpt-5.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.Provider != "openai" || ep.Model != "gpt-5.4" {
+		t.Errorf("resolved provider/model = %q/%q, want openai/gpt-5.4", ep.Provider, ep.Model)
+	}
+	if ep.Token != "sk-openai-test" {
+		t.Errorf("Token = %q, want selected provider token", ep.Token)
+	}
+	if ep.Source != "provider:openai" {
+		t.Errorf("Source = %q, want provider:openai", ep.Source)
+	}
+
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config after resolution: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("provider/model override mutated config file")
+	}
+}
+
+func TestResolveEndpointWithOverrides_ProviderMustBeConfigured(t *testing.T) {
+	clearAllEnv(t)
+
+	cfg := configFile{
+		Provider: "anthropic",
+		Providers: map[string]providerEntryConfig{
+			"anthropic": {APIKey: "sk-ant-test", Model: "claude-sonnet-4-6"},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := ResolveEndpointWithOverrides(cfgPath, "openai", "gpt-5.4")
+	if err == nil || !strings.Contains(err.Error(), `provider "openai" is set but not configured`) {
+		t.Fatalf("expected unconfigured provider error, got %v", err)
+	}
+}
+
 func TestResolveEndpoint_ProviderEntryModelOverridesDefault(t *testing.T) {
 	clearAllEnv(t)
 


### PR DESCRIPTION
## Summary
- add `--provider` to `ocr review` and `ocr scan`
- resolve provider/model overrides from configured provider maps without writing config.json
- preserve provider provenance in the resolved endpoint and review manifest

## Validation
- `go test ./internal/llm ./cmd/opencodereview`
- `go test ./...`

Closes #680