### PR TITLE
fix: no pages deployment on forks

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'alibaba/open-code-review'
     runs-on: self-hosted
     timeout-minutes: 10
     container:
@@ -47,6 +48,7 @@ jobs:
           path: _site
 
   deploy:
+    if: github.repository == 'alibaba/open-code-review'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
Contributers usually enable workflows for status checks and testing, but there is an unwanted pages deployment that should only happen in the upstream.
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [ ] `make test` passes locally
- [x] Manual testing (describe below)
Ran the workflow at the fork

## Checklist

- [x] I have performed a self-review of my code
- [x] I have signed the CLA

## Related Issues
none yet
<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
