### PR TITLE
ci: bump Go image to 1.26.6 to clear stdlib vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     container:
-      image: golang:1.26.5
+      image: golang:1.26.6
       options: --cpus=2
     steps:
       - uses: actions/checkout@v7
@@ -106,7 +106,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     container:
-      image: golang:1.26.5
+      image: golang:1.26.6
       options: --cpus=2
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 15
     container:
-      image: golang:1.26.5
+      image: golang:1.26.6
       options: --cpus=2
     strategy:
       matrix:

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     container:
       # Pinned to an exact 24.x for reproducible builds, matching the
-      # golang:1.26.5 pin used by the other jobs (avoids the mutable node:24 tag).
+      # golang:1.26.6 pin used by the other jobs (avoids the mutable node:24 tag).
       image: node:24.18.0
     steps:
       # fetch-depth: 0 so the non-blocking docs check can diff base...head.


### PR DESCRIPTION
## Description

The `Govulncheck` step in CI now fails on every pull request, blocking the pipeline before a single test runs. Nothing in this repository changed to cause it: the Go vulnerability database was updated to record fixes in Go 1.26.6 for a batch of standard-library issues, and CI pins its container image to `golang:1.26.5`.

Seven advisories are reachable from this module — GO-2026-6218, GO-2026-6091, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972 and GO-2026-5026 — via `net/url`, `html/template`, `crypto/tls`, `net/http`, `encoding/xml` and `encoding/asn1`. All of them report `Fixed in: <pkg>@go1.26.6`, so bumping the pinned toolchain is both the necessary and the sufficient fix.

Because `Govulncheck` runs ahead of `Test with coverage`, the subsequent test, coverage, build and smoke-test steps are skipped entirely. Pull requests therefore look like test failures when no test has executed.

Changes:

- `.github/workflows/ci.yml` — bump the image for both the `test` and `cross-compile` jobs.
- `.github/workflows/release.yml` — bump the image for the `build` job, so release artifacts are produced by the same toolchain as CI.
- `.github/workflows/translation-sync.yml` — refresh a comment that cited `golang:1.26.5` as the pin it matches, so it does not become stale guidance.

Two things deliberately left alone:

- `go.mod` still declares `go 1.25.5`. The advisories concern the container toolchain's standard library, so editing `go.mod` would not resolve them, and raising the language version would change the minimum Go requirement for downstream consumers — out of scope here.
- `govulncheck` still notes one vulnerability in an imported package and one in a required module, neither of which this code calls. Uncalled findings do not affect the exit code and do not block CI; addressing them is a dependency upgrade and belongs in a separate change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Go 1.26.6 was confirmed to be released and available for `linux/amd64` before changing the pin, via both `go.dev/dl` and the toolchain module proxy.

Every CI step was then reproduced locally under `GOTOOLCHAIN=go1.26.6`:

| Step | Result |
| --- | --- |
| `govulncheck ./...` | `No vulnerabilities found.`, exit 0 |
| `gofmt -s -l .` | clean |
| `go mod tidy` | no change to `go.mod` / `go.sum` |
| `go vet ./...` | clean |
| `go build ./...` | exit 0 |
| `go test ./...` | 23 packages pass, 0 failures |
| `scripts/verify-license.sh` | all files have valid headers |
| `scripts/verify-action-pins.sh` | all external actions SHA-pinned |
| `scripts/verify-english-only.go` | no unapproved non-English text (402 files) |
| workflow YAML | all 8 files parse |
| `git ls-files --eol` | all LF |

A control run pins down the cause: the same tree under `go1.26.5` exits non-zero from `govulncheck`, and switching only the toolchain to `go1.26.6` clears it.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works (not applicable; CI configuration change, verified by reproducing every CI step locally)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

None. This unblocks all currently open pull requests, which fail at the `Govulncheck` step for this reason rather than any fault of their own.