### PR TITLE
fix(llmloop): keep live rounds out of compression

### DIFF
--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -30,11 +30,15 @@ func PromptTokenLimit(maxTokens int) int {
 	return int(float64(maxTokens) * tokenWarningThreshold)
 }
 
-// round groups consecutive messages starting with an assistant message
-// followed by zero or more tool result messages.
+// round is one assistant turn plus everything that follows it up to the
+// next assistant message: its tool results and any interleaved user
+// messages, such as the no-tool retry nudge. Spanning the whole gap keeps
+// token accounting and zone boundaries aligned with the conversation the
+// model actually replays — index-only bookkeeping (assistant + tool roles)
+// left retry messages invisible to both.
 type round struct {
 	assistantIdx int
-	toolIdxs     []int
+	end          int // exclusive index of the message after the round
 }
 
 // partitionResult describes how messages should be split for compression.
@@ -74,23 +78,20 @@ func CountMessagesTokens(msgs []llm.Message) int {
 	return total
 }
 
-// groupIntoRounds parses messages[start:] into logical
-// (assistant + tool_results) pairs.
+// groupIntoRounds parses messages[start:] into rounds. Each assistant
+// message opens a round that runs until the next assistant message (or the
+// end of the conversation), so tool results and retry nudges stay with the
+// turn that produced them.
 func groupIntoRounds(messages []llm.Message, start int) []round {
 	var rounds []round
-	i := start
-	for i < len(messages) {
-		if messages[i].Role == "assistant" {
-			r := round{assistantIdx: i}
-			i++
-			for i < len(messages) && messages[i].Role == "tool" {
-				r.toolIdxs = append(r.toolIdxs, i)
-				i++
-			}
-			rounds = append(rounds, r)
-		} else {
-			i++
+	for i := start; i < len(messages); i++ {
+		if messages[i].Role != "assistant" {
+			continue
 		}
+		if n := len(rounds); n > 0 {
+			rounds[n-1].end = i
+		}
+		rounds = append(rounds, round{assistantIdx: i, end: len(messages)})
 	}
 	return rounds
 }
@@ -107,9 +108,9 @@ func computeActiveZoneSize(rounds []round, messages []llm.Message, maxTokens int
 	count := 0
 	tokensUsed := 0
 	for i := len(rounds) - 1; i >= 0; i-- {
-		roundTokens := llm.CountTokens(messages[rounds[i].assistantIdx].ExtractText())
-		for _, ti := range rounds[i].toolIdxs {
-			roundTokens += llm.CountTokens(messages[ti].ExtractText())
+		roundTokens := 0
+		for j := rounds[i].assistantIdx; j < rounds[i].end; j++ {
+			roundTokens += llm.CountTokens(messages[j].ExtractText())
 		}
 		if tokensUsed+roundTokens > budget {
 			break
@@ -146,12 +147,7 @@ func partitionMessages(messages []llm.Message, maxTokens int, prevSummaryTokenEs
 
 	// compressEnd = index after the last round NOT in active zone.
 	activeStartIdx := len(result.rounds) - result.activeCount
-	lastCompressRound := result.rounds[activeStartIdx-1]
-	if len(lastCompressRound.toolIdxs) > 0 {
-		result.compressEnd = lastCompressRound.toolIdxs[len(lastCompressRound.toolIdxs)-1] + 1
-	} else {
-		result.compressEnd = lastCompressRound.assistantIdx + 1
-	}
+	result.compressEnd = result.rounds[activeStartIdx-1].end
 
 	return result
 }

--- a/internal/llmloop/compression_test.go
+++ b/internal/llmloop/compression_test.go
@@ -49,20 +49,45 @@ func TestGroupIntoRounds(t *testing.T) {
 		t.Fatalf("expected 3 rounds, got %d", len(rounds))
 	}
 
-	if rounds[0].assistantIdx != 2 {
-		t.Errorf("round[0].assistantIdx = %d, want 2", rounds[0].assistantIdx)
+	if rounds[0].assistantIdx != 2 || rounds[0].end != 5 {
+		t.Errorf("round[0] = [%d,%d), want [2,5) covering both tool results", rounds[0].assistantIdx, rounds[0].end)
 	}
-	if len(rounds[0].toolIdxs) != 2 {
-		t.Errorf("round[0] should have 2 tool messages, got %d", len(rounds[0].toolIdxs))
+	if rounds[1].assistantIdx != 5 || rounds[1].end != 7 {
+		t.Errorf("round[1] = [%d,%d), want [5,7)", rounds[1].assistantIdx, rounds[1].end)
 	}
-	if rounds[1].assistantIdx != 5 {
-		t.Errorf("round[1].assistantIdx = %d, want 5", rounds[1].assistantIdx)
+	if rounds[2].assistantIdx != 7 || rounds[2].end != 8 {
+		t.Errorf("round[2] = [%d,%d), want [7,8) with no tool messages", rounds[2].assistantIdx, rounds[2].end)
 	}
-	if rounds[2].assistantIdx != 7 {
-		t.Errorf("round[2].assistantIdx = %d, want 7", rounds[2].assistantIdx)
+}
+
+// TestGroupIntoRounds_RetryNudgesStayWithTheirRound covers the no-tool retry
+// shape: assistant text answers interleaved with user retry nudges. Rounds
+// must span those nudges — with index-only bookkeeping they belonged to no
+// round, so partition boundaries and token accounting never saw them.
+func TestGroupIntoRounds_RetryNudgesStayWithTheirRound(t *testing.T) {
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "chatter"),
+		msg("user", "You did not successfully call any tools. Please try again or use task_done if finished."),
+		msg("assistant", "more chatter"),
+		msg("user", "You did not successfully call any tools. Please try again or use task_done if finished."),
+		msg("assistant", "resp"),
+		msg("tool", "result"),
 	}
-	if len(rounds[2].toolIdxs) != 0 {
-		t.Errorf("round[2] should have 0 tool messages")
+
+	rounds := groupIntoRounds(messages, 2)
+	if len(rounds) != 3 {
+		t.Fatalf("expected 3 rounds, got %d", len(rounds))
+	}
+	if rounds[0].assistantIdx != 2 || rounds[0].end != 4 {
+		t.Errorf("round[0] = [%d,%d), want [2,4) including its retry nudge", rounds[0].assistantIdx, rounds[0].end)
+	}
+	if rounds[1].assistantIdx != 4 || rounds[1].end != 6 {
+		t.Errorf("round[1] = [%d,%d), want [4,6) including its retry nudge", rounds[1].assistantIdx, rounds[1].end)
+	}
+	if rounds[2].assistantIdx != 6 || rounds[2].end != 8 {
+		t.Errorf("round[2] = [%d,%d), want [6,8)", rounds[2].assistantIdx, rounds[2].end)
 	}
 }
 

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -236,9 +236,15 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 
 		if len(calls) == 0 {
 			fmt.Fprintf(stdout.Writer(), "[ocr] No tool calls parsed for %s, retrying...\n", newPath)
-			messages = append(messages, llm.NewTextMessage("user", "You did not successfully call any tools. Please try again or use task_done if finished."))
+			var additions []llm.Message
 			if content != "" {
-				messages = append(messages[:len(messages)-1], llm.NewTextMessage("assistant", content), messages[len(messages)-1])
+				additions = append(additions, llm.NewTextMessage("assistant", content))
+			}
+			additions = append(additions, llm.NewTextMessage("user", "You did not successfully call any tools. Please try again or use task_done if finished."))
+			if !r.appendMessagesWithCompression(ctx, additions, &messages, newPath, st) {
+				fmt.Fprintf(stdout.Writer(), "[ocr] Context compression exceeded threshold for %s, stopping.\n", newPath)
+				stop = StopCompression
+				break
 			}
 			continue
 		}
@@ -293,7 +299,11 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 			consecutiveEmptyRounds = 0
 		}
 
-		succeed := r.addNextMessage(ctx, content, calls, results, &messages, newPath, st)
+		additions := []llm.Message{llm.NewToolCallMessage(content, calls)}
+		for _, rs := range results {
+			additions = append(additions, llm.NewToolResultMessage(rs.ToolCallID, rs.Result))
+		}
+		succeed := r.appendMessagesWithCompression(ctx, additions, &messages, newPath, st)
 		if !succeed {
 			fmt.Fprintf(stdout.Writer(), "[ocr] Context compression exceeded threshold for %s, stopping.\n", newPath)
 			stop = StopCompression
@@ -497,12 +507,14 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 	return tool.Of(result)
 }
 
-// addNextMessage extends the conversation with the assistant message and
-// tool responses, applying three-zone compression at the soft (60%) and
-// warning (80%) MaxTokens thresholds. Returns false when even after
+// appendMessagesWithCompression appends one logical conversation update and
+// applies three-zone compression at the soft (60%) and warning (80%)
+// MaxTokens thresholds. Callers pass the entire update at once so every
+// append path shares the same bounds and compression never runs between an
+// assistant message and its tool results. Returns false when even after
 // synchronous compression the conversation is still over the warning
 // threshold — caller should stop the loop in that case.
-func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, toolCalls []llm.ToolCall, results []tool.ToolCallResult, messages *[]llm.Message, filePath string, st *compressionState) bool {
+func (r *Runner) appendMessagesWithCompression(ctx context.Context, additions []llm.Message, messages *[]llm.Message, filePath string, st *compressionState) bool {
 	maxAllowed := r.deps.Template.MaxTokens
 	softLimit := int(float64(maxAllowed) * tokenSoftThreshold)
 	warnLimit := PromptTokenLimit(maxAllowed)
@@ -521,15 +533,7 @@ func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, to
 		}
 	}
 
-	if len(toolCalls) > 0 {
-		*messages = append(*messages, llm.NewToolCallMessage(assistantContent, toolCalls))
-	} else if assistantContent != "" {
-		*messages = append(*messages, llm.NewTextMessage("assistant", assistantContent))
-	}
-
-	for _, rs := range results {
-		*messages = append(*messages, llm.NewToolResultMessage(rs.ToolCallID, rs.Result))
-	}
+	*messages = append(*messages, additions...)
 
 	finalCount := CountMessagesTokens(*messages)
 	if finalCount > warnLimit {
@@ -548,7 +552,9 @@ func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, to
 		r.triggerAsyncCompression(ctx, st, *messages, filePath)
 	}
 
-	return finalCount < warnLimit
+	// The exact complement of the sync trigger above: compression only runs
+	// strictly over the warning threshold, so sitting exactly at it is fine.
+	return finalCount <= warnLimit
 }
 
 // parseToolArgs unmarshals a tool call's raw JSON arguments, always

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -308,6 +308,40 @@ func TestRunPerFile_UnknownTool(t *testing.T) {
 	}
 }
 
+// TestRunPerFile_NoToolRetryBoundedByCompression is a regression test: the
+// no-tool retry path must share the compression bounds of tool rounds. A
+// model that keeps answering without tool calls used to grow the
+// conversation without any token check; the loop must instead stop with
+// StopCompression once the conversation exceeds the warning threshold and
+// compression cannot shrink it.
+func TestRunPerFile_NoToolRetryBoundedByCompression(t *testing.T) {
+	content := strings.Repeat("chatter ", 200)
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		{Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &content}}}},
+	}}
+	deps := newTestDeps(client)
+	// No MemoryCompressionTask: compression cannot shrink the conversation,
+	// so crossing the warning threshold has to stop the loop.
+	deps.Template.MaxTokens = 100
+	deps.Template.MaxToolRequestTimes = 10
+	deps.Template.MemoryCompressionTask.Messages = nil
+	runner := NewRunner(deps)
+
+	completed, stop, err := runner.RunPerFile(context.Background(), []llm.Message{llm.NewTextMessage("user", "review")}, "main.go")
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	if completed {
+		t.Fatal("expected RunPerFile not to complete")
+	}
+	if stop != StopCompression {
+		t.Errorf("stop = %v, want StopCompression", stop)
+	}
+	if client.calls != 1 {
+		t.Errorf("LLM calls = %d, want 1 (loop must stop instead of retrying unbounded)", client.calls)
+	}
+}
+
 func TestRunPerFile_MaxToolRequestsWithoutTaskDoneDoesNotComplete(t *testing.T) {
 	content := ""
 	client := &fakeClient{responses: []*llm.ChatResponse{{

--- a/internal/llmloop/runner_test.go
+++ b/internal/llmloop/runner_test.go
@@ -644,7 +644,11 @@ func TestAddNextMessage_NoStartThenCancelSameCall(t *testing.T) {
 	}}
 
 	st := &compressionState{}
-	ok := r.addNextMessage(context.Background(), strings.Repeat("word ", 200), calls, results, &msgs, "f.go", st)
+	additions := []llm.Message{llm.NewToolCallMessage(strings.Repeat("word ", 200), calls)}
+	for _, rs := range results {
+		additions = append(additions, llm.NewToolResultMessage(rs.ToolCallID, rs.Result))
+	}
+	ok := r.appendMessagesWithCompression(context.Background(), additions, &msgs, "f.go", st)
 
 	if !ok {
 		t.Error("expected true: sync compression should bring the count under the warning threshold")


### PR DESCRIPTION
## Description

**Scoped down per review feedback: this PR now fixes only the no-tool retry bound.** The compression-zone defects that were previously bundled here (background compression summarizing the live tail, unreserved frozen-zone budget, template-less truncation) moved to #838 with standalone reproductions.

When the model answers without tool calls, the retry path appended the assistant text + retry nudge directly to `messages`, bypassing compression entirely — a model that keeps chatting without tools grows the prompt unchecked until the provider rejects it.

The fix addresses the root cause in two parts:

1. **`groupIntoRounds` could not see retry messages.** It only recognized `assistant` and `tool` roles, so the user retry nudges belonged to no round: even when compression did run, partition boundaries and token accounting skipped them. A `round` now spans from its assistant message to the next assistant message (or the end of the conversation), covering tool results and interleaved user messages alike — which also simplifies the boundary math to `compressEnd = lastCompressRound.end`.
2. **The retry path now shares the tool rounds' bounds.** `addNextMessage` is generalized to `appendMessagesWithCompression`, taking one whole logical update at a time so thresholds are evaluated once per round and compression never runs between an assistant message and its tool results. Its success predicate is the exact complement of the sync-compression trigger (`<= warnLimit`), so a conversation sitting exactly at the warning threshold is not misreported as a failure.

**Behavioral change:** a retry loop that overflows the budget now stops with `StopCompression` instead of growing until a provider error. No wire-format changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] `TestRunPerFile_NoToolRetryBoundedByCompression` discriminates: with the old retry path restored it fails (retries keep going, `StopMaxRounds`); with the fix it passes (1 LLM call, `StopCompression`)
- [x] `TestGroupIntoRounds_RetryNudgesStayWithTheirRound` pins the new round span on the retry shape; the existing `TestGroupIntoRounds` is updated to the span representation with identical boundaries for assistant+tool sequences

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable) (n/a — internal behavior)
- [x] I have signed the CLA

## Related Issues

Related to #838 (the compression-zone defects split out of this PR) and #806 (originally split out of it).
