### PR TITLE
feat(llm): add built-in Mistral AI provider preset

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -338,6 +338,22 @@ var registry = []Provider{
 			"deepseek/deepseek-chat",
 		},
 	},
+	{
+		Name:        "mistral",
+		DisplayName: "Mistral AI",
+		Protocol:    ProtocolOpenAIChatCompletions,
+		BaseURL:     "https://api.mistral.ai/v1",
+		EnvVar:      "MISTRAL_API_KEY",
+		// Deliberately minimal list to keep this preset low-maintenance for
+		// alibaba/open-code-review maintainers. Users can point to any other
+		// Mistral model via `ocr config set model <name>`; the preset only
+		// seeds the picker UI. See https://docs.mistral.ai/getting-started/models/models_overview/
+		Models: []string{
+			"codestral-latest",
+			"mistral-large-latest",
+			"mistral-small-latest",
+		},
+	},
 }
 
 var registryMap map[string]Provider

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -75,7 +75,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "minimax-cn", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "minimax-cn", "mistral", "ollama-cloud", "openai", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}
@@ -268,6 +268,41 @@ func TestLookupProvider_LiteLLMDetails(t *testing.T) {
 		"groq/llama-4-scout-17b-16e-instruct",
 		"mistral/mistral-large-latest",
 		"deepseek/deepseek-chat",
+	}
+	if len(p.Models) != len(expectedModels) {
+		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))
+	}
+	for i, model := range expectedModels {
+		if p.Models[i] != model {
+			t.Errorf("Models[%d] = %q, want %q", i, p.Models[i], model)
+		}
+	}
+}
+
+func TestLookupProvider_MistralDetails(t *testing.T) {
+	p, ok := LookupProvider("mistral")
+	if !ok {
+		t.Fatal("mistral not found")
+	}
+	if p.DisplayName != "Mistral AI" {
+		t.Errorf("DisplayName = %q, want %q", p.DisplayName, "Mistral AI")
+	}
+	if p.Protocol != ProtocolOpenAIChatCompletions {
+		t.Errorf("Protocol = %q, want %q", p.Protocol, ProtocolOpenAIChatCompletions)
+	}
+	if p.BaseURL != "https://api.mistral.ai/v1" {
+		t.Errorf("BaseURL = %q, want %q", p.BaseURL, "https://api.mistral.ai/v1")
+	}
+	if p.EnvVar != "MISTRAL_API_KEY" {
+		t.Errorf("EnvVar = %q, want %q", p.EnvVar, "MISTRAL_API_KEY")
+	}
+	if p.AuthHeader != "" {
+		t.Errorf("AuthHeader = %q, want empty (OpenAI-compatible uses Bearer by default)", p.AuthHeader)
+	}
+	expectedModels := []string{
+		"codestral-latest",
+		"mistral-large-latest",
+		"mistral-small-latest",
 	}
 	if len(p.Models) != len(expectedModels) {
 		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))


### PR DESCRIPTION
> [!NOTE]
> **Draft companion to #780.** Not requesting review until maintainers confirm the direction on the discovery issue. Opened as a draft so the concrete diff is available for inspection alongside the proposal.

## Description

Adds **Mistral AI** as a built-in LLM provider preset, so that users would be able to select it with:

```bash
ocr config set provider mistral
ocr config set model codestral-latest
export MISTRAL_API_KEY=...
ocr review
```

### Design

Mistral's Chat Completions endpoint at `https://api.mistral.ai/v1` is OpenAI-compatible (verified — see the testing section below), so this is a **registry-only addition** using the existing `ProtocolOpenAIChatCompletions`. It mirrors the pattern of the recently merged provider presets: Eden AI (#346), Ollama Cloud (#375), and LiteLLM (#385).

### Scope guardrails

**No changes to** any of:

- `internal/llm/client.go`
- `internal/llm/protocol.go`
- `internal/llm/resolver.go`
- `cmd/opencodereview/config_cmd.go`
- `cmd/opencodereview/provider_cmd.go`
- `action.yml`
- `go.mod` / `go.sum`

The diff is one new entry in `internal/llm/providers.go` and one new test in `internal/llm/providers_test.go`. Total: 52 additions, 1 deletion.

### Model list rationale

Kept deliberately minimal — the preset only seeds the interactive picker; users can select any Mistral model via `ocr config set model <name>`.

- `codestral-latest`
- `mistral-large-latest`
- `mistral-small-latest`

### Disclosure

I work at Mistral AI. This is a personal contribution submitted under the same preset pattern as PRs #346, #375, #385.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (described below)

### Local verification

| Check | Result |
|---|---|
| `make check` (license, gofmt, go vet, go mod tidy) | passes |
| `go test -race ./internal/llm/` | passes |
| `TestLookupProvider_MistralDetails` (new) | passes |
| `TestListProviders_Order` (updated to include `mistral` in sorted position) | passes |
| `TestProviders_AllProtocolsCanonical` | passes |
| `make build` | passes |
| `internal/llm` coverage | 94.3 % overall, 100 % on `providers.go` |

### Live smoke test against `api.mistral.ai`

`POST https://api.mistral.ai/v1/chat/completions` with an OpenAI-shape request body returned an OpenAI-shape response containing `id`, `object`, `created`, `model`, `choices[0].message.{role,content}`, `finish_reason`, `usage.{prompt_tokens,completion_tokens,total_tokens}`, and `tool_calls`. The existing `OpenAIClient` parses this without modification.

### End-to-end `ocr review` against Mistral

Built the `ocr` binary with this change, set `provider=mistral, model=codestral-latest`, ran `ocr review` on a scratch git repo whose staged diff introduced a SQL injection (`db.Exec("DELETE FROM users WHERE id = " + id)`). The review produced a single finding at the correct line with severity `security · high` and a parameterized-query suggested fix. Command exited cleanly.

### Paths not exercised

To be transparent about what was and was not verified:

- **Streaming responses** — the smoke-test diff was below the threshold that triggers streaming. Mistral's SSE format is documented as OpenAI-compatible, and other OpenAI-compatible presets in this repo already exercise the streaming path, but I did not personally observe a streamed response from Mistral in this run.
- **Only `codestral-latest` was exercised end-to-end.** `mistral-large-latest` and `mistral-small-latest` were only exercised at the registry-lookup level.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable) — no README changes needed; README does not enumerate providers (matches PRs #346, #375, #385)
- [ ] I have signed the CLA — will sign on bot prompt

## Related Issues

Companion to #780 (direction check). Do not auto-close on merge — #780 is for direction confirmation, not a bug to close.
