### PR TITLE
feat(allowlist): add Nim support (#798)

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -57,6 +57,12 @@ func TestIsAllowedExt(t *testing.T) {
 		{".HS", true},
 		{".lhs", true},
 		{".LHS", true},
+		{".nim", true},
+		{".NIM", true},
+		{".nims", true},
+		{".NIMS", true},
+		{".nimble", true},
+		{".NIMBLE", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -150,6 +156,12 @@ func TestIsExcludedPath(t *testing.T) {
 		{"lhs spec file", "src/ParserSpec.lhs", true},
 		{"lhs root spec file", "ParserSpec.lhs", true},
 		{"lhs non-test", "src/Tutorial.lhs", false},
+
+		// Nim test files
+		{"nim test directory", "tests/parser_test.nim", true},
+		{"nim nested test directory", "packages/core/tests/unit/parser_test.nim", true},
+		{"nim non-test", "src/parser.nim", false},
+		{"nim tests in filename", "src/tests_helper.nim", false},
 
 		// Snapshot files
 		{"jest snapshot dir", "src/__snapshots__/App.test.js.snap", true},

--- a/internal/config/allowlist/default_exclude_patterns.json
+++ b/internal/config/allowlist/default_exclude_patterns.json
@@ -20,6 +20,7 @@
   "**/*Spec.hs",
   "**/test/**/*.lhs",
   "**/*Spec.lhs",
+  "**/tests/**/*.nim",
   "**/__snapshots__/**",
   "**/*.snap",
   "**/testdata/**",

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -81,5 +81,8 @@
   ".proto",
   ".nix",
   ".hs",
-  ".lhs"
+  ".lhs",
+  ".nim",
+  ".nims",
+  ".nimble"
 ]

--- a/internal/config/rules/rule_docs/nim.md
+++ b/internal/config/rules/rule_docs/nim.md
@@ -1,0 +1,42 @@
+> Favor precision over recall: report only issues that are likely to cause incorrect behavior, memory unsafety, security vulnerabilities, or material performance problems. Do not report formatting handled by `nimpretty`, and account for the project's Nim version, memory-management mode, and compile-time defines before raising compatibility findings.
+
+#### Memory and Lifetime Safety
+- References, pointers, slices, or `openArray` views that outlive the storage they refer to, especially addresses derived from stack locals, temporary sequences, or strings
+- `cast`, `addr`, `unsafeAddr`, manual allocation, or pointer arithmetic without a locally established type, alignment, bounds, ownership, and lifetime invariant
+- Mismatched allocation and deallocation APIs, double destruction, or missing cleanup for manually managed resources
+- Reference cycles that retain resources indefinitely under ARC or another memory-management mode without cycle collection; do not report this for ORC, which includes a cycle collector
+- Do not report ordinary managed references or value copies without evidence of a lifetime or ownership defect
+
+#### Bounds, Values, and Control Flow
+- Array, sequence, or string indexing where a reachable index can be negative or exceed `low`/`high`, including incorrect inclusive range boundaries
+- Integer conversions, `ord`, enum casts, or arithmetic that can overflow, truncate, or produce an invalid enum value under the project's overflow-check settings
+- Variant objects whose discriminant is changed or read inconsistently with the active branch
+- `case` statements, object construction, or result paths that leave a reachable value unhandled or unintentionally return the default value
+- Assertions used to validate untrusted or runtime input when assertion checks may be disabled in release builds
+
+#### Errors and Resource Cleanup
+- `except:` or overly broad exception handling that swallows defects, cancellation, or actionable context and then returns a plausible result
+- Resources acquired without `defer`, `try/finally`, or an ownership abstraction when an exception or early return can leak them
+- `raiseAssert`, `quit`, or unrecoverable defects used for ordinary invalid input in reusable library or server code
+- Error-code or `Option`/`Result` values ignored at boundaries where failure changes correctness or leaves partial state behind
+
+#### Templates, Macros, and Compile-Time Code
+- Templates that evaluate an argument more than once when the argument may have side effects; bind the expression to a local `let` so it is evaluated once per template invocation
+- Macros that construct identifiers or AST nodes without preserving hygiene, source information, or the expected symbol binding
+- `static`, `compileTime`, or macro execution that reads mutable external state and makes builds non-reproducible without an explicit project requirement
+- Untrusted text incorporated into generated Nim, shell commands, or compiler invocations without strict validation
+- Do not report ordinary template or macro use when the generated behavior is clear and arguments are evaluated safely
+
+#### Concurrency, Async, and Effects
+- Shared mutable state accessed by threads without a lock, channel, atomic operation, or established single-owner design
+- Locks held across blocking operations, callbacks, or `await`, creating deadlock or starvation risks
+- Futures started without awaiting, returning, or otherwise observing failures when completion matters to correctness
+- Blocking file, process, sleep, or network operations introduced into an async request path
+- Thread procedures or callbacks that capture data whose lifetime ends before the thread or foreign caller finishes
+
+#### FFI and Security Boundaries
+- `importc`, `exportc`, `dynlib`, or callback declarations with incompatible calling conventions, types, struct layout, nullability, or ownership rules
+- C strings or buffers consumed without validating null termination, length, encoding, and lifetime
+- User-controlled data passed to `execShellCmd`, a shell invocation, SQL construction, path access, deserialization, or code evaluation without appropriate validation or parameterization
+- Secrets, credentials, tokens, or private data embedded in source, command arguments, logs, exceptions, or generated artifacts
+- Cryptographic keys or security tokens generated with non-cryptographic randomness or ad hoc cryptographic code

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -33,6 +33,7 @@
     "**/*.{tf,hcl,tfvars}": "terraform.md",
     "**/*.bicep": "bicep.md",
     "**/*.nix": "nix.md",
-    "**/*.{hs,lhs}": "haskell.md"
+    "**/*.{hs,lhs}": "haskell.md",
+    "**/*.{nim,nims,nimble}": "nim.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -112,6 +112,9 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"service.proto", "Wire Compatibility"},
 		{"src/Main.hs", "Partial Functions"},
 		{"examples/Tutorial.lhs", "Partial Functions"},
+		{"src/parser.nim", "Memory and Lifetime Safety"},
+		{"scripts/build.nims", "Memory and Lifetime Safety"},
+		{"project.nimble", "Memory and Lifetime Safety"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Adds Nim language support to OpenCodeReview.

- Allows `.nim`, `.nims`, and `.nimble` files
- Excludes conventional `tests/**/*.nim` paths
- Adds extension, exclusion, and rule-resolution tests
- Adds dedicated Nim review rules covering correctness, memory safety, error handling, metaprogramming, concurrency, FFI, and security

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Manual testing confirmed that:

- `.nim`, `.nims`, and `.nimble` files are selected for review
- Files under `tests/**/*.nim` are excluded
- All three extensions resolve to the Nim-specific review rules
- `make check`, `make build`, and `git diff --check` pass

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #798  
Part of #470