### PR TITLE
ci(pages): run tests in Pages workflow

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -33,6 +33,10 @@ jobs:
         working-directory: pages
         run: npm run lint
 
+      - name: Test
+        working-directory: pages
+        run: npm test
+
       - name: Typecheck
         working-directory: pages
         run: npm run typecheck


### PR DESCRIPTION
## Summary

Add the missing `npm test` step to the Pages CI workflow.

The workflow already installs dependencies, lints, typechecks, builds, and checks bundle size, but it did not run the existing Vitest suite. This step runs the Pages tests after lint and before typecheck/build so regressions such as critical-CSS drift and ErrorBoundary failures are covered in CI.

Closes #730

## Validation

From `pages/`:

- `npm test` — 4 test files, 16 tests passed
- `npm run lint` — passed with 2 pre-existing hook-dependency warnings
- `npm run typecheck` — passed
- `npm run build` — passed with existing webpack asset-size warnings
- `npm run size` — passed (86.67 kB Brotli against a 150 kB limit)
- `git diff --check` — passed

The commit includes a `Signed-off-by` line; the local SSH signing agent was unavailable in this checkout.
