### PR TITLE
feat(llm): add Claude Opus 5, Sonnet 5, Kimi K3, and Qwen 3.8 models

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -33,6 +33,8 @@ var registry = []Provider{
 		AuthHeader:  "x-api-key",
 		EnvVar:      "ANTHROPIC_API_KEY",
 		Models: []string{
+			"claude-opus-5",
+			"claude-sonnet-5",
 			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-opus-4-6",
@@ -77,6 +79,7 @@ var registry = []Provider{
 		BaseURL:     "https://dashscope.aliyuncs.com/compatible-mode/v1",
 		EnvVar:      "DASHSCOPE_API_KEY",
 		Models: []string{
+			"qwen3.8-max",
 			"qwen3.7-max",
 			"qwen3.7-plus",
 			"qwen3.6-plus",
@@ -95,6 +98,7 @@ var registry = []Provider{
 		BaseURL:     "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
 		EnvVar:      "DASHSCOPE_TOKENPLAN_KEY",
 		Models: []string{
+			"qwen3.8-max",
 			"qwen3.7-max",
 			"qwen3.7-plus",
 			"qwen3.6-plus",
@@ -143,7 +147,6 @@ var registry = []Provider{
 		BaseURL:     "https://tokenhub.tencentmaas.com/v1",
 		EnvVar:      "TENCENT_TOKENHUB_API_KEY",
 		Models: []string{
-			"hy3-preview",
 			"deepseek-v4-pro",
 			"deepseek-v4-flash",
 			"glm-5.2",
@@ -151,11 +154,10 @@ var registry = []Provider{
 			"glm-5",
 			"glm-5-turbo",
 			"kimi-k2.7-code",
+			"kimi-k2.7-code-highspeed",
 			"kimi-k2.6",
-			"kimi-k2.5",
 			"minimax-m3",
 			"minimax-m2.7",
-			"minimax-m2.5",
 		},
 	},
 	{
@@ -165,7 +167,7 @@ var registry = []Provider{
 		BaseURL:     "https://api.lkeap.cloud.tencent.com/plan/v3",
 		EnvVar:      "TENCENT_HUNYUAN_TOKENPLAN_KEY",
 		Models: []string{
-			"hy3-preview",
+			"hy3",
 		},
 	},
 	{
@@ -190,6 +192,7 @@ var registry = []Provider{
 		BaseURL:     "https://api.moonshot.cn/v1",
 		EnvVar:      "MOONSHOT_API_KEY",
 		Models: []string{
+			"kimi-k3",
 			"kimi-k2.7-code",
 			"kimi-k2.7-code-highspeed",
 			"kimi-k2.6",

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -76,7 +76,14 @@ func TestLookupProvider_PreservesModelOrder(t *testing.T) {
 	if !ok {
 		t.Fatal("anthropic not found")
 	}
-	expected := []string{"claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"}
+	expected := []string{
+		"claude-opus-5",
+		"claude-sonnet-5",
+		"claude-opus-4-8",
+		"claude-opus-4-7",
+		"claude-opus-4-6",
+		"claude-sonnet-4-6",
+	}
 	if len(p.Models) != len(expected) {
 		t.Fatalf("expected %d models, got %d", len(expected), len(p.Models))
 	}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
- Add newly released frontier models for Anthropic, Kimi, and DashScope Token Plan
- Complements the OpenAI GPT-5.6 changes tracked in #632

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

<img width="710" height="252" alt="image" src="https://github.com/user-attachments/assets/983ad65a-0df1-4b81-8741-a80296b77d05" />

<img width="708" height="225" alt="image" src="https://github.com/user-attachments/assets/3faf5fd2-98d1-4ae0-9451-f9dd2b50bd84" />

<img width="707" height="153" alt="image" src="https://github.com/user-attachments/assets/fd0b4685-4ffb-4c0a-a9fb-849f981524bf" />

<img width="716" height="198" alt="image" src="https://github.com/user-attachments/assets/993b7c49-0a4c-49c8-8620-dd9f657a9b0c" />


## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->

closes #632
