### PR TITLE
refactor(session): use strings.Contains in resume_test.go

### DIFF
--- a/internal/session/resume_test.go
+++ b/internal/session/resume_test.go
@@ -646,19 +646,6 @@ func mustJSON(t *testing.T, v any) []byte {
 	return b
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}
-
 func TestApplySessionStart_SetsScanPathScope(t *testing.T) {
 	paths := []string{"./internal/scan/", "cmd/opencodereview", "internal/scan"}
 	s := &ResumeState{Items: make(map[string]ResumeItem)}
@@ -711,7 +698,7 @@ func TestValidateScanOptions_RejectsScanPathScopeMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected mismatch when prior scoped scan is resumed as whole repo")
 	}
-	if !contains(err.Error(), "scan path scope") {
+	if !strings.Contains(err.Error(), "scan path scope") {
 		t.Fatalf("error = %q, want scan path scope mismatch", err.Error())
 	}
 }
@@ -726,7 +713,7 @@ func TestValidateScanOptions_RejectsWholeRepoScopeMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected mismatch when prior whole-repo scan is resumed with --path")
 	}
-	if !contains(err.Error(), "<whole repo>") {
+	if !strings.Contains(err.Error(), "<whole repo>") {
 		t.Fatalf("error = %q, want whole-repo scope in message", err.Error())
 	}
 }


### PR DESCRIPTION
## Description

Removes the two hand-rolled `contains` / `containsSubstring` helpers in `internal/session/resume_test.go` and calls `strings.Contains` directly at the two remaining call sites.

Worth noting how this regressed: PR #681 already removed these helpers and merged on 2026-08-02. PR #677 (`feat(scan): add resumable full-file scans`, commit `50bc9b1`) landed afterwards and re-introduced both helpers verbatim, plus two new call sites — which is why #699 exists. `strings` is already imported in this file and used elsewhere in it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing

No new tests. The change deletes two dead test-only helpers and repoints two existing assertions at the standard library; the behaviour is already covered by `TestValidateScanOptions_RejectsScanPathScopeMismatch` and `TestValidateScanOptions_RejectsWholeRepoScopeMismatch`, both of which exercise the rewritten lines. A table-driven test here would be testing `strings.Contains`.

```
go build ./...                     OK
gofmt -l .                         (clean)
LC_ALL=C go vet ./...              OK
make check                         check passed
make test  (go test -race -count=1, 23 packages)   all ok
make coverage                      total: 82.5%  — PASS: meets 80% threshold
go build -o ./opencodereview ./cmd/opencodereview && ./opencodereview --version
                                   open-code-review dev darwin/arm64   SMOKE OK
```

`git status --porcelain` after `make check` shows only `internal/session/resume_test.go`, so the formatter rewrote nothing else.

Confirmed no similar helpers remain anywhere in the repo:
```
grep -rnE '^func (contains|containsSubstring|hasSubstring|indexOf)\(' --include='*.go' .
exit 1
```

Not run: `govulncheck` (not installed locally; it scans dependencies and is unaffected by a test-file edit) and the cross-compile matrix (`go build ./...` covers the same compile surface for this change).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works — see above; existing tests cover the changed lines
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable) — N/A
- [ ] I have signed the CLA — please advise on the current process and I will complete it

## Related Issues

Closes #699
