### PR TITLE
feat(viewer): collapse secondary session sections

### DIFF
--- a/internal/viewer/server_extra_test.go
+++ b/internal/viewer/server_extra_test.go
@@ -156,6 +156,45 @@ func TestRenderTemplate_SessionPage(t *testing.T) {
 	}
 }
 
+func TestRenderTemplate_SecondarySectionsCollapsedByDefault(t *testing.T) {
+	rr := httptest.NewRecorder()
+	vs := &ViewSession{
+		Summary: SessionSummary{
+			SessionID:     "abc",
+			CWD:           "/test",
+			FilesReviewed: []string{"main.go"},
+		},
+		TokenUsage: TokenUsageSummary{
+			FileTokenBreakdown: []FileTokenUsage{{FilePath: "main.go"}},
+		},
+		Files: []*FileGroup{{FilePath: "main.go", Tasks: map[TaskType][]*TaskCard{}}},
+		Comments: []*ReviewComment{{
+			FilePath: "main.go",
+			Content:  "Keep this visible",
+		}},
+	}
+
+	renderTemplate(rr, "session.html", sessionPageData{
+		EncodedRepo: "repo",
+		RepoName:    "MyRepo",
+		Session:     vs,
+	})
+
+	body := rr.Body.String()
+	if count := strings.Count(body, `<details class="file-accordion section-accordion">`); count != 2 {
+		t.Fatalf("collapsed secondary section count = %d, want 2", count)
+	}
+	if strings.Contains(body, `<details class="file-accordion section-accordion" open>`) {
+		t.Fatal("secondary sections should be collapsed by default")
+	}
+	if !strings.Contains(body, `<details class="token-breakdown">`) || strings.Contains(body, `<details class="token-breakdown" open>`) {
+		t.Fatal("file token breakdown should be rendered and collapsed by default")
+	}
+	if !strings.Contains(body, `<details class="comment-file-group" open>`) {
+		t.Fatal("review comment groups should remain expanded")
+	}
+}
+
 func TestRenderTemplate_ExecutionError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	// Pass wrong data type to trigger template execution error

--- a/internal/viewer/server_extra_test.go
+++ b/internal/viewer/server_extra_test.go
@@ -195,6 +195,21 @@ func TestRenderTemplate_SecondarySectionsCollapsedByDefault(t *testing.T) {
 	}
 }
 
+func TestRenderTemplate_HidesEmptyConversationsSection(t *testing.T) {
+	rr := httptest.NewRecorder()
+	renderTemplate(rr, "session.html", sessionPageData{
+		EncodedRepo: "repo",
+		RepoName:    "MyRepo",
+		Session: &ViewSession{
+			Summary: SessionSummary{SessionID: "abc", CWD: "/test"},
+		},
+	})
+
+	if strings.Contains(rr.Body.String(), `<span class="section-title">Conversations</span>`) {
+		t.Fatal("empty conversations section should not be rendered")
+	}
+}
+
 func TestRenderTemplate_ExecutionError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	// Pass wrong data type to trigger template execution error

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -420,6 +420,26 @@ h3 {
 }
 .token-table tbody tr:hover { background: var(--accent-soft); }
 
+.token-breakdown-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.82rem;
+    font-weight: 600;
+    list-style: none;
+    padding: 0.25rem 0 0.75rem;
+}
+.token-breakdown-toggle::-webkit-details-marker { display: none; }
+.token-breakdown-toggle::marker { content: none; }
+.token-breakdown-toggle .file-count-badge { margin-left: auto; }
+.token-breakdown[open] > .token-breakdown-toggle .chevron-sm { transform: rotate(45deg); }
+.token-breakdown-body {
+    overflow-x: auto;
+    padding-top: 0.25rem;
+}
+
 /* ── File List ── */
 .file-list {
     list-style: none;
@@ -546,6 +566,18 @@ h3 {
 
 .file-accordion-body {
     padding: 1rem 1.25rem 1.25rem;
+}
+
+.section-accordion {
+    margin-top: 1.25rem;
+}
+.section-title {
+    flex: 1;
+    font-weight: 600;
+}
+.section-accordion .file-list,
+.section-accordion .conversations {
+    margin: 0;
 }
 
 /* Task Group */

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -176,6 +176,7 @@
 </details>
 {{end}}
 
+{{if .Session.Files}}
 <details class="file-accordion section-accordion">
     <summary class="file-accordion-header">
         <span class="chevron"></span>
@@ -255,6 +256,7 @@
         </div>
     </div>
 </details>
+{{end}}
 
 <script src="/static/session.js"></script>
 </main>

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -80,20 +80,29 @@
         {{end}}
     </div>
     {{with .Session.TokenUsage.FileTokenBreakdown}}
-    <table class="token-table">
-        <thead><tr><th>File</th><th>Prompt</th><th>Completion</th>{{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<th>Cache Read</th><th>Cache Write</th>{{end}}<th>Total</th></tr></thead>
-        <tbody>
-        {{range .}}
-            <tr>
-                <td title="{{.FilePath}}">{{.FilePath | truncate 60}}</td>
-                <td title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</td>
-                <td title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</td>
-                {{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<td title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</td><td title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</td>{{end}}
-                <td title="{{add .PromptTokens .CompletionTokens}}"><strong>{{formatNumber (add .PromptTokens .CompletionTokens)}}</strong></td>
-            </tr>
-        {{end}}
-        </tbody>
-    </table>
+    <details class="token-breakdown">
+        <summary class="token-breakdown-toggle">
+            <span class="chevron-sm"></span>
+            <span>File breakdown</span>
+            <span class="file-count-badge">{{len .}} files</span>
+        </summary>
+        <div class="token-breakdown-body">
+            <table class="token-table">
+                <thead><tr><th>File</th><th>Prompt</th><th>Completion</th>{{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<th>Cache Read</th><th>Cache Write</th>{{end}}<th>Total</th></tr></thead>
+                <tbody>
+                {{range .}}
+                    <tr>
+                        <td title="{{.FilePath}}">{{.FilePath | truncate 60}}</td>
+                        <td title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</td>
+                        <td title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</td>
+                        {{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<td title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</td><td title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</td>{{end}}
+                        <td title="{{add .PromptTokens .CompletionTokens}}"><strong>{{formatNumber (add .PromptTokens .CompletionTokens)}}</strong></td>
+                    </tr>
+                {{end}}
+                </tbody>
+            </table>
+        </div>
+    </details>
     {{end}}
 </div>
 
@@ -151,16 +160,30 @@
 {{end}}
 
 {{if .Session.Summary.FilesReviewed}}
-<h3>Files Reviewed</h3>
-<ul class="file-list">
-{{range .Session.Summary.FilesReviewed}}
-    <li>{{.}}</li>
-{{end}}
-</ul>
+<details class="file-accordion section-accordion">
+    <summary class="file-accordion-header">
+        <span class="chevron"></span>
+        <span class="section-title">Files Reviewed</span>
+        <span class="file-count-badge">{{len .Session.Summary.FilesReviewed}} files</span>
+    </summary>
+    <div class="file-accordion-body">
+        <ul class="file-list">
+        {{range .Session.Summary.FilesReviewed}}
+            <li>{{.}}</li>
+        {{end}}
+        </ul>
+    </div>
+</details>
 {{end}}
 
-<h3>Conversations ({{len .Session.Files}} files)</h3>
-<div class="conversations">
+<details class="file-accordion section-accordion">
+    <summary class="file-accordion-header">
+        <span class="chevron"></span>
+        <span class="section-title">Conversations</span>
+        <span class="file-count-badge">{{len .Session.Files}} files</span>
+    </summary>
+    <div class="file-accordion-body">
+        <div class="conversations">
 {{range .Session.Files}}
 <details class="file-accordion">
     <summary class="file-accordion-header">
@@ -229,7 +252,9 @@
     </div>
 </details>
 {{end}}
-</div>
+        </div>
+    </div>
+</details>
 
 <script src="/static/session.js"></script>
 </main>


### PR DESCRIPTION
## Description

Keep review findings prominent by collapsing the three secondary session details by default:

- per-file token usage
- files reviewed
- raw LLM conversations

The Viewer uses native `details` elements and the existing disclosure styling, so each section remains keyboard-accessible and can be expanded without JavaScript. Review Comments and their file groups remain open. Count badges keep the hidden scope visible at a glance, and the token table is placed in an overflow-safe body for narrow screens.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] Focused Viewer template/static tests
- [x] `go vet ./...`
- [x] Manual browser testing at desktop and mobile widths

The regression test verifies all three secondary sections render closed while Review Comment file groups remain open. Browser checks confirmed the sections stay closed at 1265px and 390px widths and expand normally when activated.

`go test ./internal/viewer` also reaches three existing permission-mode assertions that are not portable to Windows (`TestHandleRepos_PermissionDenied`, `TestDiscoverRepos_SkipsUnreadableSubdir`, and `TestListSessions_SkipsUnreadableFiles`). The focused Viewer rendering tests pass.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the new default state
- [x] Relevant tests pass locally with my changes
- [x] Documentation is unchanged because the controls use native disclosure behavior
- [ ] I have signed the CLA

## Related Issues

Closes #734