### PR TITLE
fix(tool): preserve colon paths in code_search

### DIFF
--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -75,7 +75,7 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 		cmdArgs = append(cmdArgs, "-F")
 	}
 
-	cmdArgs = append(cmdArgs, "-n", "--no-color")
+	cmdArgs = append(cmdArgs, "-z", "-n", "--no-color")
 	cmdArgs = append(cmdArgs, "--max-count", fmt.Sprintf("%d", gitGrepMaxCount))
 
 	cmdArgs = append(cmdArgs, "-e", searchText)
@@ -176,35 +176,36 @@ func (p *CodeSearchProvider) gitGrep(ctx context.Context, searchText string, cas
 	var fileOrder []string
 	seen := make(map[string]bool)
 
-	hasRef := p.FileReader.Ref != ""
-	splitN := 3
-	offset := 0
-	if hasRef {
-		splitN = 4
-		offset = 1
-	}
-
 	var sb strings.Builder
 	if truncated {
 		sb.WriteString(fmt.Sprintf("Note: The results have been truncated. Only showing first %d results.\n", gitGrepMaxCount))
 	}
 
-	for _, line := range lines {
-		if line == "" {
-			continue
+	remaining := outStr
+	for remaining != "" {
+		fname, rest, ok := strings.Cut(remaining, "\x00")
+		if !ok {
+			break
 		}
-		parts := strings.SplitN(line, ":", splitN)
-		if len(parts) < splitN {
-			continue
+		lineNum, rest, ok := strings.Cut(rest, "\x00")
+		if !ok {
+			break
 		}
-		fname := parts[offset]
+		var content string
+		content, remaining, _ = strings.Cut(rest, "\n")
+		if ref := p.FileReader.Ref; ref != "" {
+			fname, ok = strings.CutPrefix(fname, ref+":")
+			if !ok {
+				continue
+			}
+		}
 		m := match{}
-		ln, parseErr := strconv.Atoi(parts[offset+1])
+		ln, parseErr := strconv.Atoi(lineNum)
 		if parseErr != nil {
 			continue
 		}
 		m.lineNum = ln
-		m.content = parts[offset+2]
+		m.content = content
 		if !seen[fname] {
 			seen[fname] = true
 			fileOrder = append(fileOrder, fname)

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -22,6 +23,7 @@ func TestBuildGrepArgs_WorkspaceMode(t *testing.T) {
 
 	assertContainsInOrder(t, args, "-e", "myFunc", "--")
 	assertContains(t, args, "-i")
+	assertContains(t, args, "-z")
 	assertContains(t, args, "--untracked")
 	if idx := slices.Index(args, "--"); idx >= 0 {
 		for i := 0; i < idx; i++ {
@@ -149,6 +151,52 @@ func TestGitGrep_WorkspaceMode_Found(t *testing.T) {
 	}
 	if !strings.Contains(result, "hello.go") {
 		t.Errorf("expected hello.go in result, got: %s", result)
+	}
+}
+
+func TestGitGrep_PathContainingColon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain colons")
+	}
+
+	dir := setupTestRepo(t)
+	for _, name := range []string{"foo:bar.go", "plain.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("package main\n// needle\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	cmd = exec.Command("git", "commit", "-m", "add search fixtures")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	want := "File: foo:bar.go\nMatch lines: 1\n2|// needle\n\n" +
+		"File: plain.go\nMatch lines: 1\n2|// needle\n\n"
+	tests := []struct {
+		name string
+		ref  string
+		mode ReviewMode
+	}{
+		{name: "workspace", mode: ModeWorkspace},
+		{name: "commit", ref: getHeadCommit(t, dir), mode: ModeCommit},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := NewCodeSearch(&FileReader{RepoDir: dir, Ref: test.ref, Mode: test.mode})
+			got, err := p.gitGrep(context.Background(), "needle", false, false, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Errorf("gitGrep() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

`code_search` parsed `git grep` output by splitting each line on `:`. A valid
path such as `foo:bar.go` therefore produced:

```text
foo:bar.go:2:// needle
```

The parser treated `bar.go` as the line number, failed integer conversion, and
silently dropped the match.

This change requests Git's NUL-delimited output and parses records as:

```text
path\0line\0content\n
```

Commit-mode results keep their existing `ref:path` prefix handling, while the
public output format remains unchanged. A real-repository regression test
covers both a colon-containing path and an ordinary path in workspace and
commit modes.

The existing per-file result cap and truncation-reporting semantics are
intentionally unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check`
- [x] `make test`
- [x] `make build`
- [x] `make coverage` - 90.2%, meeting the 90% threshold
- [x] Real temporary Git repositories in workspace and commit modes

Before the fix, the regression test returned only `plain.go`; the
`foo:bar.go` match disappeared. After the fix, both files retain the expected
line number and content in both review modes. The focused test and the full
`internal/tool` package pass with the race detector.

Self-review used OCR Delegation Mode with the host agent:
`2/2` changed files reviewed, `0` skipped, `0` blocking findings.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal output parser fix
- [x] I have signed the CLA

## Related Issues

No existing issue found. All open issues, pull request text, and open pull
request changed files were checked before implementation; no competing
`code_search` path-parser change was found.
