### PR TITLE
ci(pages): add smoke test step to verify build output is servable

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -54,9 +54,10 @@ jobs:
           sleep 2
 
           FAILED=0
+          # `serve -s` rewrites SPA routes to index.html, so this verifies
+          # the built shell is reachable and includes bundle references.
           for path in "/" "/docs/contributing" "/docs/quickstart" "/features"; do
-            BODY=$(curl -sf "http://127.0.0.1:3999${path}")
-            if [ $? -ne 0 ]; then
+            if ! BODY=$(curl -sf "http://127.0.0.1:3999${path}"); then
               echo "FAIL: ${path} — not reachable"
               FAILED=1
             elif ! echo "$BODY" | grep -q '\.bundle\.js'; then
@@ -66,6 +67,14 @@ jobs:
               echo "OK: ${path}"
             fi
           done
+
+          # Also check a real static file to ensure dist assets are served.
+          if ! curl -sf "http://127.0.0.1:3999/404.html" >/dev/null; then
+            echo "FAIL: /404.html — static file not reachable"
+            FAILED=1
+          else
+            echo "OK: /404.html"
+          fi
 
           exit $FAILED
 

--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -45,6 +45,30 @@ jobs:
         working-directory: pages
         run: npm run build
 
+      - name: Smoke test
+        working-directory: pages
+        run: |
+          npx serve dist -s -l tcp://127.0.0.1:3999 &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+          sleep 2
+
+          FAILED=0
+          for path in "/" "/docs/contributing" "/docs/quickstart" "/features"; do
+            BODY=$(curl -sf "http://127.0.0.1:3999${path}")
+            if [ $? -ne 0 ]; then
+              echo "FAIL: ${path} — not reachable"
+              FAILED=1
+            elif ! echo "$BODY" | grep -q '\.bundle\.js'; then
+              echo "FAIL: ${path} — missing bundle reference"
+              FAILED=1
+            else
+              echo "OK: ${path}"
+            fi
+          done
+
+          exit $FAILED
+
       - name: Check bundle size
         working-directory: pages
         run: npm run size

--- a/pages/package.json
+++ b/pages/package.json
@@ -55,6 +55,7 @@
     "jsdom": "^30.0.0",
     "postcss": "^8.5.15",
     "postcss-loader": "^7.3.3",
+    "serve": "^14.2.6",
     "size-limit": "^13.0.1",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.3.5",


### PR DESCRIPTION
## Summary
- Add `serve` as a pages `devDependency` so CI can statically serve `dist/` without downloading on every run.
- After the Build step in `pages-ci.yml`, smoke-test `/`, `/docs/contributing`, `/docs/quickstart`, and `/features` for HTTP 200 responses that include `.bundle.js` references (SPA mode via `serve -s`).
- Closes #725

## Test plan
- [x] Pages CI runs on this PR (`pages/**` path filter)
- [x] Smoke test step passes (all four routes OK)
- [x] Bundle size check still runs after smoke test
- [x] Locally (Node 24.18.0): `cd pages && npm install && npm run build`, then run the smoke script from the workflow
