### PR TITLE
fix(review): filter near-duplicate comments in review output

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -637,7 +637,8 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, string,
 }
 
 // executeReviewFilter runs the REVIEW_FILTER_TASK to remove comments that are
-// provably incorrect based solely on the diff. Errors are logged and silently ignored.
+// provably incorrect or high-confidence near-duplicates. Errors are logged and
+// silently ignored so filtering remains fail-open.
 func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath string) {
 	ctx, span := telemetry.StartSpan(ctx, "review_filter.execute")
 	defer span.End()
@@ -654,7 +655,11 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	}
 	telemetry.SetAttr(span, "comments.before", len(comments))
 
-	commentsJSON := buildFilterCommentsJSON(comments)
+	// Resolve locations on a temporary copy. The collector's comments must stay
+	// untouched because they are persisted after this filter returns and are
+	// resolved again by the final output stage.
+	resolvedComments := diff.ResolveLineNumbers(comments, []model.Diff{d})
+	commentsJSON := buildFilterCommentsJSON(resolvedComments)
 
 	messages := make([]llm.Message, 0, len(ft.Messages))
 	for _, m := range ft.Messages {
@@ -704,19 +709,33 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	fmt.Fprintf(stdout.Writer(), "[ocr] Review filter removed %d comment(s) for %s\n", len(indices), newPath)
 }
 
-// buildFilterCommentsJSON serializes comments into a JSON array with generated IDs.
+// buildFilterCommentsJSON serializes comments into a JSON array with generated
+// IDs and the metadata needed to identify high-confidence duplicates. Line
+// numbers are always present; zero means that location resolution failed.
 func buildFilterCommentsJSON(comments []model.LlmComment) string {
 	type filterComment struct {
-		ID           string `json:"id"`
-		Content      string `json:"content"`
-		ExistingCode string `json:"existing_code,omitempty"`
+		ID             string `json:"id"`
+		Path           string `json:"path"`
+		Content        string `json:"content"`
+		SuggestionCode string `json:"suggestion_code,omitempty"`
+		ExistingCode   string `json:"existing_code,omitempty"`
+		StartLine      int    `json:"start_line"`
+		EndLine        int    `json:"end_line"`
+		Category       string `json:"category,omitempty"`
+		Severity       string `json:"severity,omitempty"`
 	}
 	items := make([]filterComment, len(comments))
 	for i, cm := range comments {
 		items[i] = filterComment{
-			ID:           fmt.Sprintf("c-%d", i),
-			Content:      cm.Content,
-			ExistingCode: cm.ExistingCode,
+			ID:             fmt.Sprintf("c-%d", i),
+			Path:           cm.Path,
+			Content:        cm.Content,
+			SuggestionCode: cm.SuggestionCode,
+			ExistingCode:   cm.ExistingCode,
+			StartLine:      cm.StartLine,
+			EndLine:        cm.EndLine,
+			Category:       cm.Category,
+			Severity:       cm.Severity,
 		}
 	}
 	data, _ := json.Marshal(items)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -17,9 +17,11 @@ import (
 type fakeAgentClient struct {
 	responses []*llm.ChatResponse
 	calls     int
+	requests  []llm.ChatRequest
 }
 
-func (f *fakeAgentClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+func (f *fakeAgentClient) CompletionsWithCtx(_ context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	f.requests = append(f.requests, req)
 	if f.calls >= len(f.responses) {
 		content := ""
 		return &llm.ChatResponse{
@@ -98,7 +100,16 @@ func TestBuildFilterCommentsJSON(t *testing.T) {
 		{
 			name: "single comment",
 			comments: []model.LlmComment{
-				{Content: "fix this", ExistingCode: "old code"},
+				{
+					Path:           "src/a.go",
+					Content:        "fix this",
+					SuggestionCode: "fixed code",
+					ExistingCode:   "old code",
+					StartLine:      12,
+					EndLine:        13,
+					Category:       "bug",
+					Severity:       "high",
+				},
 			},
 			wantIDs: []string{"c-0"},
 		},
@@ -118,9 +129,15 @@ func TestBuildFilterCommentsJSON(t *testing.T) {
 			got := buildFilterCommentsJSON(tt.comments)
 
 			var items []struct {
-				ID           string `json:"id"`
-				Content      string `json:"content"`
-				ExistingCode string `json:"existing_code,omitempty"`
+				ID             string `json:"id"`
+				Path           string `json:"path"`
+				Content        string `json:"content"`
+				SuggestionCode string `json:"suggestion_code,omitempty"`
+				ExistingCode   string `json:"existing_code,omitempty"`
+				StartLine      int    `json:"start_line"`
+				EndLine        int    `json:"end_line"`
+				Category       string `json:"category,omitempty"`
+				Severity       string `json:"severity,omitempty"`
 			}
 			if err := json.Unmarshal([]byte(got), &items); err != nil {
 				t.Fatalf("invalid JSON: %v\nraw: %s", err, got)
@@ -137,8 +154,20 @@ func TestBuildFilterCommentsJSON(t *testing.T) {
 				if item.Content != tt.comments[i].Content {
 					t.Errorf("items[%d].Content = %q, want %q", i, item.Content, tt.comments[i].Content)
 				}
+				if item.Path != tt.comments[i].Path {
+					t.Errorf("items[%d].Path = %q, want %q", i, item.Path, tt.comments[i].Path)
+				}
+				if item.SuggestionCode != tt.comments[i].SuggestionCode {
+					t.Errorf("items[%d].SuggestionCode = %q, want %q", i, item.SuggestionCode, tt.comments[i].SuggestionCode)
+				}
 				if item.ExistingCode != tt.comments[i].ExistingCode {
 					t.Errorf("items[%d].ExistingCode = %q, want %q", i, item.ExistingCode, tt.comments[i].ExistingCode)
+				}
+				if item.StartLine != tt.comments[i].StartLine || item.EndLine != tt.comments[i].EndLine {
+					t.Errorf("items[%d] line range = %d-%d, want %d-%d", i, item.StartLine, item.EndLine, tt.comments[i].StartLine, tt.comments[i].EndLine)
+				}
+				if item.Category != tt.comments[i].Category || item.Severity != tt.comments[i].Severity {
+					t.Errorf("items[%d] classification = %s/%s, want %s/%s", i, item.Category, item.Severity, tt.comments[i].Category, tt.comments[i].Severity)
 				}
 			}
 		})

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -275,9 +275,37 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 	}
 
 	collector := tool.NewCommentCollector()
-	collector.Add(model.LlmComment{Path: "a.go", Content: "keep this"})
-	collector.Add(model.LlmComment{Path: "a.go", Content: "remove this"})
-	collector.Add(model.LlmComment{Path: "a.go", Content: "also keep"})
+	collector.Add(model.LlmComment{
+		Path:           "a.go",
+		Content:        "keep this",
+		SuggestionCode: "keep suggestion",
+		ExistingCode:   "same code",
+		StartLine:      10,
+		EndLine:        10,
+		Category:       "bug",
+		Severity:       "high",
+	})
+	collector.Add(model.LlmComment{Path: "b.go", Content: "other file"})
+	collector.Add(model.LlmComment{
+		Path:           "a.go",
+		Content:        "remove this duplicate",
+		SuggestionCode: "duplicate suggestion",
+		ExistingCode:   "same code",
+		StartLine:      10,
+		EndLine:        10,
+		Category:       "bug",
+		Severity:       "high",
+	})
+	collector.Add(model.LlmComment{
+		Path:           "a.go",
+		Content:        "complementary finding",
+		SuggestionCode: "different suggestion",
+		ExistingCode:   "same code",
+		StartLine:      10,
+		EndLine:        10,
+		Category:       "security",
+		Severity:       "critical",
+	})
 
 	a := New(Args{
 		LLMClient:        client,
@@ -301,9 +329,69 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 		t.Fatalf("expected 2 comments after filter, got %d", len(comments))
 	}
 	for _, c := range comments {
-		if c.Content == "remove this" {
+		if c.Content == "remove this duplicate" {
 			t.Error("filtered comment should have been removed")
 		}
+	}
+	if other := collector.CommentsForPath("b.go"); len(other) != 1 || other[0].Content != "other file" {
+		t.Fatalf("comment for another path was changed: %+v", other)
+	}
+	if comments[0].SuggestionCode != "keep suggestion" || comments[0].Category != "bug" || comments[0].Severity != "high" {
+		t.Errorf("surviving canonical metadata changed: %+v", comments[0])
+	}
+	if comments[1].SuggestionCode != "different suggestion" || comments[1].Category != "security" || comments[1].Severity != "critical" {
+		t.Errorf("surviving complementary metadata changed: %+v", comments[1])
+	}
+}
+
+func TestExecuteReviewFilter_ResolvesPayloadWithoutMutatingCollector(t *testing.T) {
+	tmpDir := t.TempDir()
+	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+	filterResp := `[]`
+	client := &fakeAgentClient{
+		responses: []*llm.ChatResponse{{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &filterResp}}},
+			Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+		}},
+	}
+	collector := tool.NewCommentCollector()
+	collector.Add(model.LlmComment{
+		Path:         "a.go",
+		Content:      "The result is not checked.",
+		ExistingCode: "result := doWork()",
+	})
+
+	a := New(Args{
+		LLMClient:        client,
+		Model:            "test",
+		Session:          sess,
+		CommentCollector: collector,
+		Template: template.Template{
+			ReviewFilterTask: &template.LlmConversation{
+				Messages: []template.ChatMessage{{Role: "user", Content: "Filter {{comments}} for {{path}} in {{diff}}"}},
+			},
+			MaxTokens:           10000,
+			MaxToolRequestTimes: 5,
+			MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+		},
+	})
+
+	d := model.Diff{
+		NewPath: "a.go",
+		Diff:    "@@ -1,2 +1,3 @@\n package sample\n+result := doWork()\n return nil\n",
+	}
+	a.executeReviewFilter(context.Background(), d, "a.go")
+
+	if len(client.requests) != 1 {
+		t.Fatalf("expected one filter request, got %d", len(client.requests))
+	}
+	prompt := client.requests[0].Messages[0].ExtractText()
+	if !strings.Contains(prompt, `"start_line":2`) || !strings.Contains(prompt, `"end_line":2`) {
+		t.Fatalf("filter payload did not contain resolved location:\n%s", prompt)
+	}
+	comments := collector.CommentsForPath("a.go")
+	if len(comments) != 1 || comments[0].StartLine != 0 || comments[0].EndLine != 0 {
+		t.Fatalf("collector comment was mutated while resolving filter payload: %+v", comments)
 	}
 }
 
@@ -338,6 +426,40 @@ func TestExecuteReviewFilter_LLMError(t *testing.T) {
 	comments := collector.CommentsForPath("a.go")
 	if len(comments) != 1 {
 		t.Errorf("comments should be unchanged on LLM error, got %d", len(comments))
+	}
+}
+
+func TestExecuteReviewFilter_MalformedResponseKeepsComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+	malformed := "not valid JSON"
+	client := &fakeAgentClient{
+		responses: []*llm.ChatResponse{{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &malformed}}},
+		}},
+	}
+	collector := tool.NewCommentCollector()
+	collector.Add(model.LlmComment{Path: "a.go", Content: "keep me"})
+
+	a := New(Args{
+		LLMClient:        client,
+		Model:            "test",
+		Session:          sess,
+		CommentCollector: collector,
+		Template: template.Template{
+			ReviewFilterTask: &template.LlmConversation{
+				Messages: []template.ChatMessage{{Role: "user", Content: "{{comments}} {{path}} {{diff}}"}},
+			},
+			MaxTokens:           10000,
+			MaxToolRequestTimes: 5,
+			MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+		},
+	})
+
+	a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+x"}, "a.go")
+	comments := collector.CommentsForPath("a.go")
+	if len(comments) != 1 || comments[0].Content != "keep me" {
+		t.Fatalf("malformed filter response changed comments: %+v", comments)
 	}
 }
 

--- a/internal/config/template/prompts/review_filter_task_system.md
+++ b/internal/config/template/prompts/review_filter_task_system.md
@@ -1,7 +1,9 @@
-You are a fact-checker for code review comments.
+You are a conservative fact-checker and duplicate detector for code review comments.
 
 These review comments come from an Agent that can invoke tools to obtain the full code context. You can currently only see the code diff.
 
-Therefore, your task is NOT to verify whether all review comments are correct, but to **filter out only those review comments that can be confirmed as incorrect based solely on the current diff**.
+Therefore, your task is NOT to verify whether all review comments are correct. Filter out only comments that can be confirmed as incorrect based solely on the current diff, or comments that are high-confidence near-duplicates of another comment in the same file.
+
+For duplicate detection, preserve the most complete and actionable canonical comment. Do not rewrite or merge comments. If you are uncertain whether two comments make the same claim, keep both. A duplicate group must retain at least one canonical comment unless every comment in that group is independently provably incorrect.
 
 For review comments whose correctness cannot be determined from the diff alone, even if you find them suspicious, you should let them pass — because the Agent may have access to context that you cannot see.

--- a/internal/config/template/prompts/review_filter_task_user.md
+++ b/internal/config/template/prompts/review_filter_task_user.md
@@ -1,6 +1,9 @@
 ### Task
 
-Given a code diff and a set of review comments, identify those that are **provably incorrect based solely on the diff**.
+Given a code diff and a set of review comments, identify comments that should be removed for one of two reasons:
+
+1. They are **provably incorrect based solely on the diff**.
+2. They are high-confidence near-duplicates of another comment in the same file and describe the same underlying technical claim.
 
 ### Evaluation Principles
 
@@ -28,7 +31,19 @@ After confirming that the facts visible in the diff are accurate, determine whet
 - Does it misidentify clearly normal code in the diff as a defect?
 - Does it attribute behavior visible in the diff in a way that contradicts the code?
 
-⚠️ Only determine as incorrect when the diff can directly prove the description is wrong.
+⚠️ Only determine a comment is incorrect when the diff can directly prove the description is wrong.
+
+### Duplicate Detection Rules
+
+- Compare duplicates only within the current file.
+- When both comments have non-zero `start_line` and `end_line`, consider them duplicates only when both line ranges are identical and the comments make the same underlying technical claim.
+- When line resolution failed for either comment, use the fallback only when both comments clearly target the same non-empty `existing_code` and make the same underlying technical claim.
+- Do not deduplicate comments merely because they occur near each other, share a category, share a severity, suggest similar-looking code, or mention the same function or component.
+- Preserve complementary findings at the same location.
+- Preserve repeated instances of the same issue at different locations.
+- When comments are duplicates, keep one canonical comment and remove only the redundant IDs. Prefer the comment with the clearest cause and impact, most precise remediation, useful `suggestion_code`, and most appropriate category and severity.
+- Do not rewrite, merge, or synthesize comment content. If the relationship is uncertain, keep both comments.
+- A duplicate group must retain at least one canonical comment unless every comment in that group is independently provably incorrect.
 
 ### Code Diff
 
@@ -42,13 +57,13 @@ After confirming that the facts visible in the diff are accurate, determine whet
 
 ### Output
 
-Return all incorrect review comment IDs directly, without any explanation. Use JSON array format:
+Return all comment IDs to remove directly, without any explanation. This includes provably incorrect comments and redundant near-duplicate comments. Use JSON array format:
 
 ```json
 ["id-xxx", "id-yyy"]
 ```
 
-If there are no review comments that can be confirmed as incorrect, return an empty array:
+If there are no comments to remove, return an empty array:
 
 ```json
 []

--- a/internal/config/template/template_test.go
+++ b/internal/config/template/template_test.go
@@ -119,6 +119,33 @@ func TestLoadDefault_PlaceholdersPresent(t *testing.T) {
 	}
 }
 
+func TestLoadDefault_ReviewFilterPromptIncludesDuplicateRules(t *testing.T) {
+	tpl, err := LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
+
+	var prompt strings.Builder
+	for _, message := range tpl.ReviewFilterTask.Messages {
+		prompt.WriteString(message.Content)
+		prompt.WriteByte('\n')
+	}
+	content := strings.ToLower(prompt.String())
+	for _, required := range []string{
+		"high-confidence near-duplicates",
+		"same underlying technical claim",
+		"start_line",
+		"end_line",
+		"existing_code",
+		"preserve complementary findings",
+		"if the relationship is uncertain, keep both",
+	} {
+		if !strings.Contains(content, strings.ToLower(required)) {
+			t.Errorf("review filter prompt does not contain %q", required)
+		}
+	}
+}
+
 func TestValidate_PassesOnDefault(t *testing.T) {
 	tpl, err := LoadDefault()
 	if err != nil {


### PR DESCRIPTION

## Description

This PR fixes near-duplicate review comments in JSON and GitLab output.

The existing review filter only received comment text and existing code, so it could not reliably identify comments targeting the same file and location. The filter payload now includes file paths, resolved line ranges, suggested code, categories, and severities.

The review-filter prompt now removes only high-confidence duplicates while preserving complementary or uncertain findings. Filtering remains fail-open if the LLM response is invalid or unavailable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] Focused review-filter tests
- [x] Race-enabled full test suite
- [x] `go vet ./...`
- [x] `gofmt -s -l .`
- [x] `git diff --check`
- [x] `go mod tidy` with no module changes
- [x] Build verification
- [x] Manual testing (covered by deterministic fake LLM responses)

Tests cover duplicate removal, line-number resolution, metadata preservation, cross-file isolation, malformed responses, and fail-open behavior.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation accordingly (not applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #709