### PR TITLE
feat(pages): serve install scripts from custom domain

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           test -f _site/install.sh
           test -f _site/install.ps1
+          sh -n _site/install.sh
           cmp install.sh _site/install.sh
           cmp install.ps1 _site/install.ps1
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'pages/**'
+      - 'install.sh'
+      - 'install.ps1'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -42,6 +45,15 @@ jobs:
           mkdir -p _site
           cp -r pages/dist/* _site/
           cp pages/logo.svg _site/logo.svg
+          cp install.sh _site/install.sh
+          cp install.ps1 _site/install.ps1
+
+      - name: Verify install scripts
+        run: |
+          test -f _site/install.sh
+          test -f _site/install.ps1
+          cmp install.sh _site/install.sh
+          cmp install.ps1 _site/install.ps1
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 # Install the ocr (Open Code Review) CLI from GitHub releases on Windows.
-#   irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+#   irm https://open-codereview.ai/install.ps1 | iex
 # Prefer to inspect first:
-#   irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 -OutFile install.ps1
+#   irm https://open-codereview.ai/install.ps1 -OutFile install.ps1
 #   notepad install.ps1   # review, then: .\install.ps1
 # Env: OCR_INSTALL_DIR (default $env:LOCALAPPDATA\Programs\ocr), OCR_VERSION (default latest).
 # Requires PowerShell 5.1+ or PowerShell 7+.

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,9 @@
 # Copyright 2026 alibaba/open-code-review Contributors
 
 # Install the ocr (Open Code Review) CLI from GitHub releases.
-#   curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+#   curl -fsSL https://open-codereview.ai/install.sh | sh
 # Prefer to inspect first:
-#   curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh -o install.sh
+#   curl -fsSL https://open-codereview.ai/install.sh -o install.sh
 #   less install.sh && sh install.sh
 # Env: OCR_INSTALL_DIR (default /usr/local/bin), OCR_VERSION (default latest).
 set -eu
@@ -23,7 +23,7 @@ main() {
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   case "$os" in
     darwin|linux) ;;
-    *) err "unsupported OS: $os (on Windows use: irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex)" ;;
+    *) err "unsupported OS: $os (on Windows use: irm https://open-codereview.ai/install.ps1 | iex)" ;;
   esac
 
   arch="$(uname -m)"

--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -76,7 +76,7 @@ A convenience installer that wraps the GitHub Release binary download
 machines:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+curl -fsSL https://open-codereview.ai/install.sh | sh
 ```
 
 It honours two environment variables:
@@ -91,7 +91,7 @@ The script supports `darwin` and `linux` on `amd64` / `arm64`.
 On Windows (PowerShell 5.1+), use the PowerShell installer instead:
 
 ```powershell
-irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+irm https://open-codereview.ai/install.ps1 | iex
 ```
 
 It honours the same `OCR_INSTALL_DIR` and `OCR_VERSION` variables (set via

--- a/pages/src/content/docs/ja/installation.md
+++ b/pages/src/content/docs/ja/installation.md
@@ -74,7 +74,7 @@ GitHub Release バイナリのダウンロード（検証付き）をラップ�
 イメージやヘッドレス環境に適しています。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+curl -fsSL https://open-codereview.ai/install.sh | sh
 ```
 
 2 つの環境変数を認識します。
@@ -89,7 +89,7 @@ curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/insta
 Windows（PowerShell 5.1+）では、代わりに PowerShell インストーラーを使用してください：
 
 ```powershell
-irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+irm https://open-codereview.ai/install.ps1 | iex
 ```
 
 同じ `OCR_INSTALL_DIR` と `OCR_VERSION` を認識します（`$env:OCR_INSTALL_DIR` /

--- a/pages/src/content/docs/ru/installation.md
+++ b/pages/src/content/docs/ru/installation.md
@@ -74,7 +74,7 @@ sudo port upgrade open-code-review
 сумму. Он удобен для базовых образов CI и систем без графического интерфейса:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+curl -fsSL https://open-codereview.ai/install.sh | sh
 ```
 
 Скрипт учитывает две переменные окружения:
@@ -89,7 +89,7 @@ curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/insta
 В Windows с PowerShell 5.1 или новее запустите PowerShell-установщик:
 
 ```powershell
-irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+irm https://open-codereview.ai/install.ps1 | iex
 ```
 
 Установщик учитывает те же переменные `OCR_INSTALL_DIR` и `OCR_VERSION` (через

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -72,7 +72,7 @@ sudo port upgrade open-code-review
 镜像和无界面环境：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/install.sh | sh
+curl -fsSL https://open-codereview.ai/install.sh | sh
 ```
 
 它识别两个环境变量：
@@ -87,7 +87,7 @@ curl -fsSL https://raw.githubusercontent.com/alibaba/open-code-review/main/insta
 在 Windows（PowerShell 5.1+）上，请改用 PowerShell 安装脚本：
 
 ```powershell
-irm https://raw.githubusercontent.com/alibaba/open-code-review/main/install.ps1 | iex
+irm https://open-codereview.ai/install.ps1 | iex
 ```
 
 它同样识别 `OCR_INSTALL_DIR` 与 `OCR_VERSION`（通过 `$env:OCR_INSTALL_DIR` /


### PR DESCRIPTION
## Description

Serve the OCR installation scripts from the project’s custom domain.

The Pages deployment now publishes `install.sh` and `install.ps1` at:

- `https://open-codereview.ai/install.sh`
- `https://open-codereview.ai/install.ps1`

All installer documentation and usage comments were updated to use the shorter URLs. The existing installer and release-download logic remains unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing:
  - `sh -n install.sh`
  - `npm run typecheck`
  - `npm run build`
  - Verified both scripts are copied into the deployment artifact
  - Verified copied scripts match the repository versions with `cmp`
  - Verified no old installer URLs remain
  - `make check`
  - `git diff --check`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

Closes #411