### PR TITLE
fix(viewer): stack suggested code panels

### DIFF
--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -967,7 +967,7 @@ p {
 
 .comment-code-diff {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     gap: 0.75rem;
     margin-top: 0.85rem;
 }
@@ -1029,7 +1029,6 @@ p {
     .token-stats { grid-template-columns: repeat(2, 1fr); }
     .meta { gap: 0.5rem 1rem; font-size: 0.8rem; }
     .table th, .table td { padding: 0.6rem 0.75rem; font-size: 0.82rem; }
-    .comment-code-diff { grid-template-columns: 1fr; }
 }
 
 /* ── Accessibility: reduced motion ── */


### PR DESCRIPTION
## Description

Display the existing-code and suggested-change panels as a single vertical stack at every viewport size. Each snippet now gets the full comment width, making longer lines easier to compare and removing the redundant mobile-only grid override.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] Focused Viewer template/static tests
- [x] `go vet ./...`
- [x] Manual browser testing at desktop and mobile widths

At 1265px, both panels render at the same 1026px width on separate rows. At a 390px viewport, they remain stacked within the comment card without panel overflow.

`go test ./internal/viewer` also reaches three existing permission-mode assertions that are not portable to Windows (`TestHandleRepos_PermissionDenied`, `TestDiscoverRepos_SkipsUnreadableSubdir`, and `TestListSessions_SkipsUnreadableFiles`). The focused Viewer rendering tests pass.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] Relevant tests pass locally with my changes
- [x] Documentation is unchanged because the Viewer behavior is self-evident
- [ ] I have signed the CLA

## Related Issues

Closes #733