### PR TITLE
fix: make FileFilter patterns case-insensitive

### DIFF
--- a/internal/config/rules/system_rules.go
+++ b/internal/config/rules/system_rules.go
@@ -219,6 +219,7 @@ func (f *FileFilter) HasInclude() bool {
 }
 
 // IsUserExcluded reports whether the given path matches any user exclude pattern.
+// The check is case-insensitive: both path and pattern are lowercased.
 func (f *FileFilter) IsUserExcluded(path string) bool {
 	lowerPath := strings.ToLower(path)
 	for _, pattern := range f.Exclude {
@@ -233,6 +234,7 @@ func (f *FileFilter) IsUserExcluded(path string) bool {
 }
 
 // IsUserIncluded reports whether the given path matches any user include pattern.
+// The check is case-insensitive: both path and pattern are lowercased.
 // Returns false when Include is empty (no user include restriction defined).
 func (f *FileFilter) IsUserIncluded(path string) bool {
 	if !f.HasInclude() {

--- a/internal/config/rules/system_rules.go
+++ b/internal/config/rules/system_rules.go
@@ -224,7 +224,7 @@ func (f *FileFilter) IsUserExcluded(path string) bool {
 	for _, pattern := range f.Exclude {
 		expanded := expandBraces(pattern)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, lowerPath); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return true
 			}
 		}
@@ -242,7 +242,7 @@ func (f *FileFilter) IsUserIncluded(path string) bool {
 	for _, pattern := range f.Include {
 		expanded := expandBraces(pattern)
 		for _, p := range expanded {
-			if matched, _ := doublestar.Match(p, lowerPath); matched {
+			if matched, _ := doublestar.Match(strings.ToLower(p), lowerPath); matched {
 				return true
 			}
 		}

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -678,7 +678,7 @@ func TestFileFilter_IsUserIncluded_EmptyInclude(t *testing.T) {
 func TestFileFilter_CaseInsensitive(t *testing.T) {
 	f := &FileFilter{
 		Include: []string{"src/**/*.java", "**/CHANGELOG.md"},
-		Exclude: []string{"**/generated/**", "README.md"},
+		Exclude: []string{"**/generated/**", "README.md", "**/*.{Go,Java}"},
 	}
 
 	if !f.IsUserIncluded("SRC/Main/Foo.Java") {
@@ -689,11 +689,14 @@ func TestFileFilter_CaseInsensitive(t *testing.T) {
 	}
 
 	// Verify patterns containing uppercase letters also match.
-	if !f.IsUserIncluded("docs/changelog.md") {
+	if !f.IsUserIncluded("docs/CHANGELOG.md") {
 		t.Errorf("expected uppercase include pattern to match case-insensitively")
 	}
-	if !f.IsUserExcluded("readme.md") {
+	if !f.IsUserExcluded("README.md") {
 		t.Errorf("expected uppercase exclude pattern to match case-insensitively")
+	}
+	if !f.IsUserExcluded("pkg/Main.JAVA") {
+		t.Errorf("expected brace-expanded uppercase pattern to match case-insensitively")
 	}
 }
 

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -677,8 +677,8 @@ func TestFileFilter_IsUserIncluded_EmptyInclude(t *testing.T) {
 
 func TestFileFilter_CaseInsensitive(t *testing.T) {
 	f := &FileFilter{
-		Include: []string{"src/**/*.java"},
-		Exclude: []string{"**/generated/**"},
+		Include: []string{"src/**/*.java", "**/CHANGELOG.md"},
+		Exclude: []string{"**/generated/**", "README.md"},
 	}
 
 	if !f.IsUserIncluded("SRC/Main/Foo.Java") {
@@ -686,6 +686,14 @@ func TestFileFilter_CaseInsensitive(t *testing.T) {
 	}
 	if !f.IsUserExcluded("SRC/Generated/Api.java") {
 		t.Errorf("expected case-insensitive exclude match")
+	}
+
+	// Verify patterns containing uppercase letters also match.
+	if !f.IsUserIncluded("docs/changelog.md") {
+		t.Errorf("expected uppercase include pattern to match case-insensitively")
+	}
+	if !f.IsUserExcluded("readme.md") {
+		t.Errorf("expected uppercase exclude pattern to match case-insensitively")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #844.

`FileFilter.IsUserIncluded` and `FileFilter.IsUserExcluded` lowercased
the file path before matching, but did not lowercase the user-provided
pattern.

This caused patterns containing uppercase letters such as
`README.md` and `**/CHANGELOG.md` to fail to match.

## Changes

- Lowercase expanded exclude patterns before `doublestar.Match`
- Lowercase expanded include patterns before `doublestar.Match`
- Extended `TestFileFilter_CaseInsensitive` with uppercase-pattern
  regression coverage

## Testing

```text
go test ./internal/config/rules/...