### PR TITLE
fix(scan): preserve whitespace in Git paths

### DIFF
--- a/internal/scan/provider.go
+++ b/internal/scan/provider.go
@@ -263,7 +263,6 @@ func (p *Provider) gitLs(ctx context.Context, args ...string) ([]string, error) 
 	raw := strings.Split(strings.TrimRight(out, "\x00"), "\x00")
 	files := make([]string, 0, len(raw))
 	for _, f := range raw {
-		f = strings.TrimSpace(f)
 		if f != "" {
 			files = append(files, f)
 		}

--- a/internal/scan/provider_test.go
+++ b/internal/scan/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -172,6 +173,32 @@ func TestProvider_Enumerate_FullRepo(t *testing.T) {
 				t.Errorf("binary item must not store content, got %d bytes", len(it.Content))
 			}
 		}
+	}
+}
+
+func TestProvider_Enumerate_PreservesWhitespacePaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot end with spaces")
+	}
+
+	repo := initTestRepo(t)
+	writeFile(t, repo, " leading.go", []byte("package leading\n"))
+	writeFile(t, repo, "trailing.go ", []byte("package trailing\n"))
+	gitCommit(t, repo, "add whitespace paths")
+
+	got, err := NewProvider(repo, nil, nil, 0).Enumerate(context.Background())
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+
+	paths := make([]string, 0, len(got))
+	for _, item := range got {
+		paths = append(paths, item.Path)
+	}
+	sort.Strings(paths)
+	want := []string{" leading.go", "trailing.go "}
+	if !reflect.DeepEqual(paths, want) {
+		t.Errorf("paths = %q, want %q", paths, want)
 	}
 }
 


### PR DESCRIPTION
## Description

`ocr scan` already asks `git ls-files` for NUL-delimited paths, but then
applies `strings.TrimSpace` to every returned filename. Valid tracked files
whose names begin or end with whitespace are therefore changed before the
scanner opens them.

For example, Git returns these exact paths:

```text
< leading.go>
<trailing.go >
```

The scanner previously attempted to stat `leading.go` and `trailing.go`
instead. Both lookups failed and the files silently disappeared from the scan.

This change keeps each NUL-delimited Git path exact while continuing to ignore
genuinely empty records. User-supplied `ocr scan` path filters retain their
existing whitespace normalization.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make check`
- [x] `make test`
- [x] `make build`
- [x] `make coverage` - 90.2%, meeting the 90% threshold
- [x] Real temporary Git repository with leading- and trailing-space paths

Before the fix, the regression test logged two `cannot stat` warnings and
returned no scan items. After the fix, both files are enumerated under their
exact names. The focused test and full suite pass with the race detector.

The trailing-space fixture is skipped on Windows because the filesystem cannot
represent that filename; Windows cross-compilation remains covered by CI.

Self-review used OCR Delegation Mode with the host agent:
`2/2` changed files reviewed, `0` skipped, `0` findings.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required for this internal enumeration fix
- [x] I have signed the CLA

## Related Issues

No existing issue found. All open issues, pull request text, and open pull
request changed files were checked before implementation; no competing scan
path-enumeration change was found.
