### PR TITLE
docs(skill): avoid output truncation in agent skill instructions

### DIFF
--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -100,6 +100,7 @@ ocr review --audience agent --background "business context here" [user-args]
 **Output mode:**
 
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
+- **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
 
 ### Step 3: Classify and Report
 
@@ -216,6 +217,7 @@ ocr rules check src/main/java/com/example/Foo.java
 - **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
 - **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
 - **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
+- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Redirect output to a file and read it in full.
 
 ## Validation
 


### PR DESCRIPTION
## Description
Updates `skills/open-code-review/SKILL.md` to provide guidance on preventing output truncation when host agents run `ocr review` in command-line environments.

Host agents often enforce tool output limits (e.g. 50KB or 2000 lines) or blindly pipe output through `tail -N`, causing high/medium priority review findings to be dropped. This PR adds explicit instructions to redirect verbose review output to a temporary file (`> /tmp/ocr_out.txt 2>&1`) and inspect it in full via file tools.

## Type of Change
- [x] Documentation update (non-breaking change which improves docs/skills)

## How Has This Been Tested?
- Ran `git diff --check` (clean, no trailing whitespace).
- Verified Markdown rendering and skill formatting consistency.

## Related Issues
Fixes #796