### PR TITLE
fix(diff): parse quoted and ambiguous git paths

### DIFF
--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,13 +18,106 @@ import (
 	"github.com/alibaba/open-code-review/internal/model"
 )
 
-var (
-	diffHeaderRe = regexp.MustCompile(`^diff --git a/(.+?) b/(.+)$`)
-	// Anchored: git emits the marker at column 0 ("Binary files a/x and b/y
-	// differ"). Content lines inside hunks always carry a leading "+", "-"
-	// or " " prefix, so an anchored match can never misfire on file content.
-	binaryRe = regexp.MustCompile(`^Binary files `)
-)
+// Anchored: git emits the marker at column 0 ("Binary files a/x and b/y
+// differ"). Content lines inside hunks always carry a leading "+", "-"
+// or " " prefix, so an anchored match can never misfire on file content.
+var binaryRe = regexp.MustCompile(`^Binary files `)
+
+// parseDiffHeader extracts the old and new paths from a "diff --git" header.
+// Git C-quotes paths containing control characters. Unquoted paths may contain
+// spaces, including the literal delimiter-looking substring " b/"; for normal
+// modifications both operands name the same path, so prefer the split that
+// yields equal paths. Rename headers later provide authoritative paths when
+// the operands genuinely differ.
+func parseDiffHeader(line string) (oldPath, newPath string, ok bool) {
+	rest, ok := strings.CutPrefix(line, "diff --git ")
+	if !ok {
+		return "", "", false
+	}
+
+	oldToken, newToken, ok := splitDiffHeaderPaths(rest)
+	if !ok {
+		return "", "", false
+	}
+	oldPath, ok = decodeGitPathToken(oldToken, "a/")
+	if !ok {
+		return "", "", false
+	}
+	newPath, ok = decodeGitPathToken(newToken, "b/")
+	if !ok {
+		return "", "", false
+	}
+	return oldPath, newPath, true
+}
+
+func splitDiffHeaderPaths(header string) (oldToken, newToken string, ok bool) {
+	if strings.HasPrefix(header, `"`) {
+		quoted, err := strconv.QuotedPrefix(header)
+		if err != nil {
+			return "", "", false
+		}
+		remainder, found := strings.CutPrefix(header[len(quoted):], " ")
+		if !found || remainder == "" {
+			return "", "", false
+		}
+		return quoted, remainder, true
+	}
+
+	// If only the new path is quoted, its opening quote makes the separator
+	// unambiguous. A quote in the old path would make Git quote that operand too.
+	if i := strings.Index(header, ` "b/`); i >= 0 {
+		return header[:i], header[i+1:], true
+	}
+
+	// Unquoted paths are not tokenized on spaces by Git. Try every " b/"
+	// occurrence and prefer the split for a regular same-path modification.
+	for offset := 0; offset < len(header); {
+		i := strings.Index(header[offset:], " b/")
+		if i < 0 {
+			break
+		}
+		i += offset
+		oldCandidate := header[:i]
+		newCandidate := header[i+1:]
+		oldDecoded, oldOK := decodeGitPathToken(oldCandidate, "a/")
+		newDecoded, newOK := decodeGitPathToken(newCandidate, "b/")
+		if oldOK && newOK && oldDecoded == newDecoded {
+			return oldCandidate, newCandidate, true
+		}
+		offset = i + 1
+	}
+
+	// Renames and copies normally have different operands. Their extended
+	// headers correct the provisional paths later, so retain the historical
+	// first-delimiter fallback for those sections.
+	i := strings.Index(header, " b/")
+	if i < 0 {
+		return "", "", false
+	}
+	return header[:i], header[i+1:], true
+}
+
+func decodeGitPathToken(token, prefix string) (string, bool) {
+	if strings.HasPrefix(token, `"`) {
+		quoted, err := strconv.QuotedPrefix(token)
+		if err != nil || quoted != token {
+			return "", false
+		}
+		token, err = strconv.Unquote(quoted)
+		if err != nil {
+			return "", false
+		}
+	}
+	path, ok := strings.CutPrefix(token, prefix)
+	return path, ok
+}
+
+func decodeExtendedGitPath(path string) string {
+	if decoded, ok := decodeGitPathToken(path, ""); ok {
+		return decoded
+	}
+	return path
+}
 
 // ParseDiffText splits the unified diff text into per-file Diff structs.
 // ref, if non-empty, is a git ref used to read new-file content via
@@ -47,7 +141,7 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 	defer cancel()
 
 	for _, line := range lines {
-		if m := diffHeaderRe.FindStringSubmatch(line); m != nil {
+		if oldPath, newPath, ok := parseDiffHeader(line); ok {
 			// Flush previous diff
 			if current != nil {
 				current.Diff = strings.TrimSuffix(buf.String(), "\n")
@@ -56,8 +150,8 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 				buf.Reset()
 			}
 			current = &model.Diff{
-				OldPath: m[1],
-				NewPath: m[2],
+				OldPath: oldPath,
+				NewPath: newPath,
 			}
 			inHunk = false
 		}
@@ -84,10 +178,10 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 		case strings.HasPrefix(line, "rename from "):
 			// Authoritative old path for renames; more reliable than the
 			// "diff --git" header when paths contain spaces.
-			current.OldPath = strings.TrimPrefix(line, "rename from ")
+			current.OldPath = decodeExtendedGitPath(strings.TrimPrefix(line, "rename from "))
 			current.IsRenamed = true
 		case strings.HasPrefix(line, "rename to "):
-			current.NewPath = strings.TrimPrefix(line, "rename to ")
+			current.NewPath = decodeExtendedGitPath(strings.TrimPrefix(line, "rename to "))
 			current.IsRenamed = true
 		// git emits "--- /dev/null" / "+++ /dev/null" without a/ b/ prefixes.
 		// Guarded by inHunk: inside a hunk the same strings can be content

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -5,9 +5,166 @@ package diff
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestParseDiffHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		wantOld string
+		wantNew string
+		wantOK  bool
+	}{
+		{
+			name:    "ordinary path",
+			header:  "diff --git a/main.go b/main.go",
+			wantOld: "main.go",
+			wantNew: "main.go",
+			wantOK:  true,
+		},
+		{
+			name:    "delimiter substring in path",
+			header:  "diff --git a/dir b/file.go b/dir b/file.go",
+			wantOld: "dir b/file.go",
+			wantNew: "dir b/file.go",
+			wantOK:  true,
+		},
+		{
+			name:    "both paths quoted",
+			header:  `diff --git "a/tab\told.go" "b/tab\tnew.go"`,
+			wantOld: "tab\told.go",
+			wantNew: "tab\tnew.go",
+			wantOK:  true,
+		},
+		{
+			name:    "new path quoted",
+			header:  `diff --git a/old.go "b/tab\tnew.go"`,
+			wantOld: "old.go",
+			wantNew: "tab\tnew.go",
+			wantOK:  true,
+		},
+		{
+			name:    "old path quoted",
+			header:  `diff --git "a/tab\told.go" b/new.go`,
+			wantOld: "tab\told.go",
+			wantNew: "new.go",
+			wantOK:  true,
+		},
+		{
+			name:   "not a git diff header",
+			header: "@@ -1 +1 @@",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPath, newPath, ok := parseDiffHeader(tt.header)
+			if ok != tt.wantOK || oldPath != tt.wantOld || newPath != tt.wantNew {
+				t.Errorf("parseDiffHeader(%q) = %q, %q, %v; want %q, %q, %v",
+					tt.header, oldPath, newPath, ok, tt.wantOld, tt.wantNew, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseDiffText_PathContainingHeaderDelimiter(t *testing.T) {
+	repo := t.TempDir()
+	relPath := "dir b/file.go"
+	fullPath := filepath.Join(repo, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("create test directory: %v", err)
+	}
+	const wantContent = "package demo\nconst Value = 2\n"
+	if err := os.WriteFile(fullPath, []byte(wantContent), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	diffText := `diff --git a/dir b/file.go b/dir b/file.go
+index 74f3ac7..c32d45f 100644
+--- a/dir b/file.go
++++ b/dir b/file.go
+@@ -1,2 +1,2 @@
+ package demo
+-const Value = 1
++const Value = 2
+`
+
+	diffs, err := ParseDiffText(context.Background(), diffText, repo, "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("got %d diffs, want 1", len(diffs))
+	}
+	d := diffs[0]
+	if d.OldPath != relPath || d.NewPath != relPath {
+		t.Errorf("OldPath/NewPath = %q/%q, want %q/%q",
+			d.OldPath, d.NewPath, relPath, relPath)
+	}
+	if d.NewFileContent != wantContent {
+		t.Errorf("NewFileContent = %q, want %q", d.NewFileContent, wantContent)
+	}
+}
+
+func TestParseDiffText_CQuotedPath(t *testing.T) {
+	repo := t.TempDir()
+	relPath := "tab\tfile.go"
+	const wantContent = "package demo\nconst Value = 2\n"
+	if err := os.WriteFile(filepath.Join(repo, relPath), []byte(wantContent), 0o644); err != nil {
+		t.Skipf("filesystem does not support tab in file names: %v", err)
+	}
+
+	diffText := `diff --git "a/tab\tfile.go" "b/tab\tfile.go"
+index 74f3ac7..c32d45f 100644
+--- "a/tab\tfile.go"
++++ "b/tab\tfile.go"
+@@ -1,2 +1,2 @@
+ package demo
+-const Value = 1
++const Value = 2
+`
+
+	diffs, err := ParseDiffText(context.Background(), diffText, repo, "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("got %d diffs, want 1", len(diffs))
+	}
+	d := diffs[0]
+	if d.OldPath != relPath || d.NewPath != relPath {
+		t.Errorf("OldPath/NewPath = %q/%q, want %q/%q",
+			d.OldPath, d.NewPath, relPath, relPath)
+	}
+	if d.NewFileContent != wantContent {
+		t.Errorf("NewFileContent = %q, want %q", d.NewFileContent, wantContent)
+	}
+}
+
+func TestParseDiffText_CQuotedRename(t *testing.T) {
+	diffText := `diff --git "a/tab\told.go" "b/tab\tnew.go"
+similarity index 100%
+rename from "tab\told.go"
+rename to "tab\tnew.go"
+`
+
+	diffs, err := ParseDiffText(context.Background(), diffText, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("got %d diffs, want 1", len(diffs))
+	}
+	d := diffs[0]
+	if !d.IsRenamed || d.OldPath != "tab\told.go" || d.NewPath != "tab\tnew.go" {
+		t.Errorf("got IsRenamed=%v OldPath=%q NewPath=%q, want true/%q/%q",
+			d.IsRenamed, d.OldPath, d.NewPath, "tab\told.go", "tab\tnew.go")
+	}
+}
 
 func TestParseDiffText_StripsIndexHeadersFromPromptDiff(t *testing.T) {
 	diffText := `diff --git a/first.go b/first.go


### PR DESCRIPTION
## Description

Git diff headers are not safely tokenized by spaces. An unquoted path can
contain the delimiter-looking substring ` b/`, while paths containing control
characters are emitted as C-quoted operands.

The previous regular expression split `dir b/file.go` into `dir` and
`file.go b/dir b/file.go`, causing OCR to report the wrong path and fail to
read the file. A C-quoted path such as `tab\tfile.go` did not match at all, so
the changed file disappeared from review.

This change:

- parses quoted, unquoted, and mixed-quoted `diff --git` operands;
- prefers the same-path split for ambiguous unquoted modification headers;
- decodes quoted `rename from` / `rename to` paths;
- adds regression coverage for ordinary, ambiguous, quoted, mixed-quoted, and
  renamed paths.

The historical first-delimiter fallback remains for rename sections, whose
extended headers provide the authoritative old and new paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check`
- [x] `make test`
- [x] `make build`
- [x] `make coverage` - 90.1%, meeting the 90% threshold
- [x] Manual CLI preview against real Git repositories

Before the fix:

- `dir b/file.go` was reported as `file.go b/dir b/file.go` and file reading failed.
- `tab\tfile.go` produced zero reviewable files.

After the fix, both are reported as one modified, reviewable file with the
correct path.

Self-review used OCR Delegation Mode with the host agent:
`1/1` reviewable production files reviewed, `0` skipped, `0` findings.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal parser fix
- [x] I have signed the CLA

## Related Issues

No existing issue found. Open issues, pull request titles/bodies, and all open
pull request changed files were checked before implementation.
