### PR TITLE
fix(diff): re-file comments whose code lives in another file

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -241,6 +241,7 @@ func New(args Args) *Agent {
 		CommentWorkerPool: args.CommentWorkerPool,
 		Session:           args.Session,
 		DiffLookup:        a.findDiff,
+		AllDiffs:          a.allDiffs,
 		// Non-nil only here: the same Runner serves scan, whose requests must
 		// stay out of the retry report. See newRequestMeta.
 		NewRequestMeta: a.newRequestMeta,
@@ -1748,6 +1749,14 @@ func orderedToolParameters(raw json.RawMessage) ([]orderedToolParameter, bool) {
 		return nil, false
 	}
 	return params, true
+}
+
+// allDiffs exposes the reviewed diff set for cross-file comment re-filing.
+// It is read-only and safe to call from the per-file subtask goroutines: every
+// mutation of a.diffs (filterDiffs, filterLargeDiffs) completes before dispatch
+// begins, so the slice is stable for the rest of the run.
+func (a *Agent) allDiffs() []model.Diff {
+	return a.diffs
 }
 
 // findDiff returns the Diff for the given file path, or nil if not found.

--- a/internal/diff/relocate_across_files_test.go
+++ b/internal/diff/relocate_across_files_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/model"
+)
+
+// headerDiff declares the function; sourceDiff implements it. This is the split
+// that produces mis-filed comments in practice: the Agent reviews the header,
+// reads the source through file_read_diff, and files a comment about the body
+// against the header.
+const headerDiff = `diff --git a/src/span.h b/src/span.h
+--- a/src/span.h
++++ b/src/span.h
+@@ -10,3 +10,4 @@
+ void span_set_text(span_t * span, const char * text);
++void span_set_text_fmt(span_t * span, const char * fmt, ...);
+`
+
+const sourceDiff = `diff --git a/src/span.c b/src/span.c
+--- a/src/span.c
++++ b/src/span.c
+@@ -40,4 +40,7 @@
+ void span_set_text_fmt(span_t * span, const char * fmt, ...)
+ {
++	char * text = span_vfmt(fmt, args);
++	if(text == NULL) return;
++	va_end(args);
+ }
+`
+
+func diffsFixture() []model.Diff {
+	return []model.Diff{
+		{NewPath: "src/span.h", OldPath: "src/span.h", Diff: headerDiff},
+		{NewPath: "src/span.c", OldPath: "src/span.c", Diff: sourceDiff},
+	}
+}
+
+func TestRelocateAcrossFiles_RefilesToImplementation(t *testing.T) {
+	cm := &model.LlmComment{
+		Path:         "src/span.h",
+		Content:      "va_end is skipped on the early return",
+		ExistingCode: "\tif(text == NULL) return;\n\tva_end(args);",
+	}
+
+	got, ok := RelocateAcrossFiles(cm, diffsFixture())
+	if !ok {
+		t.Fatal("expected a unique hit in src/span.c")
+	}
+	if got != "src/span.c" || cm.Path != "src/span.c" {
+		t.Fatalf("path = %q, cm.Path = %q; want src/span.c for both", got, cm.Path)
+	}
+	// Line numbers must move with the path, or the comment is re-filed onto the
+	// right file while still pointing at the wrong line.
+	if cm.StartLine <= 0 || cm.EndLine < cm.StartLine {
+		t.Fatalf("StartLine/EndLine = %d/%d; want a resolved range", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestRelocateAcrossFiles_DeclinesWhenAmbiguous(t *testing.T) {
+	// The same excerpt in two files: re-filing onto either one would just swap
+	// one wrong location for another, so the comment must be left alone.
+	dup := `diff --git a/src/other.c b/src/other.c
+--- a/src/other.c
++++ b/src/other.c
+@@ -1,2 +1,4 @@
++	char * text = span_vfmt(fmt, args);
++	if(text == NULL) return;
++	va_end(args);
+ }
+`
+	diffs := append(diffsFixture(), model.Diff{NewPath: "src/other.c", OldPath: "src/other.c", Diff: dup})
+	cm := &model.LlmComment{
+		Path:         "src/span.h",
+		ExistingCode: "\tif(text == NULL) return;\n\tva_end(args);",
+	}
+
+	if _, ok := RelocateAcrossFiles(cm, diffs); ok {
+		t.Fatal("expected no verdict when the excerpt matches more than one file")
+	}
+	if cm.Path != "src/span.h" || cm.StartLine != 0 || cm.EndLine != 0 {
+		t.Fatalf("cm mutated on decline: path=%q start=%d end=%d", cm.Path, cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestRelocateAcrossFiles_DeclinesWhenAbsent(t *testing.T) {
+	cm := &model.LlmComment{
+		Path:         "src/span.h",
+		ExistingCode: "int nothing_here = 0;",
+	}
+	if _, ok := RelocateAcrossFiles(cm, diffsFixture()); ok {
+		t.Fatal("expected no hit for code absent from every diff")
+	}
+	if cm.Path != "src/span.h" {
+		t.Fatalf("cm.Path mutated to %q on decline", cm.Path)
+	}
+}
+
+func TestRelocateAcrossFiles_SkipsOwnFileAndEmptyInputs(t *testing.T) {
+	// A comment already resolvable in its own file must not be re-filed: the
+	// caller only reaches here after same-file resolution failed, but the
+	// function still has to exclude cm.Path so a self-match cannot masquerade
+	// as a cross-file hit.
+	cm := &model.LlmComment{
+		Path:         "src/span.c",
+		ExistingCode: "\tva_end(args);",
+	}
+	if _, ok := RelocateAcrossFiles(cm, diffsFixture()); ok {
+		t.Fatal("expected the comment's own file to be excluded from the search")
+	}
+
+	for name, arg := range map[string]*model.LlmComment{
+		"nil comment":        nil,
+		"empty ExistingCode": {Path: "src/span.h"},
+	} {
+		if _, ok := RelocateAcrossFiles(arg, diffsFixture()); ok {
+			t.Fatalf("%s: expected no hit", name)
+		}
+	}
+	if _, ok := RelocateAcrossFiles(&model.LlmComment{ExistingCode: "x"}, nil); ok {
+		t.Fatal("empty diff set: expected no hit")
+	}
+}

--- a/internal/diff/resolver.go
+++ b/internal/diff/resolver.go
@@ -72,6 +72,72 @@ func ResolveComment(cm *model.LlmComment, d *model.Diff) bool {
 	return resolveFromFileContent(d, cm)
 }
 
+// RelocateAcrossFiles handles the comment whose ExistingCode belongs to a
+// different file than the one it was filed against.
+//
+// The reviewing Agent reads related files through file_read_diff, so it can
+// describe code from a file other than the one under review and still file the
+// comment against the file under review — typically a declaration/implementation
+// split, where the comment lands on the header and its code lives in the source
+// file. ResolveComment then fails, and the LLM re-location that follows is given
+// only the wrong file's diff and a prompt that demands a code block back, so it
+// answers with whatever token in that diff looks closest. That overwrites the
+// one piece of evidence pointing at the real code, and the comment ends up
+// looking located while pointing at an unrelated line.
+//
+// So this runs first, and without a model: ExistingCode is a verbatim excerpt,
+// which makes finding its true home plain string matching over the diffs that
+// are already in memory. On a unique hit the comment is re-filed — Path,
+// StartLine and EndLine all move together — and it returns that path.
+//
+// Zero hits and multiple hits both decline, leaving cm untouched: the same
+// boilerplate can legitimately appear in several files, and guessing between
+// them would trade one wrong location for another. Callers should treat a
+// false return as "still unlocated" rather than as an error.
+//
+// cm.Path is skipped because its own file has already been tried, and probing
+// happens on a copy so a failed candidate cannot leave line numbers behind.
+func RelocateAcrossFiles(cm *model.LlmComment, diffs []model.Diff) (string, bool) {
+	if cm == nil || cm.ExistingCode == "" || len(diffs) == 0 {
+		return "", false
+	}
+
+	type hit struct {
+		path       string
+		start, end int
+	}
+	var hits []hit
+
+	for i := range diffs {
+		d := &diffs[i]
+		if d.NewPath == cm.Path || d.OldPath == cm.Path {
+			continue
+		}
+		probe := *cm
+		probe.StartLine, probe.EndLine = 0, 0
+		if !ResolveComment(&probe, d) {
+			continue
+		}
+		path := d.NewPath
+		if path == "" {
+			path = d.OldPath
+		}
+		hits = append(hits, hit{path: path, start: probe.StartLine, end: probe.EndLine})
+		if len(hits) > 1 {
+			// Ambiguous already; no verdict can come from looking further.
+			return "", false
+		}
+	}
+
+	if len(hits) != 1 {
+		return "", false
+	}
+	cm.Path = hits[0].path
+	cm.StartLine = hits[0].start
+	cm.EndLine = hits[0].end
+	return hits[0].path, true
+}
+
 // indexedLine pairs a normalized line with its absolute file line number.
 type indexedLine struct {
 	lineNum int

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -40,6 +40,15 @@ type Deps struct {
 	// NewFileContent is the whole file and Diff is empty).
 	DiffLookup func(path string) *model.Diff
 
+	// AllDiffs returns every diff this run reviews, for re-filing a comment
+	// whose ExistingCode belongs to a different file than the one it was filed
+	// against (diff.RelocateAcrossFiles). It is the reviewed set rather than
+	// every parsed diff on purpose: re-filing a comment onto a path the run
+	// excluded would point the reader at a file this review never covered.
+	// When nil, cross-file re-filing is skipped and only same-file resolution
+	// applies.
+	AllDiffs func() []model.Diff
+
 	// NewRequestMeta builds the retry-report identity for one logical LLM
 	// request. Non-nil only for review: the retry report describes ocr review,
 	// and this Runner is shared with scan (internal/scan.Agent calls RunPerFile),
@@ -548,8 +557,23 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 				if r.deps.DiffLookup != nil {
 					d = r.deps.DiffLookup(cm.Path)
 				}
+				// Resolution order: the comment's own file, then a cross-file
+				// search, then the LLM. The cross-file search precedes the LLM
+				// because it needs the Agent's original ExistingCode, which the
+				// LLM step overwrites; and it runs even when d is nil, since a
+				// comment filed against a path this run holds no diff for is
+				// exactly the case that search can still place.
+				located := d != nil && diff.ResolveComment(cm, d)
+				if !located && r.deps.AllDiffs != nil {
+					from := cm.Path
+					if to, ok := diff.RelocateAcrossFiles(cm, r.deps.AllDiffs()); ok {
+						located = true
+						r.RecordWarning("comment_refiled", to, fmt.Sprintf(
+							"comment filed against %s describes code in %s; re-filed", from, to))
+					}
+				}
 				if d != nil {
-					if !diff.ResolveComment(cm, d) && r.deps.Template.ReLocationTask != nil {
+					if !located && r.deps.Template.ReLocationTask != nil {
 						// rlStart stays ahead of prompt construction, which is
 						// where it sat when ReLocateComment built the messages
 						// itself — moving it would silently change what


### PR DESCRIPTION
## Problem

The reviewing agent reads related files through `file_read_diff`, so it can describe code from one file while still filing the comment against the file currently under review. In practice this is almost always a declaration/implementation split: the comment lands on the header, its code lives in the source file.

`ResolveComment` then fails, and `RE_LOCATION_TASK` runs. That task is handed **only the wrong file's diff**, plus a prompt that ends with:

> Output ONLY a fenced code block. No explanation, no commentary.

There is no way to answer "this code is not in here". So the model returns whichever token in that diff looks closest — usually a line containing the same identifier. Three consequences, in order of severity:

1. `ExistingCode` is overwritten, destroying the only pointer to the real code.
2. The comment now looks located, hiding the mis-filing from everything downstream.
3. The reader clicks through to an unrelated line.

Real cases from recorded sessions:

| Comment is about | It was pointed at |
|---|---|
| mpv: the callback merge/dedup logic (`command.c:7706`) | `command.h:69` — a struct definition |
| valkey: the `#ifdef USE_RDMA` body (`cli_common.c:435`) | `cli_common.h:56` — the function prototype |
| waveterm: an empty auth handler **and** a token-leaking log line (two distinct comments) | both → the same line, `wshrpctypes.go:34` |

## Change

`diff.RelocateAcrossFiles` searches the other diffs before the model runs. `ExistingCode` is a verbatim excerpt, so locating its real home is plain string matching over diffs already in memory — no request, no tokens.

- **Unique hit** → the comment is re-filed, with `Path`, `StartLine` and `EndLine` moving together.
- **Zero or multiple hits** → decline, leaving the comment untouched. The same boilerplate legitimately appears in several files, and guessing between them would trade one wrong location for another.

Two ordering details are load-bearing:

- It must run **before** the LLM step, which overwrites the excerpt the search depends on.
- It also runs when the comment's own path has no diff at all — the case the previous code skipped entirely, so those comments never got located.

Scope is the **reviewed** diff set, not every parsed diff, so a comment is never re-filed onto a path this review did not cover. `scan` leaves `AllDiffs` nil: it feeds synthetic whole-file diffs, where cross-file re-filing does not apply.

## Evaluation

Replayed against recorded review sessions: 160 sessions, 800 comments, 1170 reconstructed file diffs. No model involved — the search is pure string matching, so replaying the production `ResolveComment` / `RelocateAcrossFiles` in the order `llmloop` uses reproduces exactly what a real run decides.

Comments whose `ExistingCode` had been overwritten by `RE_LOCATION_TASK` are restored to the agent's original excerpt first; otherwise the evaluation would score the very cases this change targets as "already located".

### Mis-filed comments: 15 of 19 fixed

| Repo | Before | After |
|---|---|---|
| electron | `serial_chooser_controller.h:61` — function declaration | `serial_chooser_controller.cc:165` — the implementation |
| mpv | `command.h:69` — struct definition | `command.c:7706` — the callback logic |
| valkey | `cli_common.h:56` — prototype | `cli_common.c:435` — the `#ifdef` body |
| waveterm | `wshrpctypes.go:34` — constant | `wshproxy.go:144` — the logging call |
| dbeaver | `plugin.xml` — unlocated | `HANATable.java:161` |
| typescript-go ×2 | `cmd/tsgo/sys.go` — unlocated | `internal/execute/watch.go:45/48` |
| FreeCAD ×3 | `.h` at L0/L73/L80 | `.cpp` at L101/L180/L391 |
| timescaledb ×2 | `.sql` at L0/L306 | `refresh.c:1145`, `recompress.c:171` |
| ClickHouse, immich | `.h` / `.sql` — unlocated | `.cpp:486`, `person.service.ts:553` |

Every one moves declaration or config to implementation. The four not fixed reference lines that appear only as unchanged context, which hunk matching cannot reach; their behaviour is unchanged from before.

### Correctly located comments: unchanged

| Category | Count | Attribution changed |
|---|---|---|
| Resolved against their own file (search not invoked) | 684 | **0** |
| Search declined (zero or multiple hits) | 76 | **0** |
| **Total change surface** | **15 / 775 (1.9%)** | — |

This is also guaranteed structurally, not just empirically: the search is only reached when same-file resolution fails, and it writes no field on the comment unless it has exactly one hit. `relocate_across_files_test.go` covers re-filing to the implementation, declining on ambiguity, declining on absence, and excluding the comment's own file.

### Known limitation

The diffs reconstructed from session records carry no `NewFileContent`, so `resolveFromFileContent` is inert during replay and only hunk matching contributes. This makes the numbers conservative in one direction: **15 re-filings is a lower bound**, and the 76 declines are overstated — 75 of them did have line numbers in the original runs. The file-attribution results are unaffected, since those follow from the invocation condition and the decline semantics rather than from matching strength.

## Follow-up (not in this PR)

`RE_LOCATION_TASK` still has no way to say "not found", so comments the search declines can still receive a fabricated location from the model. Giving that prompt an explicit no-match exit is a separate change, and it needs a decision on how an unlocated comment should be represented in the JSON and SARIF output.
