### PR TITLE
fix(pages): make install-channel command box scrollable

### DIFF
--- a/pages/src/components/HeroSection.tsx
+++ b/pages/src/components/HeroSection.tsx
@@ -518,13 +518,16 @@ const HeroSection: React.FC = () => {
               }}
             >
               <span
+                className="command-scroll"
                 style={{
+                  flex: 1,
+                  minWidth: 0,
                   fontSize: 13,
                   fontFamily: 'Menlo, monospace',
                   color: 'rgba(255,255,255,0.85)',
                   whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
+                  overflowX: 'auto',
+                  overflowY: 'hidden',
                 }}
               >
                 {activeChannel.cmd}

--- a/pages/src/styles/index.css
+++ b/pages/src/styles/index.css
@@ -47,6 +47,28 @@ a {
   background: rgba(255,255,255,0.3);
 }
 
+.command-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+.command-scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.command-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.command-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+}
+
+.command-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
 /* Terminal cursor blink */
 @keyframes cursor-blink {
   0%, 100% { opacity: 1; }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
<img width="1373" height="796" alt="Screenshot 2026-08-14 at 9 42 16 PM" src="https://github.com/user-attachments/assets/f8fb65c2-ad56-4e69-a60a-c61604f9bbae" />
The command box in the picture above is not scrollable, so even if the screen is wide enough, the command will never show completely, it will always end will '...'. This PR make the command box scrollable from left to right, the scroll bar now automatically fade after a short time.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)
`npm run lint` & npm commands
Here is the final effect:

https://github.com/user-attachments/assets/d473f761-e350-4618-84ad-39b8a2704d92


## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
none yet