### PR TITLE
refactor(cli): use Cobra validation for parent commands

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -28,10 +28,10 @@ Examples:
   ocr config set model claude-opus-4-6
   ocr config set providers.anthropic.api_key "$ANTHROPIC_API_KEY"
 
-	# Custom provider
-	ocr config set provider my-gateway
-	ocr config set custom_providers.my-gateway.url https://gateway.internal.com/v1
-	ocr config set custom_providers.my-gateway.protocol openai`,
+  # Custom provider
+  ocr config set provider my-gateway
+  ocr config set custom_providers.my-gateway.url https://gateway.internal.com/v1
+  ocr config set custom_providers.my-gateway.protocol openai`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -28,14 +28,12 @@ Examples:
   ocr config set model claude-opus-4-6
   ocr config set providers.anthropic.api_key "$ANTHROPIC_API_KEY"
 
-  # Custom provider
-  ocr config set provider my-gateway
-  ocr config set custom_providers.my-gateway.url https://gateway.internal.com/v1
-  ocr config set custom_providers.my-gateway.protocol openai`,
+	# Custom provider
+	ocr config set provider my-gateway
+	ocr config set custom_providers.my-gateway.url https://gateway.internal.com/v1
+	ocr config set custom_providers.my-gateway.protocol openai`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-		}
 		return cmd.Help()
 	},
 }

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -39,12 +39,10 @@ Output review spec for host-agent delegation (no LLM required).`,
   # Preview workspace changes
   ocr delegate preview
 
-  # Get rules for multiple files (grouped by content)
-  ocr delegate rule internal/agent/agent.go internal/llm/client.go`,
+	# Get rules for multiple files (grouped by content)
+	ocr delegate rule internal/agent/agent.go internal/llm/client.go`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-		}
 		return cmd.Help()
 	},
 }

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -39,8 +39,8 @@ Output review spec for host-agent delegation (no LLM required).`,
   # Preview workspace changes
   ocr delegate preview
 
-	# Get rules for multiple files (grouped by content)
-	ocr delegate rule internal/agent/agent.go internal/llm/client.go`,
+  # Get rules for multiple files (grouped by content)
+  ocr delegate rule internal/agent/agent.go internal/llm/client.go`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()

--- a/cmd/opencodereview/llm_cmd.go
+++ b/cmd/opencodereview/llm_cmd.go
@@ -18,10 +18,8 @@ var llmCmd = &cobra.Command{
 	Long:  "LLM utility commands.",
 	Example: `  ocr llm test                   Verify LLM connectivity and configuration
   ocr llm providers              List available built-in providers`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-		}
 		return cmd.Help()
 	},
 }

--- a/cmd/opencodereview/parent_cmd_test.go
+++ b/cmd/opencodereview/parent_cmd_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"strings"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // TestParentCommands_UnknownSubcommand verifies that parent commands which
@@ -30,9 +28,9 @@ func TestParentCommands_UnknownSubcommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clone the global rootCmd tree so we can mutate it in isolation.
-			root := cloneRootCmd(t)
+			root := rootCmd
 			root.SetArgs(tt.args)
+			t.Cleanup(func() { root.SetArgs(nil) })
 
 			err := root.Execute()
 			if err == nil {
@@ -69,8 +67,9 @@ func TestParentCommands_KnownSubcommandStillWorks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := cloneRootCmd(t)
+			root := rootCmd
 			root.SetArgs(tt.args)
+			t.Cleanup(func() { root.SetArgs(nil) })
 			// Help output is not treated as an error by Cobra when invoked via --help.
 			err := root.Execute()
 			if err != nil {
@@ -97,43 +96,13 @@ func TestParentCommands_NoArgsPrintsHelp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := cloneRootCmd(t)
+			root := rootCmd
 			root.SetArgs(tt.args)
+			t.Cleanup(func() { root.SetArgs(nil) })
 			err := root.Execute()
 			if err != nil {
 				t.Fatalf("expected nil error when parent command has no args (help), got %v", err)
 			}
 		})
 	}
-}
-
-// cloneRootCmd creates a deep clone of the global rootCmd tree for isolated
-// testing. It preserves SilenceUsage / SilenceErrors so tests do not pollute
-// stdout/stderr.
-func cloneRootCmd(t *testing.T) *cobra.Command {
-	t.Helper()
-	root := &cobra.Command{
-		Use:           rootCmd.Use,
-		Short:         rootCmd.Short,
-		Long:          rootCmd.Long,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE:          rootCmd.RunE,
-	}
-	root.SetFlagErrorFunc(flagErrorWithSuggestion)
-	root.Flags().BoolP("version", "V", false, "version for ocr")
-
-	// Re-register all commands with their current definitions (including our
-	// new RunE fields) so the clone is an accurate snapshot.
-	root.AddCommand(versionCmd)
-	root.AddCommand(reviewCmd)
-	root.AddCommand(scanCmd)
-	root.AddCommand(delegateCmd)
-	root.AddCommand(sessionCmd)
-	root.AddCommand(configCmd)
-	root.AddCommand(llmCmd)
-	root.AddCommand(rulesCmd)
-	root.AddCommand(viewerCmd)
-	root.AddCommand(completionCmd)
-	return root
 }

--- a/cmd/opencodereview/rules_cmd.go
+++ b/cmd/opencodereview/rules_cmd.go
@@ -12,10 +12,8 @@ var rulesCmd = &cobra.Command{
 	Use:   "rules",
 	Short: "Inspect and debug review rules",
 	Long:  "Inspect and debug review rules.",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-		}
 		return cmd.Help()
 	},
 }

--- a/cmd/opencodereview/session_cmd.go
+++ b/cmd/opencodereview/session_cmd.go
@@ -18,10 +18,8 @@ var sessionCmd = &cobra.Command{
 	Use:     "session",
 	Aliases: []string{"sessions"},
 	Short:   "List and inspect saved review sessions",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-		}
 		return cmd.Help()
 	},
 }


### PR DESCRIPTION
## Description

Simplifies parent-command validation introduced in #660.

Parent commands now use Cobra’s built-in `cobra.NoArgs` validator instead of manually checking for unexpected arguments. This preserves the non-zero error behavior for unknown subcommands while removing duplicated validation logic.

The parent-command tests now use `rootCmd` directly, avoiding `cloneRootCmd` reparenting global Cobra command objects during tests.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing

```bash
go test ./cmd/opencodereview -run TestParentCommands -count=1 -v
go test ./cmd/opencodereview/...
make test
make check
git diff --check
```

Verified that:

- unknown parent-command subcommands return an error;
- known child commands still resolve;
- bare parent commands still print help and return successfully.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Fixes #688 
