### PR TITLE
fix(viewer): restore session response formatting

### DIFF
--- a/internal/viewer/static/session.js
+++ b/internal/viewer/static/session.js
@@ -9,7 +9,10 @@ document.querySelectorAll('.response-text').forEach(function(el) {
     };
     const codeBlocks = [];
     let html = esc(text);
-    html = html.replace(/
+    html = html.replace(/```(\w*)\n([\s\S]*?)```/g, function(_, lang, code) {
+        codeBlocks.push(code.replace(/^\n|\n$/g, ''));
+        return '%%CODEBLOCK_' + (codeBlocks.length - 1) + '%%';
+    });
     html = html
         .replace(/`([^`]+)`/g, '<code class="inline-code">$1</code>')
         .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')


### PR DESCRIPTION
## Description

  The session viewer's external JavaScript file became syntactically invalid after commit `d1008b8f3bd39a596e1bf3390ddffe2fe1ecbc49` (`feat(viewer): add defense-in-depth security headers (#735)`).

  That commit moved the response-formatting script from the inline `<script>` block in `internal/viewer/templates/session.html` to `internal/viewer/static/session.js`. During the extraction, the fenced code-block replacement callback was omitted, leaving an incomplete regular-expression statement:

  ```js
  html = html.replace(/
  ```

  This prevented the entire session viewer script from being parsed and disabled response formatting. This PR restores the omitted logic without changing the CSP, template structure, or server behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

The viewer formatting smoke test verified fenced code blocks and bold text rendering.

- [x] `make test` passes locally
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #752 
