### PR TITLE
fix(pages): keep previous page visible during lazy route transitions

### DIFF
--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -2,9 +2,10 @@
 // Copyright 2026 alibaba/open-code-review Contributors
 
 import React, { Suspense, useEffect } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import LandingPage from './components/LandingPage';
 import ErrorBoundary from './components/ErrorBoundary';
+import { useTransitionedLocation } from './hooks/useTransitionedLocation';
 import { useTranslation } from './i18n';
 import FeaturesPage from './pages/FeaturesPage';
 import FeaturesRoutePage from './pages/FeaturesRoutePage';
@@ -14,8 +15,7 @@ const QuickStartPage = React.lazy(() => import(/* webpackChunkName: "quickstart-
 const DocsPage = React.lazy(() => import(/* webpackChunkName: "docs-page" */ './pages/DocsPage'));
 const BlogPage = React.lazy(() => import(/* webpackChunkName: "blog-page" */ './pages/BlogPage'));
 
-const ScrollToTop: React.FC = () => {
-  const { pathname } = useLocation();
+const ScrollToTop: React.FC<{ pathname: string }> = ({ pathname }) => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
@@ -71,12 +71,19 @@ const RouteErrorFallback: React.FC<{ reset: () => void }> = ({ reset }) => {
 };
 
 const App: React.FC = () => {
+  // Route changes are applied inside a React transition so the previous page
+  // stays visible while a lazy route's chunk downloads. The plain black
+  // Suspense fallback is then only reachable on first paint, which removes
+  // the black flash on in-app navigation without losing the intentional
+  // dark background on initial load.
+  const displayLocation = useTransitionedLocation();
+
   return (
     <>
-      <ScrollToTop />
+      <ScrollToTop pathname={displayLocation.pathname} />
       <ErrorBoundary reloadOnChunkError fallback={(_error, reset) => <RouteErrorFallback reset={reset} />}>
         <Suspense fallback={<div style={{ minHeight: '100vh', background: '#000000' }} />}>
-          <Routes>
+          <Routes location={displayLocation}>
             <Route path="/" element={<LandingPage><FeaturesPage /></LandingPage>} />
             <Route path="/features" element={<LandingPage><FeaturesRoutePage /></LandingPage>} />
             <Route path="/benchmark" element={<LandingPage><BenchmarkPage /></LandingPage>} />

--- a/pages/src/hooks/useTransitionedLocation.test.tsx
+++ b/pages/src/hooks/useTransitionedLocation.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+import React, { Suspense } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import { useTransitionedLocation } from './useTransitionedLocation';
+
+/** A lazy component whose chunk resolves only when `resolveChunk` is called. */
+function deferredLazy(): { LazyPage: React.LazyExoticComponent<React.FC>; resolveChunk: () => Promise<void> } {
+  let resolve!: (m: { default: React.FC }) => void;
+  const chunk = new Promise<{ default: React.FC }>((r) => {
+    resolve = r;
+  });
+  const LazyPage = React.lazy(() => chunk);
+  const resolveChunk = async () => {
+    resolve({ default: () => <div>lazy page</div> });
+    // Let React finish the resumed render.
+    await act(async () => {
+      await chunk;
+    });
+  };
+  return { LazyPage, resolveChunk };
+}
+
+const HomePage: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <span>home page</span>
+      <button type="button" onClick={() => navigate('/lazy')}>
+        go
+      </button>
+    </div>
+  );
+};
+
+const Harness: React.FC<{ LazyPage: React.FC }> = ({ LazyPage }) => {
+  const displayLocation = useTransitionedLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate(-1)}>
+        back
+      </button>
+      <Suspense fallback={<div data-testid="black-fallback" />}>
+        <Routes location={displayLocation}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/lazy" element={<LazyPage />} />
+        </Routes>
+      </Suspense>
+    </>
+  );
+};
+
+describe('useTransitionedLocation', () => {
+  it('keeps the previous page visible while a lazy route loads, instead of the Suspense fallback', async () => {
+    const { LazyPage, resolveChunk } = deferredLazy();
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Harness LazyPage={LazyPage} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('home page')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    // The chunk has not resolved: the old page must still be on screen and
+    // the black fallback must not have replaced it.
+    expect(screen.getByText('home page')).toBeTruthy();
+    expect(screen.queryByTestId('black-fallback')).toBeNull();
+
+    await resolveChunk();
+    expect(await screen.findByText('lazy page')).toBeTruthy();
+    expect(screen.queryByText('home page')).toBeNull();
+  });
+
+  it('still shows the Suspense fallback on first paint, when there is no previous page', async () => {
+    const { LazyPage, resolveChunk } = deferredLazy();
+    render(
+      <MemoryRouter initialEntries={['/lazy']}>
+        <Harness LazyPage={LazyPage} />
+      </MemoryRouter>,
+    );
+    // First load of a lazy route: nothing to keep on screen, fallback shows.
+    expect(screen.getByTestId('black-fallback')).toBeTruthy();
+
+    await resolveChunk();
+    expect(await screen.findByText('lazy page')).toBeTruthy();
+  });
+
+  it('follows back/forward navigation', async () => {
+    const { LazyPage, resolveChunk } = deferredLazy();
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Harness LazyPage={LazyPage} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+    await resolveChunk();
+    expect(await screen.findByText('lazy page')).toBeTruthy();
+
+    // Back to "/" — that route is not lazy, so it renders directly.
+    fireEvent.click(screen.getByRole('button', { name: 'back' }));
+    expect(await screen.findByText('home page')).toBeTruthy();
+  });
+});

--- a/pages/src/hooks/useTransitionedLocation.ts
+++ b/pages/src/hooks/useTransitionedLocation.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+import { useEffect, useState, useTransition } from 'react';
+import { useLocation, type Location } from 'react-router-dom';
+
+/**
+ * Returns a location that trails `useLocation()` by one React transition.
+ *
+ * Rendering `<Routes location={...}>` from this value keeps the previous
+ * route on screen while the next route's lazy chunk downloads: the location
+ * update is applied inside `startTransition`, so a suspending route keeps
+ * the current content visible instead of unmounting to the `<Suspense>`
+ * fallback. The fallback still shows on first paint, when there is no
+ * previous content to keep.
+ */
+export function useTransitionedLocation(): Location {
+  const location = useLocation();
+  const [displayLocation, setDisplayLocation] = useState(location);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    startTransition(() => {
+      setDisplayLocation(location);
+    });
+  }, [location, startTransition]);
+
+  return displayLocation;
+}


### PR DESCRIPTION
Fixes #788

## Problem

Navigating to a lazy-loaded page (`/benchmark`, `/quickstart`, `/docs`, `/blog`) re-triggered the `<Suspense>` fallback — a plain black `<div>` — so the whole page went black while the route's chunk downloaded.

## Approach

Approach 3 from the issue: keep the existing fallback for the true first-load case, but prevent it from showing during in-app transitions.

- New `useTransitionedLocation()` hook: returns a location that trails `useLocation()` by one `startTransition`. `<Routes location={...}>` renders from it, so when the next route suspends, React keeps the current page visible (transition semantics) instead of unmounting to the fallback.
- First paint is unchanged — there is no previous content to keep, so the dark fallback still shows, preserving the intentional no-white-flash initial load.
- `ScrollToTop` now keys off the *displayed* location, so the scroll reset happens when the new page actually appears rather than while the old page is still on screen.
- No router migration needed — works with the existing `<Routes>` API on React Router 6.8.

## Acceptance criteria

- [x] No black flash during navigation — covered by a test: navigate to a lazy route whose chunk is deliberately unresolved, assert the old page is still on screen and the fallback is absent
- [x] First-time load still shows the dark loading state — covered by a test rendering directly at an unresolved lazy route
- [x] Back/forward navigation — covered by a test using router history
- [x] `npm test` — 19/19 pass (5 files, including the new one)
- [x] `npm run lint` — 0 errors (the 2 pre-existing warnings in `HeroSection.tsx`/`MarkdownRenderer.tsx` are untouched); `tsc --noEmit` clean