### PR TITLE
ci: add paths-ignore to skip CI on documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - '**/.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - '**/.gitignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Adds `paths-ignore` to the `push` and `pull_request` triggers in `.github/workflows/ci.yml` so changes that no CI step scans no longer spin up the full suite:

```yaml
paths-ignore:
  - '**.md'
  - '**/LICENSE'
  - '**/.gitignore'
```

Two small deviations from the list suggested in the issue, both deliberate:

- `docs/**` dropped — the repo has no top-level `docs/` directory; documentation lives in `pages/` and is already covered by `**.md`
- `LICENSE`/`.gitignore` broadened to `**/LICENSE`/`**/.gitignore` — the repo tracks these under `extensions/vscode/`, `pages/` and `plugins/` too, and none of them is scanned by any CI step

Kept triggerable, per the issue's analysis: `.yml`/`.yaml` (scanned by `verify-english-only.go`), `.github/workflows/**`, and `action.yml` (checked by `verify-action-pins.sh`).

Doc-oriented checks are unaffected: `pages-ci`, `deploy-pages` and `translation-sync` have their own path-based triggers and keep running for documentation changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- YAML syntax validated; `make check` passes
- This PR itself touches `ci.yml`, which is not in the ignore list, so its CI run verifies code changes still trigger the workflow
- The doc-only skip takes effect once merged; a follow-up docs-only PR can confirm it end to end

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have signed the CLA

## Related Issues

closes #905