### PR TITLE
fix(llm): request stream usage by default with extra_body override

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -380,9 +380,21 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 			// Ask for the final usage chunk by default.
 			params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
 		} else if streamOptions != nil {
-			// An explicit stream_options in extra_body replaces the default.
-			// An explicit null suppresses the field entirely, for gateways
-			// that reject stream_options.
+			// An explicit stream_options in extra_body replaces the default,
+			// but usage stays requested unless include_usage itself is spelled
+			// out: configuring an unrelated stream option must not silently
+			// disable cost accounting. An explicit null suppresses the field
+			// entirely, for gateways that reject stream_options.
+			if object, ok := streamOptions.(map[string]any); ok {
+				if _, has := object["include_usage"]; !has {
+					merged := make(map[string]any, len(object)+1)
+					for key, value := range object {
+						merged[key] = value
+					}
+					merged["include_usage"] = true
+					streamOptions = merged
+				}
+			}
 			opts = append(opts, openaiopt.WithJSONSet("stream_options", streamOptions))
 		}
 		return c.completionsStreaming(ctx, params, opts...)

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -365,13 +365,26 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 		// NewStreaming method sets stream=true on the wire itself. When
 		// streaming is NOT enabled, leaving the key in the body would make
 		// the API answer with text/event-stream and the non-streaming path
-		// fails to decode (see issue #647).
-		if k == "stream" {
+		// fails to decode (see issue #647). "stream_options" is owned by the
+		// streaming branch below for the same reason: providers reject it
+		// unless stream is true.
+		if k == "stream" || k == "stream_options" {
 			continue
 		}
 		opts = append(opts, openaiopt.WithJSONSet(k, v))
 	}
 	if stream, ok := c.cfg.ExtraBody["stream"].(bool); ok && stream {
+		if streamOptions, ok := c.cfg.ExtraBody["stream_options"]; !ok {
+			// OpenAI-compatible servers omit token usage from streams unless
+			// asked, silently losing cost accounting for streamed requests.
+			// Ask for the final usage chunk by default.
+			params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
+		} else if streamOptions != nil {
+			// An explicit stream_options in extra_body replaces the default.
+			// An explicit null suppresses the field entirely, for gateways
+			// that reject stream_options.
+			opts = append(opts, openaiopt.WithJSONSet("stream_options", streamOptions))
+		}
 		return c.completionsStreaming(ctx, params, opts...)
 	}
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -814,11 +814,12 @@ func TestOpenAIClient_StreamingRequestsUsageByDefault(t *testing.T) {
 	}
 }
 
-// TestOpenAIClient_StreamOptionsConfigOverrides verifies the three
-// extra_body.stream_options states: an explicit object replaces the
-// include_usage default, an explicit null suppresses the field entirely
-// (for gateways that reject stream_options), and non-streaming requests
-// never carry the field regardless of config.
+// TestOpenAIClient_StreamOptionsConfigOverrides verifies the
+// extra_body.stream_options states: an explicit include_usage value is
+// respected, an object configuring only unrelated options keeps the usage
+// default merged in, an explicit null suppresses the field entirely (for
+// gateways that reject stream_options), and non-streaming requests never
+// carry the field regardless of config.
 func TestOpenAIClient_StreamOptionsConfigOverrides(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -827,9 +828,14 @@ func TestOpenAIClient_StreamOptionsConfigOverrides(t *testing.T) {
 		wantAbsent bool
 	}{
 		{
-			name:      "explicit object replaces default",
+			name:      "explicit include_usage false is respected",
 			extraBody: map[string]any{"stream": true, "stream_options": map[string]any{"include_usage": false}},
 			want:      map[string]any{"include_usage": false},
+		},
+		{
+			name:      "unrelated option keeps the usage default",
+			extraBody: map[string]any{"stream": true, "stream_options": map[string]any{"continuous_usage_stats": true}},
+			want:      map[string]any{"continuous_usage_stats": true, "include_usage": true},
 		},
 		{
 			name:       "explicit null suppresses field",

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -760,6 +761,133 @@ func TestOpenAIClient_StreamOnlyGateway(t *testing.T) {
 	}
 	if resp.Choices[0].FinishReason != "stop" {
 		t.Errorf("finish reason = %q, want %q", resp.Choices[0].FinishReason, "stop")
+	}
+}
+
+// TestOpenAIClient_StreamingRequestsUsageByDefault verifies that streaming
+// requests ask for the final usage chunk via stream_options.include_usage
+// when the provider config does not set stream_options itself.
+// OpenAI-compatible servers omit usage from streams unless asked, silently
+// losing token accounting for every streamed request.
+func TestOpenAIClient_StreamingRequestsUsageByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		streamOptions, ok := body["stream_options"].(map[string]any)
+		if !ok || streamOptions["include_usage"] != true {
+			t.Errorf("stream_options = %#v, want include_usage true", body["stream_options"])
+			http.Error(w, "usage request required", http.StatusBadRequest)
+			return
+		}
+
+		writeOpenAISSE(t, w,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`{"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1,"model":"gpt-stream","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":3,"total_tokens":15}}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:       server.URL + "/v1",
+		APIKey:    "test-key",
+		Model:     "gpt-stream",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	resp, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if resp.Usage == nil {
+		t.Fatal("Usage = nil, want usage from the final stream chunk")
+	}
+	if resp.Usage.PromptTokens != 12 || resp.Usage.CompletionTokens != 3 || resp.Usage.TotalTokens != 15 {
+		t.Errorf("Usage = %+v, want prompt 12 / completion 3 / total 15", resp.Usage)
+	}
+}
+
+// TestOpenAIClient_StreamOptionsConfigOverrides verifies the three
+// extra_body.stream_options states: an explicit object replaces the
+// include_usage default, an explicit null suppresses the field entirely
+// (for gateways that reject stream_options), and non-streaming requests
+// never carry the field regardless of config.
+func TestOpenAIClient_StreamOptionsConfigOverrides(t *testing.T) {
+	tests := []struct {
+		name       string
+		extraBody  map[string]any
+		want       any
+		wantAbsent bool
+	}{
+		{
+			name:      "explicit object replaces default",
+			extraBody: map[string]any{"stream": true, "stream_options": map[string]any{"include_usage": false}},
+			want:      map[string]any{"include_usage": false},
+		},
+		{
+			name:       "explicit null suppresses field",
+			extraBody:  map[string]any{"stream": true, "stream_options": nil},
+			wantAbsent: true,
+		},
+		{
+			name:       "non-streaming never sends stream_options",
+			extraBody:  map[string]any{"stream_options": map[string]any{"include_usage": true}},
+			wantAbsent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streaming, _ := tt.extraBody["stream"].(bool)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+					http.Error(w, "invalid request body", http.StatusBadRequest)
+					return
+				}
+
+				value, present := body["stream_options"]
+				if tt.wantAbsent {
+					if present {
+						t.Errorf("stream_options = %#v, want absent", value)
+					}
+				} else if !reflect.DeepEqual(value, tt.want) {
+					t.Errorf("stream_options = %#v, want %#v", value, tt.want)
+				}
+
+				if streaming {
+					writeOpenAISSE(t, w,
+						`{"id":"chatcmpl-s","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}`,
+						`{"id":"chatcmpl-s","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+					)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"id":"chatcmpl-n","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+			}))
+			defer server.Close()
+
+			client := NewOpenAIClient(ClientConfig{
+				URL:       server.URL + "/v1",
+				APIKey:    "test-key",
+				Model:     "m",
+				ExtraBody: tt.extraBody,
+			})
+
+			if _, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+				Messages: []Message{{Role: "user", Content: "ping"}},
+			}); err != nil {
+				t.Fatalf("CompletionsWithCtx: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Streaming requests currently receive token usage only when the provider volunteers it. OpenAI-compatible servers omit usage from streams unless `stream_options.include_usage` is set, so every streamed review silently loses token/cost accounting (`resp.Usage` stays nil and the session totals under-report).

This PR sets `stream_options: {"include_usage": true}` by default when streaming is enabled, while keeping the existing `extra_body` passthrough fully in control:

| `extra_body.stream_options` | wire behavior |
|---|---|
| absent | `{"include_usage": true}` (new default) |
| an object | sent as-is, replaces the default |
| `null` | field omitted entirely — escape hatch for gateways that reject `stream_options` (some older vLLM/Azure builds) |

Non-streaming requests never carry the field regardless of config, mirroring how the `stream` key itself is handled (#647): providers reject `stream_options` unless `stream` is true.

**Behavioral change:** streamed requests now include `stream_options.include_usage: true` by default. Servers that implement stream_options respond with one extra final chunk carrying usage; servers that reject the field can be accommodated with `stream_options: null` in `extra_body`. No change for non-streaming requests.

Split out of #806 (which forced `include_usage` unconditionally, with no escape hatch) so it can be reviewed independently of the replay design discussion there.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] New HTTP-boundary tests assert the actual request body: `TestOpenAIClient_StreamingRequestsUsageByDefault` (default present + usage captured from the final chunk) and `TestOpenAIClient_StreamOptionsConfigOverrides` (explicit object replaces default / explicit null suppresses the field / non-streaming never sends it)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable) — `extra_body.stream` itself is currently undocumented; happy to add a Streaming section to the configuration docs (en/zh/ja/ru) in a follow-up if you'd like
- [x] I have signed the CLA

## Related Issues

Related to #806 (split out of it).
