### PR TITLE
fix(viewer): show running status for active sessions

### DIFF
--- a/cmd/opencodereview/session_cmd.go
+++ b/cmd/opencodereview/session_cmd.go
@@ -370,6 +370,9 @@ func describeFiles(s session.Summary) string {
 }
 
 func describeStatus(s session.Summary) string {
+	if s.Running {
+		return "running"
+	}
 	if s.Aborted {
 		return "aborted"
 	}

--- a/cmd/opencodereview/session_cmd_test.go
+++ b/cmd/opencodereview/session_cmd_test.go
@@ -372,3 +372,10 @@ func TestSessionDisplayDoesNotInferLegacyComplete(t *testing.T) {
 		t.Fatalf("status = %q", got)
 	}
 }
+
+func TestSessionDisplayUsesRunningStatus(t *testing.T) {
+	summary := session.Summary{Running: true, Aborted: true}
+	if got := describeStatus(summary); got != "running" {
+		t.Fatalf("describeStatus = %q, want running", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/sys v0.45.0
 )
 
 require (
@@ -69,7 +70,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/session/list.go
+++ b/internal/session/list.go
@@ -38,6 +38,7 @@ type Summary struct {
 	WaivedFiles    int           `json:"waived_files"`
 	TotalComments  int           `json:"total_comments"`
 	LLMFailures    int64         `json:"llm_failures"`
+	Running        bool          `json:"running"`
 	Aborted        bool          `json:"aborted"`
 	Legacy         bool          `json:"legacy"`
 	RunManifest    *RunManifest  `json:"run_manifest,omitempty"`
@@ -158,6 +159,9 @@ func LoadDetail(repoDir, sessionID string) (*Summary, []ItemDetail, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := updateSummaryActivity(summary); err != nil {
+		return nil, nil, err
+	}
 	if summary.SessionID == "" {
 		summary.SessionID = sessionID
 	}
@@ -174,6 +178,9 @@ func loadSummaryFromFile(path, sessionID, repoDir string) (*Summary, error) {
 	if err := walkSessionFile(path, func(rec summaryRecord) {
 		applyRecordToSummary(summary, rec)
 	}); err != nil {
+		return nil, err
+	}
+	if err := updateSummaryActivity(summary); err != nil {
 		return nil, err
 	}
 	if summary.SessionID == "" {
@@ -236,6 +243,7 @@ func applyRecordToSummary(s *Summary, rec summaryRecord) {
 	case "review_item_failed":
 		s.FailedFiles++
 	case "session_end":
+		s.Running = false
 		s.Aborted = false
 		if rec.RunManifest != nil && rec.RunManifest.SchemaVersion == ManifestSchemaVersion {
 			m := rec.RunManifest.cloned()
@@ -264,6 +272,20 @@ func applyRecordToSummary(s *Summary, rec summaryRecord) {
 		}
 		s.LLMFailures = rec.LLMFailures
 	}
+}
+
+func updateSummaryActivity(summary *Summary) error {
+	if summary == nil || !summary.Aborted {
+		return nil
+	}
+
+	running, err := IsSessionActive(summary.FilePath)
+	if err != nil {
+		return fmt.Errorf("check session activity: %w", err)
+	}
+	summary.Running = running
+	summary.Aborted = !running
+	return nil
 }
 
 func recordToItem(rec summaryRecord) (ItemDetail, bool) {

--- a/internal/session/list.go
+++ b/internal/session/list.go
@@ -159,9 +159,7 @@ func LoadDetail(repoDir, sessionID string) (*Summary, []ItemDetail, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := updateSummaryActivity(summary); err != nil {
-		return nil, nil, err
-	}
+	updateSummaryActivity(summary)
 	if summary.SessionID == "" {
 		summary.SessionID = sessionID
 	}
@@ -180,9 +178,7 @@ func loadSummaryFromFile(path, sessionID, repoDir string) (*Summary, error) {
 	}); err != nil {
 		return nil, err
 	}
-	if err := updateSummaryActivity(summary); err != nil {
-		return nil, err
-	}
+	updateSummaryActivity(summary)
 	if summary.SessionID == "" {
 		summary.SessionID = sessionID
 	}
@@ -274,18 +270,18 @@ func applyRecordToSummary(s *Summary, rec summaryRecord) {
 	}
 }
 
-func updateSummaryActivity(summary *Summary) error {
+func updateSummaryActivity(summary *Summary) {
 	if summary == nil || !summary.Aborted {
-		return nil
+		return
 	}
 
 	running, err := IsSessionActive(summary.FilePath)
 	if err != nil {
-		return fmt.Errorf("check session activity: %w", err)
+		// Activity detection is advisory; probe failures must not hide readable data.
+		return
 	}
 	summary.Running = running
 	summary.Aborted = !running
-	return nil
 }
 
 func recordToItem(rec summaryRecord) (ItemDetail, bool) {

--- a/internal/session/list_test.go
+++ b/internal/session/list_test.go
@@ -55,6 +55,9 @@ func TestListSessions_SortsAndAggregates(t *testing.T) {
 	if !got[0].Aborted {
 		t.Errorf("newest session was interrupted; expected Aborted=true")
 	}
+	if got[0].Running {
+		t.Errorf("newest interrupted session was marked running")
+	}
 	if got[1].Aborted {
 		t.Errorf("older session was finalized; expected Aborted=false")
 	}
@@ -66,6 +69,37 @@ func TestListSessions_SortsAndAggregates(t *testing.T) {
 	}
 	if got[0].CompletedFiles != 2 {
 		t.Errorf("newest CompletedFiles = %d, want 2", got[0].CompletedFiles)
+	}
+}
+
+func TestListSessionsReportsRunningSession(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	if sh.persist == nil {
+		t.Fatal("session persistence was not initialized")
+	}
+	defer sh.persist.flushAndClose()
+
+	got, err := ListSessions(repoDir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	if !got[0].Running || got[0].Aborted {
+		t.Fatalf("running session flags = running:%v aborted:%v", got[0].Running, got[0].Aborted)
+	}
+
+	summary, _, err := LoadDetail(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadDetail: %v", err)
+	}
+	if !summary.Running || summary.Aborted {
+		t.Fatalf("running detail flags = running:%v aborted:%v", summary.Running, summary.Aborted)
 	}
 }
 
@@ -259,13 +293,8 @@ func writeTestSession(t *testing.T, repoDir, from, to string, comments []model.L
 	} else {
 		// Simulate an aborted run: flush the writer without emitting session_end.
 		if sh.persist != nil {
+			sh.persist.flushAndClose()
 			sh.persist.mu.Lock()
-			if sh.persist.writer != nil {
-				sh.persist.writer.Flush()
-			}
-			if sh.persist.file != nil {
-				_ = sh.persist.file.Close()
-			}
 			sh.persist.writer = nil
 			sh.persist.file = nil
 			sh.persist.mu.Unlock()

--- a/internal/session/list_test.go
+++ b/internal/session/list_test.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -100,6 +101,57 @@ func TestListSessionsReportsRunningSession(t *testing.T) {
 	}
 	if !summary.Running || summary.Aborted {
 		t.Fatalf("running detail flags = running:%v aborted:%v", summary.Running, summary.Aborted)
+	}
+}
+
+func TestSessionSummariesSurviveActivityProbeFailure(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	if sh.persist == nil {
+		t.Fatal("session persistence was not initialized")
+	}
+	path, err := SessionFilePath(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	sh.persist.flushAndClose()
+
+	lockPath := sessionLockPath(path)
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove session lock: %v", err)
+	}
+	if err := os.Mkdir(lockPath, 0700); err != nil {
+		t.Fatalf("create invalid session lock: %v", err)
+	}
+
+	summaries, err := ListSessions(repoDir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+	if summaries[0].Running || !summaries[0].Aborted {
+		t.Fatalf("list flags = running:%v aborted:%v", summaries[0].Running, summaries[0].Aborted)
+	}
+
+	summary, err := LoadSummary(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadSummary: %v", err)
+	}
+	if summary.Running || !summary.Aborted {
+		t.Fatalf("summary flags = running:%v aborted:%v", summary.Running, summary.Aborted)
+	}
+
+	detail, items, err := LoadDetail(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadDetail: %v", err)
+	}
+	if len(items) != 0 || detail.Running || !detail.Aborted {
+		t.Fatalf("detail = %+v, items = %d", detail, len(items))
 	}
 }
 

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -37,6 +37,7 @@ type jsonlWriter struct {
 	resumedFrom string
 	file        *os.File
 	writer      *bufio.Writer
+	lock        *sessionLock
 	lastUUID    string // tracks chain of records via parentUuid
 }
 
@@ -112,13 +113,19 @@ func (jw *jsonlWriter) open() error {
 	}
 
 	filename := filepath.Join(sessionDir, jw.sessionID+".jsonl")
+	lock, err := acquireSessionLock(filename)
+	if err != nil {
+		return err
+	}
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
+		_ = lock.close()
 		return fmt.Errorf("open session file: %w", err)
 	}
 
 	jw.file = f
 	jw.writer = bufio.NewWriter(f)
+	jw.lock = lock
 	return nil
 }
 
@@ -167,6 +174,9 @@ func (jw *jsonlWriter) WriteSessionStart(startTime time.Time) string {
 	jw.mu.Lock()
 	defer jw.mu.Unlock()
 	jw.writeRecordLocked(rec)
+	if jw.writer != nil {
+		_ = jw.writer.Flush()
+	}
 	jw.lastUUID = uuid
 	return uuid
 }
@@ -326,11 +336,16 @@ func (jw *jsonlWriter) WriteToolCall(filePath string, taskType TaskType, toolNam
 // is appended. The record is flushed before the file is closed. Any marshal,
 // flush or close error is returned so the caller can surface it as a delivery
 // error rather than silently losing the manifest.
-func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []string, llmFailures int64, manifest *RunManifest) error {
+func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []string, llmFailures int64, manifest *RunManifest) (writeErr error) {
 	uuid := generateUUID()
 
 	jw.mu.Lock()
 	defer jw.mu.Unlock()
+	defer func() {
+		if err := jw.releaseLockLocked(); err != nil && writeErr == nil {
+			writeErr = fmt.Errorf("release session lock: %w", err)
+		}
+	}()
 	rec := map[string]any{
 		"uuid":             uuid,
 		"parentUuid":       jw.lastUUID,
@@ -359,7 +374,6 @@ func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []s
 		return fmt.Errorf("marshal session_end: %w", err)
 	}
 
-	var writeErr error
 	if jw.writer != nil {
 		if _, err := jw.writer.Write(data); err != nil {
 			writeErr = fmt.Errorf("write session_end: %w", err)
@@ -386,4 +400,14 @@ func (jw *jsonlWriter) flushAndClose() {
 	if jw.file != nil {
 		jw.file.Close()
 	}
+	_ = jw.releaseLockLocked()
+}
+
+func (jw *jsonlWriter) releaseLockLocked() error {
+	if jw.lock == nil {
+		return nil
+	}
+	err := jw.lock.close()
+	jw.lock = nil
+	return err
 }

--- a/internal/session/session_lock.go
+++ b/internal/session/session_lock.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var errSessionAlreadyActive = errors.New("session is already active")
+
+// sessionLock is held by the process that owns a live JSONL session. The lock
+// file may remain after a crash, but the OS lock itself is released with the
+// process and therefore remains the source of truth for activity.
+type sessionLock struct {
+	file      *os.File
+	supported bool
+}
+
+func sessionLockPath(sessionPath string) string {
+	if strings.HasSuffix(sessionPath, ".jsonl") {
+		return strings.TrimSuffix(sessionPath, ".jsonl") + ".lock"
+	}
+	return sessionPath + ".lock"
+}
+
+func acquireSessionLock(sessionPath string) (*sessionLock, error) {
+	lockPath := sessionLockPath(sessionPath)
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open session lock: %w", err)
+	}
+
+	locked, supported, err := tryLockSessionFile(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock session: %w", err)
+	}
+	if supported && !locked {
+		_ = file.Close()
+		return nil, errSessionAlreadyActive
+	}
+
+	return &sessionLock{file: file, supported: supported}, nil
+}
+
+// IsSessionActive reports whether the process that owns sessionPath currently
+// holds its lock. Missing lock files are treated as inactive for compatibility
+// with sessions written before live-state detection was introduced.
+func IsSessionActive(sessionPath string) (bool, error) {
+	lockPath := sessionLockPath(sessionPath)
+	file, err := os.OpenFile(lockPath, os.O_RDWR, 0600)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("open session lock: %w", err)
+	}
+
+	locked, supported, err := tryLockSessionFile(file)
+	if err != nil {
+		_ = file.Close()
+		return false, fmt.Errorf("probe session lock: %w", err)
+	}
+	if !supported {
+		_ = file.Close()
+		return false, nil
+	}
+	if !locked {
+		_ = file.Close()
+		return true, nil
+	}
+
+	unlockErr := unlockSessionFile(file)
+	closeErr := file.Close()
+	if err := errors.Join(unlockErr, closeErr); err != nil {
+		return false, fmt.Errorf("release session lock probe: %w", err)
+	}
+	return false, nil
+}
+
+func (l *sessionLock) close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	var unlockErr error
+	if l.supported {
+		unlockErr = unlockSessionFile(l.file)
+	}
+	closeErr := l.file.Close()
+	l.file = nil
+	return errors.Join(unlockErr, closeErr)
+}

--- a/internal/session/session_lock_test.go
+++ b/internal/session/session_lock_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionLockReportsActiveOwner(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	lock, err := acquireSessionLock(sessionPath)
+	if err != nil {
+		t.Fatalf("acquireSessionLock: %v", err)
+	}
+	if !lock.supported {
+		t.Skip("platform does not support session activity locks")
+	}
+	t.Cleanup(func() { _ = lock.close() })
+
+	active, err := IsSessionActive(sessionPath)
+	if err != nil {
+		t.Fatalf("IsSessionActive while held: %v", err)
+	}
+	if !active {
+		t.Fatal("session should be active while its lock is held")
+	}
+
+	if _, err := acquireSessionLock(sessionPath); !errors.Is(err, errSessionAlreadyActive) {
+		t.Fatalf("second acquire error = %v, want %v", err, errSessionAlreadyActive)
+	}
+
+	if err := lock.close(); err != nil {
+		t.Fatalf("close session lock: %v", err)
+	}
+	active, err = IsSessionActive(sessionPath)
+	if err != nil {
+		t.Fatalf("IsSessionActive after close: %v", err)
+	}
+	if active {
+		t.Fatal("session should be inactive after its lock is released")
+	}
+}
+
+func TestSessionLockMissingOrStaleFileIsInactive(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+
+	active, err := IsSessionActive(sessionPath)
+	if err != nil {
+		t.Fatalf("IsSessionActive without lock file: %v", err)
+	}
+	if active {
+		t.Fatal("missing lock file should be inactive")
+	}
+
+	if err := os.WriteFile(sessionLockPath(sessionPath), []byte("stale"), 0600); err != nil {
+		t.Fatalf("write stale lock file: %v", err)
+	}
+	active, err = IsSessionActive(sessionPath)
+	if err != nil {
+		t.Fatalf("IsSessionActive with stale lock file: %v", err)
+	}
+	if active {
+		t.Fatal("unheld stale lock file should be inactive")
+	}
+}

--- a/internal/session/session_lock_unix.go
+++ b/internal/session/session_lock_unix.go
@@ -6,7 +6,6 @@
 package session
 
 import (
-	"errors"
 	"os"
 	"syscall"
 )
@@ -16,7 +15,7 @@ func tryLockSessionFile(file *os.File) (locked, supported bool, err error) {
 	if err == nil {
 		return true, true, nil
 	}
-	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+	if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
 		return false, true, nil
 	}
 	return false, true, err

--- a/internal/session/session_lock_unix.go
+++ b/internal/session/session_lock_unix.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package session
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func tryLockSessionFile(file *os.File) (locked, supported bool, err error) {
+	err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, true, nil
+	}
+	return false, true, err
+}
+
+func unlockSessionFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/session/session_lock_unsupported.go
+++ b/internal/session/session_lock_unsupported.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build !windows && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package session
+
+import "os"
+
+// Unsupported targets retain session persistence but cannot distinguish a
+// live process from an interrupted one. They continue to use the historical
+// aborted fallback rather than failing the review altogether.
+func tryLockSessionFile(file *os.File) (locked, supported bool, err error) {
+	return false, false, nil
+}
+
+func unlockSessionFile(file *os.File) error {
+	return nil
+}

--- a/internal/session/session_lock_windows.go
+++ b/internal/session/session_lock_windows.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build windows
+
+package session
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	lockfileFailImmediately = 0x00000001
+	lockfileExclusiveLock   = 0x00000002
+)
+
+func tryLockSessionFile(file *os.File) (locked, supported bool, err error) {
+	overlapped := new(windows.Overlapped)
+	err = windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		lockfileFailImmediately|lockfileExclusiveLock,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if err == nil {
+		return true, true, nil
+	}
+	if err == windows.ERROR_LOCK_VIOLATION {
+		return false, true, nil
+	}
+	return false, true, err
+}
+
+func unlockSessionFile(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
+}

--- a/internal/viewer/handler_test.go
+++ b/internal/viewer/handler_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/alibaba/open-code-review/internal/session"
 )
 
 func TestHandleRepos_Success(t *testing.T) {
@@ -116,6 +118,41 @@ func TestHandleSessions_Success(t *testing.T) {
 	body := rr.Body.String()
 	if !strings.Contains(body, "project") {
 		t.Errorf("response does not contain repo display name derived from CWD")
+	}
+}
+
+func TestHandleSessionsAndSession_RunningStatus(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{ReviewMode: session.ReviewModeWorkspace})
+	defer sh.Finalize()
+
+	path, err := session.SessionFilePath(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	root := filepath.Dir(filepath.Dir(path))
+	encodedRepo := filepath.Base(filepath.Dir(path))
+
+	listReq := httptest.NewRequest("GET", "/r/"+encodedRepo, nil)
+	listRR := httptest.NewRecorder()
+	handleSessions(listRR, listReq, root, encodedRepo)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("session list status = %d, want 200", listRR.Code)
+	}
+	if !strings.Contains(listRR.Body.String(), ">running<") {
+		t.Fatalf("session list did not render running status: %s", listRR.Body.String())
+	}
+
+	detailReq := httptest.NewRequest("GET", "/r/"+encodedRepo+"/"+sh.SessionID, nil)
+	detailRR := httptest.NewRecorder()
+	handleSession(detailRR, detailReq, root, encodedRepo, sh.SessionID)
+	if detailRR.Code != http.StatusOK {
+		t.Fatalf("session detail status = %d, want 200", detailRR.Code)
+	}
+	if !strings.Contains(detailRR.Body.String(), "Status:</strong> running") {
+		t.Fatalf("session detail did not render running status: %s", detailRR.Body.String())
 	}
 }
 

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -201,9 +201,7 @@ func peekSession(path string) (SessionSummary, error) {
 			}
 		}
 	}
-	if err := updateSessionActivity(path, &summary); err != nil {
-		return SessionSummary{}, err
-	}
+	updateSessionActivity(path, &summary)
 	return summary, readErr
 }
 
@@ -569,9 +567,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 
 	vs.Summary.SessionID = sessionID
 	vs.Summary.CommentCount = len(vs.Comments)
-	if err := updateSessionActivity(path, &vs.Summary); err != nil && readErr == nil {
-		readErr = err
-	}
+	updateSessionActivity(path, &vs.Summary)
 	return vs, readErr
 }
 
@@ -615,18 +611,18 @@ func applySessionEnd(summary *SessionSummary, rec map[string]any) {
 	}
 }
 
-func updateSessionActivity(path string, summary *SessionSummary) error {
+func updateSessionActivity(path string, summary *SessionSummary) {
 	if summary == nil || !summary.Aborted {
-		return nil
+		return
 	}
 
 	running, err := session.IsSessionActive(path)
 	if err != nil {
-		return fmt.Errorf("check session activity: %w", err)
+		// Activity detection is advisory; probe failures must not hide readable data.
+		return
 	}
 	summary.Running = running
 	summary.Aborted = !running
-	return nil
 }
 
 func taskDoneSucceeded(arguments string) bool {

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -96,6 +96,7 @@ type SessionSummary struct {
 	FileCount      int
 	LLMFailures    int
 	CommentCount   int
+	Running        bool
 	Aborted        bool
 	Legacy         bool
 	TerminalState  string
@@ -199,6 +200,9 @@ func peekSession(path string) (SessionSummary, error) {
 				applySessionEnd(&summary, rec)
 			}
 		}
+	}
+	if err := updateSessionActivity(path, &summary); err != nil {
+		return SessionSummary{}, err
 	}
 	return summary, readErr
 }
@@ -565,10 +569,14 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 
 	vs.Summary.SessionID = sessionID
 	vs.Summary.CommentCount = len(vs.Comments)
+	if err := updateSessionActivity(path, &vs.Summary); err != nil && readErr == nil {
+		readErr = err
+	}
 	return vs, readErr
 }
 
 func applySessionEnd(summary *SessionSummary, rec map[string]any) {
+	summary.Running = false
 	summary.Aborted = false
 	if dur, ok := rec["duration_seconds"].(float64); ok {
 		summary.DurationSec = dur
@@ -605,6 +613,20 @@ func applySessionEnd(summary *SessionSummary, rec map[string]any) {
 		summary.Legacy = true
 		summary.FileCount = len(summary.FilesReviewed)
 	}
+}
+
+func updateSessionActivity(path string, summary *SessionSummary) error {
+	if summary == nil || !summary.Aborted {
+		return nil
+	}
+
+	running, err := session.IsSessionActive(path)
+	if err != nil {
+		return fmt.Errorf("check session activity: %w", err)
+	}
+	summary.Running = running
+	summary.Aborted = !running
+	return nil
 }
 
 func taskDoneSucceeded(arguments string) bool {

--- a/internal/viewer/store_load_test.go
+++ b/internal/viewer/store_load_test.go
@@ -203,6 +203,28 @@ func TestLoadSession_FullParse(t *testing.T) {
 	}
 }
 
+func TestLoadSession_Running(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{ReviewMode: session.ReviewModeWorkspace})
+	defer sh.Finalize()
+
+	path, err := session.SessionFilePath(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	root := filepath.Dir(filepath.Dir(path))
+	encodedRepo := filepath.Base(filepath.Dir(path))
+	vs, err := LoadSession(root, encodedRepo, sh.SessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if !vs.Summary.Running || vs.Summary.Aborted {
+		t.Fatalf("running session flags = running:%v aborted:%v", vs.Summary.Running, vs.Summary.Aborted)
+	}
+}
+
 func TestLoadSession_TaskDoneStates(t *testing.T) {
 	root := t.TempDir()
 	repoDir := filepath.Join(root, "repo")

--- a/internal/viewer/store_load_test.go
+++ b/internal/viewer/store_load_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/open-code-review/internal/session"
@@ -222,6 +223,41 @@ func TestLoadSession_Running(t *testing.T) {
 	}
 	if !vs.Summary.Running || vs.Summary.Aborted {
 		t.Fatalf("running session flags = running:%v aborted:%v", vs.Summary.Running, vs.Summary.Aborted)
+	}
+}
+
+func TestLoadSession_ActivityProbeFailureKeepsData(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(repoDir, "probe-error.jsonl")
+	writeJSONL(t, path,
+		`{"type":"session_start","timestamp":"2025-01-01T00:00:00Z","cwd":"/x","model":"m"}`)
+
+	lockPath := strings.TrimSuffix(path, ".jsonl") + ".lock"
+	if err := os.Mkdir(lockPath, 0700); err != nil {
+		t.Fatalf("create invalid session lock: %v", err)
+	}
+
+	summaries, err := ListSessions(root, "repo")
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+
+	vs, err := LoadSession(root, "repo", "probe-error")
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if vs.Summary.CWD != "/x" || vs.Summary.Model != "m" {
+		t.Fatalf("summary = %+v", vs.Summary)
+	}
+	if vs.Summary.Running || !vs.Summary.Aborted {
+		t.Fatalf("flags = running:%v aborted:%v", vs.Summary.Running, vs.Summary.Aborted)
 	}
 }
 

--- a/internal/viewer/store_test.go
+++ b/internal/viewer/store_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/alibaba/open-code-review/internal/session"
 )
 
 func writeJSONL(t *testing.T, path string, lines ...string) {
@@ -247,8 +249,31 @@ func TestPeekSession_NoSessionEnd(t *testing.T) {
 	if s.FileCount != 0 {
 		t.Errorf("FileCount should be 0 without session_end, got %d", s.FileCount)
 	}
-	if !s.Aborted || s.Legacy {
-		t.Fatalf("unfinished session flags = aborted:%v legacy:%v", s.Aborted, s.Legacy)
+	if !s.Aborted || s.Running || s.Legacy {
+		t.Fatalf("unfinished session flags = running:%v aborted:%v legacy:%v", s.Running, s.Aborted, s.Legacy)
+	}
+}
+
+func TestPeekSession_Running(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	repoDir := t.TempDir()
+	sh := session.New(repoDir, "main", "test-model", session.SessionOptions{ReviewMode: session.ReviewModeWorkspace})
+	if sh == nil {
+		t.Fatal("session.New returned nil")
+	}
+	defer sh.Finalize()
+
+	path, err := session.SessionFilePath(repoDir, sh.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	summary, err := peekSession(path)
+	if err != nil {
+		t.Fatalf("peekSession: %v", err)
+	}
+	if !summary.Running || summary.Aborted {
+		t.Fatalf("running session flags = running:%v aborted:%v", summary.Running, summary.Aborted)
 	}
 }
 

--- a/internal/viewer/store_test.go
+++ b/internal/viewer/store_test.go
@@ -6,6 +6,7 @@ package viewer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -251,6 +252,29 @@ func TestPeekSession_NoSessionEnd(t *testing.T) {
 	}
 	if !s.Aborted || s.Running || s.Legacy {
 		t.Fatalf("unfinished session flags = running:%v aborted:%v legacy:%v", s.Running, s.Aborted, s.Legacy)
+	}
+}
+
+func TestPeekSession_ActivityProbeFailureKeepsSummary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "probe-error.jsonl")
+	writeJSONL(t, path,
+		`{"type":"session_start","timestamp":"2025-01-01T00:00:00Z","cwd":"/x","model":"m"}`)
+
+	lockPath := strings.TrimSuffix(path, ".jsonl") + ".lock"
+	if err := os.Mkdir(lockPath, 0700); err != nil {
+		t.Fatalf("create invalid session lock: %v", err)
+	}
+
+	summary, err := peekSession(path)
+	if err != nil {
+		t.Fatalf("peekSession: %v", err)
+	}
+	if summary.CWD != "/x" || summary.Model != "m" {
+		t.Fatalf("summary = %+v", summary)
+	}
+	if summary.Running || !summary.Aborted {
+		t.Fatalf("flags = running:%v aborted:%v", summary.Running, summary.Aborted)
 	}
 }
 

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -26,7 +26,7 @@
         <span><strong>Model:</strong> <code>{{.Session.Summary.Model}}</code></span>
         <span><strong>Duration:</strong> {{formatDuration .Session.Summary.DurationSec}}</span>
         <span><strong>Files:</strong> {{.Session.Summary.FileCount}}</span>
-        <span><strong>Status:</strong> {{if .Session.Summary.Aborted}}aborted{{else if .Session.Summary.Legacy}}legacy{{else}}{{.Session.Summary.TerminalState}}{{end}}</span>
+        <span><strong>Status:</strong> {{if .Session.Summary.Running}}running{{else if .Session.Summary.Aborted}}aborted{{else if .Session.Summary.Legacy}}legacy{{else}}{{.Session.Summary.TerminalState}}{{end}}</span>
     </div>
 </div>
 

--- a/internal/viewer/templates/sessions.html
+++ b/internal/viewer/templates/sessions.html
@@ -22,7 +22,7 @@
             <td>{{if .ReviewMode}}{{.ReviewMode}}{{else}}-{{end}}</td>
             <td><code>{{.Model}}</code></td>
             <td>{{.FileCount}}</td>
-            <td>{{if .Aborted}}aborted{{else if .Legacy}}legacy{{else}}{{.TerminalState}}{{end}}</td>
+            <td>{{if .Running}}running{{else if .Aborted}}aborted{{else if .Legacy}}legacy{{else}}{{.TerminalState}}{{end}}</td>
             <td>{{if .CommentCount}}{{.CommentCount}}{{else}}-{{end}}</td>
             <td>{{formatDuration .DurationSec}}</td>
             <td>{{formatTime .Timestamp}}</td>


### PR DESCRIPTION
## Summary

- distinguish active sessions from interrupted sessions with a per-session OS file lock
- report `running` in the Web Viewer and `ocr session` while the owner still holds the lock
- preserve manifest terminal states, legacy sessions, and lock-less historical sessions
- flush `session_start` immediately so live sessions are visible with metadata
- add Windows and Unix lock implementations plus regression coverage for active, completed, interrupted, and legacy sessions

## Testing

- targeted session, viewer, and CLI tests passed
- targeted `go vet` passed
- `go test ./... -run '^$' -count=1` passed
- Linux and Darwin session packages cross-compiled successfully

Closes #847