### PR TITLE
fix(opencode): harden opencode plugin against abort, orphan, and arg edge cases

### DIFF
--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process"
 import { type Plugin, tool } from "@opencode-ai/plugin"
 
 interface ReviewInput {
-  repo?: string
   commit?: string
   from?: string
   to?: string
@@ -60,13 +59,16 @@ function pushValue(args: string[], flag: string, value: string | number | undefi
   }
 }
 
-function buildReviewArgs(input: ReviewInput): string[] {
+function buildReviewArgs(input: ReviewInput, repo: string): string[] {
   const hasRange = input.from !== undefined || input.to !== undefined
   if (hasRange && (!input.from || !input.to)) {
     throw new Error("Both 'from' and 'to' are required for a branch comparison.")
   }
   if (input.commit && hasRange) {
     throw new Error("Use either 'commit' or a 'from'/'to' range, not both.")
+  }
+  if (input.resume && (input.commit || hasRange)) {
+    throw new Error("'resume' cannot be combined with 'commit' or a 'from'/'to' range.")
   }
   if (input.preview && input.resume) {
     throw new Error("'preview' and 'resume' cannot be used together.")
@@ -76,8 +78,8 @@ function buildReviewArgs(input: ReviewInput): string[] {
   if (!input.preview) {
     args.push("--format", "json")
   }
+  args.push("--repo", repo)
 
-  pushValue(args, "--repo", input.repo)
   pushValue(args, "--commit", input.commit)
   pushValue(args, "--from", input.from)
   pushValue(args, "--to", input.to)
@@ -123,6 +125,7 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
         cwd: options.cwd,
         env: process.env,
         shell: false,
+        detached: true,
       },
     )
     child.stdin.end()
@@ -146,12 +149,25 @@ async function runOcr(args: string[], options: RunOptions): Promise<RunResult> {
       callback()
     }
 
+    const killProcessGroup = (signal: NodeJS.Signals): void => {
+      if (closed || child.pid === undefined) return
+      if (process.platform === "win32") {
+        spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" })
+        return
+      }
+      try {
+        process.kill(-child.pid, signal)
+      } catch {
+        child.kill(signal)
+      }
+    }
+
     const terminateChild = (): void => {
       if (closed) return
-      child.kill("SIGTERM")
+      killProcessGroup("SIGTERM")
       forceKillTimer ??= setTimeout(() => {
         if (!closed) {
-          child.kill("SIGKILL")
+          killProcessGroup("SIGKILL")
         }
       }, 3_000)
     }
@@ -238,6 +254,9 @@ function formatReviewResult(result: RunResult, preview: boolean): string {
   if (preview) {
     return result.stdout || "No files changed."
   }
+  if (result.stdout === "") {
+    return "No changes detected; OCR produced no output."
+  }
   try {
     JSON.parse(result.stdout)
     return result.stdout
@@ -270,13 +289,17 @@ const reviewArgs = {
 }
 
 export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
-  await client.app.log({
-    body: {
-      service: "open-code-review",
-      level: "info",
-      message: "OpenCodeReview tools registered",
-    },
-  })
+  try {
+    await client.app.log({
+      body: {
+        service: "open-code-review",
+        level: "info",
+        message: "OpenCodeReview tools registered",
+      },
+    })
+  } catch {
+    // Best-effort telemetry; a failed log call must not block tool registration.
+  }
 
   return {
     config: async (config) => {
@@ -304,10 +327,7 @@ export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
         async execute(args, context) {
           const input = args as ReviewInput
           const cwd = context.worktree || context.directory || worktree
-          const result = await runOcr(buildReviewArgs({
-            ...input,
-            repo: cwd,
-          }), { cwd, signal: context.abort })
+          const result = await runOcr(buildReviewArgs(input, cwd), { cwd, signal: context.abort })
           return formatReviewResult(result, input.preview === true)
         },
       }),
@@ -332,7 +352,7 @@ export const OpenCodeReviewPlugin: Plugin = async ({ client, worktree }) => {
           const rejected = [version, llm].find(
             (result): result is PromiseRejectedResult => result.status === "rejected",
           )
-          if (context.abort.aborted && rejected) {
+          if (context.abort?.aborted && rejected) {
             throw rejected.reason
           }
 

--- a/plugins/open-code-review/opencode/test/open-code-review.test.mjs
+++ b/plugins/open-code-review/opencode/test/open-code-review.test.mjs
@@ -117,6 +117,20 @@ test("plugin registers tools and preserves existing user commands", async () => 
   assert.match(config.command["ocr-health"].template, /ocr_health/)
 })
 
+test("plugin still registers tools when the telemetry log call fails", async () => {
+  const hooks = await OpenCodeReviewPlugin({
+    client: {
+      app: {
+        log: async () => {
+          throw new Error("log service unavailable")
+        },
+      },
+    },
+    worktree: "/tmp/project",
+  })
+  assert.deepEqual(Object.keys(hooks.tool).sort(), ["ocr_health", "ocr_review"])
+})
+
 test("fake OCR helper removes its temporary directory", async () => {
   let temporaryDirectory
   await withFakeOcr("", async (directory) => {
@@ -202,6 +216,20 @@ test("ocr_review rejects incompatible review targets before starting OCR", async
         toolContext(worktree),
       ),
       /cannot be used together/,
+    )
+    await assert.rejects(
+      hooks.tool.ocr_review.execute(
+        { resume: "session-1", commit: "abc" },
+        toolContext(worktree),
+      ),
+      /'resume' cannot be combined/,
+    )
+    await assert.rejects(
+      hooks.tool.ocr_review.execute(
+        { resume: "session-1", from: "main", to: "feature" },
+        toolContext(worktree),
+      ),
+      /'resume' cannot be combined/,
     )
   })
 })
@@ -310,6 +338,42 @@ test("ocr_review force-kills a child that ignores cancellation", async () => {
   )
 })
 
+test("ocr_review kills the whole process group on cancellation", { skip: process.platform === "win32" }, async () => {
+  const grandchildSource = [
+    "require('node:fs').writeFileSync('grandchild.pid', String(process.pid))",
+    "setInterval(() => {}, 1000)",
+  ].join("\n")
+  await withFakeOcr(
+    [
+      "const { spawn } = require('node:child_process')",
+      `const g = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildSource)}], { stdio: 'ignore' })`,
+      "g.unref()",
+      "setInterval(() => {}, 1000)",
+    ].join("\n"),
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const controller = new AbortController()
+      const execution = hooks.tool.ocr_review.execute(
+        {},
+        toolContext(worktree, controller.signal),
+      )
+      const pidPath = join(worktree, "grandchild.pid")
+      await waitForFile(pidPath)
+      const pid = Number(await readFile(pidPath, "utf8"))
+
+      controller.abort()
+      await assert.rejects(execution, /cancelled by OpenCode/)
+      try {
+        await waitForProcessExit(pid)
+      } finally {
+        if (isProcessRunning(pid)) {
+          process.kill(pid, "SIGKILL")
+        }
+      }
+    },
+  )
+})
+
 test("ocr_review terminates after its overall timeout", async () => {
   await withFakeOcr(
     "setInterval(() => {}, 1000)",
@@ -354,6 +418,14 @@ test("ocr_review rejects invalid JSON output", async () => {
   )
 })
 
+test("ocr_review reports no output instead of invalid JSON when OCR prints nothing", async () => {
+  await withFakeOcr("", async (worktree) => {
+    const { hooks } = await loadPlugin(worktree)
+    const output = await hooks.tool.ocr_review.execute({}, toolContext(worktree))
+    assert.match(output, /No changes detected/)
+  })
+})
+
 test("ocr_review preserves valid JSON after validation", async () => {
   await withFakeOcr(
     "console.log('{\"status\":\"success\",\"findings\":[]}')",
@@ -383,6 +455,28 @@ test("ocr_health reports both version success and LLM failure", async () => {
       const output = await hooks.tool.ocr_health.execute(
         {},
         toolContext(worktree),
+      )
+      assert.match(output, /OpenCodeReview 1\.2\.3/)
+      assert.match(output, /LLM connection check failed: missing LLM credentials/)
+    },
+  )
+})
+
+test("ocr_health works when no abort signal is provided", async () => {
+  await withFakeOcr(
+    [
+      "if (process.argv[2] === 'version') {",
+      "  console.log('OpenCodeReview 1.2.3')",
+      "} else {",
+      "  console.error('missing LLM credentials')",
+      "  process.exitCode = 7",
+      "}",
+    ].join("\n"),
+    async (worktree) => {
+      const { hooks } = await loadPlugin(worktree)
+      const output = await hooks.tool.ocr_health.execute(
+        {},
+        { worktree, directory: worktree },
       )
       assert.match(output, /OpenCodeReview 1\.2\.3/)
       assert.match(output, /LLM connection check failed: missing LLM credentials/)


### PR DESCRIPTION
Fixes #702 (the six findings not covered by #717).

Implements M1, M2, M3, M4, L1, L2 from the issue:

- M1: telemetry app.log failure no longer blocks tool registration
- M2: context.abort.aborted guarded for hosts without an abort signal
- M3: resume is now rejected alongside commit or a from/to range
- M4: OCR spawns detached and the whole process group is killed on timeout/cancel, so git/LLM grandchildren cannot orphan
- L1: empty stdout reads as no changes instead of a misleading invalid JSON error
- L2: dead ReviewInput.repo field removed; cwd is passed as the repo arg directly

H1 is intentionally left to #717.

Tests: ran `npm run check` in plugins/open-code-review/opencode, all 21 tests pass. New tests cover each fix; the process-group test fails without the detached/kill-group change.