### PR TITLE
fix(tool): preserve special paths in file_find

### DIFF
--- a/internal/tool/file_find.go
+++ b/internal/tool/file_find.go
@@ -79,9 +79,9 @@ func (p *FileFindProvider) listGitFiles(parentCtx context.Context) ([]string, er
 
 	var args []string
 	if ref := p.FileReader.Ref; ref != "" {
-		args = []string{"ls-tree", "-r", "--name-only", "--end-of-options", ref}
+		args = []string{"ls-tree", "-r", "--name-only", "-z", "--end-of-options", ref}
 	} else {
-		args = []string{"ls-files", "--cached", "--others", "--exclude-standard"}
+		args = []string{"ls-files", "-z", "--cached", "--others", "--exclude-standard"}
 	}
 
 	if p.FileReader.Runner != nil {
@@ -107,10 +107,10 @@ func (p *FileFindProvider) listGitFiles(parentCtx context.Context) ([]string, er
 	}
 
 	var files []string
-	lines := bytes.Split(bytes.TrimRight(output, "\n"), []byte{'\n'})
-	for _, line := range lines {
-		if len(line) > 0 {
-			s := string(line)
+	paths := bytes.Split(output, []byte{0})
+	for _, path := range paths {
+		if len(path) > 0 {
+			s := string(path)
 			// Skip binary-like files that lack meaningful extensions patterns
 			// and filter out paths in common generated/artifact directories.
 			if shouldSkipFile(s) {

--- a/internal/tool/file_find_test.go
+++ b/internal/tool/file_find_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -156,6 +157,88 @@ func TestFileFind_GitRepo_CommitMode(t *testing.T) {
 	}
 	if !strings.Contains(got, "main.go") {
 		t.Errorf("expected main.go in commit mode, got: %s", got)
+	}
+}
+
+func TestFileFind_GitRepo_PreservesSpecialPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test paths contain characters unsupported by Windows")
+	}
+
+	dir := setupFileFindRepo(t)
+	specialPaths := []string{
+		"unicode-测试.go",
+		"tab\tquote\"file.go",
+		"line\nbreak.go",
+	}
+	for _, path := range specialPaths {
+		if err := os.WriteFile(filepath.Join(dir, path), []byte("package special\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("add", ".")
+	git("commit", "-m", "add special paths")
+	commit := git("rev-parse", "HEAD")
+
+	tests := []struct {
+		name string
+		mode ReviewMode
+		ref  string
+	}{
+		{name: "workspace", mode: ModeWorkspace},
+		{name: "commit", mode: ModeCommit, ref: commit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewFileFind(&FileReader{RepoDir: dir, Mode: tt.mode, Ref: tt.ref})
+
+			files, err := p.listGitFiles(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Newline paths are asserted only at the enumeration layer because
+			// Execute intentionally joins multiple results with newlines.
+			for _, want := range append([]string{"main.go"}, specialPaths...) {
+				found := false
+				for _, got := range files {
+					if got == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("listGitFiles() missing original path %q; got %q", want, files)
+				}
+			}
+
+			for _, query := range []struct {
+				name string
+				want string
+			}{
+				{name: "main.go", want: "main.go"},
+				{name: "unicode-", want: "unicode-测试.go"},
+				{name: "quote", want: "tab\tquote\"file.go"},
+			} {
+				got, err := p.Execute(context.Background(), map[string]any{"query_name": query.name})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got != query.want {
+					t.Errorf("Execute(query_name=%q) = %q, want %q", query.name, got, query.want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

`file_find` parsed `git ls-files` and `git ls-tree` as newline-delimited
text. Git C-quotes paths containing non-ASCII or special characters in that
mode, so the tool returned strings such as:

```text
"unicode-\346\265\213\350\257\225.go"
```

Those strings are display representations rather than real repository paths,
so a follow-up `file_read` cannot open the selected file.

This change requests NUL-delimited output from both Git commands and parses the
raw paths by NUL. Workspace and commit-mode discovery now preserve Unicode,
tabs, quotes, and other Git-valid path bytes without changing the existing
newline-delimited `file_find` response contract.

Paths containing literal newlines are covered at the enumeration layer only;
representing those unambiguously in the final text response is outside this
PR's scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check`
- [x] `make test`
- [x] `make build`
- [x] `make coverage` - 90.2%, meeting the 90% threshold
- [x] Real temporary Git repositories in workspace and commit modes

Before the fix, the new regression test failed because `listGitFiles` returned
Git's C-quoted display strings instead of the original paths. After the fix,
the same test passes for Unicode, tab, quote, and newline path cases in both
enumeration modes. The full `internal/tool` package also passes with the race
detector.

Self-review used OCR Delegation Mode with the host agent:
`2/2` changed files reviewed, `0` skipped, `0` findings.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal path enumeration fix
- [x] I have signed the CLA

## Related Issues

No existing issue found. All open issues, pull request text, and open pull
request changed files were checked before implementation; no competing
`file_find` path-enumeration change was found.
