### PR TITLE
ci: limit container CPU to 2 cores for stable multi-runner concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 15
     container:
       image: golang:1.26.5
+      options: --cpus=2
     steps:
       - uses: actions/checkout@v7
 
@@ -90,6 +91,7 @@ jobs:
     timeout-minutes: 10
     container:
       image: golang:1.26.5
+      options: --cpus=2
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 15
     container:
       image: golang:1.26.5
+      options: --cpus=2
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

- Add `options: --cpus=2` to all Go build containers in CI and Release workflows
- Limits each job container to 2 CPU cores via cgroup, allowing 3 runners to run concurrently on an 8c16g machine without resource contention
- Go 1.25+ automatically reads the cgroup CPU quota and sets GOMAXPROCS accordingly

## Test plan

- [x] Verified `docker run --rm --cpus=2 golang:1.26.5 sh -c 'cat /sys/fs/cgroup/cpu.max'` outputs `200000 100000` (2 cores)
- [ ] Monitor CI runs to confirm jobs complete successfully with the CPU limit
- [ ] Verify CPU usage stays under 80% with 3 concurrent runners