### PR TITLE
fix(LE): normalize line endings via `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,4 @@
 *.jpeg binary
 *.gif binary
 *.ico binary
-*.svg binary
 *.tiktoken binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.tiktoken binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
             gofmt -s -d .
             exit 1
           fi
-
+      
+      - name: Check line endings
+        run: |
+          git add --renormalize .
+          git diff --quiet || { echo 'Line endings must end with LF. Have you normalized line endings?'; exit 1; }
+        
       - name: Check go.mod is tidy
         run: |
           go mod tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
       
       - name: Check line endings
         run: |
-          git add --renormalize .
-          git diff --quiet || { echo 'Line endings must end with LF. Have you normalized line endings?'; exit 1; }
+          if git ls-files --eol | grep -v 'i/lf\|i/none\|i/-text'; then
+            echo 'Line endings must end with LF. Have you normalized line endings?'
+            exit 1
+          fi
         
       - name: Check go.mod is tidy
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ open-code-review (`ocr`) is an AI-powered code review CLI tool written in Go (mo
   ocr review --audience agent --background "briefly summarize the background requirements"
   ```
 - Commit messages must be written in English.
+- Verify line endings. Line endings must be LF, not CRLF. Run `git add --renormalize .` to correct line endings and commit them. New binary files must have their extensions added to .gitattributes. 
 
 ## License Headers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,16 @@ If everything passes, you're ready to contribute.
 
 > **Note:** The `upstream` remote is read-only for contributors — it is used to pull the latest changes from the main repository. You cannot push directly to upstream. All commits must be pushed to your fork (`origin`) and submitted via Pull Request.
 
+### Line Endings
+
+This project enforces LF line endings via `.gitattributes`. Configure Git to normalize line endings automatically:
+
+```bash
+git config core.autocrlf input
+```
+
+This ensures any CRLF is converted to LF on commit, preventing line-ending issues in CI.
+
 ## Development Workflow
 
 ### Branching


### PR DESCRIPTION
## Description
Lots of contributors run agents on Windows, and that brings CRLF(^M) into the repository. Because some agents' edit tools uses CRLF by default to keep in sync with windows. This PR avoids CRLF in unix-only files, e.g, *.sh
After a new file creation, check with `git add --renormalize .` to correct line endings.
Currently no files are incorrect, and this `.gitattributes` acts as a shield.
<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues
none yet

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
