### PR TITLE
feat(providers): add glm-5.3 to the Z.AI Coding Plan provider

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -226,6 +226,7 @@ var registry = []Provider{
 		BaseURL:     "https://open.bigmodel.cn/api/coding/paas/v4",
 		EnvVar:      "Z_AI_CODING_API_KEY",
 		Models: []string{
+			"glm-5.3",
 			"glm-5.2",
 			"glm-5.1",
 			"glm-5-turbo",


### PR DESCRIPTION
## Description

Z.ai released **GLM-5.3** on 2026-08-14 and rolled it out to all GLM Coding Plan tiers, so `z-ai-coding` users can select it today. This adds `glm-5.3` to that provider's model list (newest-first, matching the existing ordering).

**Scoped to `z-ai-coding` deliberately.** It is *not* added to the general `z-ai` provider, because at the time of writing:

- the official Z.AI docs page for GLM-5.3 still states the **API is "coming soon"** for the general endpoint, and
- the community model registry ([models.dev](https://github.com/anomalyco/models.dev)) carries `glm-5.3` under the **coding-plan** providers (`zai-coding-plan`, `zhipuai-coding-plan`) but **not** under the general `zai` / `zhipuai` providers — whereas `glm-5.2` is present under both.

Once GLM-5.3 reaches the general endpoint, adding it to `z-ai` is a one-line follow-up.

Same shape as #163 (`add glm-5.2 to z-ai provider models`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] `make check` passes locally (`gofmt`, `go vet`, license headers — `check passed`)

`go test ./internal/llm/...` → `ok github.com/alibaba/open-code-review/internal/llm`. No test fixtures assert the `z-ai-coding` model list, so no test changes were required (the model-order assertions cover `anthropic`, `openai`, and `ollama-cloud` only).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (n/a — the `configuration.md` provider table lists providers and base URLs, not individual models)
- [x] I have signed the CLA

## Related Issues

None.
