### PR TITLE
fix(cli): stop preview from creating a review session

### DIFF
--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -127,7 +127,7 @@ func loadDelegateContext(opts delegateOptions) (*delegateContext, error) {
 
 // preview runs the agent's file-selection logic and returns the preview result.
 func (dc *delegateContext) preview(ctx context.Context) (*agent.DiffPreview, error) {
-	ag := agent.New(agent.Args{
+	return agent.Preview(ctx, agent.Args{
 		RepoDir:    dc.cc.RepoDir,
 		From:       dc.opts.from,
 		To:         dc.opts.to,
@@ -135,7 +135,6 @@ func (dc *delegateContext) preview(ctx context.Context) (*agent.DiffPreview, err
 		FileFilter: dc.cc.FileFilter,
 		GitRunner:  dc.cc.GitRunner,
 	})
-	return ag.Preview(ctx)
 }
 
 // mergeBase computes the merge-base for range mode. Returns "" for other modes.

--- a/cmd/opencodereview/delegate_exec_test.go
+++ b/cmd/opencodereview/delegate_exec_test.go
@@ -68,6 +68,30 @@ func silenceStdout(t *testing.T, fn func()) {
 	fn()
 }
 
+// freshOCRHome points the OCR home at a temp dir so a test can assert on what a
+// command wrote there. It also neutralizes global git config: git resolves that
+// via XDG_CONFIG_HOME as well, so overriding HOME alone would still pick up the
+// developer's settings (e.g. commit.gpgsign, which fails without their keyring).
+func freshOCRHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	return home
+}
+
+// assertNoSessionStore fails if the session store was created under home.
+// Preview neither runs nor finalizes a review, so it must not open persistence
+// at all; session.New creates this directory before writing its JSONL file.
+func assertNoSessionStore(t *testing.T, home string) {
+	t.Helper()
+	store := filepath.Join(home, ".opencodereview", "sessions")
+	if _, err := os.Stat(store); !os.IsNotExist(err) {
+		t.Errorf("preview created the session store at %s (stat err = %v)", store, err)
+	}
+}
+
 func TestExecuteDelegatePreview_Workspace(t *testing.T) {
 	dir := initTestGitRepo(t)
 	// Uncommitted change so the workspace preview has at least one entry.
@@ -102,6 +126,22 @@ func TestExecuteDelegatePreview_Commit(t *testing.T) {
 			t.Fatalf("executeDelegatePreview(commit) error: %v", err)
 		}
 	})
+}
+
+// TestExecuteDelegatePreviewCreatesNoSession covers the third preview entry
+// point, which built its agent the same leaky way as review and scan.
+func TestExecuteDelegatePreviewCreatesNoSession(t *testing.T) {
+	home := freshOCRHome(t)
+
+	dir := initTestGitRepo(t)
+	gitCommitFile(t, dir, "d.go", "package d\n", "add d")
+	silenceStdout(t, func() {
+		if err := executeDelegatePreview(delegateOptions{repoDir: dir, commit: "HEAD"}); err != nil {
+			t.Fatalf("executeDelegatePreview error: %v", err)
+		}
+	})
+
+	assertNoSessionStore(t, home)
 }
 
 func TestExecuteDelegateRule(t *testing.T) {

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -375,7 +375,7 @@ func validateReviewRefs(repoDir string, opts reviewOptions) error {
 }
 
 func runPreview(cc *commonContext, opts reviewOptions) error {
-	ag := agent.New(agent.Args{
+	preview, err := agent.Preview(context.Background(), agent.Args{
 		RepoDir:    cc.RepoDir,
 		From:       opts.from,
 		To:         opts.to,
@@ -383,8 +383,6 @@ func runPreview(cc *commonContext, opts reviewOptions) error {
 		FileFilter: cc.FileFilter,
 		GitRunner:  cc.GitRunner,
 	})
-
-	preview, err := ag.Preview(context.Background())
 	if err != nil {
 		return fmt.Errorf("preview failed: %w", err)
 	}

--- a/cmd/opencodereview/review_helpers_test.go
+++ b/cmd/opencodereview/review_helpers_test.go
@@ -55,6 +55,28 @@ func TestRunPreviewJSONFormat(t *testing.T) {
 	}
 }
 
+// TestRunPreviewCreatesNoSession pins that previewing never opens session
+// persistence. Building the agent with agent.New auto-created a session, which
+// left an unfinalized (and usually empty) JSONL file under the OCR home even
+// though preview never runs or finalizes a review.
+func TestRunPreviewCreatesNoSession(t *testing.T) {
+	home := freshOCRHome(t)
+
+	dir := initTestGitRepo(t)
+	gitCommitFile(t, dir, "x.go", "package x\n", "add x")
+	cc, err := loadCommonContext(dir, "", 0, 0, true)
+	if err != nil {
+		t.Fatalf("loadCommonContext: %v", err)
+	}
+	silenceStdout(t, func() {
+		if err := runPreview(cc, reviewOptions{commit: "HEAD"}); err != nil {
+			t.Fatalf("runPreview error: %v", err)
+		}
+	})
+
+	assertNoSessionStore(t, home)
+}
+
 func TestLoadReviewResumeState(t *testing.T) {
 	dir := initTestGitRepo(t)
 

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -252,7 +252,7 @@ func loadScanResumeState(repoDir string, opts scanOptions, scanPaths []string) (
 }
 
 func runScanPreview(cc *commonContext, scanTpl *template.ScanTemplate, scanPaths []string, outputFormat string) error {
-	ag := scan.NewAgent(scan.Args{
+	preview, err := scan.Preview(context.Background(), scan.Args{
 		RepoDir:          cc.RepoDir,
 		Paths:            scanPaths,
 		FileFilter:       cc.FileFilter,
@@ -262,8 +262,6 @@ func runScanPreview(cc *commonContext, scanTpl *template.ScanTemplate, scanPaths
 		// value so MaxFileSizeBytes is consistent.
 		Template: *scanTpl,
 	})
-
-	preview, err := ag.Preview(context.Background())
 	if err != nil {
 		return fmt.Errorf("scan preview failed: %w", err)
 	}

--- a/cmd/opencodereview/scan_helpers_test.go
+++ b/cmd/opencodereview/scan_helpers_test.go
@@ -77,3 +77,28 @@ func TestRunScanPreviewJSONFormat(t *testing.T) {
 		t.Errorf("y.go missing from scan preview: %+v", got.Entries)
 	}
 }
+
+// TestRunScanPreviewCreatesNoSession mirrors TestRunPreviewCreatesNoSession:
+// scan.NewAgent auto-creates a session too, so scan preview leaked the same
+// unfinalized JSONL artifact.
+func TestRunScanPreviewCreatesNoSession(t *testing.T) {
+	home := freshOCRHome(t)
+
+	dir := initTestGitRepo(t)
+	gitCommitFile(t, dir, "y.go", "package y\n", "add y")
+	cc, err := loadCommonContext(dir, "", 0, 0, false)
+	if err != nil {
+		t.Fatalf("loadCommonContext: %v", err)
+	}
+	scanTpl, err := template.LoadScanDefault()
+	if err != nil {
+		t.Fatalf("LoadScanDefault: %v", err)
+	}
+	silenceStdout(t, func() {
+		if err := runScanPreview(cc, scanTpl, nil, "text"); err != nil {
+			t.Fatalf("runScanPreview error: %v", err)
+		}
+	})
+
+	assertNoSessionStore(t, home)
+}

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -61,7 +61,15 @@ func (a *Agent) whyExcluded(d model.Diff) ExcludeReason {
 
 // Preview loads diffs and applies the filter algorithm, returning structured
 // preview data without dispatching any LLM calls.
-func (a *Agent) Preview(ctx context.Context) (*DiffPreview, error) {
+//
+// It builds none of the review runtime — no session, manifest, or runner — so
+// previewing cannot open session persistence. Going through New instead would
+// auto-create a session and leave an unfinalized JSONL file under the OCR home.
+func Preview(ctx context.Context, args Args) (*DiffPreview, error) {
+	return (&Agent{args: args}).preview(ctx)
+}
+
+func (a *Agent) preview(ctx context.Context) (*DiffPreview, error) {
 	if err := a.loadDiffs(ctx); err != nil {
 		return nil, fmt.Errorf("load diffs: %w", err)
 	}

--- a/internal/agent/preview_run_test.go
+++ b/internal/agent/preview_run_test.go
@@ -48,7 +48,7 @@ func TestPreview(t *testing.T) {
 	}
 
 	a := New(Args{RepoDir: dir})
-	preview, err := a.Preview(context.Background())
+	preview, err := a.preview(context.Background())
 	if err != nil {
 		t.Fatalf("Preview error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestPreviewEmptyEntriesNotNil(t *testing.T) {
 	dir := initPreviewRepo(t)
 
 	a := New(Args{RepoDir: dir})
-	preview, err := a.Preview(context.Background())
+	preview, err := a.preview(context.Background())
 	if err != nil {
 		t.Fatalf("Preview error: %v", err)
 	}

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -108,7 +108,7 @@ func TestPreview_DoesNotMutateAgentItems(t *testing.T) {
 	if got := a.items; got != nil {
 		t.Fatalf("pre-Preview items should be nil, got %v", got)
 	}
-	if _, err := a.Preview(t.Context()); err != nil {
+	if _, err := a.preview(t.Context()); err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
 	if a.items != nil {
@@ -125,7 +125,7 @@ func TestPreview_EmptyResultEntriesIsNonNilSlice(t *testing.T) {
 		RepoDir:  repo,
 		Template: makeTemplateWithFullScan(),
 	})
-	got, err := a.Preview(t.Context())
+	got, err := a.preview(t.Context())
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}

--- a/internal/scan/preview.go
+++ b/internal/scan/preview.go
@@ -14,11 +14,18 @@ import (
 // without dispatching any LLM calls. Returns a *model.Preview ready for
 // cmd/opencodereview.outputPreviewText to render.
 //
-// Preview is read-only with respect to the Agent: it does not mutate
+// It builds none of the scan runtime — no session or runner — so previewing
+// cannot open session persistence. Going through NewAgent instead would
+// auto-create a session and leave an unfinalized JSONL file under the OCR home.
+func Preview(ctx context.Context, args Args) (*model.Preview, error) {
+	return (&Agent{args: args}).preview(ctx)
+}
+
+// preview is read-only with respect to the Agent: it does not mutate
 // a.items. (Earlier versions did, which made a subsequent Run on the same
 // Agent silently observe the preview's enumeration instead of re-running
 // it.) Callers that want to reuse the enumeration should call Run once.
-func (a *Agent) Preview(ctx context.Context) (*model.Preview, error) {
+func (a *Agent) preview(ctx context.Context) (*model.Preview, error) {
 	provider := NewProvider(a.args.RepoDir, a.args.Paths, a.args.GitRunner, a.args.MaxFileSizeBytes)
 	items, err := provider.Enumerate(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

`runPreview`, `runScanPreview`, and delegate's `preview` each built a throwaway agent via `agent.New` / `scan.NewAgent` purely to reach `Preview`. Both constructors auto-create a session, and `session.New` opens persistence and buffers a `session_start` record, so every preview created a JSONL file under the OCR home. Preview never runs or finalizes a review, so that file was left unfinalized and usually empty.

Make the exported entry point a package-level `Preview(ctx, args)` in both `internal/agent` and `internal/scan`. It builds only what file selection needs, so there is no session, manifest, or runner to leak. The existing bodies stay as unexported methods, keeping the in-package tests (including scan's regression test that `Preview` must not mutate `a.items`).

Deleting the file afterwards was rejected: it would still leak on crash and would keep the wrong abstraction.

Tests assert at the CLI boundary, with a temporary OCR home, that no session store is created by any of the three preview commands. They also neutralize global git config, which git resolves via `XDG_CONFIG_HOME` independently of `HOME`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Run against `6aa3f50`, a commit already on `main`, using a throwaway `HOME` so the real session store is untouched.

Before this change, a preview leaves a phantom session behind:

```
$ ocr review --commit 6aa3f50 --preview
$ ocr session list
SESSION ID                            MODE  RANGE  FILES  COMMENTS  STATUS   STARTED
1b4ff2d7-22e5-4e4e-856b-ad936a5b7c26  -     -      0      0         aborted  -
```

That row is backed by a 0-byte `.jsonl` file: the `session_start` record was still buffered when the process exited, so the session has no mode, range, or start time and is reported as `aborted`.

With this change, the same invocation creates nothing:

```
$ ocr review --commit 6aa3f50 --preview
$ ocr session list
No sessions found for /path/to/open-code-review
```

`ocr scan --preview` and `ocr delegate preview` behave the same way.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

None.

---

Disclosure: PR authored by AI with human guidance and careful review.
