### PR TITLE
feat(llm): add Novita AI as a built-in provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -295,6 +295,21 @@ var registry = []Provider{
 		},
 	},
 	{
+		Name:        "novita",
+		DisplayName: "Novita AI",
+		Protocol:    ProtocolOpenAIChatCompletions,
+		BaseURL:     "https://api.novita.ai/v3/openai",
+		EnvVar:      "NOVITA_API_KEY",
+		Models: []string{
+			"deepseek/deepseek-v4-pro",
+			"deepseek/deepseek-v4-flash",
+			"qwen/qwen3.7-max",
+			"qwen/qwen3-coder-480b-a35b-instruct",
+			"moonshotai/kimi-k2.7-code",
+			"zai-org/glm-5.2",
+		},
+	},
+	{
 		Name:        "litellm",
 		DisplayName: "LiteLLM AI Gateway",
 		Protocol:    ProtocolOpenAIChatCompletions,

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -298,7 +298,7 @@ var registry = []Provider{
 		Name:        "novita",
 		DisplayName: "Novita AI",
 		Protocol:    ProtocolOpenAIChatCompletions,
-		BaseURL:     "https://api.novita.ai/v3/openai",
+		BaseURL:     "https://api.novita.ai/openai",
 		EnvVar:      "NOVITA_API_KEY",
 		Models: []string{
 			"deepseek/deepseek-v4-pro",

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -296,7 +296,7 @@ var registry = []Provider{
 	},
 	{
 		Name:        "novita",
-		DisplayName: "Novita AI",
+		DisplayName: "Novita API",
 		Protocol:    ProtocolOpenAIChatCompletions,
 		BaseURL:     "https://api.novita.ai/openai",
 		EnvVar:      "NOVITA_API_KEY",

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -301,12 +301,9 @@ var registry = []Provider{
 		BaseURL:     "https://api.novita.ai/openai",
 		EnvVar:      "NOVITA_API_KEY",
 		Models: []string{
-			"deepseek/deepseek-v4-pro",
-			"deepseek/deepseek-v4-flash",
-			"qwen/qwen3.7-max",
-			"qwen/qwen3-coder-480b-a35b-instruct",
-			"moonshotai/kimi-k2.7-code",
+			"moonshotai/kimi-k3",
 			"zai-org/glm-5.2",
+			"deepseek/deepseek-v4-flash-0731",
 		},
 	},
 	{

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -40,7 +40,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "novita", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -58,6 +58,7 @@ environment variable.
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
 
 ### Custom providers
 

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -58,7 +58,7 @@ environment variable.
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
-| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/openai` | `NOVITA_API_KEY` |
 
 ### Custom providers
 

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -56,7 +56,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
-| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/openai` | `NOVITA_API_KEY` |
 
 ### カスタム provider
 

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -56,6 +56,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
 
 ### カスタム provider
 

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -55,7 +55,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
-| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/openai` | `NOVITA_API_KEY` |
 
 ### 自定义 provider
 

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -55,6 +55,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` |
 | `baidu-qianfan` | openai | `https://qianfan.baidubce.com/v2` | `QIANFAN_API_KEY` |
+| `novita` | openai | `https://api.novita.ai/v3/openai` | `NOVITA_API_KEY` |
 
 ### 自定义 provider
 


### PR DESCRIPTION

Adds `novita` to the built-in provider registry in `internal/llm/providers.go`. Novita's endpoint is OpenAI-compatible, so it registers the same way as the other openai-protocol providers (deepseek, kimi, z-ai, ...) — no new client code needed.

- Base URL: `https://api.novita.ai/openai` (current documented endpoint)
- Auth: `NOVITA_API_KEY` env var (Bearer, OpenAI-compatible default)
- Models: `moonshotai/kimi-k3`, `zai-org/glm-5.2`, `deepseek/deepseek-v4-flash-0731` — current flagships per Novita's live `/openai/v1/models`

Also updates the provider table in the en/ja/zh configuration docs and the provider-order test in `providers_test.go`.

Verified against the real Novita endpoint via `ocr llm test` (the repo's own connectivity-check command), which returned a live response from `moonshotai/kimi-k3` through the configured provider.
