### PR TITLE
feat(llm): add dynamic cache breakpoint on last message for Anthropic

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -833,6 +833,16 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 		tools[len(tools)-1].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
 		params.Tools = tools
 	}
+	// Dynamic breakpoint on the latest message so multi-turn history is
+	// cached incrementally: read the full previous prefix, write only the delta.
+	if len(messages) > 0 {
+		last := &messages[len(messages)-1]
+		if len(last.Content) > 0 {
+			if cc := last.Content[len(last.Content)-1].GetCacheControl(); cc != nil {
+				*cc = anthropic.NewCacheControlEphemeralParam()
+			}
+		}
+	}
 	if req.Temperature != nil {
 		params.Temperature = anthropic.Float(*req.Temperature)
 	}

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -227,6 +227,91 @@ func TestBuildAnthropicParams_CacheControl_NoSystem(t *testing.T) {
 	}
 }
 
+func TestBuildAnthropicParams_DynamicCacheBreakpoint(t *testing.T) {
+	client := NewAnthropicClient(ClientConfig{URL: "https://api.anthropic.com"})
+
+	t.Run("conversation ending in tool result", func(t *testing.T) {
+		req := ChatRequest{
+			Messages: []Message{
+				{Role: "system", Content: "You are a code reviewer."},
+				{Role: "user", Content: "Review this code."},
+				{
+					Role:    "assistant",
+					Content: "Let me check.",
+					ToolCalls: []ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: FunctionCall{
+							Name:      "code_comment",
+							Arguments: `{}`,
+						},
+					}},
+				},
+				{Role: "tool", ToolCallID: "call_1", Content: "Successfully commented."},
+			},
+			Tools: []ToolDef{
+				{Type: "function", Function: FunctionDef{Name: "code_comment", Description: "comment", Parameters: map[string]any{"type": "object"}}},
+			},
+		}
+
+		params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+
+		last := params.Messages[len(params.Messages)-1]
+		if len(last.Content) == 0 {
+			t.Fatal("last message has no content blocks")
+		}
+		lastBlock := last.Content[len(last.Content)-1]
+		if lastBlock.OfToolResult == nil {
+			t.Fatal("last block is not a tool_result block")
+		}
+		if lastBlock.OfToolResult.CacheControl.Type != "ephemeral" {
+			t.Errorf("last tool_result CacheControl.Type = %q, want %q", lastBlock.OfToolResult.CacheControl.Type, "ephemeral")
+		}
+
+		// Earlier user message stays unmarked.
+		earlier := params.Messages[0]
+		if len(earlier.Content) == 0 {
+			t.Fatal("earlier user message has no content blocks")
+		}
+		earlierBlock := earlier.Content[0]
+		if earlierBlock.OfText == nil {
+			t.Fatal("earlier block is not a text block")
+		}
+		if earlierBlock.OfText.CacheControl.Type != "" {
+			t.Errorf("earlier user text CacheControl.Type = %q, want empty", earlierBlock.OfText.CacheControl.Type)
+		}
+	})
+
+	t.Run("conversation ending in user text", func(t *testing.T) {
+		req := ChatRequest{
+			Messages: []Message{
+				{Role: "system", Content: "You are a planner."},
+				{Role: "user", Content: "Plan the review."},
+			},
+		}
+
+		params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+
+		last := params.Messages[len(params.Messages)-1]
+		if len(last.Content) == 0 {
+			t.Fatal("last message has no content blocks")
+		}
+		lastBlock := last.Content[len(last.Content)-1]
+		if lastBlock.OfText == nil {
+			t.Fatal("last block is not a text block")
+		}
+		if lastBlock.OfText.CacheControl.Type != "ephemeral" {
+			t.Errorf("last user text CacheControl.Type = %q, want %q", lastBlock.OfText.CacheControl.Type, "ephemeral")
+		}
+	})
+}
+
 func TestBuildAnthropicParams_NullToolCallArguments(t *testing.T) {
 	// "arguments": null (as emitted by some OpenAI-compatible gateways)
 	// unmarshals a pre-initialized map back to nil; the Anthropic API


### PR DESCRIPTION
## Description

Mark the last content block of the final message with ephemeral `cache_control` so multi-turn conversations cache the growing history, not just the static system+tools prefix. Each turn then reads the previous full prefix and only writes the new delta.

Previously only two static breakpoints were set (last system block, last tool definition), so everything after the tools — the growing multi-turn conversation — was re-processed as fresh input on every turn of the per-file review loop.

This change adds a dynamic breakpoint on the last content block of the final message (user text, `tool_result`, or `tool_use` — all handled generically via the SDK's `GetCacheControl()` helper). Since request params are rebuilt from the append-only history on every turn, the marker never leaks back into stored history, and the breakpoint simply advances with each turn. Total breakpoints stay at 3, within Anthropic's limit of 4.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Added `TestBuildAnthropicParams_DynamicCacheBreakpoint` covering:
- conversations ending in a `tool_result` block (the typical agent-loop turn shape) — the last block gets `cache_control: {"type":"ephemeral"}` and earlier messages stay unmarked
- conversations ending in user text

Also verified against the Anthropic API in a real multi-turn review session: turns after the first report `cache_read` tokens for the full prior prefix and only write the delta.

## Checklist 

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues
