### PR TITLE
fix(tool/code_search): guard option-like refs in buildGrepArgs

### DIFF
--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -78,7 +78,14 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 	cmdArgs = append(cmdArgs, "-e", searchText)
 
 	if ref := p.FileReader.Ref; ref != "" {
-		cmdArgs = append(cmdArgs, "--end-of-options")
+		if strings.HasPrefix(ref, "-") {
+			// Defense-in-depth: reject option-like refs here even though
+			// validateReviewRefs already verifies the ref upstream.
+			// NOTE: git grep < 2.45 does not support --end-of-options before
+			// the revision, so this is the one git invocation where we can't
+			// rely on that separator.
+			return nil
+		}
 		cmdArgs = append(cmdArgs, ref)
 	}
 
@@ -125,6 +132,9 @@ func (p *CodeSearchProvider) runGitGrep(parentCtx context.Context, cmdArgs []str
 
 func (p *CodeSearchProvider) gitGrep(ctx context.Context, searchText string, caseSensitive bool, usePerlRegexp bool, pathspec []string) (string, error) {
 	cmdArgs := p.buildGrepArgs(searchText, caseSensitive, usePerlRegexp, false, pathspec)
+	if cmdArgs == nil {
+		return "Error: ref must not start with '-'", nil
+	}
 
 	outStr, errStr, err := p.runGitGrep(ctx, cmdArgs)
 

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -33,15 +33,28 @@ func TestBuildGrepArgs_CommitMode(t *testing.T) {
 	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: "abc1234"})
 	args := p.buildGrepArgs("myFunc", false, false, false, []string{"pkg/"})
 
-	assertContainsInOrder(t, args, "-e", "myFunc", "--end-of-options", "abc1234", "--", "pkg/")
+	assertContainsInOrder(t, args, "-e", "myFunc", "abc1234", "--", "pkg/")
 	assertNotContains(t, args, "--untracked")
+	assertNotContains(t, args, "--end-of-options")
 }
 
-func TestBuildGrepArgs_RefUsesEndOfOptions(t *testing.T) {
+func TestBuildGrepArgs_RejectsOptionLikeRef(t *testing.T) {
 	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: "-O./pwn.sh"})
 	args := p.buildGrepArgs("myFunc", false, false, false, nil)
+	if args != nil {
+		t.Fatalf("expected buildGrepArgs to return nil for option-like ref, got %v", args)
+	}
+}
 
-	assertContainsInOrder(t, args, "-e", "myFunc", "--end-of-options", "-O./pwn.sh", "--")
+func TestGitGrep_RejectsOptionLikeRef(t *testing.T) {
+	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: "-O./pwn.sh"})
+	result, err := p.gitGrep(context.Background(), "myFunc", false, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Error: ref must not start with '-'" {
+		t.Fatalf("unexpected result: %s", result)
+	}
 }
 
 func TestBuildGrepArgs_PatternStartingWithDash(t *testing.T) {


### PR DESCRIPTION
Fixes #645

## Description

`git grep` on Git < 2.45 does not accept `--end-of-options` between the pattern and revision arguments. It treats `--end-of-options` as a revision and fails with:

```
fatal: ambiguous argument '--end-of-options': unknown revision or path not in the working tree.
```

This PR removes `--end-of-options` from `buildGrepArgs` for `git grep` and moves the defense-in-depth check (reject refs starting with `-`) into `buildGrepArgs()` so the guard is co-located with argument construction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (described below)

I ran the `internal/tool` tests locally with `go test ./internal/tool/ -run 'CodeSearch|BuildGrepArgs|GitGrep'` and all 25 tests passed. The new test `TestBuildGrepArgs_RejectsOptionLikeRef` specifically covers the nil-return path when a ref starts with `-`.

**Describe the tests you ran to verify your changes:**
- `TestBuildGrepArgs_RejectsOptionLikeRef` — verifies `buildGrepArgs` returns `nil` for option-like refs
- `TestGitGrep_RejectsOptionLikeRef` — verifies `gitGrep` returns the correct error string
- `TestGitGrep_OptionLikeRefDoesNotLaunchPager` — verifies no file is created when an option-like ref is passed
- All existing `BuildGrepArgs` and `GitGrep` tests continue to pass

**Include relevant details about your test configuration:**
- Go 1.23.4 windows/amd64
- Git 2.55.0.windows.3

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA

## Related Issues

Fixes #645
Addresses review feedback from @lizhengfeng101 in #663

## Security Note

Upstream `validateReviewRefs` (review_cmd.go:340-365) already rejects refs starting with `-` and verifies the ref resolves to a real commit via `git rev-parse --verify`. The check inside `buildGrepArgs` is defense-in-depth in case that function is ever called from a new code path. A comment explains why `--end-of-options` can't be used here: `git grep < 2.45` does not support `--end-of-options` before the revision.
