### PR TITLE
feat(providers): add kimi-global (Moonshot international API) to built-in providers

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -206,6 +206,20 @@ var registry = []Provider{
 		},
 	},
 	{
+		Name:        "kimi-global",
+		DisplayName: "Kimi Moonshot API (Global)",
+		Protocol:    ProtocolOpenAIChatCompletions,
+		BaseURL:     "https://api.moonshot.ai/v1",
+		EnvVar:      "MOONSHOT_GLOBAL_API_KEY",
+		Models: []string{
+			"kimi-k3",
+			"kimi-k2.7-code",
+			"kimi-k2.7-code-highspeed",
+			"kimi-k2.6",
+			"kimi-k2.5",
+		},
+	},
+	{
 		Name:        "z-ai",
 		DisplayName: "Z.AI API",
 		Protocol:    ProtocolOpenAIChatCompletions,

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -75,7 +75,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "litellm", "mimo", "minimax", "minimax-cn", "mistral", "novita", "ollama-cloud", "openai", "siliconflow", "siliconflow-cn", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "hy-tokenplan", "iflytek", "kimi", "kimi-global", "litellm", "mimo", "minimax", "minimax-cn", "mistral", "novita", "ollama-cloud", "openai", "siliconflow", "siliconflow-cn", "tencent-tokenhub", "volcengine", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -54,6 +54,7 @@ environment variable.
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
 | `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
+| `kimi-global` | openai | `https://api.moonshot.ai/v1` | `MOONSHOT_GLOBAL_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimax.io/v1` | `MINIMAX_GLOBAL_API_KEY` |

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -52,6 +52,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
 | `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
+| `kimi-global` | openai | `https://api.moonshot.ai/v1` | `MOONSHOT_GLOBAL_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimax.io/v1` | `MINIMAX_GLOBAL_API_KEY` |

--- a/pages/src/content/docs/ru/configuration.md
+++ b/pages/src/content/docs/ru/configuration.md
@@ -57,6 +57,7 @@ API-ключ. Если `providers.<name>.api_key` не задан, OCR испо�
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
 | `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
+| `kimi-global` | openai | `https://api.moonshot.ai/v1` | `MOONSHOT_GLOBAL_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimax.io/v1` | `MINIMAX_GLOBAL_API_KEY` |

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -51,6 +51,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `hy-tokenplan` | openai | `https://api.lkeap.cloud.tencent.com/plan/v3` | `TENCENT_HUNYUAN_TOKENPLAN_KEY` |
 | `iflytek` | openai | `https://spark-api-open.xf-yun.com/v1` | `SPARK_API_KEY` |
 | `kimi` | openai | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
+| `kimi-global` | openai | `https://api.moonshot.ai/v1` | `MOONSHOT_GLOBAL_API_KEY` |
 | `z-ai` | openai | `https://open.bigmodel.cn/api/paas/v4` | `Z_AI_API_KEY` |
 | `mimo` | openai | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` |
 | `minimax` | openai | `https://api.minimax.io/v1` | `MINIMAX_GLOBAL_API_KEY` |


### PR DESCRIPTION
## Description

Moonshot operates two first-party API endpoints:

| Endpoint | Region | In OCR today |
|---|---|---|
| `https://api.moonshot.cn/v1` | mainland China | ✅ registered as `kimi` |
| `https://api.moonshot.ai/v1` | international | ❌ missing |

Only the mainland endpoint is currently registered, so users outside mainland China can't pick a Kimi model from the built-in provider list — they have to hand-configure a custom base URL.

This PR registers `kimi-global` for the international endpoint. It's OpenAI-compatible, so it uses the existing `openai` chat-completions protocol with **no new client code** — the same shape as the existing global/CN provider pairs already in the registry (`siliconflow` / `siliconflow-cn`, `minimax` / `minimax-cn`).

- **Base URL:** `https://api.moonshot.ai/v1`
- **Auth:** `MOONSHOT_GLOBAL_API_KEY` (mirrors the `SILICONFLOW_GLOBAL_API_KEY` / `MINIMAX_GLOBAL_API_KEY` naming already used for the global half of a pair)
- **Models:** mirrors the existing `kimi` list — both are Moonshot's own platform serving the same model family (`siliconflow` / `siliconflow-cn` mirror each other the same way). `kimi-k3` has been served on the international platform since its 2026-07-16 API launch.

The existing `kimi` provider is **left untouched**, so this is non-breaking for current users.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] `make check` passes locally (`gofmt`, `go vet`, license headers — `check passed`)
- [x] Manual testing (described below)

Verified the endpoint is live and OpenAI-compatible — an unauthenticated request returns the standard OpenAI error envelope rather than a transport error:

```
$ curl -s https://api.moonshot.ai/v1/models
{"error":{"message":"Incorrect API key provided","type":"incorrect_api_key_error"}}
```

`go test ./internal/llm/...` → `ok github.com/alibaba/open-code-review/internal/llm`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works (updated the provider-list assertion in `providers_test.go`)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (`configuration.md` provider table, all 4 locales: en/ja/ru/zh)
- [x] I have signed the CLA

## Related Issues

None — filed directly, matching the precedent of #772 (`siliconflow` GLOBAL) which was merged without a linked issue.
