### PR TITLE
refactor(filter): use tool call for review filter output

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1373,6 +1373,25 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 		messages = append(messages, llm.NewTextMessage(m.Role, content))
 	}
 
+	filterTool := llm.ToolDef{
+		Type: "function",
+		Function: llm.FunctionDef{
+			Name:        "report_incorrect_comments",
+			Description: "Report the IDs of review comments that are provably incorrect based on the diff.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"comment_ids": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Array of incorrect comment IDs (e.g. [\"c-0\", \"c-2\"]). Empty array if none are incorrect.",
+					},
+				},
+				"required": []any{"comment_ids"},
+			},
+		},
+	}
+
 	fs := a.session.GetOrCreateFileSession(newPath)
 	rec := fs.AppendTaskRecord(session.ReviewFilterTask, messages)
 	ctx = llm.ContextWithSessionKey(ctx,
@@ -1384,6 +1403,7 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	resp, err := a.args.LLMClient.CompletionsWithCtx(reqCtx, llm.ChatRequest{
 		Model:     a.args.Model,
 		Messages:  messages,
+		Tools:     []llm.ToolDef{filterTool},
 		MaxTokens: a.args.Template.CompletionTokenLimit(),
 	})
 	duration := time.Since(startTime)
@@ -1405,7 +1425,7 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	rec.SetResponse(resp, duration)
 	a.runner.RecordUsage(resp.Usage)
 
-	indices := parseFilterResponse(resp.Content(), len(comments))
+	indices := parseFilterToolCall(resp, len(comments))
 	telemetry.SetAttr(span, "comments.filtered", len(indices))
 	if len(indices) == 0 {
 		return
@@ -1434,21 +1454,37 @@ func buildFilterCommentsJSON(comments []model.LlmComment) string {
 	return string(data)
 }
 
-// parseFilterResponse extracts comment indices from the LLM filter response.
+// parseFilterToolCall extracts comment indices from the report_incorrect_comments tool call.
 // Returns a set of 0-based indices. Invalid IDs or out-of-range indices are ignored.
-func parseFilterResponse(raw string, total int) map[int]struct{} {
-	raw = llmloop.StripMarkdownFences(raw)
-	var ids []string
-	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
-		preview := raw
-		if len(preview) > 200 {
-			preview = preview[:200] + "..."
-		}
-		fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: failed to parse LLM response: %v, raw: %s\n", err, preview)
+func parseFilterToolCall(resp *llm.ChatResponse, total int) map[int]struct{} {
+	toolCalls := resp.ToolCalls()
+	if len(toolCalls) == 0 {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: no tool call in response\n")
 		return nil
 	}
+
+	var tc llm.ToolCall
+	for _, c := range toolCalls {
+		if c.Function.Name == "report_incorrect_comments" {
+			tc = c
+			break
+		}
+	}
+	if tc.Function.Name == "" {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: unexpected tool call %q\n", toolCalls[0].Function.Name)
+		return nil
+	}
+
+	var args struct {
+		CommentIDs []string `json:"comment_ids"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Review filter: failed to parse tool call arguments: %v\n", err)
+		return nil
+	}
+
 	indices := make(map[int]struct{})
-	for _, id := range ids {
+	for _, id := range args.CommentIDs {
 		var idx int
 		if _, err := fmt.Sscanf(id, "c-%d", &idx); err == nil && idx >= 0 && idx < total {
 			indices[idx] = struct{}{}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -151,52 +151,82 @@ func TestBuildFilterCommentsJSON(t *testing.T) {
 	}
 }
 
-func TestParseFilterResponse(t *testing.T) {
+func TestParseFilterToolCall(t *testing.T) {
+	makeResp := func(name, args string) *llm.ChatResponse {
+		content := ""
+		return &llm.ChatResponse{
+			Choices: []llm.Choice{{
+				Message: llm.ResponseMessage{
+					Role:    "assistant",
+					Content: &content,
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      name,
+							Arguments: args,
+						},
+					}},
+				},
+			}},
+		}
+	}
+
 	tests := []struct {
 		name    string
-		raw     string
+		resp    *llm.ChatResponse
 		total   int
 		wantSet map[int]struct{}
 	}{
 		{
-			name:    "valid JSON array",
-			raw:     `["c-0","c-2","c-4"]`,
+			name:    "valid tool call",
+			resp:    makeResp("report_incorrect_comments", `{"comment_ids":["c-0","c-2","c-4"]}`),
 			total:   5,
 			wantSet: map[int]struct{}{0: {}, 2: {}, 4: {}},
 		},
 		{
-			name:    "markdown fenced JSON",
-			raw:     "```json\n[\"c-1\"]\n```",
-			total:   3,
-			wantSet: map[int]struct{}{1: {}},
-		},
-		{
 			name:    "out-of-range indices ignored",
-			raw:     `["c-0","c-10","c-99"]`,
+			resp:    makeResp("report_incorrect_comments", `{"comment_ids":["c-0","c-10","c-99"]}`),
 			total:   5,
 			wantSet: map[int]struct{}{0: {}},
 		},
 		{
 			name:    "negative index ignored",
-			raw:     `["c--1","c-0"]`,
+			resp:    makeResp("report_incorrect_comments", `{"comment_ids":["c--1","c-0"]}`),
 			total:   2,
 			wantSet: map[int]struct{}{0: {}},
 		},
 		{
 			name:    "invalid ID format ignored",
-			raw:     `["x-0","c-abc","c-1"]`,
+			resp:    makeResp("report_incorrect_comments", `{"comment_ids":["x-0","c-abc","c-1"]}`),
 			total:   3,
 			wantSet: map[int]struct{}{1: {}},
 		},
 		{
-			name:    "invalid JSON returns nil",
-			raw:     `not json`,
+			name: "no tool call returns nil",
+			resp: &llm.ChatResponse{
+				Choices: []llm.Choice{{
+					Message: llm.ResponseMessage{Role: "assistant"},
+				}},
+			},
+			total:   5,
+			wantSet: nil,
+		},
+		{
+			name:    "wrong tool name returns nil",
+			resp:    makeResp("other_tool", `{"comment_ids":["c-0"]}`),
+			total:   5,
+			wantSet: nil,
+		},
+		{
+			name:    "invalid arguments returns nil",
+			resp:    makeResp("report_incorrect_comments", `not json`),
 			total:   5,
 			wantSet: nil,
 		},
 		{
 			name:    "empty array",
-			raw:     `[]`,
+			resp:    makeResp("report_incorrect_comments", `{"comment_ids":[]}`),
 			total:   5,
 			wantSet: map[int]struct{}{},
 		},
@@ -204,7 +234,7 @@ func TestParseFilterResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseFilterResponse(tt.raw, tt.total)
+			got := parseFilterToolCall(tt.resp, tt.total)
 			if tt.wantSet == nil {
 				if got != nil {
 					t.Errorf("expected nil, got %v", got)

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -269,11 +269,19 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
 
-	filterResp := `["c-1"]`
 	client := &fakeAgentClient{
 		responses: []*llm.ChatResponse{{
 			Choices: []llm.Choice{{
-				Message: llm.ResponseMessage{Content: &filterResp},
+				Message: llm.ResponseMessage{
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "report_incorrect_comments",
+							Arguments: `{"comment_ids":["c-1"]}`,
+						},
+					}},
+				},
 			}},
 			Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
 		}},
@@ -775,11 +783,21 @@ func TestExecuteReviewFilter_WithTimeout(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
 
-	filterResp := `[]`
 	client := &fakeAgentClient{
 		responses: []*llm.ChatResponse{{
-			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &filterResp}}},
-			Usage:   &llm.UsageInfo{PromptTokens: 5, CompletionTokens: 2},
+			Choices: []llm.Choice{{
+				Message: llm.ResponseMessage{
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "report_incorrect_comments",
+							Arguments: `{"comment_ids":[]}`,
+						},
+					}},
+				},
+			}},
+			Usage: &llm.UsageInfo{PromptTokens: 5, CompletionTokens: 2},
 		}},
 	}
 

--- a/internal/config/template/prompts/review_filter_task_user.md
+++ b/internal/config/template/prompts/review_filter_task_user.md
@@ -42,14 +42,4 @@ After confirming that the facts visible in the diff are accurate, determine whet
 
 ### Output
 
-Return all incorrect review comment IDs directly, without any explanation. Use JSON array format:
-
-```json
-["id-xxx", "id-yyy"]
-```
-
-If there are no review comments that can be confirmed as incorrect, return an empty array:
-
-```json
-[]
-```
+After completing your evaluation, call the `report_incorrect_comments` tool with the IDs of all comments that are provably incorrect. If no comments can be confirmed as incorrect, call the tool with an empty array.


### PR DESCRIPTION
## Summary

- Replace the text-based JSON array output with a structured `report_incorrect_comments` tool call for the review filter task
- The LLM's native tool-call mechanism guarantees valid JSON schema, eliminating the need for `StripMarkdownFences` and fragile text parsing
- If no tool call is returned, it's treated as an error (consistent with how the main agent loop handles tool calls)

## Changes

- **Prompt** (`review_filter_task_user.md`): Updated output instructions to call the tool instead of returning raw JSON
- **Agent** (`agent.go`): Inject `report_incorrect_comments` tool definition into `ChatRequest.Tools`; replace `parseFilterResponse` with `parseFilterToolCall` that extracts results from tool call arguments
- **Tests**: Updated mock responses to use tool call format

## Test plan

- [x] `make check` passes
- [x] `make test` passes
- [x] `TestParseFilterToolCall` covers: valid tool call, out-of-range/negative/invalid IDs, no tool call, wrong tool name, invalid arguments, empty array
- [x] `TestExecuteReviewFilter_RemovesComments` and `TestExecuteReviewFilter_WithTimeout` updated and passing