### PR TITLE
fix(diff): match gitignore directory patterns

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -304,12 +303,8 @@ func matchGitignorePattern(relPath, pat string) bool {
 // the pattern with any leading "!" already stripped.
 func matchGitignoreBody(relPath, body string) bool {
 	// Directory-only patterns (trailing /)
-	if before, ok := strings.CutSuffix(body, "/"); ok {
-		// Only a real directory component can match, so the final segment (the
-		// file's own name) is excluded from consideration: `vendor/` must not
-		// match a *file* named "vendor", and `*/` must not match every path.
-		segments := strings.Split(relPath, "/")
-		return slices.Contains(segments[:max(len(segments)-1, 0)], before)
+	if pattern, ok := strings.CutSuffix(body, "/"); ok {
+		return matchGitignoreDirectory(relPath, pattern)
 	}
 
 	// A leading "/" anchors the pattern to the repository root rather than
@@ -351,6 +346,34 @@ func matchGitignoreBody(relPath, body string) bool {
 		return true
 	}
 
+	return false
+}
+
+func matchGitignoreDirectory(relPath, pattern string) bool {
+	pattern, anchored := strings.CutPrefix(pattern, "/")
+	if pattern == "" {
+		return false
+	}
+
+	lastSlash := strings.LastIndex(relPath, "/")
+	if lastSlash < 0 {
+		return false
+	}
+
+	components := strings.Split(relPath[:lastSlash], "/")
+	// Slash-containing patterns are relative to the .gitignore location;
+	// slashless patterns match a directory name at any depth.
+	matchFullPath := anchored || strings.Contains(pattern, "/")
+	for i, component := range components {
+		candidate := component
+		if matchFullPath {
+			candidate = strings.Join(components[:i+1], "/")
+		}
+		matched, err := doublestar.Match(pattern, candidate)
+		if err == nil && matched {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/diff/gitignore_test.go
+++ b/internal/diff/gitignore_test.go
@@ -84,6 +84,34 @@ func TestIsPathExcluded(t *testing.T) {
 	}
 }
 
+func TestIsPathExcluded_DirectoryPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		relPath string
+		pattern string
+		want    bool
+	}{
+		{"path pattern", "docs/generated/file.go", "docs/generated/", true},
+		{"path pattern is root relative", "nested/docs/generated/file.go", "docs/generated/", false},
+		{"globstar at root", "generated/file.go", "**/generated/", true},
+		{"globstar nested", "src/generated/file.go", "**/generated/", true},
+		{"component glob", "src/build-cache/file.go", "build*/", true},
+		{"root anchored", "generated/file.go", "/generated/", true},
+		{"root anchored does not match nested", "src/generated/file.go", "/generated/", false},
+		{"file name is not a directory", "src/generated", "generated/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPathExcluded(".", tt.relPath, []string{tt.pattern})
+			if got != tt.want {
+				t.Errorf("IsPathExcluded(%q, %q) = %v, want %v",
+					tt.relPath, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
 // allowListGitignore is the "ignore everything, then re-include" idiom from
 // github/gitignore's Go.AllowList.gitignore. Repositories using it are the
 // reason negation patterns cannot be discarded: the leading `*` matches every


### PR DESCRIPTION
## Description

Directory-only `.gitignore` patterns were matched by comparing the complete
pattern body with individual path components. This worked for a literal
basename such as `vendor/`, but not for path patterns or globs:

- `docs/generated/` did not exclude `docs/generated/file.go`;
- `**/generated/` did not exclude generated directories at any depth;
- `build*/` did not exclude matching directory names;
- `/generated/` did not exclude the root directory.

This change matches directory-only patterns against ancestor directories:

- patterns containing `/` match complete ancestor paths relative to the
  repository root;
- slashless patterns match ancestor directory names at any depth;
- leading `/` remains root-anchored;
- the existing doublestar matcher handles glob and globstar syntax.

The file's final path segment is intentionally excluded from consideration, so
a file named `generated` is not treated as a directory.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check`
- [x] `make test`
- [x] `make build`
- [x] `make coverage` - 90.2%, meeting the 90% threshold
- [x] Compared all eight regression cases with `git check-ignore --no-index`
- [x] Manual CLI preview in a repository containing a tracked
  `docs/generated/file.go`

Before the fix, five new regression cases failed. After the fix, all directory
pattern cases pass and match Git's result. The CLI preview excludes the tracked
generated file while retaining a normal modified file.

Self-review used OCR Delegation Mode with the host agent:
`1/1` reviewable production files reviewed, `0` skipped, `0` findings.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal matcher fix
- [x] I have signed the CLA

## Related Issues

No existing issue found. Open issue and pull request text, plus all open pull
request changed files, were checked before implementation.
