### PR TITLE
chore: remove Chinese doc references from retry test comments

### DIFF
--- a/cmd/opencodereview/manual_e2e_retry_test.go
+++ b/cmd/opencodereview/manual_e2e_retry_test.go
@@ -3,8 +3,7 @@
 
 //go:build manual_e2e
 
-// Manual end-to-end verification harness for #368 P5 (see
-// docs/368/LLM请求重试实施路线图.md, P5 开工决策 8). It is excluded from the
+// Manual end-to-end verification harness for #368 P5. It is excluded from the
 // default build: run it explicitly with
 //
 //	go test -tags manual_e2e -run TestManualE2ERetryReport -v ./cmd/opencodereview/
@@ -89,7 +88,7 @@ func runManualReview(t *testing.T, srv *fakeLLM) manualResult {
 	comments, runErr := ag.Run(context.Background())
 	manifest := ag.RunManifest()
 
-	// P5 决策 7: the frozen run ID is the session's in-memory UUID, not the
+	// The frozen run ID is the session's in-memory UUID, not the
 	// persistence-gated ag.SessionID().
 	runID := ag.Session().SessionID
 	report, freezeErr := rt.RetryCollector.Freeze(runID)
@@ -174,7 +173,7 @@ func TestManualE2ERetryReport(t *testing.T) {
 		if res.report == nil {
 			t.Fatal("expected a report when every file failed")
 		}
-		// P5 决策 3: this is the exit where emitRunResult and emitFailureUsage
+		// This is the exit where emitRunResult and emitFailureUsage
 		// can both run, so record which one the report must travel through.
 		t.Logf("manifest==nil? %v ; runErr!=nil? %v -> emitRunResult runs: %v",
 			res.manifest == nil, res.runErr != nil, res.manifest != nil || res.runErr == nil)

--- a/cmd/opencodereview/retry_report_e2e_test.go
+++ b/cmd/opencodereview/retry_report_e2e_test.go
@@ -17,7 +17,7 @@ import (
 // End-to-end coverage of the #368 P5 wiring: a real review run against the fake
 // Anthropic server, driven through runReview so review_cmd.go's own Freeze /
 // publish decisions are the thing under test rather than a re-implementation of
-// them. See docs/368/LLM请求重试实施路线图.md, P5 开工决策 3/4/7/8.
+// them.
 
 // runReviewCapturingBoth runs a review and returns (stdout, stderr, error).
 // Both streams are needed because the report has two possible exits and the
@@ -165,7 +165,7 @@ func TestReviewE2E_RetryReportReachesTextExit(t *testing.T) {
 
 // Every file failing still produces a manifest (terminal_state=failed), so the
 // normal exit runs and the failure-usage record must not repeat the report.
-// This is the dedup rule of 决策 3, and the only case where both exits execute.
+// This is the dedup rule, and the only case where both exits execute.
 func TestReviewE2E_AllFilesFailPublishesReportOnce(t *testing.T) {
 	repoDir := retryTestRepo(t)
 	srv := newFakeLLM()
@@ -220,7 +220,7 @@ func TestReviewE2E_AllFilesFailTextPublishesReportOnce(t *testing.T) {
 	}
 }
 
-// 决策 4: a report-construction error is an observability warning. It must not
+// A report-construction error is an observability warning. It must not
 // change a successful review's exit status, print a --resume hint, emit a
 // failure-usage record, or publish a partial report — while the review's own
 // result is still published.
@@ -259,7 +259,7 @@ func TestReviewE2E_FreezeErrorIsAWarning(t *testing.T) {
 	}
 }
 
-// 决策 7: run_id is the session's in-memory UUID rather than the
+// The run_id is the session's in-memory UUID rather than the
 // persistence-gated ag.SessionID(), so a session whose JSONL file could not be
 // created still yields a report with usable logical_request_ids — while
 // session_id stays empty and no --resume hint is printed, because there is

--- a/cmd/opencodereview/retry_report_render_test.go
+++ b/cmd/opencodereview/retry_report_render_test.go
@@ -56,8 +56,8 @@ func retryReportFixture() *llm.RetryReport {
 	}
 }
 
-// The expected rendering is fixed by docs/368/LLM请求重试实施细节.md §5, so the
-// text contract is asserted whole rather than by substring.
+// The expected rendering is fixed, so the text contract is asserted whole
+// rather than by substring.
 const wantRetryReportText = `
 LLM retry report: 1/12 requests retried, 2 retries, 1 recovered, 1 failed, 0 cancelled
 - payment.go / main_task #2: rate_limited(429) -> overloaded(529) -> success

--- a/internal/llmloop/retry_background_test.go
+++ b/internal/llmloop/retry_background_test.go
@@ -57,7 +57,7 @@ func (c *blockingCompressionClient) CompletionsWithCtx(ctx context.Context, _ ll
 	return &llm.ChatResponse{Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &summary}}}}, nil
 }
 
-// #368 P5 决策 1: the run boundary joins background memory compression before
+// The run boundary joins background memory compression before
 // the report is frozen. Without that join, Freeze can see a request that
 // recorded attempts but was never finalized, which is an invariant violation and
 // drops the whole run's report — so the barrier is what makes the report


### PR DESCRIPTION
## Description
The HEAD state CI failed because AI generated tons of code comments and some include unapproved non-english characters. This PR resolves the failure by removing invalid references.
<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)
Ran the script locally
## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
The HEAD state CI failure