### PR TITLE
refactor(telemetry): replace PrintTraceSummary positional params with TraceSummary struct

### DIFF
--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -403,9 +403,17 @@ func emitRunResult(
 	}
 
 	if !machineReadable {
-		telemetry.PrintTraceSummary(ag.FilesReviewed(), int64(len(comments)),
-			ag.TotalInputTokens(), ag.TotalOutputTokens(), ag.TotalTokensUsed(),
-			ag.TotalCacheReadTokens(), ag.TotalCacheWriteTokens(), duration, ag.SessionID())
+		telemetry.PrintTraceSummary(telemetry.TraceSummary{
+			FilesReviewed:     ag.FilesReviewed(),
+			CommentsGenerated: int64(len(comments)),
+			InputTokens:       ag.TotalInputTokens(),
+			OutputTokens:      ag.TotalOutputTokens(),
+			TotalTokens:       ag.TotalTokensUsed(),
+			CacheReadTokens:   ag.TotalCacheReadTokens(),
+			CacheWriteTokens:  ag.TotalCacheWriteTokens(),
+			Duration:          duration,
+			SessionID:         ag.SessionID(),
+		})
 	}
 
 	if outputFormat == "json" {

--- a/internal/stdout/stdout.go
+++ b/internal/stdout/stdout.go
@@ -49,8 +49,9 @@ func Quiet() func() {
 //	var buf bytes.Buffer
 //	defer stdout.Swap(&buf)()
 //
-// Like Quiet, Swap is not designed for concurrent use from multiple
-// goroutines; keep swapping and restoring on one goroutine.
+// Like Quiet, Swap acquires the package mutex for memory safety, but concurrent
+// swaps from multiple goroutines produce non-deterministic restore ordering.
+// Keep swapping and restoring on a single goroutine.
 func Swap(replacement io.Writer) func() {
 	mu.Lock()
 	old := w

--- a/internal/stdout/stdout.go
+++ b/internal/stdout/stdout.go
@@ -41,3 +41,24 @@ func Quiet() func() {
 		mu.Unlock()
 	}
 }
+
+// Swap replaces the stdout writer with replacement and returns a restore
+// function. It lets tests capture output written through Writer().
+// Usage:
+//
+//	var buf bytes.Buffer
+//	defer stdout.Swap(&buf)()
+//
+// Like Quiet, Swap is not designed for concurrent use from multiple
+// goroutines; keep swapping and restoring on one goroutine.
+func Swap(replacement io.Writer) func() {
+	mu.Lock()
+	old := w
+	w = replacement
+	mu.Unlock()
+	return func() {
+		mu.Lock()
+		w = old
+		mu.Unlock()
+	}
+}

--- a/internal/stdout/stdout_test.go
+++ b/internal/stdout/stdout_test.go
@@ -4,6 +4,7 @@
 package stdout
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"testing"
@@ -29,5 +30,43 @@ func TestQuiet(t *testing.T) {
 	w = Writer()
 	if w != os.Stdout {
 		t.Error("expected Writer to be os.Stdout after restore")
+	}
+}
+
+func TestSwap(t *testing.T) {
+	var buf bytes.Buffer
+	restore := Swap(&buf)
+
+	if _, err := io.WriteString(Writer(), "captured"); err != nil {
+		t.Fatalf("write to swapped writer failed: %v", err)
+	}
+	if got := buf.String(); got != "captured" {
+		t.Errorf("expected swapped writer to capture %q, got %q", "captured", got)
+	}
+
+	restore()
+
+	if w := Writer(); w != os.Stdout {
+		t.Error("expected Writer to be os.Stdout after restore")
+	}
+}
+
+func TestSwap_Composable(t *testing.T) {
+	var buf bytes.Buffer
+	outer := Swap(&buf)
+
+	innerRestore := Quiet()
+	if w := Writer(); w != io.Discard {
+		t.Error("expected Writer to be io.Discard after nested Quiet()")
+	}
+	innerRestore()
+
+	if w := Writer(); w != &buf {
+		t.Error("expected Writer to be the swapped buffer after nested restore")
+	}
+	outer()
+
+	if w := Writer(); w != os.Stdout {
+		t.Error("expected Writer to be os.Stdout after outer restore")
 	}
 }

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -68,23 +68,36 @@ func FormatDuration(dur time.Duration) string {
 	return dur.Round(time.Millisecond).String()
 }
 
+// TraceSummary carries the metrics printed by PrintTraceSummary.
+type TraceSummary struct {
+	FilesReviewed     int64
+	CommentsGenerated int64
+	InputTokens       int64
+	OutputTokens      int64
+	TotalTokens       int64
+	CacheReadTokens   int64
+	CacheWriteTokens  int64
+	Duration          time.Duration
+	SessionID         string
+}
+
 // PrintTraceSummary prints a one-line summary of the review to stdout.
-// If sessionID is non-empty, an "[ocr] Session: <id>" line follows the summary.
-func PrintTraceSummary(filesReviewed, commentsGenerated int64, inputTokens, outputTokens, totalTokens int64, cacheReadTokens, cacheWriteTokens int64, duration time.Duration, sessionID string) {
-	elapsed := duration.Round(time.Second).String()
-	if inputTokens > 0 || outputTokens > 0 {
+// If SessionID is non-empty, an "[ocr] Session: <id>" line follows the summary.
+func PrintTraceSummary(s TraceSummary) {
+	elapsed := s.Duration.Round(time.Second).String()
+	if s.InputTokens > 0 || s.OutputTokens > 0 {
 		base := fmt.Sprintf("[ocr] Summary: %d file(s) reviewed, %d comment(s), ~%d token(s) used (input: ~%d, output: ~%d)",
-			filesReviewed, commentsGenerated, totalTokens, inputTokens, outputTokens)
-		if cacheReadTokens > 0 || cacheWriteTokens > 0 {
-			base += fmt.Sprintf(", cache(read: ~%d, write: ~%d)", cacheReadTokens, cacheWriteTokens)
+			s.FilesReviewed, s.CommentsGenerated, s.TotalTokens, s.InputTokens, s.OutputTokens)
+		if s.CacheReadTokens > 0 || s.CacheWriteTokens > 0 {
+			base += fmt.Sprintf(", cache(read: ~%d, write: ~%d)", s.CacheReadTokens, s.CacheWriteTokens)
 		}
 		fmt.Fprintf(stdout.Writer(), "%s, %s elapsed\n", base, elapsed)
 	} else {
 		fmt.Fprintf(stdout.Writer(), "[ocr] Summary: %d file(s) reviewed, %d comment(s), ~%d token(s) used, %s elapsed\n",
-			filesReviewed, commentsGenerated, totalTokens, elapsed)
+			s.FilesReviewed, s.CommentsGenerated, s.TotalTokens, elapsed)
 	}
-	if sessionID != "" {
-		fmt.Fprintf(stdout.Writer(), "[ocr] Session: %s\n", sessionID)
+	if s.SessionID != "" {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Session: %s\n", s.SessionID)
 	}
 }
 

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -19,6 +19,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/alibaba/open-code-review/internal/stdout"
 )
 
 func setupEnabledTelemetry(t *testing.T) {
@@ -124,30 +126,88 @@ func TestPhaseEvent_WithError(t *testing.T) {
 	PhaseEvent(ctx, "scan", "main.go", 500*time.Millisecond, errors.New("parse error"))
 }
 
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	restore := stdout.Swap(&buf)
+	defer restore()
+	fn()
+	return buf.String()
+}
+
 func TestPrintTraceSummary_WithTokenDetails(t *testing.T) {
-	PrintTraceSummary(5, 10, 1000, 200, 1200, 0, 0, 3*time.Second, "")
+	out := captureStdout(t, func() {
+		PrintTraceSummary(TraceSummary{
+			FilesReviewed: 5, CommentsGenerated: 10,
+			InputTokens: 1000, OutputTokens: 200, TotalTokens: 1200,
+			Duration: 3 * time.Second,
+		})
+	})
+	want := "[ocr] Summary: 5 file(s) reviewed, 10 comment(s), ~1200 token(s) used (input: ~1000, output: ~200), 3s elapsed\n"
+	if out != want {
+		t.Errorf("PrintTraceSummary output = %q, want %q", out, want)
+	}
 }
 
 func TestPrintTraceSummary_WithCacheTokens(t *testing.T) {
-	PrintTraceSummary(3, 2, 500, 100, 600, 200, 50, 2*time.Second, "")
+	out := captureStdout(t, func() {
+		PrintTraceSummary(TraceSummary{
+			FilesReviewed: 3, CommentsGenerated: 2,
+			InputTokens: 500, OutputTokens: 100, TotalTokens: 600,
+			CacheReadTokens: 200, CacheWriteTokens: 50,
+			Duration: 2 * time.Second,
+		})
+	})
+	want := "[ocr] Summary: 3 file(s) reviewed, 2 comment(s), ~600 token(s) used (input: ~500, output: ~100), cache(read: ~200, write: ~50), 2s elapsed\n"
+	if out != want {
+		t.Errorf("PrintTraceSummary output = %q, want %q", out, want)
+	}
 }
 
 func TestPrintTraceSummary_NoTokenDetails(t *testing.T) {
-	PrintTraceSummary(2, 1, 0, 0, 500, 0, 0, 1*time.Second, "")
+	out := captureStdout(t, func() {
+		PrintTraceSummary(TraceSummary{
+			FilesReviewed: 2, CommentsGenerated: 1,
+			TotalTokens: 500,
+			Duration:    1 * time.Second,
+		})
+	})
+	want := "[ocr] Summary: 2 file(s) reviewed, 1 comment(s), ~500 token(s) used, 1s elapsed\n"
+	if out != want {
+		t.Errorf("PrintTraceSummary output = %q, want %q", out, want)
+	}
 }
 
 func TestPrintTraceSummary_WithSessionID(t *testing.T) {
-	// A non-empty session ID prints the session line after the summary.
-	// Mirrors the smoke-test style of the existing PrintTraceSummary tests;
-	// stdout.Writer() captures os.Stdout at init, so output text is not asserted here.
-	PrintTraceSummary(5, 10, 1000, 200, 1200, 0, 0, 3*time.Second, "3a7f2b1c-9d4e-4f8a-b2c1-6e7f8a9b0c1d")
+	out := captureStdout(t, func() {
+		PrintTraceSummary(TraceSummary{
+			FilesReviewed: 5, CommentsGenerated: 10,
+			InputTokens: 1000, OutputTokens: 200, TotalTokens: 1200,
+			Duration:  3 * time.Second,
+			SessionID: "3a7f2b1c-9d4e-4f8a-b2c1-6e7f8a9b0c1d",
+		})
+	})
+	want := "[ocr] Summary: 5 file(s) reviewed, 10 comment(s), ~1200 token(s) used (input: ~1000, output: ~200), 3s elapsed\n" +
+		"[ocr] Session: 3a7f2b1c-9d4e-4f8a-b2c1-6e7f8a9b0c1d\n"
+	if out != want {
+		t.Errorf("PrintTraceSummary output = %q, want %q", out, want)
+	}
 }
 
 func TestPrintTraceSummary_WithoutSessionID(t *testing.T) {
-	// An empty session ID exercises the omit path (no session line printed).
+	// An empty session ID exercises the omit path: no session line is printed.
 	// The empty case arises when session persistence is unavailable, not from
 	// preview mode (preview does not reach PrintTraceSummary).
-	PrintTraceSummary(2, 1, 0, 0, 500, 0, 0, 1*time.Second, "")
+	out := captureStdout(t, func() {
+		PrintTraceSummary(TraceSummary{
+			FilesReviewed: 2, CommentsGenerated: 1,
+			TotalTokens: 500,
+			Duration:    1 * time.Second,
+		})
+	})
+	if strings.Contains(out, "Session:") {
+		t.Errorf("expected no session line for empty session ID, got %q", out)
+	}
 }
 
 func TestPrintToolCallStarted_WithArgs(t *testing.T) {


### PR DESCRIPTION
## Description

`PrintTraceSummary` had grown to nine positional parameters after the session ID parameter landed in #870, making call sites hard to read and easy to get wrong as the signature grows. This PR implements issue #906, Option A:

- Introduce a `TraceSummary` struct and change `PrintTraceSummary` to accept it as a single parameter. Printed output is byte-for-byte unchanged.
- Add `stdout.Swap(replacement io.Writer) func()` to `internal/stdout`, which swaps the package writer under the existing mutex and returns a restore function. This finally lets tests redirect and assert output written through `stdout.Writer()`.
- Rewrite the five `PrintTraceSummary` tests from smoke tests ("call it and hope it does not panic") into output assertions covering the exact summary line, the cache-token variant, the no-token-details variant, and the presence/absence of the `[ocr] Session:` line.
- Update the single production caller in `cmd/opencodereview/shared.go` to pass the struct with named fields.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

Note: `PrintTraceSummary`'s signature changes, but it is internal to the module (`internal/telemetry`), so no external API breaks.

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

- New `stdout.Swap` tests cover capture, restore, and nesting with `Quiet()`; the telemetry tests were written first and watched to fail (`undefined: Swap`, `undefined: TraceSummary`) before implementation.
- Full suite passes under the race detector (`make test`), and `make coverage` reports 91.3%, above the 90% threshold.
- `make check` (license headers, English-only scan, `go mod tidy`, `gofmt -s`, `go vet`) passes.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #906
