### PR TITLE
fix(delegate): guard JSON workflow against old CLI versions

### DIFF
--- a/cmd/opencodereview/delegate_helpers_test.go
+++ b/cmd/opencodereview/delegate_helpers_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestValidateDelegateOptions(t *testing.T) {
@@ -31,6 +33,42 @@ func TestValidateDelegateOptions(t *testing.T) {
 				t.Errorf("validateDelegateOptions() err = %v, wantErr %v", err, c.wantErr)
 			}
 		})
+	}
+}
+
+func TestDelegateFlags_RegisterJSONFormat(t *testing.T) {
+	var opts delegateOptions
+	cmd := &cobra.Command{
+		Use:           "preview",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return validateDelegateOptions(&opts)
+		},
+	}
+	registerDelegateFlags(cmd, &opts)
+	cmd.SetArgs([]string{"--format", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("delegate preview rejected --format json: %v", err)
+	}
+	if opts.format != "json" {
+		t.Fatalf("format = %q, want json", opts.format)
+	}
+
+	formatFlag := cmd.Flags().Lookup("format")
+	if formatFlag == nil {
+		t.Fatal("delegate preview did not register --format")
+	}
+	if formatFlag.Shorthand != "f" {
+		t.Fatalf("format shorthand = %q, want f", formatFlag.Shorthand)
+	}
+
+	for _, command := range []*cobra.Command{delegatePreviewCmd, delegateRuleCmd} {
+		if command.Flags().Lookup("format") == nil {
+			t.Errorf("%s did not register --format", command.Name())
+		}
 	}
 }
 

--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -41,6 +41,20 @@ npm install -g @alibaba-group/open-code-review
 
 No LLM configuration is needed for delegation mode.
 
+The delegation JSON workflow requires an OCR CLI release that supports the
+`--format` flag on both `delegate preview` and `delegate rule`. Verify the
+installed binary before starting:
+
+```bash
+ocr delegate preview --help
+```
+
+Continue only when the help output includes `--format` (or `-f`). If the flag
+is missing, the installed CLI is older than this skill's JSON protocol. Upgrade
+OCR to a release that supports delegation JSON output before continuing; do not
+silently fall back to text output because the steps below consume structured
+fields such as `reviewable_files`, `mode`, and `merge_base`.
+
 ## Workflow
 
 ### Step 1: Preview — Determine What to Review

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -36,6 +36,20 @@ npm install -g @alibaba-group/open-code-review
 
 No LLM configuration is needed for delegation mode.
 
+The delegation JSON workflow requires an OCR CLI release that supports the
+`--format` flag on both `delegate preview` and `delegate rule`. Verify the
+installed binary before starting:
+
+```bash
+ocr delegate preview --help
+```
+
+Continue only when the help output includes `--format` (or `-f`). If the flag
+is missing, the installed CLI is older than this skill's JSON protocol. Upgrade
+OCR to a release that supports delegation JSON output before continuing; do not
+silently fall back to text output because the steps below consume structured
+fields such as `reviewable_files`, `mode`, and `merge_base`.
+
 ## Workflow
 
 ### Step 1: Preview — Determine What to Review


### PR DESCRIPTION
## Description

Fixes the delegation skill/CLI version mismatch where newer skill instructions invoke:

```bash
ocr delegate preview --format json
```

against older OCR binaries that do not support the `--format` flag.

This adds CLI parser regression coverage and updates both delegation skill copies to detect unsupported OCR versions and instruct users to upgrade instead of silently falling back to incompatible text output.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual and automated testing:
  - `go test ./...`
  - `go test ./cmd/opencodereview -run TestDelegateFlags_RegisterJSONFormat -count=1`
  - `make check`
  - `go run ./cmd/opencodereview delegate preview --help`
  - `go run ./cmd/opencodereview delegate rule --help`
  - `ocr delegate preview --format json` output validated as JSON
  - `git diff --check`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of the code
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

Closes #800