### PR TITLE
fix(cmd): report expected arguments when positional count is wrong

### DIFF
--- a/cmd/opencodereview/arg_errors.go
+++ b/cmd/opencodereview/arg_errors.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Positional-argument validators that replace Cobra's raw count message
+// ("accepts 2 arg(s), received 1") with an actionable one built from metadata
+// the command already declares — the positional signature in Use, plus Example
+// and ValidArgs where present — so the guidance cannot drift from the command's
+// own help output. Because the root command sets SilenceUsage, everything the
+// user sees has to travel in the error itself.
+
+// exactArgs behaves like cobra.ExactArgs(n) but reports a wrong count with the
+// command's own usage information.
+func exactArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == n {
+			return nil
+		}
+		return argCountError(cmd, fmt.Sprintf("requires exactly %d argument(s)", n))
+	}
+}
+
+// minimumArgs behaves like cobra.MinimumNArgs(n) but reports too few arguments
+// with the command's own usage information.
+func minimumArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) >= n {
+			return nil
+		}
+		return argCountError(cmd, fmt.Sprintf("requires at least %d argument(s)", n))
+	}
+}
+
+// argCountError assembles the guidance for a wrong argument count. The count the
+// user supplied is deliberately not echoed back — it adds nothing they do not
+// already know from the line they just typed.
+func argCountError(cmd *cobra.Command, requirement string) error {
+	var b strings.Builder
+	b.Grow(256)
+
+	path := cmd.CommandPath()
+	fmt.Fprintf(&b, "%q %s", path, requirement)
+	if sig := positionalSignature(cmd); sig != "" {
+		fmt.Fprintf(&b, " (%s)", sig)
+	}
+
+	if len(cmd.ValidArgs) > 0 {
+		b.WriteString("\n\nValid values: ")
+		b.WriteString(strings.Join(validArgNames(cmd.ValidArgs), ", "))
+	}
+
+	b.WriteString("\n\nUsage:\n  ")
+	b.WriteString(cmd.UseLine())
+
+	if example := strings.TrimRight(cmd.Example, "\n"); example != "" {
+		b.WriteString("\n\nExample:\n")
+		b.WriteString(example)
+	}
+
+	b.WriteString("\n\nRun '")
+	b.WriteString(path)
+	b.WriteString(" --help' for more information.")
+
+	return errors.New(b.String())
+}
+
+// positionalSignature extracts the positional-argument part of cmd.Use, e.g.
+// "<key> <value>" from "set <key> <value>" and "<path...>" from
+// "rule [flags] <path...>". Bracketed fields are not placeholders the user
+// types, so "[flags]" and inline enumerations such as "[bash|zsh]" are dropped;
+// enumerated values are reported from ValidArgs instead.
+func positionalSignature(cmd *cobra.Command) string {
+	fields := strings.Fields(cmd.Use)
+	if len(fields) < 2 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(fields)-1)
+	for _, f := range fields[1:] {
+		if strings.HasPrefix(f, "<") {
+			parts = append(parts, f)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// validArgNames strips the "name\tdescription" form Cobra allows in ValidArgs,
+// keeping only the value the user is expected to type. The split matches the one
+// cobra.OnlyValidArgs applies, so the listed values are exactly those accepted.
+func validArgNames(valid []string) []string {
+	names := make([]string, 0, len(valid))
+	for _, v := range valid {
+		names = append(names, strings.SplitN(v, "\t", 2)[0])
+	}
+	return names
+}

--- a/cmd/opencodereview/arg_errors_test.go
+++ b/cmd/opencodereview/arg_errors_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestArgCountErrors_AreActionable verifies that a wrong positional-argument
+// count reports what the command expects instead of Cobra's raw
+// "accepts 2 arg(s), received 1". Because the root command sets SilenceUsage,
+// the guidance has to travel inside the error itself.
+//
+// See: https://github.com/alibaba/open-code-review/issues/890
+func TestArgCountErrors_AreActionable(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string // substrings expected in the error message
+	}{
+		{
+			name: "config set with no args",
+			args: []string{"config", "set"},
+			want: []string{
+				`"ocr config set" requires exactly 2 argument(s) (<key> <value>)`,
+				"Usage:\n  ocr config set <key> <value>",
+				"Example:",
+				"ocr config set provider anthropic",
+				"Run 'ocr config set --help' for more information.",
+			},
+		},
+		{
+			name: "config set missing value",
+			args: []string{"config", "set", "provider"},
+			want: []string{
+				`requires exactly 2 argument(s) (<key> <value>)`,
+				"Usage:\n  ocr config set <key> <value>",
+			},
+		},
+		{
+			// Too many arguments reports the same expectation as too few: the
+			// requirement and how to write it, without echoing the count back.
+			name: "config set with too many args",
+			args: []string{"config", "set", "provider", "anthropic", "extra"},
+			want: []string{
+				`requires exactly 2 argument(s) (<key> <value>)`,
+				"Usage:\n  ocr config set <key> <value>",
+			},
+		},
+		{
+			name: "config unset with no args",
+			args: []string{"config", "unset"},
+			want: []string{
+				`"ocr config unset" requires exactly 1 argument(s) (<key>)`,
+				"Example:",
+			},
+		},
+		{
+			name: "rules check with no args",
+			args: []string{"rules", "check"},
+			want: []string{
+				`"ocr rules check" requires exactly 1 argument(s) (<file-path>)`,
+				"Usage:\n  ocr rules check",
+				"Example:",
+			},
+		},
+		{
+			name: "session show with no args",
+			args: []string{"session", "show"},
+			want: []string{
+				`"ocr session show" requires exactly 1 argument(s) (<session-id>)`,
+				"Run 'ocr session show --help' for more information.",
+			},
+		},
+		{
+			name: "session comments with no args",
+			args: []string{"session", "comments"},
+			want: []string{`"ocr session comments" requires exactly 1 argument(s) (<session-id>)`},
+		},
+		{
+			name: "delegate rule with no args",
+			args: []string{"delegate", "rule"},
+			want: []string{
+				`"ocr delegate rule" requires at least 1 argument(s) (<path...>)`,
+				"Usage:\n  ocr delegate rule",
+			},
+		},
+		{
+			// completion enumerates its values inline in Use, so they are reported
+			// once from ValidArgs rather than repeated in the signature.
+			name: "completion with no args lists valid values",
+			args: []string{"completion"},
+			want: []string{
+				`"ocr completion" requires exactly 1 argument(s)`,
+				"Valid values: bash, zsh, fish, powershell",
+			},
+		},
+		{
+			// Flags do not count as positional arguments, so declaring one does
+			// not satisfy the requirement.
+			name: "flags do not satisfy the positional requirement",
+			args: []string{"rules", "check", "--rule", "custom.json"},
+			want: []string{`"ocr rules check" requires exactly 1 argument(s) (<file-path>)`},
+		},
+		{
+			// Reached through an alias, the error names the canonical path. That
+			// matches what "ocr d rule --help" prints, so the two stay in step.
+			name: "alias reports the canonical command path",
+			args: []string{"d", "rule"},
+			want: []string{
+				`"ocr delegate rule" requires at least 1 argument(s) (<path...>)`,
+				"Usage:\n  ocr delegate rule",
+			},
+		},
+		{
+			name: "sessions alias reports the canonical command path",
+			args: []string{"sessions", "show"},
+			want: []string{`"ocr session show" requires exactly 1 argument(s) (<session-id>)`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd.SetArgs(tt.args)
+			// Execute really parses flags, so a case that declares one leaves it
+			// bound to its package-level variable and would leak into later tests.
+			t.Cleanup(func() {
+				rootCmd.SetArgs(nil)
+				rulesCheckRulePath = ""
+			})
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for args %v, got nil", tt.args)
+			}
+			got := err.Error()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("error message missing %q\n--- full message ---\n%s", want, got)
+				}
+			}
+			if strings.Contains(got, "arg(s)") {
+				t.Errorf("error still uses Cobra's raw wording: %q", got)
+			}
+			// The supplied count tells the user nothing they cannot see in the
+			// line they just typed; the message should only carry guidance.
+			if strings.Contains(got, "received") {
+				t.Errorf("error echoes the supplied argument count back: %q", got)
+			}
+		})
+	}
+}
+
+// TestArgCountErrors_MatchHelpOutput guards the property that makes this
+// approach maintainable: the usage line in the error is the command's own
+// UseLine, so it cannot drift away from what --help prints.
+func TestArgCountErrors_MatchHelpOutput(t *testing.T) {
+	for _, path := range [][]string{
+		{"config", "set"},
+		{"config", "unset"},
+		{"rules", "check"},
+		{"session", "show"},
+		{"session", "comments"},
+		{"delegate", "rule"},
+		{"completion"},
+	} {
+		name := strings.Join(path, " ")
+		t.Run(name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find(path)
+			if err != nil {
+				t.Fatalf("find %q: %v", name, err)
+			}
+			argErr := argCountError(cmd, "requires exactly 1 argument(s)")
+			if !strings.Contains(argErr.Error(), cmd.UseLine()) {
+				t.Errorf("error does not carry UseLine %q:\n%s", cmd.UseLine(), argErr)
+			}
+			if !strings.Contains(argErr.Error(), cmd.CommandPath()) {
+				t.Errorf("error does not name the command path %q", cmd.CommandPath())
+			}
+		})
+	}
+}
+
+// TestEveryPositionalCommandUsesFriendlyErrors walks the whole command tree and
+// fails if a command that declares positional placeholders in Use still reports
+// Cobra's raw count message. This is what keeps a newly added command from
+// silently regressing: wiring it to cobra.ExactArgs directly trips this test.
+func TestEveryPositionalCommandUsesFriendlyErrors(t *testing.T) {
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		for _, sub := range cmd.Commands() {
+			walk(sub)
+		}
+		if cmd.Args == nil || positionalSignature(cmd) == "" {
+			return
+		}
+		// Passing no arguments must trip the requirement for any command that
+		// declares a placeholder, and the resulting message must be the friendly
+		// one. Commands whose placeholders are all optional legitimately accept
+		// zero arguments, so a nil error is not a failure.
+		err := cmd.Args(cmd, nil)
+		if err == nil {
+			return
+		}
+		if strings.Contains(err.Error(), "arg(s)") {
+			t.Errorf("%q still reports Cobra's raw count message; use exactArgs/minimumArgs instead:\n%s",
+				cmd.CommandPath(), err)
+		}
+		if !strings.Contains(err.Error(), cmd.UseLine()) {
+			t.Errorf("%q arg error omits its own usage line %q:\n%s",
+				cmd.CommandPath(), cmd.UseLine(), err)
+		}
+	}
+	walk(rootCmd)
+}
+
+// TestValidInvocationsStillResolve is a regression guard: swapping the
+// validators must not reject argument counts that were previously accepted.
+func TestValidInvocationsStillResolve(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator cobra.PositionalArgs
+		args      []string
+	}{
+		{"exact 1 with 1", exactArgs(1), []string{"a"}},
+		{"exact 2 with 2", exactArgs(2), []string{"a", "b"}},
+		{"minimum 1 with 1", minimumArgs(1), []string{"a"}},
+		{"minimum 1 with 3", minimumArgs(1), []string{"a", "b", "c"}},
+	}
+
+	cmd := &cobra.Command{Use: "demo <x>"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.validator(cmd, tt.args); err != nil {
+				t.Errorf("expected %v to be accepted, got %v", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestPositionalSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		use  string
+		want string
+	}{
+		{"two placeholders", "set <key> <value>", "<key> <value>"},
+		{"flags marker is dropped", "rule [flags] <path...>", "<path...>"},
+		{"inline enumeration is dropped", "completion [bash|zsh|fish]", ""},
+		{"command name only", "version", ""},
+		{"placeholder after flags marker", "show [flags] <session-id>", "<session-id>"},
+		{"empty use", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := positionalSignature(&cobra.Command{Use: tt.use}); got != tt.want {
+				t.Errorf("positionalSignature(%q) = %q, want %q", tt.use, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidArgNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid []string
+		want  []string
+	}{
+		{"plain values", []string{"bash", "zsh"}, []string{"bash", "zsh"}},
+		{"tab-separated descriptions are stripped", []string{"bash\tBourne again shell", "zsh\tZ shell"}, []string{"bash", "zsh"}},
+		// Values pass through as cobra.OnlyValidArgs sees them, so the listed
+		// values are exactly the accepted ones.
+		{"values are not otherwise altered", []string{"bash", " fish"}, []string{"bash", " fish"}},
+		{"none", nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validArgNames(tt.valid)
+			if len(got) != len(tt.want) {
+				t.Fatalf("validArgNames(%v) = %v, want %v", tt.valid, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("validArgNames(%v)[%d] = %q, want %q", tt.valid, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/cmd/opencodereview/completion.go
+++ b/cmd/opencodereview/completion.go
@@ -15,7 +15,7 @@ var completionCmd = &cobra.Command{
 	Short:     "Generate shell completion scripts",
 	Long:      completionLongHelp,
 	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
-	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Args:      cobra.MatchAll(exactArgs(1), cobra.OnlyValidArgs),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "bash":

--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -45,7 +45,7 @@ var configSetCmd = &cobra.Command{
 	Use:     "set <key> <value>",
 	Short:   "Set a configuration value",
 	Example: "  ocr config set llm.model claude-opus-4-6\n  ocr config set provider anthropic",
-	Args:    cobra.ExactArgs(2),
+	Args:    exactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runConfigSet(args[0], args[1])
 	},
@@ -56,7 +56,7 @@ var configUnsetCmd = &cobra.Command{
 	Short:   "Remove a configuration value",
 	Long:    "Remove a provider, custom_providers.<name>, or mcp_servers.<name>.",
 	Example: "  ocr config unset provider\n  ocr config unset custom_providers.my-provider\n  ocr config unset mcp_servers.github",
-	Args:    cobra.ExactArgs(1),
+	Args:    exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runConfigUnset(args[0])
 	},

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -70,7 +70,7 @@ var delegateRuleCmd = &cobra.Command{
 	Use:   "rule [flags] <path...>",
 	Short: "Output resolved review rules grouped by content",
 	Long:  "Outputs resolved review rules grouped by content. Accepts multiple paths.",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  minimumArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateDelegateOptions(&delegateRuleOpts); err != nil {
 			return err

--- a/cmd/opencodereview/rules_cmd.go
+++ b/cmd/opencodereview/rules_cmd.go
@@ -30,7 +30,7 @@ var rulesCheckCmd = &cobra.Command{
 	Long:  "Show which review rule applies to the given file path, including its source layer and matched pattern.",
 	Example: `  ocr rules check src/main/java/com/example/Foo.java
   ocr rules check --rule custom.json src/main/resources/mapper/UserMapper.xml`,
-	Args: cobra.ExactArgs(1),
+	Args: exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runRulesCheck(args[0])
 	},

--- a/cmd/opencodereview/session_cmd.go
+++ b/cmd/opencodereview/session_cmd.go
@@ -48,7 +48,7 @@ var sessionShowJSON bool
 var sessionShowCmd = &cobra.Command{
 	Use:               "show [flags] <session-id>",
 	Short:             "Show one session's metadata and per-file items",
-	Args:              cobra.ExactArgs(1),
+	Args:              exactArgs(1),
 	ValidArgsFunction: completeSessionIDs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSessionShow(args[0])
@@ -64,7 +64,7 @@ var sessionCommentsCmd = &cobra.Command{
 	Use:               "comments [flags] <session-id>",
 	Short:             "Show the review comments recorded in one session",
 	Long:              "Print every review comment persisted in a session, formatted like 'ocr review' terminal output.\nUse --json for machine-readable output and --severity/--category to filter findings.",
-	Args:              cobra.ExactArgs(1),
+	Args:              exactArgs(1),
 	ValidArgsFunction: completeSessionIDs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSessionComments(args[0])


### PR DESCRIPTION
## What

Cobra's default message for a wrong positional-argument count names neither the command nor what it expects, and the root command sets `SilenceUsage`, so no usage block follows it:

```console
$ ocr config set provider
Error: accepts 2 arg(s), received 1
```

After:

```console
$ ocr config set provider
Error: "ocr config set" requires exactly 2 argument(s) (<key> <value>)

Usage:
  ocr config set <key> <value> [flags]

Example:
  ocr config set llm.model claude-opus-4-6
  ocr config set provider anthropic

Run 'ocr config set --help' for more information.
```

## How

`exactArgs` and `minimumArgs` are drop-in replacements for `cobra.ExactArgs` and `cobra.MinimumNArgs` that build the message from metadata the command already declares: the positional signature in `Use`, plus `Example` and `ValidArgs` where present.

The guidance therefore cannot drift from the command's own `--help` output, and no command carries a hand-written error string. This mirrors how the existing `flagErrorWithSuggestion` handles the analogous flag-error case.

The supplied count is deliberately not echoed back: it adds nothing the user cannot already see in the command they just typed.

Seven commands are wired: `config set`, `config unset`, `rules check`, `session show`, `session comments`, `delegate rule`, and `completion`.

Aliases report the canonical path (`ocr d rule` → `"ocr delegate rule"`), matching what `--help` prints.

## Scope

Message text only. Exit codes are unchanged, and every previously accepted argument count is still accepted.

I diffed the built binary against `main` across 29 invocations: 14 differ in text, 0 differ in exit code, and 15 are byte-identical. The byte-identical cases cover all `NoArgs` commands, unknown subcommands, `OnlyValidArgs` rejections, unknown flags, and all success paths.

Two adjacent gaps are deliberately left out to keep this reviewable and are worth follow-up issues:

1. The `OnlyValidArgs` error (`ocr completion xyz`) does not list valid values despite the command declaring them.
2. The 15 `NoArgs` commands hit the same dead end under `SilenceUsage`.

Both require a different mechanism than a count validator.

## Tests

`TestEveryPositionalCommandUsesFriendlyErrors` walks the command tree and fails if a command declaring positional placeholders still reports Cobra's raw message, so wiring a future command to `cobra.ExactArgs` directly is caught.

I validated this guard destructively: reverting `rules check` to `cobra.ExactArgs(1)` makes it fail as intended.

Verified locally against every CI gate: license headers, action pins, `gofmt -s`, line endings, `go mod tidy`, `go vet`, tests (23 packages, 0 failures), coverage at 90.3% against the 90% threshold, build, and the smoke test's 10 assertions.

`arg_errors.go` is at 100% per-function coverage.

I did not run `govulncheck` because there are no dependency changes and `go.mod` is untouched, or the cross-compile matrix because this is pure Go with no build tags or cgo.

Fixes #890
