### PR TITLE
feat(llm): support custom retry status codes via retry_codes config

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -537,9 +537,12 @@ func setConfigValue(cfg *Config, key, value string) error {
 		}
 		cfg.Llm.ExtraBody = m
 	case "llm.retry_codes", "llm.RetryCodes":
-		codes, err := llm.ParseRetryCodes(value)
+		codes, warnings, err := llm.ParseRetryCodes(value)
 		if err != nil {
 			return err
+		}
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %s\n", w)
 		}
 		cfg.Llm.RetryCodes = codes
 	default:
@@ -587,9 +590,12 @@ func applyProviderField(entry *ProviderEntry, field, key, value string) error {
 		}
 		entry.ExtraHeaders = parsed
 	case "retry_codes":
-		codes, err := llm.ParseRetryCodes(value)
+		codes, warnings, err := llm.ParseRetryCodes(value)
 		if err != nil {
 			return fmt.Errorf("invalid retry codes for %s: %w", key, err)
+		}
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %s\n", w)
 		}
 		entry.RetryCodes = codes
 	default:

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -293,6 +293,7 @@ type ProviderEntry struct {
 	TimeoutSec   int               `json:"timeout_sec,omitempty"` // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	RetryCodes   []int             `json:"retry_codes,omitempty"`
 }
 
 // MCPServerConfig holds configuration for a single MCP server.
@@ -331,6 +332,7 @@ type LlmConfig struct {
 	TimeoutSec   int               `json:"timeout_sec,omitempty"`   // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	RetryCodes   []int             `json:"retry_codes,omitempty"`
 }
 
 // TelemetryConfig holds telemetry-specific settings.
@@ -390,6 +392,7 @@ var supportedConfigKeys = []string{
 	"llm.use_anthropic",
 	"llm.extra_body",
 	"llm.extra_headers",
+	"llm.retry_codes",
 	"language",
 	"telemetry.enabled",
 	"telemetry.exporter",
@@ -533,8 +536,14 @@ func setConfigValue(cfg *Config, key, value string) error {
 			return fmt.Errorf("invalid JSON for llm.extra_body: %w", err)
 		}
 		cfg.Llm.ExtraBody = m
+	case "llm.retry_codes", "llm.RetryCodes":
+		codes, err := llm.ParseRetryCodes(value)
+		if err != nil {
+			return err
+		}
+		cfg.Llm.RetryCodes = codes
 	default:
-		return fmt.Errorf("unknown config key: %s\nSupported keys: %s\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\nProtocol values: anthropic, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key, strings.Join(supportedConfigKeys, ", "))
+		return fmt.Errorf("unknown config key: %s\nSupported keys: %s\nProvider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes\nProtocol values: anthropic, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key, strings.Join(supportedConfigKeys, ", "))
 	}
 	return nil
 }
@@ -577,8 +586,14 @@ func applyProviderField(entry *ProviderEntry, field, key, value string) error {
 			return fmt.Errorf("invalid extra headers for %s: %w", key, err)
 		}
 		entry.ExtraHeaders = parsed
+	case "retry_codes":
+		codes, err := llm.ParseRetryCodes(value)
+		if err != nil {
+			return fmt.Errorf("invalid retry codes for %s: %w", key, err)
+		}
+		entry.RetryCodes = codes
 	default:
-		return fmt.Errorf("unknown provider field %q: supported fields are api_key, url, protocol, model, models, auth_header, extra_body, extra_headers", field)
+		return fmt.Errorf("unknown provider field %q: supported fields are api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes", field)
 	}
 	return nil
 }

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -1473,3 +1473,49 @@ func TestSetMCPServerValue_HeadersEmptyValue(t *testing.T) {
 		t.Fatal("expected error for empty header value, got nil")
 	}
 }
+
+func TestSetConfigValueLlmRetryCodesRedundantWarning(t *testing.T) {
+	cfg := &Config{}
+	stderr := captureConfigStderr(t, func() {
+		if err := setConfigValue(cfg, "llm.retry_codes", "429,403"); err != nil {
+			t.Fatalf("setConfigValue: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "WARNING") || !strings.Contains(stderr, "429") {
+		t.Errorf("expected warning about 429 on stderr, got %q", stderr)
+	}
+	if len(cfg.Llm.RetryCodes) != 1 || cfg.Llm.RetryCodes[0] != 403 {
+		t.Errorf("RetryCodes = %v, want [403]", cfg.Llm.RetryCodes)
+	}
+}
+
+func TestSetConfigValueProviderRetryCodesRedundantWarning(t *testing.T) {
+	cfg := &Config{}
+	stderr := captureConfigStderr(t, func() {
+		if err := setConfigValue(cfg, "custom_providers.test.retry_codes", "408,400"); err != nil {
+			t.Fatalf("setConfigValue: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "WARNING") || !strings.Contains(stderr, "408") {
+		t.Errorf("expected warning about 408 on stderr, got %q", stderr)
+	}
+	entry := cfg.CustomProviders["test"]
+	if len(entry.RetryCodes) != 1 || entry.RetryCodes[0] != 400 {
+		t.Errorf("RetryCodes = %v, want [400]", entry.RetryCodes)
+	}
+}
+
+func TestSetConfigValueLlmRetryCodesNoWarningForValidCodes(t *testing.T) {
+	cfg := &Config{}
+	stderr := captureConfigStderr(t, func() {
+		if err := setConfigValue(cfg, "llm.retry_codes", "403,400"); err != nil {
+			t.Fatalf("setConfigValue: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Errorf("expected no stderr output, got %q", stderr)
+	}
+	if len(cfg.Llm.RetryCodes) != 2 {
+		t.Errorf("RetryCodes = %v, want [403 400]", cfg.Llm.RetryCodes)
+	}
+}

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -997,8 +997,8 @@ func TestSetConfigValueUnknownKeyMessage(t *testing.T) {
 		t.Fatal("expected error for unknown key")
 	}
 	want := "unknown config key: bogus.key\n" +
-		"Supported keys: provider, model, max_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
-		"Provider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers\n" +
+		"Supported keys: provider, model, max_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, llm.retry_codes, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
+		"Provider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes\n" +
 		"Protocol values: anthropic, openai, openai-responses\n" +
 		"MCP server fields: type, command, args, env, url, headers, tools, setup"
 	if err.Error() != want {

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1189,12 +1189,19 @@ func cloneProviderEntry(v ProviderEntry) ProviderEntry {
 		Model:      v.Model,
 		Models:     append([]string(nil), v.Models...),
 		AuthHeader: v.AuthHeader,
+		TimeoutSec: v.TimeoutSec,
+		RetryCodes: append([]int(nil), v.RetryCodes...),
 	}
 	if v.ExtraBody != nil {
 		out.ExtraBody = make(map[string]any, len(v.ExtraBody))
 		for k, val := range v.ExtraBody {
-			// Shallow copy only: nested maps/slices inside val are not cloned.
 			out.ExtraBody[k] = val
+		}
+	}
+	if v.ExtraHeaders != nil {
+		out.ExtraHeaders = make(map[string]string, len(v.ExtraHeaders))
+		for k, val := range v.ExtraHeaders {
+			out.ExtraHeaders[k] = val
 		}
 	}
 	return out

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -245,6 +245,51 @@ func TestCloneProviderEntry_NilExtraBody(t *testing.T) {
 	}
 }
 
+func TestCloneProviderEntry_TimeoutAndRetryCodes(t *testing.T) {
+	orig := ProviderEntry{
+		APIKey:       "key",
+		URL:          "http://localhost",
+		TimeoutSec:   30,
+		RetryCodes:   []int{403, 400},
+		ExtraHeaders: map[string]string{"X-Custom": "val", "X-Other": "val2"},
+	}
+	clone := cloneProviderEntry(orig)
+
+	if clone.TimeoutSec != 30 {
+		t.Errorf("TimeoutSec = %d, want 30", clone.TimeoutSec)
+	}
+	if len(clone.RetryCodes) != 2 || clone.RetryCodes[0] != 403 || clone.RetryCodes[1] != 400 {
+		t.Errorf("RetryCodes = %v, want [403 400]", clone.RetryCodes)
+	}
+	if clone.ExtraHeaders["X-Custom"] != "val" || clone.ExtraHeaders["X-Other"] != "val2" {
+		t.Errorf("ExtraHeaders = %v, want map with X-Custom and X-Other", clone.ExtraHeaders)
+	}
+
+	clone.RetryCodes = append(clone.RetryCodes, 401)
+	if len(orig.RetryCodes) != 2 {
+		t.Error("modifying clone should not affect original RetryCodes")
+	}
+
+	clone.ExtraHeaders["X-New"] = "new"
+	if _, ok := orig.ExtraHeaders["X-New"]; ok {
+		t.Error("modifying clone should not affect original ExtraHeaders")
+	}
+}
+
+func TestCloneProviderEntry_NilRetryCodesAndExtraHeaders(t *testing.T) {
+	orig := ProviderEntry{
+		APIKey: "key",
+		URL:    "http://localhost",
+	}
+	clone := cloneProviderEntry(orig)
+	if clone.RetryCodes != nil {
+		t.Errorf("RetryCodes should remain nil, got %v", clone.RetryCodes)
+	}
+	if clone.ExtraHeaders != nil {
+		t.Errorf("ExtraHeaders should remain nil, got %v", clone.ExtraHeaders)
+	}
+}
+
 func TestCustomListCount(t *testing.T) {
 	cfg := &Config{
 		CustomProviders: map[string]ProviderEntry{

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -195,6 +196,32 @@ type ClientConfig struct {
 	Timeout      time.Duration     // Request timeout
 	ExtraBody    map[string]any    // Vendor-specific fields merged into every request body
 	ExtraHeaders map[string]string // Extra HTTP headers sent with every request
+	RetryCodes   []int             // Additional HTTP status codes that trigger retry
+}
+
+// retryCodesMiddleware returns an HTTP middleware that forces the SDK to retry
+// responses whose status code is in the given set, by injecting the
+// x-should-retry: true response header. Returns nil when codes is empty.
+// The returned function is structurally compatible with both option.Middleware
+// (Anthropic SDK) and openaiopt.Middleware (OpenAI SDK).
+func retryCodesMiddleware(codes []int) func(*http.Request, func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+	if len(codes) == 0 {
+		return nil
+	}
+	codeSet := make(map[int]bool, len(codes))
+	for _, c := range codes {
+		codeSet[c] = true
+	}
+	return func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+		resp, err := next(req)
+		if err != nil {
+			return resp, err
+		}
+		if codeSet[resp.StatusCode] {
+			resp.Header.Set("x-should-retry", "true")
+		}
+		return resp, err
+	}
 }
 
 // --- Factory ---
@@ -217,6 +244,7 @@ func NewLLMClient(ep ResolvedEndpoint) LLMClient {
 		Timeout:      ep.Timeout,
 		ExtraBody:    ep.ExtraBody,
 		ExtraHeaders: ep.ExtraHeaders,
+		RetryCodes:   ep.RetryCodes,
 	}
 	switch ep.Protocol {
 	case ProtocolAnthropic:
@@ -323,6 +351,9 @@ func NewOpenAIClient(cfg ClientConfig) *OpenAIClient {
 	}
 	for k, v := range cfg.ExtraHeaders {
 		opts = append(opts, openaiopt.WithHeader(k, v))
+	}
+	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
+		opts = append(opts, openaiopt.WithMiddleware(mw))
 	}
 
 	return &OpenAIClient{
@@ -642,6 +673,9 @@ func NewAnthropicClient(cfg ClientConfig) *AnthropicClient {
 
 	for k, v := range cfg.ExtraHeaders {
 		opts = append(opts, option.WithHeader(k, v))
+	}
+	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
+		opts = append(opts, option.WithMiddleware(mw))
 	}
 
 	return &AnthropicClient{

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1388,3 +1388,162 @@ func TestStripThinkTags(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryCodesMiddleware_Nil(t *testing.T) {
+	mw := retryCodesMiddleware(nil)
+	if mw != nil {
+		t.Fatal("expected nil middleware for empty codes")
+	}
+	mw = retryCodesMiddleware([]int{})
+	if mw != nil {
+		t.Fatal("expected nil middleware for zero-length codes")
+	}
+}
+
+func TestRetryCodesMiddleware_SetsHeader(t *testing.T) {
+	mw := retryCodesMiddleware([]int{403, 400})
+
+	resp := &http.Response{
+		StatusCode: 403,
+		Header:     http.Header{},
+	}
+	next := func(req *http.Request) (*http.Response, error) {
+		return resp, nil
+	}
+
+	got, err := mw(nil, next)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Header.Get("x-should-retry") != "true" {
+		t.Error("expected x-should-retry: true for status 403")
+	}
+}
+
+func TestRetryCodesMiddleware_NoHeaderForNonMatchingCode(t *testing.T) {
+	mw := retryCodesMiddleware([]int{403})
+
+	resp := &http.Response{
+		StatusCode: 401,
+		Header:     http.Header{},
+	}
+	next := func(req *http.Request) (*http.Response, error) {
+		return resp, nil
+	}
+
+	got, err := mw(nil, next)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Header.Get("x-should-retry") != "" {
+		t.Errorf("unexpected x-should-retry header for status 401: %q", got.Header.Get("x-should-retry"))
+	}
+}
+
+func TestRetryCodesMiddleware_PassthroughError(t *testing.T) {
+	mw := retryCodesMiddleware([]int{403})
+
+	wantErr := errors.New("connection refused")
+	next := func(req *http.Request) (*http.Response, error) {
+		return nil, wantErr
+	}
+
+	resp, err := mw(nil, next)
+	if err != wantErr {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	if resp != nil {
+		t.Fatal("expected nil response on error")
+	}
+}
+
+func TestOpenAIClient_RetryCodesTriggersRetry(t *testing.T) {
+	const responseBody = `{
+		"id":"chatcmpl-retry",
+		"object":"chat.completion",
+		"model":"gpt-test",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"success"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+	}`
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n <= 2 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:        server.URL + "/v1",
+		APIKey:     "test-key",
+		Model:      "gpt-test",
+		RetryCodes: []int{403},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:  []Message{{Role: "user", Content: "ping"}},
+		MaxTokens: 64,
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if got := requests.Load(); got < 3 {
+		t.Fatalf("requests = %d, want >= 3 (should retry on 403)", got)
+	}
+	if got := resp.Content(); got != "success" {
+		t.Errorf("Content() = %q, want %q", got, "success")
+	}
+}
+
+func TestAnthropicClient_RetryCodesTriggersRetry(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n <= 2 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id":"msg-test",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-test",
+			"content":[{"type":"text","text":"success"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient(ClientConfig{
+		URL:        server.URL + "/v1/messages",
+		APIKey:     "test-key",
+		Model:      "claude-test",
+		AuthHeader: "x-api-key",
+		RetryCodes: []int{403},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:  []Message{{Role: "user", Content: "ping"}},
+		MaxTokens: 64,
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if got := requests.Load(); got < 3 {
+		t.Fatalf("requests = %d, want >= 3 (should retry on 403)", got)
+	}
+	if got := resp.Content(); got != "success" {
+		t.Errorf("Content() = %q, want %q", got, "success")
+	}
+}

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -421,7 +421,8 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q: %w", cfg.Provider, err)
 	}
 
-	if err := validateRetryCodes(entry.RetryCodes); err != nil {
+	retryCodes, _, err := sanitizeRetryCodes(entry.RetryCodes)
+	if err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q: %w", cfg.Provider, err)
 	}
 
@@ -440,7 +441,7 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		ExtraBody:    extraBody,
 		ExtraHeaders: extraHeaders,
 		Timeout:      timeout,
-		RetryCodes:   entry.RetryCodes,
+		RetryCodes:   retryCodes,
 	}, true, nil
 }
 
@@ -491,7 +492,8 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
 	}
 
-	if err := validateRetryCodes(cfg.Llm.RetryCodes); err != nil {
+	retryCodes, _, err := sanitizeRetryCodes(cfg.Llm.RetryCodes)
+	if err != nil {
 		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
 	}
 
@@ -505,7 +507,7 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 		ExtraBody:    cfg.Llm.ExtraBody,
 		ExtraHeaders: cfg.Llm.ExtraHeaders,
 		Timeout:      timeout,
-		RetryCodes:   cfg.Llm.RetryCodes,
+		RetryCodes:   retryCodes,
 	}, true, nil
 }
 
@@ -744,28 +746,32 @@ func ensureMessagesSuffix(rawURL string) string {
 	return u + "/v1/messages"
 }
 
-// validateRetryCodes checks that every code is a 4xx status code not already
-// retried by the SDK (408, 409, 429). Returns an error on the first violation.
-func validateRetryCodes(codes []int) error {
+// sanitizeRetryCodes filters out SDK-default codes (408, 409, 429) and returns
+// the remaining valid codes, any warnings for filtered codes, and an error if
+// any code is outside the 4xx range.
+func sanitizeRetryCodes(codes []int) (filtered []int, warnings []string, err error) {
 	for _, code := range codes {
 		if code < 400 || code > 499 {
-			return fmt.Errorf("invalid retry code %d: must be a 4xx status code (5xx codes are already retried by default)", code)
+			return nil, nil, fmt.Errorf("invalid retry code %d: must be a 4xx status code (5xx codes are already retried by default)", code)
 		}
 		if code == 408 || code == 409 || code == 429 {
-			return fmt.Errorf("retry code %d is unnecessary: the SDK already retries this status code", code)
+			warnings = append(warnings, fmt.Sprintf("retry code %d is unnecessary (SDK already retries it) and will be ignored", code))
+			continue
 		}
+		filtered = append(filtered, code)
 	}
-	return nil
+	return filtered, warnings, nil
 }
 
 // ParseRetryCodes parses a comma-separated list of HTTP status codes that
 // should trigger retry. Only 4xx codes not already retried by the SDK
 // (408, 409, 429) are accepted; 5xx codes are rejected because the SDK
-// retries all of them by default. An empty input returns nil.
-func ParseRetryCodes(raw string) ([]int, error) {
+// retries all of them by default. SDK-default codes are silently filtered
+// out and reported as warnings. An empty input returns nil.
+func ParseRetryCodes(raw string) ([]int, []string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	parts := strings.Split(raw, ",")
 	seen := make(map[int]bool, len(parts))
@@ -777,15 +783,16 @@ func ParseRetryCodes(raw string) ([]int, error) {
 		}
 		code, err := strconv.Atoi(p)
 		if err != nil {
-			return nil, fmt.Errorf("invalid retry code %q: must be an integer", p)
+			return nil, nil, fmt.Errorf("invalid retry code %q: must be an integer", p)
 		}
 		if !seen[code] {
 			seen[code] = true
 			codes = append(codes, code)
 		}
 	}
-	if err := validateRetryCodes(codes); err != nil {
-		return nil, err
+	filtered, warnings, err := sanitizeRetryCodes(codes)
+	if err != nil {
+		return nil, nil, err
 	}
-	return codes, nil
+	return filtered, warnings, nil
 }

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -30,7 +30,8 @@ type ResolvedEndpoint struct {
 	// Only config file (llm/provider sections) and OCR_LLM_TIMEOUT env var can set this.
 	// tryCCEnv and tryShellRC always leave it at 0 since those sources have no timeout
 	// knob; users can still override via OCR_LLM_TIMEOUT.
-	Timeout time.Duration
+	Timeout    time.Duration
+	RetryCodes []int // additional HTTP status codes that trigger exponential-backoff retry
 }
 
 // Environment variable names for OCR-specific configuration.
@@ -244,6 +245,7 @@ type llmFileConfig struct {
 	TimeoutSec   int               `json:"timeout_sec,omitempty"`   // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	RetryCodes   []int             `json:"retry_codes,omitempty"`
 }
 
 // providerEntryConfig represents a single provider entry in config.json.
@@ -257,6 +259,7 @@ type providerEntryConfig struct {
 	TimeoutSec   int               `json:"timeout_sec,omitempty"` // per-request HTTP timeout in seconds
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+	RetryCodes   []int             `json:"retry_codes,omitempty"`
 }
 
 type configFile struct {
@@ -418,6 +421,10 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q: %w", cfg.Provider, err)
 	}
 
+	if err := validateRetryCodes(entry.RetryCodes); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("provider %q: %w", cfg.Provider, err)
+	}
+
 	if protocol == ProtocolAnthropic {
 		url = ensureMessagesSuffix(url)
 	}
@@ -433,6 +440,7 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		ExtraBody:    extraBody,
 		ExtraHeaders: extraHeaders,
 		Timeout:      timeout,
+		RetryCodes:   entry.RetryCodes,
 	}, true, nil
 }
 
@@ -483,7 +491,22 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
 	}
 
-	return ResolvedEndpoint{URL: cfg.Llm.URL, Token: cfg.Llm.AuthToken, Model: model, Protocol: protocol, AuthHeader: authHeader, Source: "OCR config file", ExtraBody: cfg.Llm.ExtraBody, ExtraHeaders: cfg.Llm.ExtraHeaders, Timeout: timeout}, true, nil
+	if err := validateRetryCodes(cfg.Llm.RetryCodes); err != nil {
+		return ResolvedEndpoint{}, false, fmt.Errorf("OCR config file: %w", err)
+	}
+
+	return ResolvedEndpoint{
+		URL:          cfg.Llm.URL,
+		Token:        cfg.Llm.AuthToken,
+		Model:        model,
+		Protocol:     protocol,
+		AuthHeader:   authHeader,
+		Source:       "OCR config file",
+		ExtraBody:    cfg.Llm.ExtraBody,
+		ExtraHeaders: cfg.Llm.ExtraHeaders,
+		Timeout:      timeout,
+		RetryCodes:   cfg.Llm.RetryCodes,
+	}, true, nil
 }
 
 // tryCCEnv reads Claude Code environment variables.
@@ -719,4 +742,50 @@ func ensureMessagesSuffix(rawURL string) string {
 		return rawURL
 	}
 	return u + "/v1/messages"
+}
+
+// validateRetryCodes checks that every code is a 4xx status code not already
+// retried by the SDK (408, 409, 429). Returns an error on the first violation.
+func validateRetryCodes(codes []int) error {
+	for _, code := range codes {
+		if code < 400 || code > 499 {
+			return fmt.Errorf("invalid retry code %d: must be a 4xx status code (5xx codes are already retried by default)", code)
+		}
+		if code == 408 || code == 409 || code == 429 {
+			return fmt.Errorf("retry code %d is unnecessary: the SDK already retries this status code", code)
+		}
+	}
+	return nil
+}
+
+// ParseRetryCodes parses a comma-separated list of HTTP status codes that
+// should trigger retry. Only 4xx codes not already retried by the SDK
+// (408, 409, 429) are accepted; 5xx codes are rejected because the SDK
+// retries all of them by default. An empty input returns nil.
+func ParseRetryCodes(raw string) ([]int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	seen := make(map[int]bool, len(parts))
+	codes := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		code, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid retry code %q: must be an integer", p)
+		}
+		if !seen[code] {
+			seen[code] = true
+			codes = append(codes, code)
+		}
+	}
+	if err := validateRetryCodes(codes); err != nil {
+		return nil, err
+	}
+	return codes, nil
 }

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -764,10 +764,9 @@ func sanitizeRetryCodes(codes []int) (filtered []int, warnings []string, err err
 }
 
 // ParseRetryCodes parses a comma-separated list of HTTP status codes that
-// should trigger retry. Only 4xx codes not already retried by the SDK
-// (408, 409, 429) are accepted; 5xx codes are rejected because the SDK
-// retries all of them by default. SDK-default codes are silently filtered
-// out and reported as warnings. An empty input returns nil.
+// should trigger retry. Non-4xx codes return an error; SDK-default codes
+// (408, 409, 429) are filtered out and reported via warnings; the
+// remaining codes are returned. An empty input returns nil.
 func ParseRetryCodes(raw string) ([]int, []string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -2226,10 +2226,11 @@ func TestEnsureMessagesSuffix(t *testing.T) {
 
 func TestParseRetryCodes(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    []int
-		wantErr string
+		name     string
+		input    string
+		want     []int
+		wantWarn bool
+		wantErr  string
 	}{
 		{name: "empty string", input: "", want: nil},
 		{name: "whitespace only", input: "   ", want: nil},
@@ -2242,13 +2243,14 @@ func TestParseRetryCodes(t *testing.T) {
 		{name: "rejects 3xx", input: "301", wantErr: "must be a 4xx status code"},
 		{name: "rejects 5xx", input: "500", wantErr: "must be a 4xx status code"},
 		{name: "rejects 600", input: "600", wantErr: "must be a 4xx status code"},
-		{name: "rejects 408", input: "408", wantErr: "unnecessary"},
-		{name: "rejects 409", input: "409", wantErr: "unnecessary"},
-		{name: "rejects 429", input: "429", wantErr: "unnecessary"},
+		{name: "filters 408 with warning", input: "408", want: nil, wantWarn: true},
+		{name: "filters 409 with warning", input: "409", want: nil, wantWarn: true},
+		{name: "filters 429 with warning", input: "429", want: nil, wantWarn: true},
+		{name: "filters redundant keeps valid", input: "429,403", want: []int{403}, wantWarn: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseRetryCodes(tt.input)
+			got, warnings, err := ParseRetryCodes(tt.input)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
@@ -2260,6 +2262,12 @@ func TestParseRetryCodes(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantWarn && len(warnings) == 0 {
+				t.Fatal("expected warnings, got none")
+			}
+			if !tt.wantWarn && len(warnings) > 0 {
+				t.Fatalf("unexpected warnings: %v", warnings)
 			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
@@ -2337,7 +2345,7 @@ func TestResolveEndpoint_InvalidRetryCodes(t *testing.T) {
 				URL:        "http://localhost/v1",
 				Protocol:   "openai",
 				Model:      "m",
-				RetryCodes: []int{429},
+				RetryCodes: []int{500},
 			},
 		},
 	}
@@ -2346,9 +2354,37 @@ func TestResolveEndpoint_InvalidRetryCodes(t *testing.T) {
 
 	_, err := ResolveEndpoint(cfgFile)
 	if err == nil {
-		t.Fatal("expected error for invalid retry code 429")
+		t.Fatal("expected error for invalid retry code 500")
 	}
-	if !strings.Contains(err.Error(), "unnecessary") {
-		t.Errorf("error %q does not mention unnecessary", err.Error())
+	if !strings.Contains(err.Error(), "must be a 4xx status code") {
+		t.Errorf("error %q does not mention 4xx requirement", err.Error())
+	}
+}
+
+func TestResolveEndpoint_RedundantRetryCodesFiltered(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	cfg := configFile{
+		Provider: "test",
+		Model:    "m",
+		CustomProviders: map[string]providerEntryConfig{
+			"test": {
+				APIKey:     "k",
+				URL:        "http://localhost/v1",
+				Protocol:   "openai",
+				Model:      "m",
+				RetryCodes: []int{429, 403},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	os.WriteFile(cfgFile, data, 0o644)
+
+	ep, err := ResolveEndpoint(cfgFile)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if len(ep.RetryCodes) != 1 || ep.RetryCodes[0] != 403 {
+		t.Errorf("RetryCodes = %v, want [403] (429 should be filtered)", ep.RetryCodes)
 	}
 }

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -2223,3 +2223,132 @@ func TestEnsureMessagesSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRetryCodes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []int
+		wantErr string
+	}{
+		{name: "empty string", input: "", want: nil},
+		{name: "whitespace only", input: "   ", want: nil},
+		{name: "single code", input: "403", want: []int{403}},
+		{name: "multiple codes", input: "403,400", want: []int{403, 400}},
+		{name: "with spaces", input: " 403 , 400 ", want: []int{403, 400}},
+		{name: "deduplicates", input: "403,403,400", want: []int{403, 400}},
+		{name: "rejects non-integer", input: "abc", wantErr: "invalid retry code"},
+		{name: "rejects 2xx", input: "200", wantErr: "must be a 4xx status code"},
+		{name: "rejects 3xx", input: "301", wantErr: "must be a 4xx status code"},
+		{name: "rejects 5xx", input: "500", wantErr: "must be a 4xx status code"},
+		{name: "rejects 600", input: "600", wantErr: "must be a 4xx status code"},
+		{name: "rejects 408", input: "408", wantErr: "unnecessary"},
+		{name: "rejects 409", input: "409", wantErr: "unnecessary"},
+		{name: "rejects 429", input: "429", wantErr: "unnecessary"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRetryCodes(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveEndpoint_ProviderRetryCodes(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	cfg := configFile{
+		Provider: "test",
+		Model:    "m",
+		CustomProviders: map[string]providerEntryConfig{
+			"test": {
+				APIKey:     "k",
+				URL:        "http://localhost/v1",
+				Protocol:   "openai",
+				Model:      "m",
+				RetryCodes: []int{403, 400},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	os.WriteFile(cfgFile, data, 0o644)
+
+	ep, err := ResolveEndpoint(cfgFile)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if len(ep.RetryCodes) != 2 || ep.RetryCodes[0] != 403 || ep.RetryCodes[1] != 400 {
+		t.Errorf("RetryCodes = %v, want [403, 400]", ep.RetryCodes)
+	}
+}
+
+func TestResolveEndpoint_LegacyLlmRetryCodes(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	cfg := configFile{
+		Llm: llmFileConfig{
+			URL:        "http://localhost/v1/messages",
+			AuthToken:  "t",
+			Model:      "m",
+			Protocol:   "anthropic",
+			RetryCodes: []int{403},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	os.WriteFile(cfgFile, data, 0o644)
+
+	ep, err := ResolveEndpoint(cfgFile)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if len(ep.RetryCodes) != 1 || ep.RetryCodes[0] != 403 {
+		t.Errorf("RetryCodes = %v, want [403]", ep.RetryCodes)
+	}
+}
+
+func TestResolveEndpoint_InvalidRetryCodes(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	cfg := configFile{
+		Provider: "test",
+		Model:    "m",
+		CustomProviders: map[string]providerEntryConfig{
+			"test": {
+				APIKey:     "k",
+				URL:        "http://localhost/v1",
+				Protocol:   "openai",
+				Model:      "m",
+				RetryCodes: []int{429},
+			},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	os.WriteFile(cfgFile, data, 0o644)
+
+	_, err := ResolveEndpoint(cfgFile)
+	if err == nil {
+		t.Fatal("expected error for invalid retry code 429")
+	}
+	if !strings.Contains(err.Error(), "unnecessary") {
+		t.Errorf("error %q does not mention unnecessary", err.Error())
+	}
+}

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -46,6 +46,9 @@ func NewOpenAIResponsesClient(cfg ClientConfig) *OpenAIResponsesClient {
 	for k, v := range cfg.ExtraHeaders {
 		opts = append(opts, openaiopt.WithHeader(k, v))
 	}
+	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
+		opts = append(opts, openaiopt.WithMiddleware(mw))
+	}
 
 	return &OpenAIResponsesClient{
 		cfg: cfg,


### PR DESCRIPTION
## Summary

Some self-hosted LLM clusters misuse HTTP status codes — e.g., returning 403 or 400 for rate limiting instead of the standard 429. This PR adds a `retry_codes` configuration field that lets users specify additional 4xx status codes to trigger exponential backoff retry.

- Adds `retry_codes` field to provider config, legacy llm config, and CLI `config set`
- Implements SDK middleware that injects `x-should-retry: true` response header on configured status codes, reusing the existing SDK retry mechanism (up to 5 retries with exponential backoff)
- Redundant codes (408/409/429) are silently filtered at resolve time and emit a warning at `config set` time, rather than blocking startup
- Fixes `cloneProviderEntry` to copy previously missing fields (`TimeoutSec`, `ExtraHeaders`, `RetryCodes`)

### Configuration example

```json
{
  "provider": "my-cluster",
  "custom_providers": {
    "my-cluster": {
      "api_key": "sk-xxx",
      "url": "https://internal.llm.corp/v1",
      "protocol": "openai",
      "model": "gpt-4o",
      "retry_codes": [403, 400]
    }
  }
}
```

Or via CLI:
```bash
ocr config set custom_providers.my-cluster.retry_codes 403,400
```

## Bugfix: cloneProviderEntry data loss

`cloneProviderEntry` (used by TUI for rollback snapshots) was missing `TimeoutSec`, `ExtraHeaders`, and `RetryCodes`. This caused silent data loss on failed edits — rolling back would discard the user's timeout and extra headers settings. Now fixed with full test coverage for deep-copy isolation and nil preservation.

## Test plan

- [x] `make check` passes (formatting, vet, license headers)
- [x] `make test` passes (all existing + new tests)
- [x] `TestCloneProviderEntry_TimeoutAndRetryCodes` — verifies deep-copy and mutation isolation
- [x] `TestCloneProviderEntry_NilRetryCodesAndExtraHeaders` — pins nil-stays-nil behavior
- [ ] Manual test: configure `retry_codes` with a mock server returning the configured status code, verify retry behavior