### PR TITLE
chore: remove leftover Chinese from the Go core, CI examples and pages comments

### DIFF
--- a/examples/gitlab_ci/.gitlab-ci.yml
+++ b/examples/gitlab_ci/.gitlab-ci.yml
@@ -18,7 +18,7 @@
 #
 # Optional CI/CD Variables (LLM provider configuration):
 #   OCR_LANGUAGE          - Review output language, written via `ocr config set language`
-#                          (e.g. English, 中文). Defaults to OCR's built-in default (English).
+#                          (e.g. English, Chinese). Defaults to OCR's built-in default (English).
 #   OCR_LLM_AUTH_HEADER   - Custom auth header name, written via `ocr config set llm.auth_header`
 #                          (e.g. "x-api-key" for some providers).
 #   OCR_LLM_EXTRA_HEADERS - Extra headers "K=V,K=V", written via `ocr config set llm.extra_headers`.

--- a/examples/gitlab_ci/README.md
+++ b/examples/gitlab_ci/README.md
@@ -41,7 +41,7 @@ Go to your project's **Settings → CI/CD → Variables** and add:
 | `OCR_LLM_MODEL` | Yes | No | Model name (e.g., `gpt-4o`) — OCR has no built-in default model and fails when this is unset |
 | `GITLAB_API_TOKEN` | No | Yes | GitLab access token with `api` scope (falls back to `CI_JOB_TOKEN` if not set) |
 | `OCR_VERSION` | No | No | npm version spec for `@alibaba-group/open-code-review` (default: `latest`). Pin it (e.g. `1.8.8` or `~1.8`) for reproducible reviews. |
-| `OCR_LANGUAGE` | No | No | Review output language, written via `ocr config set language` (e.g. `English`, `中文`). Defaults to OCR's built-in default. |
+| `OCR_LANGUAGE` | No | No | Review output language, written via `ocr config set language` (e.g. `English`, `Chinese`). Defaults to OCR's built-in default. |
 | `OCR_LLM_AUTH_HEADER` | No | No | Custom auth header name, written via `ocr config set llm.auth_header` (e.g. `x-api-key` for some providers). |
 | `OCR_LLM_EXTRA_HEADERS` | No | No | Extra headers `K=V,K=V`, written via `ocr config set llm.extra_headers`. |
 | `OCR_LLM_TIMEOUT` | No | No | LLM request timeout in seconds (read natively by OCR from the env). Unset/empty = OCR's default. |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1153,7 +1153,7 @@ func (a *Agent) executeSubtask(ctx context.Context, d model.Diff) (bool, *subtas
 		// Always substitute the {{plan_guidance}} token so the literal placeholder
 		// never leaks into the rendered prompt. When the plan phase produced no
 		// output, strip the surrounding "### Review Plan (Optional)\n…\n\n" wrapper
-		// (any language variant) so the LLM does not see a dangling section header.
+		// so the LLM does not see a dangling section header.
 		// Strip MUST run before ReplaceAll: the regex requires the literal
 		// {{plan_guidance}} token to be present; if we replace first, the token
 		// is gone and the wrapper can't be matched.

--- a/internal/agent/util.go
+++ b/internal/agent/util.go
@@ -17,13 +17,10 @@ import (
 
 // planBlockPattern matches the optional "Review Plan" section in a MAIN_TASK
 // template user message: a header line beginning with "### " whose text
-// contains "Review Plan" or "审查计划" (with optional ASCII "(Optional)" /
-// Chinese "（可选）" suffix), the {{plan_guidance}} placeholder on its own
-// line, and one trailing blank line. The ASCII and Chinese header forms
-// are matched separately because Go's regexp engine does not define \b
-// around CJK ideographs.
+// contains "Review Plan" (with an optional "(Optional)" suffix), the
+// {{plan_guidance}} placeholder on its own line, and one trailing blank line.
 var planBlockPattern = regexp.MustCompile(
-	`(?m)^### [^\n]*(?:Review Plan|审查计划)[^\n]*\n\{\{plan_guidance\}\}\n\n?`)
+	`(?m)^### [^\n]*Review Plan[^\n]*\n\{\{plan_guidance\}\}\n\n?`)
 
 // stripEmptyPlanBlock removes the "### Review Plan …\n{{plan_guidance}}\n\n"
 // wrapper from a MAIN_TASK user message when the plan phase produced no

--- a/internal/agent/util_test.go
+++ b/internal/agent/util_test.go
@@ -28,23 +28,13 @@ func TestStripEmptyPlanBlock(t *testing.T) {
 			want:  "header\ntail",
 		},
 		{
-			name:  "chinese template wrapper is removed",
-			input: "header\n### 审查计划\n{{plan_guidance}}\n\ntail",
-			want:  "header\ntail",
-		},
-		{
-			name:  "chinese optional wrapper is removed",
-			input: "header\n### 审查计划（可选）\n{{plan_guidance}}\n\ntail",
-			want:  "header\ntail",
-		},
-		{
 			name:  "no wrapper present is a no-op",
 			input: "no plan block here\njust text",
 			want:  "no plan block here\njust text",
 		},
 		{
 			name:  "multiple wrappers all removed",
-			input: "### Review Plan (Optional)\n{{plan_guidance}}\n\nmiddle\n### 审查计划\n{{plan_guidance}}\n\nend",
+			input: "### Review Plan (Optional)\n{{plan_guidance}}\n\nmiddle\n### Review Plan\n{{plan_guidance}}\n\nend",
 			want:  "middle\nend",
 		},
 	}

--- a/internal/config/allowlist/allowed_ext.go
+++ b/internal/config/allowlist/allowed_ext.go
@@ -5,26 +5,26 @@
 // an extension allowlist (which file types to review) and a path-based
 // exclude list (which files to skip regardless of extension).
 //
-// # default_exclude_patterns.json 配置说明
+// # The default_exclude_patterns.json format
 //
-// 文件包含一个 JSON 字符串数组，每个元素是一个 glob 排除模式。
-// 支持的通配符语法（基于 doublestar 库）:
+// The file holds a JSON array of strings, each one a glob exclude pattern.
+// Supported wildcard syntax (as implemented by the doublestar library):
 //
-//   - 匹配单层路径内的任意字符（不跨越 /）
-//     例: "*_test.go" 匹配 "foo_test.go"，不匹配 "pkg/foo_test.go"
+//	"*"        matches any character within a single path segment (never crosses /)
+//	           e.g. "*_test.go" matches "foo_test.go" but not "pkg/foo_test.go"
 //
-//     **       匹配零个或多个路径段（可跨越 /）
-//     例: "**/*_test.go" 匹配 "foo_test.go" 和 "a/b/c_test.go"
+//	"**"       matches zero or more path segments (may cross /)
+//	           e.g. "**/*_test.go" matches both "foo_test.go" and "a/b/c_test.go"
 //
-//     {a,b,c}  花括号展开，匹配其中任意一项
-//     例: "**/*.{js,ts}" 匹配所有层级的 .js 和 .ts 文件
+//	"{a,b,c}"  brace expansion, matches any one of the alternatives
+//	           e.g. "**/*.{js,ts}" matches .js and .ts files at any depth
 //
-// 组合示例:
+// Combined examples:
 //
-//	"**/*_test.go"                 — 任意层级的 Go 测试文件
-//	"**/src/test/java/**/*.java"   — Java 标准测试目录下所有文件
-//	"**/*.spec.{js,jsx,ts,tsx}"    — 任意层级的前端 spec 测试文件
-//	"*_test.go"                    — 仅匹配根目录下的 Go 测试文件（不跨目录）
+//	"**/*_test.go"                 — Go test files at any depth
+//	"**/src/test/java/**/*.java"   — everything under the standard Java test directory
+//	"**/*.spec.{js,jsx,ts,tsx}"    — frontend spec test files at any depth
+//	"*_test.go"                    — Go test files in the root directory only (does not cross directories)
 package allowedext
 
 import (

--- a/pages/src/components/HighlightsSection.tsx
+++ b/pages/src/components/HighlightsSection.tsx
@@ -16,9 +16,9 @@ function formatNpmDownloads(n: number): string {
   return `${n}`;
 }
 
-// 从字符串中解析数字和前后缀
+// Parse the number plus its surrounding prefix and suffix out of a string
 function parseStatValue(value: string): { prefix: string; number: number; suffix: string } {
-  // 匹配 "> 30%" 等格式
+  // Matches formats such as "> 30%"
   const match = value.match(/^([^\d]*?)(\d+)(.*)$/);
   if (match) {
     return { prefix: match[1], number: parseInt(match[2], 10), suffix: match[3] };
@@ -58,7 +58,7 @@ const CountUpValue: React.FC<{ value: string; isVisible: boolean }> = ({ value, 
   const count = useCountUp(number, 2000, isVisible);
 
   if (number === 0) {
-    // 无法解析数字，直接显示原文
+    // No number could be parsed, render the original text as-is
     return <>{value}</>;
   }
 


### PR DESCRIPTION
## What

Clears out the remaining Chinese text outside the VSCode extension, in three unrelated-but-adjacent spots.

### 1. Translate comments to English

- **`internal/config/allowlist/allowed_ext.go`** — the package doc describing the `default_exclude_patterns.json` format.
- **`pages/src/components/HighlightsSection.tsx`** — three comments in `parseStatValue` / `CountUpValue`, matching the English comments already in that file.

While translating, the wildcard list in the package doc turned out to be subtly broken: `gofmt` treats a leading `*` inside an indented doc block as a markdown bullet and reflows it to `- `, which had swallowed the first entry's wildcard and left the list misaligned in `godoc`. Quoting the wildcards (`"*"`, `"**"`, `"{a,b,c}"`) stops the reflow and restores the intended layout.

### 2. Use `Chinese` instead of `中文` in the GitLab CI example

`OCR_LANGUAGE` is fed to the LLM, which understands `Chinese` just as well, and `Chinese` is what the rest of the project already uses (`skills/open-code-review/SKILL.md`, `config_cmd_test.go`, `ApplyLanguage("Chinese")`). Applied to both `.gitlab-ci.yml` and the parallel row in that example's `README.md` so the two don't contradict each other.

### 3. Drop the unreachable Chinese branch from `planBlockPattern`

`internal/agent/util.go` matched `(?:Review Plan|审查计划)` when stripping the empty plan wrapper. `task_template.json` ships a single English template (`### Review Plan (Optional)`) and is embedded via `go:embed` with no override path, so the `审查计划` alternative could never match anything — it came from the pre-open-source template and survived the #33 fix as dead defensive code. The two test cases that only exercised that alternative are dropped; `multiple wrappers all removed` keeps its second header as `### Review Plan` (without the `(Optional)` suffix) so it still proves the replacement is global.

## Verification

- `gofmt -l` — clean
- `go vet ./internal/agent/ ./internal/config/allowlist/` — pass
- `go test ./internal/agent/ ./internal/config/allowlist/ ./internal/config/template/ ./internal/scan/` — ok
- `npx tsc --noEmit` in `pages/` — no errors
- `go doc ./internal/config/allowlist` — renders the wildcard list correctly

## Out of scope

- `extensions/vscode/` still has ~106 Chinese comment lines and ~91 Chinese test names; left for a separate change.
- `internal/agent/util.go` no longer contains Chinese, but `examples/gerrit_ci/post_review_test.py` keeps its Chinese test data on purpose — it exists to verify UTF-8 path and comment encoding.
- The `ocr config set language 中文` snippets in `pages/src/content/docs/*/configuration.md` are user-facing command examples kept in sync across four locales; untouched.