### PR TITLE
feat(cmd): add no-review cmd

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -45,6 +45,7 @@ type reviewOptions struct {
 	maxGitProcs     int
 	maxTokens       int
 	maxTokensBudget int
+	noFilter        bool
 	preview         bool
 }
 
@@ -207,6 +208,7 @@ func executeReview(opts reviewOptions) error {
 		GitRunner:             cc.GitRunner,
 		Resume:                resumeState,
 		MaxTokensBudget:       int64(opts.maxTokensBudget),
+		SkipFilter:            opts.noFilter,
 		RuntimeConfig:         rt.RuntimeConfig,
 	})
 

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -178,6 +178,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	addBackgroundFlags(cmd, &opts.background, &opts.backgroundFile)
 	addProviderFlag(cmd, &opts.provider)
 	addModelFlag(cmd, &opts.model)
+	cmd.Flags().BoolVar(&opts.noFilter, "no-filter", false, "skip the per-file REVIEW_FILTER_TASK")
 	addPreviewFlag(cmd, &opts.preview)
 }
 

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -178,7 +178,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	addBackgroundFlags(cmd, &opts.background, &opts.backgroundFile)
 	addProviderFlag(cmd, &opts.provider)
 	addModelFlag(cmd, &opts.model)
-	cmd.Flags().BoolVar(&opts.noFilter, "no-filter", false, "skip the per-file REVIEW_FILTER_TASK")
+	cmd.Flags().BoolVar(&opts.noFilter, "no-filter", false, "keep all review comments without LLM post-filtering")
 	addPreviewFlag(cmd, &opts.preview)
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -139,6 +139,10 @@ type Args struct {
 	// would exceed it. 0 = unlimited. Mirrors scan.Args.MaxTokensBudget.
 	MaxTokensBudget int64
 
+	// SkipFilter disables the REVIEW_FILTER_TASK even when the template
+	// defines one. Set via the --no-filter CLI flag.
+	SkipFilter bool
+
 	// RuntimeConfig carries the non-secret, allowlisted runtime settings that
 	// identify how this run was configured, for the manifest's
 	// runtime_config_sha256. It is populated by the cmd layer from the resolved
@@ -1235,6 +1239,12 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 
 	ft := a.args.Template.ReviewFilterTask
 	if ft == nil || len(ft.Messages) == 0 {
+		return
+	}
+
+	if a.args.SkipFilter {
+		telemetry.SetAttr(span, "skipped", true)
+		fmt.Fprintf(stdout.Writer(), "[ocr] Review filter skipped for %s (--no-filter)\n", newPath)
 		return
 	}
 

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -346,6 +346,182 @@ func TestExecuteReviewFilter_LLMError(t *testing.T) {
 	}
 }
 
+func TestExecuteReviewFilter_SkipFilter(t *testing.T) {
+	t.Run("AC-1: SkipFilter disables the filter", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+		client := &fakeAgentClient{}
+		collector := tool.NewCommentCollector()
+		collector.Add(model.LlmComment{Path: "a.go", Content: "comment"})
+
+		a := New(Args{
+			LLMClient:        client,
+			Model:            "test",
+			Session:          sess,
+			SkipFilter:       true,
+			CommentCollector: collector,
+			Template: template.Template{
+				ReviewFilterTask: &template.LlmConversation{
+					Messages: []template.ChatMessage{{Role: "user", Content: "Filter: {{comments}}"}},
+				},
+				MaxTokens:           10000,
+				MaxToolRequestTimes: 5,
+				MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+			},
+		})
+
+		a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+code"}, "a.go")
+
+		if client.calls != 0 {
+			t.Errorf("no LLM calls expected when SkipFilter is true, got %d", client.calls)
+		}
+		comments := collector.CommentsForPath("a.go")
+		if len(comments) != 1 {
+			t.Errorf("comments should be unchanged when filter is skipped, got %d", len(comments))
+		}
+	})
+
+	t.Run("AC-2: All comments preserved when skipped", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+		client := &fakeAgentClient{}
+		collector := tool.NewCommentCollector()
+		collector.Add(model.LlmComment{Path: "a.go", Content: "comment 1"})
+		collector.Add(model.LlmComment{Path: "a.go", Content: "comment 2"})
+		collector.Add(model.LlmComment{Path: "a.go", Content: "comment 3"})
+
+		a := New(Args{
+			LLMClient:        client,
+			Model:            "test",
+			Session:          sess,
+			SkipFilter:       true,
+			CommentCollector: collector,
+			Template: template.Template{
+				ReviewFilterTask: &template.LlmConversation{
+					Messages: []template.ChatMessage{{Role: "user", Content: "Filter: {{comments}}"}},
+				},
+				MaxTokens:           10000,
+				MaxToolRequestTimes: 5,
+				MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+			},
+		})
+
+		a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+code"}, "a.go")
+
+		comments := collector.CommentsForPath("a.go")
+		if len(comments) != 3 {
+			t.Fatalf("expected 3 comments when filter is skipped, got %d", len(comments))
+		}
+	})
+
+	t.Run("AC-3: Default (no SkipFilter) still runs filter", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+
+		filterResp := `["c-1"]`
+		client := &fakeAgentClient{
+			responses: []*llm.ChatResponse{{
+				Choices: []llm.Choice{{
+					Message: llm.ResponseMessage{Content: &filterResp},
+				}},
+				Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+			}},
+		}
+
+		collector := tool.NewCommentCollector()
+		collector.Add(model.LlmComment{Path: "a.go", Content: "keep this"})
+		collector.Add(model.LlmComment{Path: "a.go", Content: "remove this"})
+
+		a := New(Args{
+			LLMClient:        client,
+			Model:            "test",
+			Session:          sess,
+			CommentCollector: collector,
+			Template: template.Template{
+				ReviewFilterTask: &template.LlmConversation{
+					Messages: []template.ChatMessage{{Role: "user", Content: "Filter: {{comments}} path={{path}} diff={{diff}}"}},
+				},
+				MaxTokens:           10000,
+				MaxToolRequestTimes: 5,
+				MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+			},
+		})
+
+		a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+code"}, "a.go")
+
+		if client.calls == 0 {
+			t.Error("LLM client should have been called when SkipFilter is false (default)")
+		}
+		comments := collector.CommentsForPath("a.go")
+		if len(comments) != 1 {
+			t.Errorf("expected 1 comment after filter, got %d", len(comments))
+		}
+	})
+
+	t.Run("AC-4: SkipFilter is reached when ReviewFilterTask is non-nil", func(t *testing.T) {
+		// After the nil-template guard, SkipFilter is the next early-return.
+		// With a non-nil ReviewFilterTask + zero comments, the function would
+		// normally fall through to the LLM call; SkipFilter must short-circuit it.
+		tmpDir := t.TempDir()
+		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+		client := &fakeAgentClient{}
+		collector := tool.NewCommentCollector()
+		collector.Add(model.LlmComment{Path: "a.go", Content: "comment"})
+
+		a := New(Args{
+			LLMClient:        client,
+			Model:            "test",
+			Session:          sess,
+			SkipFilter:       true,
+			CommentCollector: collector,
+			Template: template.Template{
+				ReviewFilterTask: &template.LlmConversation{
+					Messages: []template.ChatMessage{{Role: "user", Content: "Filter: {{comments}}"}},
+				},
+				MaxTokens:           10000,
+				MaxToolRequestTimes: 5,
+				MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+			},
+		})
+
+		a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+x"}, "a.go")
+
+		if client.calls != 0 {
+			t.Errorf("no LLM calls expected when SkipFilter is true, got %d", client.calls)
+		}
+		if len(collector.CommentsForPath("a.go")) != 1 {
+			t.Errorf("comments should be unchanged when filter is skipped")
+		}
+	})
+
+	t.Run("AC-5: Skip takes priority over no comments", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})
+		client := &fakeAgentClient{}
+
+		a := New(Args{
+			LLMClient:  client,
+			Model:      "test",
+			Session:    sess,
+			SkipFilter: true,
+			Template: template.Template{
+				ReviewFilterTask: &template.LlmConversation{
+					Messages: []template.ChatMessage{{Role: "user", Content: "Filter: {{comments}}"}},
+				},
+				MaxTokens:           10000,
+				MaxToolRequestTimes: 5,
+				MainTask:            template.LlmConversation{Messages: []template.ChatMessage{{Role: "user", Content: "t"}}},
+			},
+		})
+
+		a.executeReviewFilter(context.Background(), model.Diff{NewPath: "a.go", Diff: "+x"}, "a.go")
+
+		if client.calls != 0 {
+			t.Errorf("no LLM calls expected when SkipFilter is true, got %d", client.calls)
+		}
+	})
+}
+
 func TestExecutePlanPhase(t *testing.T) {
 	tmpDir := t.TempDir()
 	sess := session.New(tmpDir, "main", "test", session.SessionOptions{ReviewMode: "diff"})


### PR DESCRIPTION
## Description

Adds `--no-filter` flag to `ocr review`, allowing users to skip the `REVIEW_FILTER_TASK` post-processing phase — eliminating one LLM call per reviewed file and reducing token consumption.

The `REVIEW_FILTER_TASK` runs after each file's main review loop to filter out false-positive comments. Every reviewed file triggers exactly one additional LLM call for this phase. While effective for trimming low-quality comments, this per-file call adds up quickly — a 20-file PR costs 20 extra LLM round-trips even when the filter produces no actionable removals.

`ocr scan` already provides `--no-plan`, `--no-dedup`, and `--no-summary` flags to skip optional LLM stages, but `ocr review` had no equivalent. This PR closes the gap by following the same established pattern.

**Design:** mirrors the existing `--no-dedup` pattern from `internal/scan/agent.go`. The skip check lives inside `executeReviewFilter`, placed **after** the `ReviewFilterTask == nil` guard (so users aren't spammed with misleading skip messages when the template doesn't configure a filter task) and **after** the telemetry span is created (so the skip is still observable in traces via the `skipped=true` span attribute). When the flag is set, a log line `[ocr] Review filter skipped for <file> (--no-filter)` is emitted and the function returns immediately.

**Files changed** (4 files, 6 code locations):

| File | Change |
|---|---|
| `internal/agent/agent.go` | Added `SkipFilter bool` to `Args` struct with doc comment |
| `internal/agent/agent.go` (`executeReviewFilter`) | Added early-return check after the nil-template guard and span setup; sets `skipped=true` span attr |
| `cmd/opencodereview/review_cmd.go` | Added `noFilter bool` to `reviewOptions`; wired to `Args.SkipFilter` |
| `cmd/opencodereview/shared_flags.go` | Registered `--no-filter` bool flag (default `false`) in `registerReviewFlags` |
| `internal/agent/coverage_test.go` | Added `TestExecuteReviewFilter_SkipFilter` with 5 sub-tests |

No changes to `internal/scan/`, `internal/llmloop/`, `internal/tool/`, `internal/diff/`, or `internal/config/`. Zero new third-party Go dependencies.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

All tests use `fakeAgentClient` (an in-package mock with a `calls` counter) — no real LLM configuration needed. The counter-argument test (AC-3, no flag) proves the mock is correctly invoked when the filter runs, so the zero-call assertions in AC-1/2/4/5 are meaningful.

**New tests** (5 sub-tests in `TestExecuteReviewFilter_SkipFilter`):

| Sub-test | Verifies |
|---|---|
| `AC-1: SkipFilter disables the filter` | With `SkipFilter=true` + `ReviewFilterTask` present + comments exist → `client.calls == 0`, comments untouched |
| `AC-2: All comments preserved when skipped` | 3 comments added → all 3 remain after skip |
| `AC-3: Default (no SkipFilter) still runs filter` | `SkipFilter` zero-value (`false`) → `client.calls > 0`, comments filtered normally (backward compat) |
| `AC-4: SkipFilter is reached when ReviewFilterTask is non-nil` | `SkipFilter=true` + non-nil `ReviewFilterTask` + 1 comment → `client.calls == 0`, comment preserved (exercises the skip branch, not the nil-template guard) |
| `AC-5: Skip takes priority over no comments` | `SkipFilter=true` + zero comments → `client.calls == 0` |

**Regression:** all 6 existing `TestExecuteReviewFilter_*` tests pass unchanged (`NoFilterTask`, `NoComments`, `RemovesComments`, `LLMError`, `WithTimeout`, plus the existing timeout variant).

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

closes #833
