### PR TITLE
docs(installation): add shell completion instructions for Homebrew users

### DIFF
--- a/pages/src/content/docs/en/installation.md
+++ b/pages/src/content/docs/en/installation.md
@@ -55,6 +55,21 @@ To upgrade later:
 brew upgrade open-code-review
 ```
 
+#### Shell Completion
+
+To enable shell completion after installing via Homebrew:
+
+```bash
+# zsh
+ocr completion zsh > "$(brew --prefix)/share/zsh/site-functions/_ocr"
+
+# bash
+ocr completion bash > "$(brew --prefix)/etc/bash_completion.d/ocr"
+
+# fish
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
 ## MacPorts (macOS)
 
 ```bash

--- a/pages/src/content/docs/zh/installation.md
+++ b/pages/src/content/docs/zh/installation.md
@@ -52,6 +52,21 @@ brew install open-code-review
 brew upgrade open-code-review
 ```
 
+#### Shell 自动补全
+
+通过 Homebrew 安装后，若需开启 Shell 自动补全：
+
+```bash
+# zsh
+ocr completion zsh > "$(brew --prefix)/share/zsh/site-functions/_ocr"
+
+# bash
+ocr completion bash > "$(brew --prefix)/etc/bash_completion.d/ocr"
+
+# fish
+ocr completion fish > ~/.config/fish/completions/ocr.fish
+```
+
 ## MacPorts（macOS）
 
 ```bash


### PR DESCRIPTION
## Description
Adds shell completion setup instructions under the Homebrew installation section in both English and Chinese documentation (`pages/src/content/docs/{en,zh}/installation.md`).

Users installing `open-code-review` via `brew install open-code-review` are now provided with one-line shell completion commands for `zsh`, `bash`, and `fish` to easily generate and store completion scripts in Homebrew's standard completion directories.

## Type of Change
- [x] Documentation update (non-breaking change which improves docs/skills)

## How Has This Been Tested?
- Ran `git diff --check` (clean, no trailing whitespace).
- Verified Markdown formatting and double-language documentation consistency.

## Related Issues
Fixes #736