### PR TITLE
fix(viewer): externalize repos page inline script to comply with CSP

### DIFF
--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-//go:embed templates/*.html static/style.css static/session.js
+//go:embed templates/*.html static/style.css static/session.js static/repos.js
 var assets embed.FS
 
 func StartServer(addr string) error {

--- a/internal/viewer/server_extra_test.go
+++ b/internal/viewer/server_extra_test.go
@@ -84,10 +84,7 @@ func TestRenderTemplate_WithRepos(t *testing.T) {
 		`id="repository-search-input"`,
 		`id="repositories-table"`,
 		"data-repository-name",
-		`addEventListener("input"`,
-		"toLowerCase()",
-		"name.includes(query)",
-		"row.hidden",
+		`src="/static/repos.js"`,
 	} {
 		if !strings.Contains(body, required) {
 			t.Errorf("rendered repository page missing %q", required)

--- a/internal/viewer/static/repos.js
+++ b/internal/viewer/static/repos.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+(() => {
+    const input = document.getElementById("repository-search-input");
+    const table = document.getElementById("repositories-table");
+    if (!input || !table) return;
+
+    const rows = table.querySelectorAll("tbody tr");
+    input.addEventListener("input", () => {
+        const query = input.value.trim().toLowerCase();
+        rows.forEach((row) => {
+            const nameCell = row.querySelector("[data-repository-name]");
+            const name = nameCell ? nameCell.textContent.trim().toLowerCase() : "";
+            row.hidden = !name.includes(query);
+        });
+    });
+})();

--- a/internal/viewer/templates/repos.html
+++ b/internal/viewer/templates/repos.html
@@ -28,23 +28,7 @@
     {{end}}
     </tbody>
 </table>
-<script>
-(() => {
-    const input = document.getElementById("repository-search-input");
-    const table = document.getElementById("repositories-table");
-    if (!input || !table) return;
-
-    const rows = table.querySelectorAll("tbody tr");
-    input.addEventListener("input", () => {
-        const query = input.value.trim().toLowerCase();
-        rows.forEach((row) => {
-            const nameCell = row.querySelector("[data-repository-name]");
-            const name = nameCell ? nameCell.textContent.trim().toLowerCase() : "";
-            row.hidden = !name.includes(query);
-        });
-    });
-})();
-</script>
+<script src="/static/repos.js"></script>
 {{else}}
 <p>No session data found. Run a code review first.</p>
 {{end}}


### PR DESCRIPTION
## Description
The repos page search/filter feature was broken because its inline <script> block was blocked by the strict Content-Security-Policy (script-src 'self') introduced in #735. The PR fixes it
<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
closes #757 