### PR TITLE
fix(install): detect stale or shadowed ocr command after install

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -1,0 +1,39 @@
+name: install-scripts
+
+# Tests the npm installer's post-install PATH checks (scripts/install.js):
+# shadowed or stale-hash-prone `ocr` resolutions must be detected and
+# reported at install time. Kept out of ci.yml (Go-only container),
+# mirroring the scoped translation-sync.yml workflow.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/install.js"
+      - "scripts/install.test.js"
+      - "scripts/platform.js"
+      - "package.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-scripts:
+    runs-on: self-hosted
+    timeout-minutes: 10
+    container:
+      # Pinned to an exact 24.x for reproducible builds, matching the
+      # translation-sync.yml pin (avoids the mutable node:24 tag).
+      image: node:24.18.0
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trust workspace
+        run: git config --global --replace-all safe.directory '*'
+
+      # Plain Node, no deps; runs on node >= 14 (engines field).
+      - name: Test installer PATH-resolution checks
+        run: node scripts/install.test.js

--- a/install.ps1
+++ b/install.ps1
@@ -76,8 +76,27 @@ function Show-PostInstallPathNotice([string]$BinName, [string]$InstallDir) {
         Write-Host "note: $InstallDir is not on your PATH; add it or run $InstallDir\$BinName directly"
         return
     }
-    if (-not (Get-Command $BinName -ErrorAction SilentlyContinue)) {
-        Write-Host "note: open a new shell so $BinName resolves on PATH"
+    # Resolve the bare name so lookalikes (ocr.cmd, ocr.bat, ...) are caught,
+    # matching what the user's shell would actually execute.
+    $bareName = [System.IO.Path]::GetFileNameWithoutExtension($BinName)
+    $expected = Join-Path $InstallDir $BinName
+    $resolved = @(Get-Command $bareName -All -ErrorAction SilentlyContinue)
+    if ($resolved.Count -eq 0) {
+        Write-Host "note: open a new shell so $bareName resolves on PATH"
+        return
+    }
+    $first = $resolved[0]
+    if (-not [string]::Equals($first.Source, $expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Warning "$bareName resolves to $($first.Source), which takes precedence over $expected. Remove/rename $($first.Source) or move $InstallDir earlier in your PATH; verify with: $bareName version"
+        return
+    }
+    # The new binary wins on PATH, but terminals opened earlier may have
+    # cached a different `ocr` location and keep running that stale program;
+    # only new shells re-resolve the command.
+    $others = @($resolved | Where-Object { -not [string]::Equals($_.Source, $expected, [System.StringComparison]::OrdinalIgnoreCase) })
+    if ($others.Count -gt 0) {
+        Write-Host "note: another $bareName exists at $($others[0].Source). Terminals opened before this install may have"
+        Write-Host "note: cached that location; if $bareName misbehaves in your current terminal, open a new one"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -80,12 +80,52 @@ install_binary() {
 
 post_install_path_notice() {
   bin="$1"
-  install_dir="$2"
+  install_dir="${2%/}"
   case ":$PATH:" in
     *":$install_dir:"*) ;;
     *) printf 'note: %s is not on your PATH; add it or run %s/%s directly\n' "$install_dir" "$install_dir" "$bin"; return ;;
   esac
-  command -v "$bin" >/dev/null 2>&1 || printf 'note: open a new shell so %s resolves on PATH\n' "$bin"
+  resolved="$(command -v "$bin" 2>/dev/null || true)"
+  if [ -z "$resolved" ]; then
+    printf 'note: open a new shell so %s resolves on PATH\n' "$bin"
+    return
+  fi
+  if [ "$resolved" != "$install_dir/$bin" ]; then
+    printf 'warning: %s resolves to %s, which takes precedence over %s/%s.\n' "$bin" "$resolved" "$install_dir" "$bin" >&2
+    printf 'warning: remove/rename %s or move %s earlier in your PATH; verify with: %s version\n' "$resolved" "$install_dir" "$bin" >&2
+    return
+  fi
+  # The new binary wins on PATH, but shells that were open earlier may have
+  # cached a different `ocr` location (bash/zsh hash table) and keep running
+  # that stale program in the current terminal; only new shells re-resolve.
+  other="$(find_other_binary_on_path "$install_dir" "$bin")"
+  if [ -n "$other" ]; then
+    printf 'note: another %s exists at %s. Terminals opened before this install may have\n' "$bin" "$other"
+    printf 'note: cached that location; if %s misbehaves in your current terminal, run\n' "$bin"
+    printf 'note:   bash/zsh: hash -r    (zsh also: rehash)    or open a new terminal\n'
+  fi
+}
+
+# Print the first executable named <bin> found on PATH outside <install_dir>.
+find_other_binary_on_path() {
+  install_dir="$1"
+  bin="$2"
+  saved_ifs="$IFS"
+  IFS=':'
+  set -f
+  set -- $PATH
+  set +f
+  IFS="$saved_ifs"
+  for dir in "$@"; do
+    [ -n "$dir" ] || continue
+    dir="${dir%/}" # PATH entries may carry a trailing slash
+    [ "$dir" = "$install_dir" ] && continue
+    if [ -x "$dir/$bin" ] && [ ! -d "$dir/$bin" ]; then
+      printf '%s' "$dir/$bin"
+      return 0
+    fi
+  done
+  return 0
 }
 
 # Print the SHA-256 of a file, preferring shasum (macOS) over sha256sum (Linux).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/install.js",
+    "test:install": "node scripts/install.test.js",
     "test:github-actions": "node scripts/github-actions/post-review-comments.test.js && node scripts/github-actions/check-translation-sync.test.js"
   },
   "repository": {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -153,6 +153,256 @@ function computeChecksum(filePath) {
   });
 }
 
+// Default PATHEXT on Windows when the variable is unset/empty.
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
+
+// File names a shell may resolve for the `ocr` command. POSIX executes the
+// plain name only; Windows probes the PATHEXT variants in the same order
+// cmd.exe would, plus the bare name last for POSIX-like shells (Git Bash).
+function ocrCandidateNames(isWindows, pathExtEnv) {
+  if (!isWindows) {
+    return ["ocr"];
+  }
+  const raw = pathExtEnv && String(pathExtEnv).trim() ? pathExtEnv : DEFAULT_PATHEXT;
+  const names = String(raw)
+    .split(";")
+    .map((e) => e.trim().toLowerCase())
+    .filter((e) => e.startsWith("."))
+    .map((e) => "ocr" + e);
+  names.push("ocr");
+  return Array.from(new Set(names));
+}
+
+// Path comparisons must be case-insensitive on Windows: realpath output and
+// env-derived paths (npm_config_prefix, shim targets) can legitimately
+// differ in casing (drive letter, profile dir, junctions).
+function pathsEqual(a, b, isWindows) {
+  return isWindows ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+function pathHasPrefix(p, prefix, isWindows) {
+  return isWindows
+    ? p.toLowerCase().startsWith(prefix.toLowerCase())
+    : p.startsWith(prefix);
+}
+
+// Walk PATH in order and return every entry that contains an `ocr` executable
+// as { dir, name, path }. Within one directory only the first matching
+// variant is reported, mirroring how a shell resolves that directory.
+// candidateNames defaults to ocrCandidateNames(isWindows).
+function findOcrOnPath(pathEnv, isWindows, pathSep, candidateNames) {
+  const names = candidateNames || ocrCandidateNames(isWindows);
+  const found = [];
+  const seenDirs = new Set();
+  for (const dir of String(pathEnv || "").split(pathSep || (isWindows ? ";" : ":"))) {
+    if (!dir) {
+      continue;
+    }
+    let realDir = dir;
+    try {
+      realDir = fs.realpathSync(dir);
+    } catch (_) {
+      // Leave the dir as written; a stat failure below skips it anyway.
+    }
+    const key = isWindows ? realDir.toLowerCase() : realDir;
+    if (seenDirs.has(key)) {
+      continue;
+    }
+    seenDirs.add(key);
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      try {
+        const st = fs.statSync(candidate); // follows symlinks
+        if (!st.isFile()) {
+          continue;
+        }
+        if (!isWindows && (st.mode & 0o111) === 0) {
+          continue; // not executable on POSIX
+        }
+        found.push({ dir, name, path: candidate });
+        break; // first matching variant in this directory wins
+      } catch (_) {
+        // Missing or unreadable entry: try the next variant.
+      }
+    }
+  }
+  return found;
+}
+
+// True when a resolved PATH entry belongs to *this* installation: either a
+// symlink to bin/ocr.js (npm/yarn/pnpm on POSIX) or a package-manager shim
+// (npm .cmd/.ps1 on Windows, wrapper scripts elsewhere) that launches it.
+function isOurCommand(filePath, packageRoot, pkgName, isWindows) {
+  const ourJs = path.join(packageRoot, "bin", "ocr.js");
+  let real = filePath;
+  try {
+    real = fs.realpathSync(filePath);
+  } catch (_) {
+    // Keep the raw path; the comparison below simply won't match.
+  }
+  try {
+    if (pathsEqual(real, fs.realpathSync(ourJs), isWindows)) {
+      return true;
+    }
+  } catch (_) {
+    // bin/ocr.js missing: fall through to the shim content check.
+  }
+  try {
+    const st = fs.statSync(filePath);
+    if (st.isFile() && st.size < 4096) {
+      // Shims embed the script they launch; compare with normalized slashes
+      // and casing (the embedded path follows the installer's casing).
+      const content = fs.readFileSync(filePath, "utf8").replace(/\\/g, "/").toLowerCase();
+      if (content.includes(`node_modules/${pkgName}/bin/ocr.js`.toLowerCase())) {
+        return true;
+      }
+    }
+  } catch (_) {
+    // Unreadable candidate: treat as foreign.
+  }
+  return false;
+}
+
+// For a global install npm links `ocr` into <prefix>/bin (POSIX) or <prefix>
+// (Windows). Returns that directory when packageRoot lives under the global
+// prefix, otherwise null (a local install does not expect a PATH command).
+function globalBinDir(packageRoot, isWindows, env) {
+  const prefix = env && env.npm_config_prefix;
+  if (!prefix) {
+    return null;
+  }
+  const globalRoot = isWindows
+    ? path.join(prefix, "node_modules")
+    : path.join(prefix, "lib", "node_modules");
+  if (!pathHasPrefix(packageRoot, globalRoot + path.sep, isWindows)) {
+    return null;
+  }
+  return isWindows ? prefix : path.join(prefix, "bin");
+}
+
+// Classify how `ocr` resolves in the installing shell right after install.
+//
+// Why this exists: shells cache command locations (the bash/zsh hash table).
+// If the session ever ran a different executable named `ocr` before this
+// install, the *current* terminal keeps running that cached location even
+// though the real `ocr` now sits earlier on PATH; only new terminals resolve
+// correctly. The installer cannot clear the parent shell's cache, so it must
+// detect the situation and tell the user (see printPathResolutionNotice).
+//
+// Returns one of:
+//   { status: "ok", resolved }                 resolves here, no lookalikes
+//   { status: "stale-hash-risk", resolved,
+//     stale: [paths] }                         resolves here, but another ocr
+//                                              exists that open shells may have
+//                                              cached
+//   { status: "shadowed", resolved,
+//     ours: [paths] }                          a different executable wins in
+//                                              every terminal, though ours is
+//                                              also on PATH
+//   { status: "not-on-path", binDir,
+//     occupiedBy }                             global install, but this
+//                                              installation's `ocr` is not
+//                                              resolvable; occupiedBy is the
+//                                              foreign executable holding the
+//                                              name, or null
+//   { status: "unknown" }                      not resolvable; local install
+function checkOcrCommand(opts) {
+  const { packageRoot, pkgName, pathEnv, isWindows, env } = opts;
+  const pathSep = opts.pathSep || (isWindows ? ";" : ":");
+  const names = ocrCandidateNames(isWindows, env && env.PATHEXT);
+  const found = findOcrOnPath(pathEnv, isWindows, pathSep, names);
+  // Classify each entry once; isOurCommand performs filesystem I/O.
+  const classified = found.map((f) => ({
+    dir: f.dir,
+    name: f.name,
+    path: f.path,
+    ours: isOurCommand(f.path, packageRoot, pkgName, isWindows),
+  }));
+  const ours = classified.filter((f) => f.ours);
+  if (ours.length === 0) {
+    // This installation has no resolvable `ocr` on PATH. For global installs
+    // we know where the command should live, so report that — including who
+    // currently occupies the command name, if anyone.
+    const binDir = globalBinDir(packageRoot, isWindows, env);
+    if (!binDir) {
+      return { status: "unknown" };
+    }
+    return {
+      status: "not-on-path",
+      binDir,
+      occupiedBy: classified.length > 0 ? classified[0].path : null,
+    };
+  }
+  const foreign = classified.filter((f) => !f.ours);
+  const first = classified[0];
+  if (first.ours) {
+    if (foreign.length > 0) {
+      return {
+        status: "stale-hash-risk",
+        resolved: first.path,
+        stale: foreign.map((f) => f.path),
+      };
+    }
+    return { status: "ok", resolved: first.path };
+  }
+  return {
+    status: "shadowed",
+    resolved: first.path,
+    ours: ours.map((f) => f.path),
+  };
+}
+
+// Render the classification from checkOcrCommand as install-time notices.
+function printPathResolutionNotice() {
+  let result;
+  try {
+    result = checkOcrCommand({
+      packageRoot,
+      pkgName: loadPackageJson().name,
+      pathEnv: process.env.PATH || "",
+      isWindows: IS_WINDOWS,
+      env: process.env,
+    });
+  } catch (e) {
+    warn(`Could not verify how the ocr command resolves: ${e.message}`);
+    return;
+  }
+  switch (result.status) {
+    case "ok":
+      break;
+    case "stale-hash-risk":
+      warn(`Another executable named 'ocr' exists on your PATH: ${result.stale.join(", ")}.`);
+      warn("Terminals opened before this install may have cached that location and keep");
+      warn("running it instead of OpenCodeReview (new terminals are not affected).");
+      warn("If 'ocr' misbehaves in your current terminal, refresh the shell's command cache:");
+      warn("  bash/zsh: hash -r    (zsh also: rehash)    or simply open a new terminal");
+      warn("Verify with: ocr version   (expected output: open-code-review vX.Y.Z ...)");
+      break;
+    case "shadowed": {
+      const oursNote = result.ours.length > 0 ? ` (${result.ours[0]})` : "";
+      warn(`'ocr' resolves to ${result.resolved}, which takes precedence over the`);
+      warn(`OpenCodeReview you just installed${oursNote}. Commands like 'ocr config`);
+      warn("provider' will run that other program in every terminal. Remove or rename the");
+      warn("file above, or move OpenCodeReview's bin directory earlier in your PATH.");
+      warn("Verify with: ocr version   (expected output: open-code-review vX.Y.Z ...)");
+      break;
+    }
+    case "not-on-path":
+      if (result.occupiedBy) {
+        warn(`'ocr' resolves to ${result.occupiedBy}, but that is a different program: the`);
+        warn(`ocr you just installed is not resolvable on PATH. It should live in`);
+        warn(`${result.binDir}; add that directory to your PATH (earlier than the entry`);
+        warn("above), then open a new terminal.");
+      } else {
+        warn(`'ocr' was not found on your PATH. Add ${result.binDir} to your PATH (then open`);
+        warn("a new terminal), or run the binary from that directory directly.");
+      }
+      break;
+    default:
+      break; // local install without a PATH entry: nothing to verify
+  }
+}
+
 async function main() {
   info("OpenCodeReview Installer");
   info("=========================");
@@ -161,6 +411,7 @@ async function main() {
   if (existing && existing.fromPlatformPkg) {
     info("Binary provided by platform package, skipping download.");
     info(`  ${existing.path}`);
+    printPathResolutionNotice();
     return;
   }
 
@@ -250,6 +501,7 @@ async function main() {
   info("  ocr version             Show version info");
   info("  ocr config set          Configure your LLM provider");
   info("  ocr review              Start a code review");
+  printPathResolutionNotice();
 }
 
 if (require.main === module) {
@@ -268,5 +520,12 @@ if (require.main === module) {
     downloadText,
     downloadBinary,
     computeChecksum,
+    ocrCandidateNames,
+    pathsEqual,
+    pathHasPrefix,
+    findOcrOnPath,
+    isOurCommand,
+    globalBinDir,
+    checkOcrCommand,
   };
 }

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+"use strict";
+
+// Unit tests for the PATH resolution checks in scripts/install.js.
+//
+// Run via: node scripts/install.test.js
+// (also wired as `npm run test:install`).
+//
+// Plain Node + assert, no external deps and no `node --test`, mirroring
+// check-translation-sync.test.js so both run on node >= 14.
+//
+// Background: shells cache command locations (the bash/zsh hash table). When
+// a terminal ran some other executable named `ocr` before the install, that
+// terminal keeps running the cached (wrong) program even after the real ocr
+// appears earlier on PATH; only new terminals resolve correctly. install.js
+// must detect and report these situations at install time.
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  ocrCandidateNames,
+  pathsEqual,
+  pathHasPrefix,
+  findOcrOnPath,
+  isOurCommand,
+  globalBinDir,
+  checkOcrCommand,
+} = require(path.join(__dirname, "install.js"));
+
+const POSIX = process.platform !== "win32";
+const PKG_NAME = "@alibaba-group/open-code-review";
+
+// Build a throwaway layout:
+//   root/pkg/bin/ocr.js   the wrapper this install ships
+//   root/<dir>/...        fake PATH directories created per test
+let root;
+let packageRoot;
+
+function setUp() {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ocr-install-test-"));
+  packageRoot = path.join(root, "pkg");
+  fs.mkdirSync(path.join(packageRoot, "bin"), { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "bin", "ocr.js"),
+    "#!/usr/bin/env node\nconsole.log('ocr');\n"
+  );
+  // The real installer chmods the wrapper to 0755 before linking it.
+  fs.chmodSync(path.join(packageRoot, "bin", "ocr.js"), 0o755);
+}
+
+function tearDown() {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+function makeDir(name) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// A foreign executable named `ocr` (stands in for e.g. a tmux helper script
+// the user had on PATH before installing OpenCodeReview).
+function makeForeignOcr(dir, content) {
+  const p = path.join(dir, "ocr");
+  fs.writeFileSync(p, content || "#!/bin/sh\necho foreign ocr\n");
+  fs.chmodSync(p, 0o755);
+  return p;
+}
+
+// What npm creates on POSIX: <prefix>/bin/ocr -> <pkg>/bin/ocr.js.
+function makeOurLink(dir) {
+  const p = path.join(dir, "ocr");
+  if (POSIX) {
+    fs.symlinkSync(path.join(packageRoot, "bin", "ocr.js"), p);
+  } else {
+    // File symlinks may need elevation on Windows; a shim with the launch
+    // target embedded (what npm generates there) exercises the same logic.
+    fs.writeFileSync(
+      p,
+      `#!/bin/sh\nexec node "node_modules/${PKG_NAME}/bin/ocr.js" "$@"\n`
+    );
+  }
+  return p;
+}
+
+// npm-style Windows shim: a small generated file referencing the target.
+function makeWindowsShim(dir, name) {
+  const p = path.join(dir, name || "ocr.cmd");
+  fs.writeFileSync(
+    p,
+    `@ECHO off\r\nSETLOCAL\r\nCALL node "%~dp0\\node_modules\\${PKG_NAME}\\bin\\ocr.js" %*\r\n`
+  );
+  return p;
+}
+
+function testCandidateNames() {
+  assert.deepStrictEqual(ocrCandidateNames(false), ["ocr"]);
+  // Windows follows the supplied PATHEXT order, like cmd.exe would.
+  assert.deepStrictEqual(
+    ocrCandidateNames(true, ".EXE;.CMD;.BAT"),
+    ["ocr.exe", "ocr.cmd", "ocr.bat", "ocr"]
+  );
+  // Without PATHEXT the Windows default applies (.com before .exe), and the
+  // bare name stays last for POSIX-like shells (Git Bash).
+  const def = ocrCandidateNames(true, "");
+  assert.strictEqual(def[0], "ocr.com");
+  assert.ok(def.includes("ocr.exe"));
+  assert.strictEqual(def[def.length - 1], "ocr");
+  assert.strictEqual(new Set(def).size, def.length);
+}
+
+function testPathHelpersCaseSensitivity() {
+  assert.strictEqual(pathsEqual("C:\\A\\b", "c:\\a\\B", true), true);
+  assert.strictEqual(pathsEqual("C:\\A\\b", "c:\\a\\B", false), false);
+  assert.strictEqual(pathsEqual("/A/b", "/A/b", false), true);
+  assert.strictEqual(pathHasPrefix("C:\\Users\\x\\pkg", "c:\\users\\x\\", true), true);
+  assert.strictEqual(pathHasPrefix("C:\\Users\\x\\pkg", "c:\\users\\x\\", false), false);
+  assert.strictEqual(pathHasPrefix("/usr/lib/pkg", "/usr/lib/", false), true);
+}
+
+function testFindOcrOnPathOrderAndEmpty() {
+  const a = makeDir("a");
+  const b = makeDir("b");
+  makeForeignOcr(a);
+  makeForeignOcr(b);
+  const found = findOcrOnPath([a, b].join(":"), false, ":");
+  assert.deepStrictEqual(
+    found.map((f) => f.path),
+    [path.join(a, "ocr"), path.join(b, "ocr")]
+  );
+  assert.deepStrictEqual(findOcrOnPath("", false, ":"), []);
+}
+
+function testFindOcrOnPathSkipsNonExecutableAndDirs() {
+  if (!POSIX) {
+    return; // the executable bit is not meaningful on Windows
+  }
+  const dir = makeDir("mixed");
+  const notExec = path.join(dir, "ocr");
+  fs.writeFileSync(notExec, "data");
+  fs.chmodSync(notExec, 0o644); // present but not executable -> skipped
+  assert.deepStrictEqual(findOcrOnPath(dir, false, ":"), []);
+
+  const dirDir = makeDir("asdir");
+  fs.mkdirSync(path.join(dirDir, "ocr")); // a directory named ocr -> skipped
+  assert.deepStrictEqual(findOcrOnPath(dirDir, false, ":"), []);
+}
+
+function testFindOcrOnPathDedupesDuplicateDirs() {
+  const a = makeDir("dup");
+  makeForeignOcr(a);
+  // The same directory listed twice (and via a `..` alias on POSIX, which
+  // realpath dedupes) still yields a single entry.
+  const pathEnv = POSIX ? [a, a, path.join(a, "..", "dup")].join(":") : [a, a].join(";");
+  const found = findOcrOnPath(pathEnv, !POSIX, POSIX ? ":" : ";");
+  assert.strictEqual(found.length, 1);
+}
+
+function testIsOurCommandSymlinkAndForeign() {
+  const dir = makeDir("link");
+  const ours = makeOurLink(dir);
+  assert.strictEqual(isOurCommand(ours, packageRoot, PKG_NAME, false), true);
+
+  const foreignDir = makeDir("foreign");
+  const foreign = makeForeignOcr(foreignDir);
+  assert.strictEqual(isOurCommand(foreign, packageRoot, PKG_NAME, false), false);
+}
+
+function testIsOurCommandShimContent() {
+  const dir = makeDir("shim");
+  const shim = makeWindowsShim(dir); // backslash paths inside
+  assert.strictEqual(isOurCommand(shim, packageRoot, PKG_NAME, true), true);
+
+  // Casing inside the shim must not matter (Windows paths).
+  const upper = path.join(dir, "upper.cmd");
+  fs.writeFileSync(
+    upper,
+    `@ECHO off\r\nCALL node "%~dp0\\NODE_MODULES\\@Alibaba-Group\\open-code-review\\BIN\\OCR.JS" %*\r\n`
+  );
+  assert.strictEqual(isOurCommand(upper, packageRoot, PKG_NAME, true), true);
+
+  const otherShim = path.join(dir, "other.cmd");
+  fs.writeFileSync(otherShim, "@ECHO off\r\nCALL node \"C:\\some\\other\\tool.js\" %*\r\n");
+  assert.strictEqual(isOurCommand(otherShim, packageRoot, PKG_NAME, true), false);
+}
+
+function testGlobalBinDir() {
+  const prefix = path.join(root, "prefix");
+  const globalRoot = POSIX
+    ? path.join(prefix, "lib", "node_modules")
+    : path.join(prefix, "node_modules");
+  const globalPkg = path.join(globalRoot, "@alibaba-group", "open-code-review");
+  const env = { npm_config_prefix: prefix };
+
+  assert.strictEqual(
+    globalBinDir(globalPkg, !POSIX ? true : false, env),
+    POSIX ? path.join(prefix, "bin") : prefix
+  );
+  // Windows prefix casing may differ from the real on-disk casing.
+  if (!POSIX) {
+    assert.strictEqual(
+      globalBinDir(globalPkg.toUpperCase(), true, { npm_config_prefix: prefix.toLowerCase() }),
+      prefix.toLowerCase()
+    );
+  }
+  // A local install (outside the prefix) does not expect a PATH command.
+  assert.strictEqual(globalBinDir(packageRoot, false, env), null);
+  // No prefix reported -> nothing to claim.
+  assert.strictEqual(globalBinDir(globalPkg, false, {}), null);
+}
+
+function testCheckOcrCommandOk() {
+  const dir = makeDir("ok");
+  const ours = makeOurLink(dir);
+  const r = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: dir,
+    isWindows: false,
+    env: {},
+  });
+  assert.strictEqual(r.status, "ok");
+  assert.strictEqual(r.resolved, ours);
+}
+
+// The reported bug: the install's own `ocr` is first on PATH, but another
+// `ocr` exists later on it. Terminals open since before the install may have
+// hashed that later location and keep running it.
+function testCheckOcrCommandStaleHashRisk() {
+  const npmBin = makeDir("npm-bin");
+  const localBin = makeDir("local-bin");
+  const ours = makeOurLink(npmBin);
+  const stale = makeForeignOcr(localBin);
+  const r = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: [npmBin, localBin].join(":"),
+    isWindows: false,
+    env: {},
+  });
+  assert.strictEqual(r.status, "stale-hash-risk");
+  assert.strictEqual(r.resolved, ours);
+  assert.deepStrictEqual(r.stale, [stale]);
+}
+
+function testCheckOcrCommandShadowed() {
+  const npmBin = makeDir("npm-bin2");
+  const localBin = makeDir("local-bin2");
+  const ours = makeOurLink(npmBin);
+  const winner = makeForeignOcr(localBin);
+  const r = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: [localBin, npmBin].join(":"), // foreign entry comes first
+    isWindows: false,
+    env: {},
+  });
+  assert.strictEqual(r.status, "shadowed");
+  assert.strictEqual(r.resolved, winner);
+  assert.deepStrictEqual(r.ours, [ours]);
+}
+
+function testCheckOcrCommandNotOnPathGlobal() {
+  const empty = makeDir("empty");
+  const prefix = path.join(root, "prefix2");
+  const globalPkg = path.join(prefix, "lib", "node_modules", "@alibaba-group", "open-code-review");
+  const r = checkOcrCommand({
+    packageRoot: globalPkg,
+    pkgName: PKG_NAME,
+    pathEnv: empty,
+    isWindows: false,
+    env: { npm_config_prefix: prefix },
+  });
+  assert.strictEqual(r.status, "not-on-path");
+  assert.strictEqual(r.binDir, path.join(prefix, "bin"));
+}
+
+function testCheckOcrCommandUnknownForLocalInstall() {
+  const empty = makeDir("empty2");
+  const r = checkOcrCommand({
+    packageRoot, // not under any npm prefix
+    pkgName: PKG_NAME,
+    pathEnv: empty,
+    isWindows: false,
+    env: { npm_config_prefix: path.join(root, "prefix3") },
+  });
+  assert.strictEqual(r.status, "unknown");
+
+  // A foreign ocr on PATH does not change that: a local install has no
+  // PATH expectation, so there is nothing actionable to report.
+  const foreignDir = makeDir("foreign-local");
+  const foreign = makeForeignOcr(foreignDir);
+  const r2 = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: foreignDir,
+    isWindows: false,
+    env: { npm_config_prefix: path.join(root, "prefix3") },
+  });
+  assert.strictEqual(r2.status, "unknown");
+  assert.strictEqual(r2.occupiedBy, undefined);
+  assert.notStrictEqual(foreign, null);
+}
+
+// Global install whose own `ocr` is missing from PATH while a foreign
+// executable occupies the command name: report where ours should live and
+// who currently holds the name.
+function testCheckOcrCommandNotOnPathOccupied() {
+  const foreignDir = makeDir("occupant");
+  const foreign = makeForeignOcr(foreignDir);
+  const prefix = path.join(root, "prefix4");
+  const globalPkg = path.join(prefix, "lib", "node_modules", "@alibaba-group", "open-code-review");
+  const r = checkOcrCommand({
+    packageRoot: globalPkg,
+    pkgName: PKG_NAME,
+    pathEnv: foreignDir,
+    isWindows: false,
+    env: { npm_config_prefix: prefix },
+  });
+  assert.strictEqual(r.status, "not-on-path");
+  assert.strictEqual(r.binDir, path.join(prefix, "bin"));
+  assert.strictEqual(r.occupiedBy, foreign);
+}
+
+function testCheckOcrCommandWindowsVariants() {
+  const dir = makeDir("winbin");
+  // Within one directory only the first PATHEXT match is reported.
+  fs.writeFileSync(path.join(dir, "ocr.cmd"), "@ECHO off\r\nREM foreign\r\n");
+  fs.writeFileSync(path.join(dir, "ocr.exe"), "MZ-not-really");
+  const ourDir = makeDir("winbin-ours");
+  const shim = makeWindowsShim(ourDir);
+  const pathEnv = [dir, ourDir].join(";");
+
+  // Foreign directory first: shadowed. Under the default PATHEXT the
+  // directory's ocr.exe wins over its ocr.cmd (.com does not exist here).
+  const r = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv,
+    isWindows: true,
+    env: {},
+  });
+  assert.strictEqual(r.status, "shadowed");
+  assert.strictEqual(r.resolved, path.join(dir, "ocr.exe"));
+  assert.deepStrictEqual(r.ours, [shim]);
+
+  // PATHEXT ordering is honored: with .CMD before .EXE the ocr.cmd wins,
+  // exactly as cmd.exe would resolve it.
+  const r2 = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv,
+    isWindows: true,
+    env: { PATHEXT: ".CMD;.EXE" },
+  });
+  assert.strictEqual(r2.status, "shadowed");
+  assert.strictEqual(r2.resolved, path.join(dir, "ocr.cmd"));
+
+  // Our npm .cmd shim alone resolves as ours.
+  const r3 = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: ourDir,
+    isWindows: true,
+    env: {},
+  });
+  assert.strictEqual(r3.status, "ok");
+  assert.strictEqual(r3.resolved, shim);
+
+  // Foreign-only without any prefix info: nothing actionable -> unknown.
+  const r4 = checkOcrCommand({
+    packageRoot,
+    pkgName: PKG_NAME,
+    pathEnv: dir,
+    isWindows: true,
+    env: {},
+  });
+  assert.strictEqual(r4.status, "unknown");
+}
+
+function main() {
+  const tests = [
+    testCandidateNames,
+    testPathHelpersCaseSensitivity,
+    testFindOcrOnPathOrderAndEmpty,
+    testFindOcrOnPathSkipsNonExecutableAndDirs,
+    testFindOcrOnPathDedupesDuplicateDirs,
+    testIsOurCommandSymlinkAndForeign,
+    testIsOurCommandShimContent,
+    testGlobalBinDir,
+    testCheckOcrCommandOk,
+    testCheckOcrCommandStaleHashRisk,
+    testCheckOcrCommandShadowed,
+    testCheckOcrCommandNotOnPathGlobal,
+    testCheckOcrCommandNotOnPathOccupied,
+    testCheckOcrCommandUnknownForLocalInstall,
+    testCheckOcrCommandWindowsVariants,
+  ];
+  for (const t of tests) {
+    setUp();
+    try {
+      t();
+    } finally {
+      tearDown();
+    }
+  }
+  console.log("All install PATH-resolution tests passed.");
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Background

Right after installing (e.g. `npm i -g @alibaba-group/open-code-review`), running `ocr config provider` **in the same terminal** can fail with a confusing error coming from an unrelated program — while a newly opened terminal works fine.

Reproduced scenario:

1. The user has some other executable named `ocr` on PATH (in my case a tmux session helper at `~/.local/bin/ocr`) and that terminal ran it once before the install.
2. `npm i -g @alibaba-group/open-code-review` succeeds; the real `ocr` is linked into the npm prefix, which is *earlier* on PATH.
3. Running `ocr config provider` in the same terminal still executes the old program:

   ```
   ❌ 找不到编号或名称为 'config' 的项目。
   ```

   New terminals work fine.

## Root cause

Shells cache command locations (the bash/zsh hash table). Once a session has resolved `ocr` to some path, it keeps using that cached path even after the real `ocr` appears earlier on PATH — only new shells re-resolve. (Verified with a minimal zsh reproduction: same-window run hits the stale cached binary; `rehash` fixes it.) A foreign `ocr` that precedes the install on PATH is the worse variant: it wins in *every* terminal.

The installers previously printed "OpenCodeReview is ready!" without verifying that the `ocr` command actually resolves to this installation, so users got no hint that a different program was answering their first command.

## Fix

All three installers now verify how `ocr` resolves right after installing and print actionable guidance:

- **npm postinstall** (`scripts/install.js`): classifies the resolution and warns on
  - `stale-hash-risk` — ours wins on PATH, but another `ocr` exists that open terminals may have cached → advises `hash -r` / `rehash` / opening a new terminal (the reported bug);
  - `shadowed` — a foreign executable wins in every terminal → advises removing it or reordering PATH;
  - `not-on-path` — global install whose bin dir is missing from PATH, also reporting who occupies the command name, if anything.
  Windows handling follows `PATHEXT` order (like cmd.exe) and compares paths case-insensitively.
- **`install.sh` / `install.ps1`**: the same detection for the shell/PowerShell install flows.

Example output for the reported scenario (validated against the real environment):

```
[WARN]  Another executable named 'ocr' exists on your PATH: /Users/x/.local/bin/ocr.
[WARN]  Terminals opened before this install may have cached that location and keep
[WARN]  running it instead of OpenCodeReview (new terminals are not affected).
[WARN]  If 'ocr' misbehaves in your current terminal, refresh the shell's command cache:
[WARN]    bash/zsh: hash -r    (zsh also: rehash)    or simply open a new terminal
[WARN]  Verify with: ocr version   (expected output: open-code-review vX.Y.Z ...)
```

Note: an installer subprocess cannot clear the parent shell's hash table, so detection plus precise guidance at install time is the fix.

## Tests

- New `scripts/install.test.js` (plain Node + assert, node >= 14, mirroring `check-translation-sync.test.js`): 15 tests covering PATH walking, ours/foreign classification (symlink + npm shim content), PATHEXT ordering, Windows case-insensitivity, and all classification statuses. Wired as `npm run test:install` and a scoped `install-scripts` CI workflow (node:24.18.0 container, mirroring `translation-sync.yml`).
- `install.sh` notice logic verified in all four scenarios (ours-first-with-lookalike / shadowed / not-on-PATH / clean) under `sh -n` and `set -eu`.
- `make check` and `scripts/verify-license.sh` pass; existing `test:github-actions` tests unaffected.
- The change was reviewed with `ocr review --audience agent` and all findings were addressed (single-pass classification, Windows path casing, PATHEXT semantics, trailing-slash PATH entries, workflow concurrency).