### PR TITLE
fix(plugin): separate client marketplace registrations

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "open-code-review",
+  "interface": {
+    "displayName": "Open Code Review"
+  },
+  "plugins": [
+    {
+      "name": "open-code-review-codex",
+      "source": {
+        "source": "local",
+        "path": "./plugins/open-code-review"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,6 @@
       "description": "Perform AI code review on Git diffs — supports workspace changes, branch ranges, and single commits with concurrent per-file analysis, codebase search, and deep context-aware review.",
       "version": "1.0.0",
       "license": "Apache-2.0"
-    },
-    {
-      "name": "open-code-review-codex",
-      "source": "./plugins/open-code-review"
     }
   ]
 }


### PR DESCRIPTION
## Description

Separate the Claude Code and Codex marketplace registrations so each client only exposes its compatible integration.

The plugin packages were already isolated, but both were registered in `.claude-plugin/marketplace.json`. Codex therefore listed the Claude Code package as an installable plugin. This change:

- keeps only `open-code-review` in the Claude Code marketplace;
- adds a native Codex marketplace at `.agents/plugins/marketplace.json` containing only `open-code-review-codex`;
- leaves both existing plugin packages and installation commands unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Manual verification used isolated client homes with the native Codex and Claude Code CLIs:

- Codex listed and installed only `open-code-review-codex`; installing `open-code-review` was rejected.
- Claude Code listed and installed only `open-code-review`; installing `open-code-review-codex` was rejected.
- `make check`, JSON validation, and `git diff --check` passed locally.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

No automated test was added because marketplace discovery and cross-client rejection require the external Codex and Claude Code CLIs. The behavior was verified end to end with both native clients.

## Related Issues

Fixes #903
