### PR TITLE
feat(viewer): add back navigation

### DIFF
--- a/internal/viewer/server_extra_test.go
+++ b/internal/viewer/server_extra_test.go
@@ -156,6 +156,66 @@ func TestRenderTemplate_SessionPage(t *testing.T) {
 	}
 }
 
+func TestRenderTemplate_BackNavigation(t *testing.T) {
+	tests := []struct {
+		name          string
+		template      string
+		data          any
+		wantLink      string
+		wantAriaLabel string
+	}{
+		{
+			name:          "sessions to repositories",
+			template:      "sessions.html",
+			data:          sessionsData{EncodedRepo: "repo", RepoName: "MyRepo"},
+			wantLink:      `class="back-link" href="/"`,
+			wantAriaLabel: `aria-label="Back to repositories"`,
+		},
+		{
+			name:     "session to sessions",
+			template: "session.html",
+			data: sessionPageData{
+				EncodedRepo: "owner%2Frepo",
+				RepoName:    "MyRepo",
+				Session:     &ViewSession{Summary: SessionSummary{SessionID: "abc"}},
+			},
+			wantLink:      `class="back-link" href="/r/owner%2Frepo"`,
+			wantAriaLabel: `aria-label="Back to sessions"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			renderTemplate(rr, tt.template, tt.data)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rr.Code)
+			}
+			body := rr.Body.String()
+			for _, required := range []string{tt.wantLink, tt.wantAriaLabel, `<nav class="breadcrumb">`} {
+				if !strings.Contains(body, required) {
+					t.Errorf("rendered %s missing %q", tt.template, required)
+				}
+			}
+		})
+	}
+}
+
+func TestBackNavigationTouchTarget(t *testing.T) {
+	stylesheet, err := assets.ReadFile("static/style.css")
+	if err != nil {
+		t.Fatalf("read style.css: %v", err)
+	}
+
+	css := string(stylesheet)
+	for _, required := range []string{".back-link {", "min-width: 44px;", "min-height: 44px;"} {
+		if !strings.Contains(css, required) {
+			t.Errorf("back-link styles missing %q", required)
+		}
+	}
+}
+
 func TestRenderTemplate_SecondarySectionsCollapsedByDefault(t *testing.T) {
 	rr := httptest.NewRecorder()
 	vs := &ViewSession{

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -316,6 +316,47 @@ h3 {
     word-break: break-all;
     font-size: 1.25rem;
 }
+.page-heading {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+.page-heading h2,
+.session-header .page-heading h2 {
+    min-width: 0;
+    margin: 0;
+}
+.session-header .page-heading {
+    margin-bottom: 0.75rem;
+}
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    gap: 0.35rem;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 0.75rem;
+    color: var(--text-secondary);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: color var(--transition), background var(--transition), border-color var(--transition);
+}
+.back-link:hover {
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-color: var(--accent);
+}
+.back-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
 .meta {
     display: flex;
     flex-wrap: wrap;

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -11,7 +11,10 @@
 <nav class="breadcrumb"><a href="/" class="nav-brand"><span class="brand-icon"></span>Open Code Review Viewer</a><span class="sep">/</span><a href="/r/{{.EncodedRepo}}">{{.RepoName}}</a><span class="sep">/</span><span class="current">{{.Session.Summary.SessionID | truncate 12}}</span></nav>
 <main>
 <div class="session-header">
-    <h2>Session: {{.Session.Summary.SessionID}}</h2>
+    <div class="page-heading">
+        <a class="back-link" href="/r/{{.EncodedRepo}}" aria-label="Back to sessions"><span aria-hidden="true">&larr;</span> Back</a>
+        <h2>Session: {{.Session.Summary.SessionID}}</h2>
+    </div>
     <div class="meta">
         <span><strong>CWD:</strong> {{.Session.Summary.CWD}}</span>
         <span><strong>Branch:</strong> {{.Session.Summary.GitBranch}}</span>

--- a/internal/viewer/templates/sessions.html
+++ b/internal/viewer/templates/sessions.html
@@ -10,7 +10,10 @@
 <body>
 <nav class="breadcrumb"><a href="/" class="nav-brand"><span class="brand-icon"></span>Open Code Review Viewer</a><span class="sep">/</span><span class="current">{{.RepoName}}</span></nav>
 <main>
-<h2>Sessions: {{.RepoName}}</h2>
+<div class="page-heading">
+    <a class="back-link" href="/" aria-label="Back to repositories"><span aria-hidden="true">&larr;</span> Back</a>
+    <h2>Sessions: {{.RepoName}}</h2>
+</div>
 {{if .Sessions}}
 <table class="table">
     <thead><tr><th>Session ID</th><th>Branch</th><th>Mode</th><th>Model</th><th>Files</th><th>Status</th><th>Comments</th><th>Duration</th><th>Started At</th></tr></thead>


### PR DESCRIPTION
## Description

Adds an explicit, accessible back affordance to each viewer sub-page while preserving the existing breadcrumbs:

- sessions return to the repository list (`/`)
- session details return to their sessions list (`/r/{EncodedRepo}`)
- shared token-based styling provides hover/focus states, dark-mode support, and a minimum 44 x 44 px touch target
- template regressions cover both parent routes, contextual accessible labels, breadcrumb preservation, and the touch-target contract

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (desktop and mobile details below)

Additional validation:

- `make check`
- `make build`
- `make coverage` - 90.2% total (90% required)
- rendered both navigation levels at 1280 x 720 and 390 x 844 in dark mode
- clicked both back links end to end and measured each at 77.7 x 44 px

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable; the viewer affordance is self-describing)
- [ ] I have signed the CLA

## Related Issues

Closes #830