### PR TITLE
fix(action): pin nested action references to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Verify license headers
         run: bash scripts/verify-license.sh
 
+      - name: Verify action pins
+        run: bash scripts/verify-action-pins.sh
+
       - name: Check formatting
         run: |
           unformatted="$(gofmt -s -l .)"

--- a/action.yml
+++ b/action.yml
@@ -198,7 +198,7 @@ runs:
 
     - name: Setup Node.js
       if: steps.check_deps.outputs.node_installed != 'true'
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -218,7 +218,7 @@ runs:
         echo "PR head sha: $HEAD_SHA"
 
     - name: Checkout base
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # Checkout the trusted base, not the PR head. OCR reviews the
         # base-to-head diff from git objects; the head commit's blobs are
@@ -292,7 +292,7 @@ runs:
 
     - name: Upload review artifacts
       if: ${{ always() && inputs.upload_artifacts == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ocr-review-result-${{ github.run_id }}-${{ github.run_attempt }}
         path: |
@@ -310,7 +310,7 @@ runs:
     - name: Post review comments
       if: env.OCR_EXIT_CODE == '0'
       id: post
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         OCR_INCREMENTAL_OVERLAP_THRESHOLD: ${{ inputs.incremental_overlap_threshold }}
         OCR_REVIEW_COMMENT_BATCH_SIZE: ${{ inputs.review_comment_batch_size }}

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -4,7 +4,7 @@ This directory provides a ready-to-use GitHub Actions workflow demo that integra
 
 ## Quick Start: `ocr-review.yml`
 
-The simplest adoption path: this demo delegates every step — checkout, OCR install, review, comment posting, artifact upload — to the official reusable composite action at [`action.yml`](../../action.yml) via a single `uses: alibaba/open-code-review@main` step. It covers both automatic PR review (`pull_request_target: opened/synchronize/reopened`) and on-demand re-review via comments (`/open-code-review` or `@open-code-review`). No inline scripts to maintain — `@main` always runs the latest action; pin to a version tag or commit SHA when reproducibility matters.
+The simplest adoption path: this demo delegates every step — checkout, OCR install, review, comment posting, artifact upload — to the official reusable composite action at [`action.yml`](../../action.yml) via a single `uses: alibaba/open-code-review@main` step. It covers both automatic PR review (`pull_request_target: opened/synchronize/reopened`) and on-demand re-review via comments (`/open-code-review` or `@open-code-review`). No inline scripts to maintain — `@main` always runs the latest action; see [Reproducible pinning](#reproducible-pinning) when you need runs to be repeatable.
 
 ```bash
 mkdir -p .github/workflows
@@ -23,6 +23,22 @@ The core of the demo is a single action step:
 ```
 
 See [`action.yml`](../../action.yml) for the full list of inputs, outputs, security guidance, and the four comment-posting modes (sticky summary + incremental).
+
+## Reproducible pinning
+
+The Action is an orchestrator: it installs the OCR CLI from npm at run time (`ocr_version`, default `latest`). Pinning only the Action reference therefore does **not** freeze review behavior — a new CLI release still changes what runs. For a fully reproducible setup, pin both:
+
+```yaml
+- uses: alibaba/open-code-review@<full-commit-sha> # vX.Y.Z
+  with:
+    ocr_version: 'X.Y.Z'
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+```
+
+Take the commit SHA from the [releases page](https://github.com/alibaba/open-code-review/releases) and keep the `# vX.Y.Z` comment next to it so update tooling (Dependabot, Renovate) can track it. Every action referenced *inside* [`action.yml`](../../action.yml) is itself pinned to a full commit SHA (enforced by `scripts/verify-action-pins.sh` in CI), so the outer SHA transitively freezes the whole workflow — only the two coordinates above are yours to choose.
 
 ## Running on a self-hosted runner
 

--- a/scripts/verify-action-pins.sh
+++ b/scripts/verify-action-pins.sh
@@ -19,6 +19,10 @@ local_ref='uses:[[:space:]]*\./'
 
 bad=""
 for file in "${files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "ERROR: $file not found; the pin check cannot run." >&2
+    exit 1
+  fi
   hits="$(grep -nE 'uses:' "$file" || true)"
   [ -n "$hits" ] || continue
   while IFS= read -r line; do

--- a/scripts/verify-action-pins.sh
+++ b/scripts/verify-action-pins.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 alibaba/open-code-review Contributors
+
+# Verify that every external action referenced by the published composite
+# action (action.yml) is pinned to a full 40-hex commit SHA with a trailing
+# "# vX.Y.Z" version comment. A floating tag inside action.yml silently
+# undermines consumers who SHA-pin alibaba/open-code-review itself: the
+# outer pin freezes this repository, but a moved inner tag still changes
+# what actually runs (see issue #816).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+files=("action.yml")
+pinned='uses:[[:space:]]*[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@[0-9a-f]{40}[[:space:]]+#[[:space:]]*v[0-9]'
+local_ref='uses:[[:space:]]*\./'
+
+bad=""
+for file in "${files[@]}"; do
+  hits="$(grep -nE 'uses:' "$file" || true)"
+  [ -n "$hits" ] || continue
+  while IFS= read -r line; do
+    if printf '%s' "$line" | grep -qE "$local_ref"; then
+      continue
+    fi
+    if ! printf '%s' "$line" | grep -qE "$pinned"; then
+      bad="${bad}${file}:${line}"$'\n'
+    fi
+  done <<< "$hits"
+done
+
+if [ -n "$bad" ]; then
+  echo "The following action references are not pinned to a full commit SHA"
+  echo "with a '# vX.Y.Z' comment:"
+  printf '%s' "$bad"
+  echo "Pin them like: uses: owner/repo@<40-hex-sha> # vX.Y.Z"
+  exit 1
+fi
+
+echo "All external action references in ${files[*]} are SHA-pinned."


### PR DESCRIPTION
## Description

Closes the floating-tag gap in #816, scoped to what was agreed there ("PR1"):

- **`action.yml`**: the four nested `actions/*` references are pinned to full commit SHAs with a trailing `# vX.Y.Z` comment (`checkout@v7 → v7.0.1`, `setup-node@v7 → v7.0.0`, `upload-artifact@v4 → v4.6.2`, `github-script@v9 → v9.0.0`). Each SHA was cross-checked against the exact version tag before embedding.
- **`scripts/verify-action-pins.sh`**: fails when any external `uses:` in `action.yml` is not a 40-hex SHA followed by a `# vX.Y.Z` comment (local `./` references exempt). Wired into CI next to the license check, so the invariant holds on every PR — which also makes it hold at release time, since releases are cut from CI-green commits.
- **`examples/github_actions/README.md`**: new "Reproducible pinning" section demonstrating the fully pinned invocation, and spelling out why the Action SHA alone is not enough — `ocr_version` must be pinned too because the CLI is installed from npm at run time.

Deliberately **not** in this PR: any change to the `ocr_version: latest` default, release-tag lineage, or versioning scheme — that design question now lives in #839. `@main` convenience usage in the example workflow is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- `bash scripts/verify-action-pins.sh` passes on the pinned `action.yml`.
- Negative test: reverting one pin back to `actions/checkout@v7` makes the script exit 1 and print the offending line.
- Every embedded SHA verified to equal the commit its `# vX.Y.Z` comment names, via the GitHub API.

- [ ] `make test` passes locally (no Go changes; `go test ./...` unaffected)
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

Fixes #816

The `ocr_version` default discussion continues in #839

