### PR TITLE
fix(pages): use startTransition to eliminate black screen flash during page navigation

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,6 +14,7 @@ jobs:
   eslint:
     name: Run ESLint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,28 @@
+name: ESLint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  eslint:
+    name: Run ESLint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: pages
-        run: npm ci
+        run: npm install
 
       - name: Run ESLint
         working-directory: pages

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,9 +20,12 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          cache-dependency-path: pages/package-lock.json
 
       - name: Install dependencies
+        working-directory: pages
         run: npm ci
 
       - name: Run ESLint
+        working-directory: pages
         run: npm run lint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   eslint:
     name: Run ESLint
@@ -19,8 +23,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: pages/package-lock.json
 
       - name: Install dependencies
         working-directory: pages

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 alibaba/open-code-review Contributors
 
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useState, useTransition } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import LandingPage from './components/LandingPage';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -70,13 +70,55 @@ const RouteErrorFallback: React.FC<{ reset: () => void }> = ({ reset }) => {
   );
 };
 
+const TopProgressBar: React.FC = () => (
+  <div
+    style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: 2,
+      zIndex: 200,
+      pointerEvents: 'none',
+    }}
+  >
+    <div
+      style={{
+        height: '100%',
+        background: '#756BFF',
+        animation: 'ocr-transition-bar 1.2s ease-in-out infinite',
+      }}
+    />
+    <style>{`
+      @keyframes ocr-transition-bar {
+        0%   { width: 0%; margin-left: 0%; }
+        30%  { width: 40%; margin-left: 0%; }
+        60%  { width: 30%; margin-left: 40%; }
+        85%  { width: 10%; margin-left: 70%; }
+        100% { width: 0%; margin-left: 100%; }
+      }
+    `}</style>
+  </div>
+);
+
 const App: React.FC = () => {
+  const [isPending, startTransition] = useTransition();
+  const location = useLocation();
+  const [displayLocation, setDisplayLocation] = useState(location);
+
+  useEffect(() => {
+    startTransition(() => {
+      setDisplayLocation(location);
+    });
+  }, [location]);
+
   return (
     <>
       <ScrollToTop />
+      {isPending && <TopProgressBar />}
       <ErrorBoundary reloadOnChunkError fallback={(_error, reset) => <RouteErrorFallback reset={reset} />}>
         <Suspense fallback={<div style={{ minHeight: '100vh', background: '#000000' }} />}>
-          <Routes>
+          <Routes location={displayLocation}>
             <Route path="/" element={<LandingPage><FeaturesPage /></LandingPage>} />
             <Route path="/features" element={<LandingPage><FeaturesRoutePage /></LandingPage>} />
             <Route path="/benchmark" element={<LandingPage><BenchmarkPage /></LandingPage>} />

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -82,22 +82,7 @@ const TopProgressBar: React.FC = () => (
       pointerEvents: 'none',
     }}
   >
-    <div
-      style={{
-        height: '100%',
-        background: '#756BFF',
-        animation: 'ocr-transition-bar 1.2s ease-in-out infinite',
-      }}
-    />
-    <style>{`
-      @keyframes ocr-transition-bar {
-        0%   { width: 0%; margin-left: 0%; }
-        30%  { width: 40%; margin-left: 0%; }
-        60%  { width: 30%; margin-left: 40%; }
-        85%  { width: 10%; margin-left: 70%; }
-        100% { width: 0%; margin-left: 100%; }
-      }
-    `}</style>
+    <div className="ocr-transition-bar" />
   </div>
 );
 

--- a/pages/src/styles/index.css
+++ b/pages/src/styles/index.css
@@ -57,6 +57,29 @@ a {
   animation: cursor-blink 1s step-end infinite;
 }
 
+/* Top-of-page transition progress bar */
+@keyframes ocr-transition-bar {
+  0%   { width: 0%; margin-left: 0%; }
+  30%  { width: 40%; margin-left: 0%; }
+  60%  { width: 30%; margin-left: 40%; }
+  85%  { width: 10%; margin-left: 70%; }
+  100% { width: 0%; margin-left: 100%; }
+}
+
+.ocr-transition-bar {
+  height: 100%;
+  background: #756BFF;
+  animation: ocr-transition-bar 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ocr-transition-bar {
+    animation: none;
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
 /* UseCases card hover effect */
 @property --sweep-angle {
   syntax: '<angle>';


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
startTransition keeps old page visible; Suspense fallback navigation only triggers on initial load
and also added a progess bar
and avaliable for deskotp + mobile devices
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)
`npm run lint`
`npm test` gives errors that are not specific to my edits.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
closes #788 