### PR TITLE
feat(action): render category/severity badge as a shields.io image

### DIFF
--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -1380,6 +1380,73 @@ function buildBadge(comment) {
   return "";
 }
 
+// Shields.io color per severity, following the reviewer-suggested scale in
+// #882 (low -> green, medium -> orange, high -> red). "critical" is not in
+// that three-level scale; it extends it one step hotter (darkred, a standard
+// CSS color name shields.io accepts). Keys match SEVERITIES.
+const SEVERITY_BADGE_COLOR = Object.freeze({
+  critical: "darkred",
+  high: "red",
+  medium: "orange",
+  low: "green",
+});
+// Fallback color when severity is missing or not a known enum member. The
+// reviewer's guidance was to render these rather than fall back to plain text,
+// with any color acceptable; blue reads as informational.
+const CATEGORY_BADGE_COLOR = "blue";
+
+// Escape a value for a shields.io static-badge path segment ("-" separates
+// segments, "_" renders as a space). Our enum values contain neither, but the
+// escape keeps the helper correct if the enums ever grow such a value.
+function shieldsEscape(value) {
+  return encodeURIComponent(value.replace(/-/g, "--").replace(/_/g, "__"));
+}
+
+// Escape Markdown image alt text. The alt is derived from the plain-text badge
+// whose metadata has had control chars stripped but may still carry
+// Markdown-special characters (e.g. a stray "]" from high-temperature model
+// output), which would prematurely close the image's [...] alt span. Escaping
+// "\", "[", and "]" keeps the image intact and the alt rendering to the literal
+// text. "[" is escaped defensively; "]" and "\" are the structural ones.
+function escapeMarkdownAlt(value) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
+// Build the category/severity badge as a single shields.io static badge
+// (#882) for surfaces that render Markdown (GitHub review/summary comments),
+// in the format img.shields.io/badge/<label>-<color>. flat is shields.io's
+// default style, so the URL carries no style parameter. The image's alt text
+// is the plain-text badge content from buildBadge (with Markdown-special
+// characters escaped), so screen readers and image-load failures degrade to
+// the previous text form.
+//
+//   both fields -> ![category · severity](…/badge/category-severity-<color>)
+//   one field   -> ![field](…/badge/field-<color>)
+//   neither     -> "" (no badge line)
+//
+// The color comes from the severity when known, otherwise the fixed category
+// color — no lookup can ever yield "undefined". Values are sanitized (control
+// chars stripped) and URL-escaped before interpolation, so rendering an
+// unrecognized value is safe: it is only ever the same text already shown in
+// the plain-text badge. This is a deliberate divergence from strict CLI
+// byte-parity (I6): the CLI keeps the plain-text badge (a terminal cannot
+// render images); the alt text preserves the shared form across surfaces.
+function buildBadgeImage(comment) {
+  const text = buildBadge(comment);
+  if (text === "") return "";
+  const category = sanitizeMetadata(comment && comment.category).trim().toLowerCase();
+  const severity = sanitizeMetadata(comment && comment.severity).trim().toLowerCase();
+  const color = SEVERITY_BADGE_COLOR[severity] || CATEGORY_BADGE_COLOR;
+  const alt = escapeMarkdownAlt(text.slice(1, -1)); // "[bug · high]" -> "bug · high"
+  const label = category && severity
+    ? `${shieldsEscape(category)}-${shieldsEscape(severity)}`
+    : shieldsEscape(category || severity);
+  return `![${alt}](https://img.shields.io/badge/${label}-${color})`;
+}
+
 // Parse the publication policy from the raw opt-in inputs. Returns a normalized
 // policy object, or the NO_ROUTING sentinel when no routing is requested or any
 // value is malformed (fail-open for the policy itself, upholding I1).
@@ -1467,7 +1534,7 @@ function routeComment(comment, policy) {
 // as the first visible line. The code suggestion block is appended if present.
 function formatComment(comment, id) {
   let body = id ? `<!-- ${id} -->\n` : "";
-  const badge = buildBadge(comment);
+  const badge = buildBadgeImage(comment);
   if (badge) body += `${badge}\n`;
   body += comment.content || "";
   if (comment.suggestion_code && comment.existing_code) {
@@ -1483,7 +1550,7 @@ function formatCommentMarkdown(comment, error) {
   // with formatComment), so the heading/reason lines still anchor the comment
   // and existing substring assertions on them are unaffected. The badge is ""
   // for any finding without category/severity metadata.
-  const badge = buildBadge(comment);
+  const badge = buildBadgeImage(comment);
   if (badge) md += `${badge}\n`;
   md += `### 📄 \`${comment.path}\``;
   if (comment.start_line && comment.end_line) {
@@ -2105,6 +2172,8 @@ module.exports = {
   setStatsOutputs,
   DEFAULT_BATCH_SIZE,
   buildRunTags,
+  buildBadgeImage,
+  SEVERITY_BADGE_COLOR,
   NO_ROUTING,
   CATEGORIES,
   SEVERITIES,

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -16,7 +16,7 @@
 
 const assert = require("assert");
 const path = require("path");
-const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks } = require(path.join(__dirname, "post-review-comments.js"));
+const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, buildBadgeImage, SEVERITY_BADGE_COLOR, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks } = require(path.join(__dirname, "post-review-comments.js"));
 
 // REVIEW_TAG as the production code builds it for this test's hardcoded run
 // identity (context.runId=undefined -> 0, runAttempt=undefined -> 1). Used as
@@ -1714,6 +1714,104 @@ function testBuildBadgeMatchesCliDegeneration() {
   assert.strictEqual(buildBadge({ category: "\n\r\t", severity: "\n" }), "");
 }
 
+// #882: buildBadgeImage renders category+severity metadata as a single
+// shields.io static badge in the reviewer-suggested format
+// img.shields.io/badge/<category>-<severity>-<color> (color keyed off
+// severity: low green, medium orange, high red, critical darkred), whose alt
+// text is the exact plain-text badge content. Any non-empty metadata renders a
+// badge — a single field gets a single segment, and an unknown severity falls
+// back to the fixed category color rather than yielding "undefined".
+function testBuildBadgeImage() {
+  // both known -> single combined badge, severity picks the color
+  assert.strictEqual(
+    buildBadgeImage({ category: "bug", severity: "high" }),
+    "![bug · high](https://img.shields.io/badge/bug-high-red)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "security", severity: "critical" }),
+    "![security · critical](https://img.shields.io/badge/security-critical-darkred)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "performance", severity: "medium" }),
+    "![performance · medium](https://img.shields.io/badge/performance-medium-orange)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "style", severity: "low" }),
+    "![style · low](https://img.shields.io/badge/style-low-green)"
+  );
+  // only one field present -> single-segment badge in a fixed color
+  assert.strictEqual(
+    buildBadgeImage({ category: "documentation" }),
+    "![documentation](https://img.shields.io/badge/documentation-blue)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ severity: "critical" }),
+    "![critical](https://img.shields.io/badge/critical-darkred)"
+  );
+  // neither -> "" (no badge line), matching buildBadge
+  assert.strictEqual(buildBadgeImage({}), "");
+  assert.strictEqual(buildBadgeImage(null), "");
+  assert.strictEqual(buildBadgeImage(undefined), "");
+  // unknown values -> badge still renders; a known severity picks its color,
+  // an unknown severity falls back to the fixed category color
+  assert.strictEqual(
+    buildBadgeImage({ category: "weird", severity: "high" }),
+    "![weird · high](https://img.shields.io/badge/weird-high-red)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "bug", severity: "extreme" }),
+    "![bug · extreme](https://img.shields.io/badge/bug-extreme-blue)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "weird" }),
+    "![weird](https://img.shields.io/badge/weird-blue)"
+  );
+  // case-insensitive enum match (metadata is normalized before comparison,
+  // but the alt text preserves the sanitized original like buildBadge does)
+  assert.strictEqual(
+    buildBadgeImage({ category: "Bug", severity: "HIGH" }),
+    "![Bug · HIGH](https://img.shields.io/badge/bug-high-red)"
+  );
+  // control chars are stripped before enum matching (sanitizeMetadata), so a
+  // value that sanitizes to a known enum still renders as an image
+  assert.strictEqual(
+    buildBadgeImage({ category: "bu\ng", severity: "high" }),
+    "![bug · high](https://img.shields.io/badge/bug-high-red)"
+  );
+  // Markdown-special characters in metadata are escaped in the alt text so a
+  // stray "]" can't prematurely close the image's [...] span and a "\" can't
+  // escape it (malformed model output at high temperature).
+  assert.strictEqual(
+    buildBadgeImage({ category: "x]y", severity: "high" }),
+    "![x\\]y · high](https://img.shields.io/badge/x%5Dy-high-red)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "a[b", severity: "high" }),
+    "![a\\[b · high](https://img.shields.io/badge/a%5Bb-high-red)"
+  );
+  assert.strictEqual(
+    buildBadgeImage({ category: "bug", severity: "hi\\gh" }),
+    "![bug · hi\\\\gh](https://img.shields.io/badge/bug-hi%5Cgh-blue)"
+  );
+}
+
+// Drift guard for the SEVERITIES <-> SEVERITY_BADGE_COLOR invariant: every
+// severity enum member must have an explicit color so it does not silently
+// fall back to the fixed category color.
+function testSeverityBadgeColorCoversSeverities() {
+  for (const s of SEVERITIES) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(SEVERITY_BADGE_COLOR, s),
+      `SEVERITY_BADGE_COLOR is missing an entry for severity "${s}"`
+    );
+  }
+  // A non-enum severity (high-temperature model output, per reviewer) still
+  // renders via the fixed fallback color, never a "-undefined" URL.
+  const out = buildBadgeImage({ category: "bug", severity: "blocker" });
+  assert.strictEqual(out, "![bug · blocker](https://img.shields.io/badge/bug-blocker-blue)");
+  assert.ok(!out.includes("undefined"), "no undefined interpolated into output");
+}
+
 function testSanitizeMetadataStripsControlChars() {
   assert.strictEqual(sanitizeMetadata("clean"), "clean");
   assert.strictEqual(sanitizeMetadata("a\nb"), "ab");
@@ -1855,11 +1953,14 @@ function testFormatCommentBadgePlacement() {
   // with id and badge: id HTML comment stays first, badge on the next line
   const withBadge = formatComment({ content: "body", category: "bug", severity: "high" }, "ocr-1-1-abcd");
   assert.ok(withBadge.startsWith("<!-- ocr-1-1-abcd -->\n"), "id HTML comment is the first bytes");
-  assert.ok(withBadge.startsWith("<!-- ocr-1-1-abcd -->\n[bug · high]\n"), "badge follows id line");
+  assert.ok(
+    withBadge.startsWith("<!-- ocr-1-1-abcd -->\n![bug · high](https://img.shields.io/badge/bug-high-red)\n"),
+    "badge image follows id line"
+  );
   assert.ok(withBadge.endsWith("body"), "content preserved at the end");
   // without id: badge is the first line
   const noId = formatComment({ content: "body", category: "style", severity: "low" });
-  assert.ok(noId.startsWith("[style · low]\n"));
+  assert.ok(noId.startsWith("![style · low](https://img.shields.io/badge/style-low-green)\n"));
   // no metadata -> no badge line at all (byte-identical to pre-change output)
   const noBadge = formatComment({ content: "body" }, "ocr-1-1-abcd");
   assert.strictEqual(noBadge, "<!-- ocr-1-1-abcd -->\nbody");
@@ -1868,7 +1969,7 @@ function testFormatCommentBadgePlacement() {
     { content: "c", category: "bug", severity: "high", existing_code: "old", suggestion_code: "new" },
     "ocr-1-1-abcd"
   );
-  assert.match(withSuggestion, /\[bug · high\]/);
+  assert.match(withSuggestion, /!\[bug · high\]/);
   assert.match(withSuggestion, /\*\*Suggestion:\*\*/);
   assert.match(withSuggestion, /```suggestion/);
 }
@@ -1877,8 +1978,8 @@ function testFormatCommentBadgePlacement() {
 // path heading (PLAN_VALIDATION Risk A confirmed placement).
 function testFormatCommentMarkdownBadgePlacement() {
   const md = formatCommentMarkdown({ path: "a.js", content: "body", category: "bug", severity: "high" });
-  // badge is the first line, before the heading
-  assert.ok(md.startsWith("[bug · high]\n"), "badge is the leading line");
+  // badge image is the first line, before the heading
+  assert.ok(md.startsWith("![bug · high](https://img.shields.io/badge/bug-high-red)\n"), "badge is the leading line");
   assert.match(md, /### 📄 `a.js`/);
   assert.match(md, /body/);
   // no metadata -> no badge line, heading is first (byte-identical to pre-change)
@@ -2170,6 +2271,8 @@ async function main() {
   await testBatchTelemetryOutputs();
   // Badge + publication policy (#478)
   testBuildBadgeMatchesCliDegeneration();
+  testBuildBadgeImage();
+  testSeverityBadgeColorCoversSeverities();
   testSanitizeMetadataStripsControlChars();
   testBuildPolicyFailsOpenOnMalformed();
   testRouteCommentUnknownMetadataNeverRouted();


### PR DESCRIPTION
Closes #882

## What

Replaces the plain-text badge line (`[bug · high]`) in GitHub Actions review and summary comments with a single static shields.io badge, using exactly the format suggested in the issue discussion:

`https://img.shields.io/badge/<category>-<severity>-<color>`

The color is keyed off severity, with `blue` used as a fixed fallback when the severity is missing or unrecognized:

| Severity | Color |
| --- | --- |
| low | green |
| medium | orange |
| high | red |
| critical | darkred |
| *(missing / unknown)* | blue |

## How

- Adds a GitHub Actions-only `buildBadgeImage()` in `scripts/github-actions/post-review-comments.js`; the CLI's plain-text `buildBadge()` output is untouched.
- The badge is built from the structured `category` / `severity` fields (validated OCR enums), not by parsing comment text.
- Any non-empty metadata renders a badge: both fields → `category-severity`, one field → a single segment. The color comes from the severity when known, otherwise a fixed `blue`, so no lookup can ever yield a broken `-undefined` URL and no non-empty finding falls back to plain text.
- Values are sanitized (control chars stripped) and URL-escaped before interpolation.
- The image alt text keeps the plain-text form (`bug · high`), so screen readers and image-load failures degrade to the previous output.
- The hidden `ocr-id` marker stays as the first line; badge placement in `formatComment` / `formatCommentMarkdown` is unchanged.
- No new dependencies, no custom badge rendering.

## Testing

- `npm run test:github-actions` — passes. `testBuildBadgeImage` covers the full severity-color matrix, single-field badges, unknown-value rendering, case-insensitive matching, and control-char sanitization; `testSeverityBadgeColorCoversSeverities` guards the enum ↔ color-map invariant.
- E2E: generated badge URLs for known, single-field, and unknown-value cases from the real code path and verified each returns `200 image/svg+xml` from shields.io; rendered the output through GitHub's Markdown API and confirmed the badges resolve.

### Screenshot
<img width="891" height="728" alt="截屏2026-08-13 13 24 23" src="https://github.com/user-attachments/assets/5dd371f8-1eb4-4a84-b63d-988506322dfa" />
