### PR TITLE
test(agent): add end-to-end regression test for review item fingerprint stability

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -6,11 +6,14 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/config/toolsconfig"
+	"github.com/alibaba/open-code-review/internal/diff"
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
@@ -585,6 +588,60 @@ func TestReviewItemFingerprintIgnoresTrailingLineEndings(t *testing.T) {
 	withContextLine.Diff += "\n "
 	if got := reviewItemFingerprint(session.ReviewModeRange, withContextLine); got == want {
 		t.Error("fingerprint ignored a real trailing context line")
+	}
+}
+
+// TestReviewItemFingerprintStableAcrossPatchPosition pins down the --resume
+// guarantee end to end: the patch splitter leaves position-dependent trailing
+// line endings on each file section, so the fingerprint must be derived from
+// real diff.ParseDiffText output with the target file in different positions.
+func TestReviewItemFingerprintStableAcrossPatchPosition(t *testing.T) {
+	section := func(path, from, to string) string {
+		return "diff --git a/" + path + " b/" + path + "\n" +
+			"--- a/" + path + "\n+++ b/" + path + "\n" +
+			"@@ -1 +1 @@\n-" + from + "\n+" + to + "\n"
+	}
+
+	// Pre-create the files so finalizeDiff's working-tree read succeeds and the
+	// test does not emit spurious "cannot read file" warnings.
+	dir := t.TempDir()
+	for _, name := range []string{"a.go", "z.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("new\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	target, other := section("a.go", "old", "new"), section("z.go", "x", "y")
+
+	fingerprintOfA := func(t *testing.T, patch string) string {
+		t.Helper()
+		diffs, err := diff.ParseDiffText(context.Background(), patch, dir, "", nil)
+		if err != nil {
+			t.Fatalf("ParseDiffText: %v", err)
+		}
+		for _, d := range diffs {
+			if d.NewPath == "a.go" {
+				return reviewItemFingerprint(session.ReviewModeRange, d)
+			}
+		}
+		t.Fatal("a.go missing from parsed diffs")
+		return ""
+	}
+
+	for _, tc := range []struct {
+		name, last, first string
+	}{
+		// The splitter leaves a trailing newline on whichever file is last.
+		{"plain patch", other + target, target + other},
+		// Workspace mode joins untracked file diffs with "\n\n", so the trailing
+		// run is longer than a single newline.
+		{"untracked join", other + "\n\n" + target + "\n\n", target + "\n\n" + other + "\n\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := fingerprintOfA(t, tc.last), fingerprintOfA(t, tc.first); got != want {
+				t.Errorf("fingerprint depends on position in patch:\n last  = %s\n first = %s", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Adds the regression test described in #897: `TestReviewItemFingerprintStableAcrossPatchPosition` derives fingerprints from real `diff.ParseDiffText` output and asserts they do not depend on a file's position within the patch.

#732 fixed #718 by normalizing trailing line endings in `reviewItemFingerprint`, but the existing helper-level test feeds hand-written strings and never exercises `ParseDiffText` — the component that actually produces the position-dependent trailing newlines. This test pins the user-visible `--resume` guarantee (same unchanged file keeps the same fingerprint regardless of patch position) on the real parser path:

- **plain patch**: two-file patch with the target file last vs. first (the splitter leaves one trailing newline on the last file)
- **untracked join**: workspace-mode `"\n\n"` joining, where the trailing run is 2-3 newlines — the case only `TrimRight` (not `TrimSuffix`) handles

Test-only change; no production code modified.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- New test passes on `main` with both sub-cases (`plain patch`, `untracked join`)
- Mutation check: removing the `strings.TrimRight(d.Diff, "\r\n")` normalization makes the test fail (verified locally, then reverted)
- No spurious `cannot read file` warnings on stderr
- `make test` passes (full suite)
- `make check` passes

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA

## Related Issues

closes #897