### PR TITLE
feat(actions): render review metadata as Shields badges

### DIFF
--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -61,6 +61,22 @@ const SEVERITY_RANK = new Map(
   SEVERITIES.map((s, i) => [s, SEVERITIES.length - i])
 ); // critical=4, high=3, medium=2, low=1
 
+// GitHub review comments support Markdown images but do not expose a native
+// severity-pill field to third-party Actions. Render the two structured
+// metadata dimensions as one compact Shields badge instead: category stays on
+// the neutral left segment and severity controls the right-segment color.
+// Values are fixed enums, not arbitrary model output, so no untrusted text is
+// interpolated into the image URL.
+const GITHUB_BADGE_LABEL_COLOR = "24292f";
+// Keep Shields' white text legible while following #882's requested semantic
+// progression: low=green, medium=orange, high=red, critical=dark red.
+const GITHUB_BADGE_SEVERITY_COLORS = Object.freeze({
+  critical: "82071e",
+  high: "b60205",
+  medium: "a45a00",
+  low: "1a7f37",
+});
+
 // Sentinel policy object: "do not route anything". Returned by buildPolicy on
 // any parse problem so the partition loop falls open to today's behavior (I1).
 // Equivalently produced by an empty policy (no threshold, no categories).
@@ -1380,6 +1396,29 @@ function buildBadge(comment) {
   return "";
 }
 
+// Build the GitHub-only graphical rendering of the category/severity badge.
+// Keep buildBadge as the canonical text representation (and CLI byte-match),
+// then enhance it only when both values normalize to known schema enums. The
+// alt text carries the same metadata for image-disabled and assistive clients;
+// missing or unknown values fall back to the canonical plain-text badge.
+function buildGitHubBadge(comment) {
+  const fallback = buildBadge(comment);
+  const category = sanitizeMetadata(comment && comment.category).trim().toLowerCase();
+  const severity = sanitizeMetadata(comment && comment.severity).trim().toLowerCase();
+  if (!CATEGORIES.includes(category) || !SEVERITY_RANK.has(severity)) {
+    return fallback;
+  }
+
+  const color = GITHUB_BADGE_SEVERITY_COLORS[severity];
+  if (!color) return fallback;
+  const label = category.toUpperCase();
+  const message = severity.toUpperCase();
+  const url =
+    `https://img.shields.io/badge/${label}-${message}-${color}` +
+    `?style=flat&labelColor=${GITHUB_BADGE_LABEL_COLOR}`;
+  return `![${category} · ${severity}](${url})`;
+}
+
 // Parse the publication policy from the raw opt-in inputs. Returns a normalized
 // policy object, or the NO_ROUTING sentinel when no routing is requested or any
 // value is malformed (fail-open for the policy itself, upholding I1).
@@ -1467,7 +1506,7 @@ function routeComment(comment, policy) {
 // as the first visible line. The code suggestion block is appended if present.
 function formatComment(comment, id) {
   let body = id ? `<!-- ${id} -->\n` : "";
-  const badge = buildBadge(comment);
+  const badge = buildGitHubBadge(comment);
   if (badge) body += `${badge}\n`;
   body += comment.content || "";
   if (comment.suggestion_code && comment.existing_code) {
@@ -1483,7 +1522,7 @@ function formatCommentMarkdown(comment, error) {
   // with formatComment), so the heading/reason lines still anchor the comment
   // and existing substring assertions on them are unaffected. The badge is ""
   // for any finding without category/severity metadata.
-  const badge = buildBadge(comment);
+  const badge = buildGitHubBadge(comment);
   if (badge) md += `${badge}\n`;
   md += `### 📄 \`${comment.path}\``;
   if (comment.start_line && comment.end_line) {
@@ -2087,6 +2126,7 @@ module.exports = {
   newCommentId,
   sanitizeMetadata,
   buildBadge,
+  buildGitHubBadge,
   buildPolicy,
   routeComment,
   formatComment,

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -16,7 +16,7 @@
 
 const assert = require("assert");
 const path = require("path");
-const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks } = require(path.join(__dirname, "post-review-comments.js"));
+const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, buildGitHubBadge, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks } = require(path.join(__dirname, "post-review-comments.js"));
 
 // REVIEW_TAG as the production code builds it for this test's hardcoded run
 // identity (context.runId=undefined -> 0, runAttempt=undefined -> 1). Used as
@@ -1714,6 +1714,52 @@ function testBuildBadgeMatchesCliDegeneration() {
   assert.strictEqual(buildBadge({ category: "\n\r\t", severity: "\n" }), "");
 }
 
+// #882: the GitHub surface upgrades complete, known metadata to one flat
+// two-segment Shields badge. Category remains neutral; severity supplies the
+// accessible, fixed color mapping. buildBadge itself stays unchanged above.
+function testBuildGitHubBadgeUsesFlatShieldsRendering() {
+  const colors = {
+    critical: "82071e",
+    high: "b60205",
+    medium: "a45a00",
+    low: "1a7f37",
+  };
+  // Cover every category/severity combination. This pins the complete schema
+  // allowlist and proves that only predetermined labels/messages/colors enter
+  // a Shields URL, never arbitrary model-provided metadata.
+  for (const category of CATEGORIES) {
+    for (const severity of SEVERITIES) {
+      assert.ok(colors[severity], `missing graphical badge color for ${severity}`);
+      assert.strictEqual(
+        buildGitHubBadge({ category, severity }),
+        `![${category} · ${severity}](` +
+          `https://img.shields.io/badge/${category.toUpperCase()}-${severity.toUpperCase()}-${colors[severity]}` +
+          "?style=flat&labelColor=24292f)"
+      );
+    }
+  }
+  // Schema values are case-insensitive at the GitHub presentation boundary.
+  assert.strictEqual(
+    buildGitHubBadge({ category: "Bug", severity: "HIGH" }),
+    "![bug · high](https://img.shields.io/badge/BUG-HIGH-b60205?style=flat&labelColor=24292f)"
+  );
+  // The existing sanitizer removes layout-breaking controls before enum
+  // validation, so otherwise valid metadata is still rendered safely.
+  assert.strictEqual(
+    buildGitHubBadge({ category: "bu\ng", severity: "hi\tgh" }),
+    "![bug · high](https://img.shields.io/badge/BUG-HIGH-b60205?style=flat&labelColor=24292f)"
+  );
+}
+
+function testBuildGitHubBadgeFallsBackToCanonicalText() {
+  assert.strictEqual(buildGitHubBadge({ category: "bug" }), "[bug]");
+  assert.strictEqual(buildGitHubBadge({ severity: "high" }), "[high]");
+  assert.strictEqual(buildGitHubBadge({ category: "custom", severity: "high" }), "[custom · high]");
+  assert.strictEqual(buildGitHubBadge({ category: "bug", severity: "urgent" }), "[bug · urgent]");
+  assert.strictEqual(buildGitHubBadge({}), "");
+  assert.strictEqual(buildGitHubBadge(null), "");
+}
+
 function testSanitizeMetadataStripsControlChars() {
   assert.strictEqual(sanitizeMetadata("clean"), "clean");
   assert.strictEqual(sanitizeMetadata("a\nb"), "ab");
@@ -1855,11 +1901,21 @@ function testFormatCommentBadgePlacement() {
   // with id and badge: id HTML comment stays first, badge on the next line
   const withBadge = formatComment({ content: "body", category: "bug", severity: "high" }, "ocr-1-1-abcd");
   assert.ok(withBadge.startsWith("<!-- ocr-1-1-abcd -->\n"), "id HTML comment is the first bytes");
-  assert.ok(withBadge.startsWith("<!-- ocr-1-1-abcd -->\n[bug · high]\n"), "badge follows id line");
+  assert.ok(
+    withBadge.startsWith(
+      "<!-- ocr-1-1-abcd -->\n" +
+        "![bug · high](https://img.shields.io/badge/BUG-HIGH-b60205?style=flat&labelColor=24292f)\n"
+    ),
+    "graphical badge follows id line"
+  );
   assert.ok(withBadge.endsWith("body"), "content preserved at the end");
   // without id: badge is the first line
   const noId = formatComment({ content: "body", category: "style", severity: "low" });
-  assert.ok(noId.startsWith("[style · low]\n"));
+  assert.ok(
+    noId.startsWith(
+      "![style · low](https://img.shields.io/badge/STYLE-LOW-1a7f37?style=flat&labelColor=24292f)\n"
+    )
+  );
   // no metadata -> no badge line at all (byte-identical to pre-change output)
   const noBadge = formatComment({ content: "body" }, "ocr-1-1-abcd");
   assert.strictEqual(noBadge, "<!-- ocr-1-1-abcd -->\nbody");
@@ -1868,7 +1924,7 @@ function testFormatCommentBadgePlacement() {
     { content: "c", category: "bug", severity: "high", existing_code: "old", suggestion_code: "new" },
     "ocr-1-1-abcd"
   );
-  assert.match(withSuggestion, /\[bug · high\]/);
+  assert.match(withSuggestion, /!\[bug · high\]\(https:\/\/img\.shields\.io\/badge\/BUG-HIGH-b60205/);
   assert.match(withSuggestion, /\*\*Suggestion:\*\*/);
   assert.match(withSuggestion, /```suggestion/);
 }
@@ -1878,7 +1934,12 @@ function testFormatCommentBadgePlacement() {
 function testFormatCommentMarkdownBadgePlacement() {
   const md = formatCommentMarkdown({ path: "a.js", content: "body", category: "bug", severity: "high" });
   // badge is the first line, before the heading
-  assert.ok(md.startsWith("[bug · high]\n"), "badge is the leading line");
+  assert.ok(
+    md.startsWith(
+      "![bug · high](https://img.shields.io/badge/BUG-HIGH-b60205?style=flat&labelColor=24292f)\n"
+    ),
+    "graphical badge is the leading line"
+  );
   assert.match(md, /### 📄 `a.js`/);
   assert.match(md, /body/);
   // no metadata -> no badge line, heading is first (byte-identical to pre-change)
@@ -2170,6 +2231,8 @@ async function main() {
   await testBatchTelemetryOutputs();
   // Badge + publication policy (#478)
   testBuildBadgeMatchesCliDegeneration();
+  testBuildGitHubBadgeUsesFlatShieldsRendering();
+  testBuildGitHubBadgeFallsBackToCanonicalText();
   testSanitizeMetadataStripsControlChars();
   testBuildPolicyFailsOpenOnMalformed();
   testRouteCommentUnknownMetadataNeverRouted();


### PR DESCRIPTION
## Summary

- render structured review `category` and `severity` metadata as one standard `flat` Shields badge in GitHub Actions comments
- keep the existing plain-text `buildBadge()` output unchanged for CLI compatibility and safe fallback behavior
- preserve the hidden `ocr-id` marker and use the same graphical rendering for inline comments and summary fallbacks

## Design

The GitHub-only renderer uses the static Shields endpoint format suggested in #882:

```text
https://img.shields.io/badge/<CATEGORY>-<SEVERITY>-<COLOR>?style=flat&labelColor=24292f
```

Only known schema enums are allowed into the URL. Missing or unknown metadata falls back to the existing text badge instead of generating an image URL. The severity colors follow the requested progression: low is green, medium is orange, high is red, and critical is dark red. The Markdown alt text retains both metadata values for image-disabled and assistive clients.

This reads the structured fields directly and does not parse or split the comment body.

## Validation

- `npm run test:github-actions`
- `make test`
- `make check`
- all 8 category x 4 severity combinations covered by unit tests
- all four severity badge URLs verified to return `200 image/svg+xml`
- rendered through GitHub's Markdown API and confirmed to use the Camo image proxy

Fixes #882
