### PR TITLE
fix(cli): report the real exit code when the binary is killed by a signal

### DIFF
--- a/bin/ocr.js
+++ b/bin/ocr.js
@@ -21,12 +21,21 @@ const { resolveNativeBinary } = require("../scripts/platform");
 // Exported for testing.
 function computeExit(result) {
   if (result.signal) {
+    // os.constants.signals has no entry for signal names Node doesn't
+    // recognize on this platform; fall back to SIGHUP's number (1) so we
+    // still report a signal-related failure instead of throwing.
     return {
       code: 128 + (os.constants.signals[result.signal] || 1),
       message: `[ERROR] OpenCodeReview binary was terminated by signal ${result.signal}`,
     };
   }
-  return { code: result.status ?? (result.error ? 1 : 0), message: null };
+  if (result.error) {
+    return {
+      code: result.status ?? 1,
+      message: `[ERROR] Failed to run OpenCodeReview binary: ${result.error.message}`,
+    };
+  }
+  return { code: result.status ?? 0, message: null };
 }
 
 function main() {

--- a/bin/ocr.js
+++ b/bin/ocr.js
@@ -12,52 +12,79 @@ const os = require("os");
 
 const { resolveNativeBinary } = require("../scripts/platform");
 
-const resolved = resolveNativeBinary();
-if (!resolved) {
-  console.error(
-    "[ERROR] OpenCodeReview binary not found. Run: npm install -g @alibaba-group/open-code-review"
-  );
-  process.exit(1);
-}
-const binaryPath = resolved.path;
-
-const hintFile = path.join(os.homedir(), ".opencodereview", "update-available");
-try {
-  const hint = JSON.parse(fs.readFileSync(hintFile, "utf8"));
-  if (hint.version && hint.pkg) {
-    console.error(
-      `\x1b[33m[ocr] A new version (v${hint.version}) is available. Run to update:\x1b[0m\n` +
-      `\x1b[33m  npm i -g ${hint.pkg}@${hint.version}\x1b[0m\n`
-    );
+// Determines the exit code for a spawnSync() result against the native
+// binary. `result.status` is null when the process was terminated by a
+// signal rather than exiting normally -- e.g. OOM-killed -- and in that
+// case `result.error` is also unset, since no spawn error occurred. Exit
+// with 128 + signal number, the same convention shells use, instead of
+// falling through to 0 and reporting a signal-killed run as a success.
+// Exported for testing.
+function computeExit(result) {
+  if (result.signal) {
+    return {
+      code: 128 + (os.constants.signals[result.signal] || 1),
+      message: `[ERROR] OpenCodeReview binary was terminated by signal ${result.signal}`,
+    };
   }
-} catch (_) {}
+  return { code: result.status ?? (result.error ? 1 : 0), message: null };
+}
 
-if (!process.env.OCR_NO_UPDATE) {
-  const stateDir = path.join(os.homedir(), ".opencodereview");
-  const tsFile = path.join(stateDir, "last-update-check");
-  const cooldownMs =
-    (parseInt(process.env.OCR_UPDATE_INTERVAL, 10) || 18) * 60 * 1000;
+function main() {
+  const resolved = resolveNativeBinary();
+  if (!resolved) {
+    console.error(
+      "[ERROR] OpenCodeReview binary not found. Run: npm install -g @alibaba-group/open-code-review"
+    );
+    process.exit(1);
+  }
+  const binaryPath = resolved.path;
 
-  let shouldCheck = true;
+  const hintFile = path.join(os.homedir(), ".opencodereview", "update-available");
   try {
-    const mt = fs.statSync(tsFile).mtimeMs;
-    if (Date.now() - mt < cooldownMs) shouldCheck = false;
+    const hint = JSON.parse(fs.readFileSync(hintFile, "utf8"));
+    if (hint.version && hint.pkg) {
+      console.error(
+        `\x1b[33m[ocr] A new version (v${hint.version}) is available. Run to update:\x1b[0m\n` +
+        `\x1b[33m  npm i -g ${hint.pkg}@${hint.version}\x1b[0m\n`
+      );
+    }
   } catch (_) {}
 
-  if (shouldCheck) {
-    const updateScript = path.join(__dirname, "..", "scripts", "update.js");
-    const child = spawn(process.execPath, [updateScript], {
-      detached: true,
-      stdio: "ignore",
-      env: Object.assign({}, process.env, { OCR_NO_UPDATE: "1" }),
-    });
-    child.unref();
+  if (!process.env.OCR_NO_UPDATE) {
+    const stateDir = path.join(os.homedir(), ".opencodereview");
+    const tsFile = path.join(stateDir, "last-update-check");
+    const cooldownMs =
+      (parseInt(process.env.OCR_UPDATE_INTERVAL, 10) || 18) * 60 * 1000;
+
+    let shouldCheck = true;
+    try {
+      const mt = fs.statSync(tsFile).mtimeMs;
+      if (Date.now() - mt < cooldownMs) shouldCheck = false;
+    } catch (_) {}
+
+    if (shouldCheck) {
+      const updateScript = path.join(__dirname, "..", "scripts", "update.js");
+      const child = spawn(process.execPath, [updateScript], {
+        detached: true,
+        stdio: "ignore",
+        env: Object.assign({}, process.env, { OCR_NO_UPDATE: "1" }),
+      });
+      child.unref();
+    }
   }
+
+  const result = spawnSync(binaryPath, process.argv.slice(2), {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  const { code, message } = computeExit(result);
+  if (message) console.error(message);
+  process.exit(code);
 }
 
-const result = spawnSync(binaryPath, process.argv.slice(2), {
-  stdio: "inherit",
-  env: process.env,
-});
+if (require.main === module) {
+  main();
+}
 
-process.exit(result.status ?? (result.error ? 1 : 0));
+module.exports = { computeExit };

--- a/bin/ocr.test.js
+++ b/bin/ocr.test.js
@@ -26,10 +26,11 @@ const { computeExit } = require("./ocr.js");
 }
 
 // spawnSync itself failed (e.g. ENOENT) -- no status, no signal, has error.
+// The error's message should be surfaced, not silently discarded.
 {
   const { code, message } = computeExit({ status: null, signal: null, error: new Error("ENOENT") });
   assert.strictEqual(code, 1);
-  assert.strictEqual(message, null);
+  assert.match(message, /Failed to run OpenCodeReview binary: ENOENT/);
 }
 
 // Terminated by a signal: status is null and error is unset (this is the

--- a/bin/ocr.test.js
+++ b/bin/ocr.test.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+// Unit tests for bin/ocr.js's computeExit().
+//
+// Run via: node bin/ocr.test.js
+
+"use strict";
+
+const assert = require("assert");
+const { computeExit } = require("./ocr.js");
+
+// Normal exit, no signal.
+{
+  const { code, message } = computeExit({ status: 0, signal: null, error: undefined });
+  assert.strictEqual(code, 0);
+  assert.strictEqual(message, null);
+}
+
+{
+  const { code, message } = computeExit({ status: 2, signal: null, error: undefined });
+  assert.strictEqual(code, 2);
+  assert.strictEqual(message, null);
+}
+
+// spawnSync itself failed (e.g. ENOENT) -- no status, no signal, has error.
+{
+  const { code, message } = computeExit({ status: null, signal: null, error: new Error("ENOENT") });
+  assert.strictEqual(code, 1);
+  assert.strictEqual(message, null);
+}
+
+// Terminated by a signal: status is null and error is unset (this is the
+// bug -- the old code fell through to 0, reporting a signal-killed run as
+// a success).
+{
+  const { code, message } = computeExit({ status: null, signal: "SIGKILL", error: undefined });
+  assert.strictEqual(code, 137); // 128 + 9
+  assert.match(message, /terminated by signal SIGKILL/);
+}
+
+{
+  const { code, message } = computeExit({ status: null, signal: "SIGTERM", error: undefined });
+  assert.strictEqual(code, 143); // 128 + 15
+  assert.match(message, /terminated by signal SIGTERM/);
+}
+
+console.log("ocr.test.js: all tests passed");


### PR DESCRIPTION
Fixes #931.

`process.exit(result.status ?? (result.error ? 1 : 0))` exits 0 when spawnSync's result has neither `status` nor `error` set, which is exactly what happens when the binary gets killed by a signal (OOM etc.) — `status` is null and there's no spawn error, so a signal-killed run looked like success to any CI/automation gating on exit code. Now it exits with 128 + the signal number, same convention shells use, and prints which signal killed it.

Also pulled the exit-code decision into a small `computeExit()` function and moved the rest into `main()` guarded by `require.main === module`, since the file previously ran everything at require time and couldn't be tested without spawning a real subprocess. Added `bin/ocr.test.js` covering normal exit, spawn error, and both signal cases.