### PR TITLE
docs(installation): add Homebrew install method

### DIFF
--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-There are four supported ways to install the `ocr` CLI.
+There are five supported ways to install the `ocr` CLI.
 
 ## NPM (recommended)
 
@@ -39,6 +39,20 @@ export OCR_NO_UPDATE=1
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
+```
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew install open-code-review
+```
+
+The formula installs the `ocr` binary built from source.
+
+To upgrade later:
+
+```bash
+brew upgrade open-code-review
 ```
 
 ## Install script (curl | sh)

--- a/pages/src/content/docs/ja/installation.md
+++ b/pages/src/content/docs/ja/installation.md
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-`ocr` CLI をインストールするには、サポートされた 4 つの方法があります。
+`ocr` CLI をインストールするには、サポートされた 5 つの方法があります。
 
 ## NPM（推奨）
 
@@ -38,6 +38,20 @@ export OCR_NO_UPDATE=1
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
+```
+
+## Homebrew（macOS / Linux）
+
+```bash
+brew install open-code-review
+```
+
+この formula はソースからビルドして `ocr` バイナリをインストールします。
+
+後でアップグレードするには：
+
+```bash
+brew upgrade open-code-review
 ```
 
 ## インストールスクリプト（curl | sh）

--- a/pages/src/content/docs/ru/installation.md
+++ b/pages/src/content/docs/ru/installation.md
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-Установить CLI `ocr` можно четырьмя способами.
+Установить CLI `ocr` можно пятью способами.
 
 ## npm (рекомендуется)
 
@@ -38,6 +38,20 @@ export OCR_NO_UPDATE=1
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
+```
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew install open-code-review
+```
+
+Формула собирает `ocr` из исходников и устанавливает бинарник.
+
+Для обновления:
+
+```bash
+brew upgrade open-code-review
 ```
 
 ## Скрипт установки (curl | sh)

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-安装 `ocr` CLI 有四种受支持的方式。
+安装 `ocr` CLI 有五种受支持的方式。
 
 ## NPM（推荐）
 
@@ -36,6 +36,20 @@ export OCR_NO_UPDATE=1
 
 ```bash
 npm uninstall -g @alibaba-group/open-code-review
+```
+
+## Homebrew（macOS / Linux）
+
+```bash
+brew install open-code-review
+```
+
+该 formula 会从源码构建并安装 `ocr` 二进制。
+
+后续升级：
+
+```bash
+brew upgrade open-code-review
 ```
 
 ## 安装脚本（curl | sh）


### PR DESCRIPTION
## Summary

- `open-code-review` has been accepted into [homebrew-core](https://github.com/Homebrew/homebrew-core/commit/031ca4df4a33ac2c5db2235cbfc7f4191fd70007) since v1.8.6.
- Add a **Homebrew (macOS / Linux)** section to the installation docs (after NPM, before the curl install script).
- Update the install method count from "four" to "five" in all variants.
- Synced across all four language versions: en, zh, ja, ru.