### PR TITLE
fix(agent): name the main-loop stop trigger in item failure reasons

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1123,14 +1123,20 @@ func classifyItemError(err error) (session.FailureClass, string) {
 
 // classifyMainLoopStop maps a non-error, non-completed main-loop stop to an item
 // failure class and a safe reason. Only the configured max-tool-request budget is
-// a declared budget stop; the empty-round and compression exits are genuine but
-// unclassifiable, so they map to the honest unknown catch-all. Only an explicit
-// budget trigger may use the budget classification.
+// a declared budget stop, so only it may use the budget classification. The
+// empty-round and compression exits keep the unknown class — the FailureClass
+// taxonomy has no fitting category — but the reason names the trigger: in
+// --format json runs the progress lines that would say why an item stopped are
+// discarded, so this string is the only thing that leaves a CI runner.
 func classifyMainLoopStop(stop llmloop.MainLoopStop) (session.FailureClass, string) {
 	switch stop {
 	case llmloop.StopMaxRounds:
 		return session.FailureBudget, "reached the maximum tool-request rounds without finishing"
-	default: // StopEmptyRounds, StopCompression, StopNone
+	case llmloop.StopEmptyRounds:
+		return session.FailureUnknown, "stopped after repeated rounds without a usable tool result"
+	case llmloop.StopCompression:
+		return session.FailureUnknown, "stopped because context compression exceeded its threshold"
+	default: // StopNone
 		return session.FailureUnknown, "main task stopped before completing"
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1123,22 +1123,21 @@ func classifyItemError(err error) (session.FailureClass, string) {
 
 // classifyMainLoopStop maps a non-error, non-completed main-loop stop to an item
 // failure class and a safe reason. Only the configured max-tool-request budget is
-// a declared budget stop, so only it may use the budget classification. The
-// empty-round and compression exits keep the unknown class — the FailureClass
-// taxonomy has no fitting category — but the reason names the trigger: in
-// --format json runs the progress lines that would say why an item stopped are
-// discarded, so this string is the only thing that leaves a CI runner.
+// a declared budget stop, so only it may use the budget classification; every
+// other stop keeps the unknown class, because the FailureClass taxonomy has no
+// category that fits an empty-round or compression exit. Stating that as "not
+// max-rounds" rather than case-by-case is deliberate: a stop added to the enum
+// later must default to the honest catch-all class, never inherit "budget".
+//
+// The reason text comes from stop.Reason(), shared with the scan path so the
+// same stop cannot read differently in the two commands' output. In --format
+// json runs the progress lines that would say why an item stopped are discarded,
+// so that string is the only stop diagnostic that leaves a CI runner.
 func classifyMainLoopStop(stop llmloop.MainLoopStop) (session.FailureClass, string) {
-	switch stop {
-	case llmloop.StopMaxRounds:
-		return session.FailureBudget, "reached the maximum tool-request rounds without finishing"
-	case llmloop.StopEmptyRounds:
-		return session.FailureUnknown, "stopped after repeated rounds without a usable tool result"
-	case llmloop.StopCompression:
-		return session.FailureUnknown, "stopped because context compression exceeded its threshold"
-	default: // StopNone
-		return session.FailureUnknown, "main task stopped before completing"
+	if stop == llmloop.StopMaxRounds {
+		return session.FailureBudget, stop.Reason()
 	}
+	return session.FailureUnknown, stop.Reason()
 }
 
 // subtaskStop is the structured, non-error reason a single-file review stopped

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alibaba/open-code-review/internal/config/rules"
 	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/alibaba/open-code-review/internal/tool"
@@ -917,6 +918,39 @@ func TestClassifyItemError(t *testing.T) {
 			if strings.Contains(reason, "sk-LEAKED-SECRET") || strings.Contains(reason, "/home/alice") {
 				t.Errorf("reason leaked raw error text: %q", reason)
 			}
+		})
+	}
+}
+
+// classifyMainLoopStop keeps the unknown class for the empty-round and
+// compression exits, but each reason must name its trigger: in --format json
+// runs the manifest reason is the only stop diagnostic that leaves the runner,
+// so the three non-budget stops must not collapse into one string.
+func TestClassifyMainLoopStop(t *testing.T) {
+	reasons := make(map[string]llmloop.MainLoopStop)
+	for _, tc := range []struct {
+		name       string
+		stop       llmloop.MainLoopStop
+		wantClass  session.FailureClass
+		wantReason string
+	}{
+		{"max_rounds", llmloop.StopMaxRounds, session.FailureBudget, "reached the maximum tool-request rounds without finishing"},
+		{"empty_rounds", llmloop.StopEmptyRounds, session.FailureUnknown, "stopped after repeated rounds without a usable tool result"},
+		{"compression", llmloop.StopCompression, session.FailureUnknown, "stopped because context compression exceeded its threshold"},
+		{"none", llmloop.StopNone, session.FailureUnknown, "main task stopped before completing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			class, reason := classifyMainLoopStop(tc.stop)
+			if class != tc.wantClass {
+				t.Errorf("class = %q, want %q", class, tc.wantClass)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+			if prev, dup := reasons[reason]; dup {
+				t.Errorf("reason %q is shared by %v and %v; stops must stay distinguishable", reason, prev, tc.stop)
+			}
+			reasons[reason] = tc.stop
 		})
 	}
 }

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -228,6 +228,53 @@ const (
 	StopCompression
 )
 
+// String names the stop for diagnostics — telemetry attributes, log lines and
+// test failure messages. Without it a MainLoopStop formats as a bare integer,
+// which tells the reader nothing about which exit fired.
+func (s MainLoopStop) String() string {
+	switch s {
+	case StopNone:
+		return "none"
+	case StopMaxRounds:
+		return "max_rounds"
+	case StopEmptyRounds:
+		return "empty_rounds"
+	case StopCompression:
+		return "compression"
+	default:
+		return fmt.Sprintf("MainLoopStop(%d)", int(s))
+	}
+}
+
+// Reason is the safe, human-facing sentence for a stop, and the single source of
+// truth for it: the diff-review manifest reason and the scan subtask warning
+// both render this string, so the same stop can never read differently in the
+// two commands' output. Each return is a static literal — never error text, a
+// path or a provider payload — because callers persist it into machine-readable
+// output.
+//
+// Under --format json the [ocr] progress lines that would say which exit fired
+// are discarded by stdout.Quiet(), so this is the only stop diagnostic that
+// survives an ephemeral CI runner. Every stop must therefore read distinctly,
+// including one added to the enum after this was written: the default names the
+// unrecognized value instead of silently reusing the StopNone catch-all, so a
+// new constant announces itself in the artifact rather than hiding behind a
+// message that says nothing.
+func (s MainLoopStop) Reason() string {
+	switch s {
+	case StopNone:
+		return "main task stopped before completing"
+	case StopMaxRounds:
+		return "reached the maximum tool-request rounds without finishing"
+	case StopEmptyRounds:
+		return "stopped after repeated rounds without a usable tool result"
+	case StopCompression:
+		return "stopped because context compression exceeded its threshold"
+	default:
+		return fmt.Sprintf("main task stopped for an unrecognized reason (stop=%d)", int(s))
+	}
+}
+
 // RunPerFile drives the main LLM conversation loop for a single file.
 // It sends messages with the configured tool definitions, executes any
 // tool calls returned by the model, and collects review comments until

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -793,3 +793,59 @@ func TestRunPerFile_GraceRoundNotTriggeredOnEmptyRoundsStop(t *testing.T) {
 		t.Fatalf("LLM calls = %d, want 3 (no grace round on empty-rounds stop)", client.calls)
 	}
 }
+
+// MainLoopStop must be self-describing in both registers: String() for logs and
+// telemetry, Reason() for the manifest reason and scan warning that are the only
+// stop diagnostics surviving a --format json run. Neither may collide across
+// stops, or a reader cannot tell which exit fired from the artifact alone.
+func TestMainLoopStopStringAndReason(t *testing.T) {
+	names := make(map[string]MainLoopStop)
+	reasons := make(map[string]MainLoopStop)
+	for _, tc := range []struct {
+		stop     MainLoopStop
+		wantName string
+	}{
+		{StopNone, "none"},
+		{StopMaxRounds, "max_rounds"},
+		{StopEmptyRounds, "empty_rounds"},
+		{StopCompression, "compression"},
+	} {
+		t.Run(tc.wantName, func(t *testing.T) {
+			name := tc.stop.String()
+			if name != tc.wantName {
+				t.Errorf("String() = %q, want %q", name, tc.wantName)
+			}
+			reason := tc.stop.Reason()
+			if reason == "" {
+				t.Fatal("Reason() is empty; every stop needs a diagnostic sentence")
+			}
+			if prev, dup := names[name]; dup {
+				t.Errorf("String() %q is shared by %v and %v", name, prev, tc.stop)
+			}
+			if prev, dup := reasons[reason]; dup {
+				t.Errorf("Reason() %q is shared by %v and %v; stops must stay distinguishable", reason, prev, tc.stop)
+			}
+			names[name] = tc.stop
+			reasons[reason] = tc.stop
+		})
+	}
+}
+
+// A value outside the enum must name itself in both registers rather than borrow
+// the StopNone catch-all. This also guards the enum's growth: adding a constant
+// after StopCompression makes this test fail, which is the prompt to give the new
+// stop its own String() and Reason() case instead of letting it fall through to
+// a message that says nothing.
+func TestMainLoopStopUnknownValue(t *testing.T) {
+	unknown := StopCompression + 1
+
+	if got, want := unknown.String(), "MainLoopStop(4)"; got != want {
+		t.Errorf("String() = %q, want %q; a new constant needs its own case in String() and Reason()", got, want)
+	}
+	if got, want := unknown.Reason(), "main task stopped for an unrecognized reason (stop=4)"; got != want {
+		t.Errorf("Reason() = %q, want %q; a new constant needs its own case in String() and Reason()", got, want)
+	}
+	if unknown.Reason() == StopNone.Reason() {
+		t.Error("an unrecognized stop reuses the StopNone catch-all; the collapsed message is back")
+	}
+}

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -738,12 +738,19 @@ func (a *Agent) executeSubtask(ctx context.Context, it model.ScanItem) (bool, st
 		return false, "", nil
 	}
 
-	completed, _, err := a.runner.RunPerFile(ctx, messages, it.Path)
+	completed, stop, err := a.runner.RunPerFile(ctx, messages, it.Path)
 	if err != nil {
 		return false, "", err
 	}
 	if !completed {
-		return false, "main_task did not complete before stopping", nil
+		// Scan sessions opt out of the run manifest, so this one string is the
+		// whole diagnostic: it feeds both RecordReviewItemFailed and the
+		// scan_subtask_error warning, and under --format json the [ocr] progress
+		// lines that would say which exit fired are discarded. Name the trigger
+		// via the shared Reason() instead of a second hardcoded sentence, so
+		// scan and review never describe the same stop differently. The prefix
+		// stays for the resume records and warnings that already match on it.
+		return false, "main_task did not complete before stopping: " + stop.Reason(), nil
 	}
 	return true, "", nil
 }

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alibaba/open-code-review/internal/config/rules"
 	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/alibaba/open-code-review/internal/tool"
@@ -768,6 +769,13 @@ func TestDispatchSubtasks_WithoutTaskDoneIsAllFailed(t *testing.T) {
 	if len(warnings) != 1 || warnings[0].Type != "scan_subtask_error" ||
 		!strings.Contains(warnings[0].Message, "main_task did not complete") {
 		t.Fatalf("warnings = %+v, want one incomplete scan subtask error", warnings)
+	}
+	// Scan opts out of the run manifest and --format json discards the progress
+	// lines, so this warning is the whole diagnostic: it must name the trigger
+	// (here the exhausted MaxToolRequestTimes budget), not just report that the
+	// task did not finish.
+	if want := llmloop.StopMaxRounds.Reason(); !strings.Contains(warnings[0].Message, want) {
+		t.Errorf("warning %q does not name the stop trigger %q", warnings[0].Message, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #842.

When a per-file review stops without completing, `classifyMainLoopStop` collapsed `StopEmptyRounds`, `StopCompression` and `StopNone` into one opaque reason, `"main task stopped before completing"`. The two named stops call for opposite responses (model/tool-loop trouble vs. context budget), and in `--format json` runs the `[ocr]` progress lines that would say which one fired are discarded by `stdout.Quiet()` — so on an ephemeral CI runner the manifest reason is the only stop diagnostic that survives, and it said the same thing for every exit. In practice that meant a recurring per-file failure could not be triaged from uploaded artifacts at all (how #842 was found).

**Change** — exactly the two-line shape proposed in the issue, keeping the `FailureUnknown` class untouched:

- `StopEmptyRounds` → `"stopped after repeated rounds without a usable tool result"`
- `StopCompression` → `"stopped because context compression exceeded its threshold"`
- `StopNone` (non-completed) keeps the existing catch-all string, and `StopMaxRounds` is unchanged.

**Test** — `TestClassifyMainLoopStop` (beside the existing `TestClassifyItemError` it mirrors) pins the full stop→(class, reason) mapping and additionally asserts no two stops share a reason string, so a future regression back into a collapsed message fails the table even if the strings are edited.

No behavior change beyond the reason text: classes, exit codes and manifest shape are untouched. Verified with `go vet` and the full `internal/agent` test suite.
