### PR TITLE
fix(diff,tool): fix CRLF parsing and cross-platform path traversal handling

### DIFF
--- a/internal/diff/hunk.go
+++ b/internal/diff/hunk.go
@@ -43,6 +43,7 @@ func ParseHunks(rawDiffText string) []Hunk {
 	var current *Hunk
 
 	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
 		if m := hunkHeaderRe.FindStringSubmatch(line); m != nil {
 			// Flush previous hunk
 			if current != nil {

--- a/internal/diff/hunk_test.go
+++ b/internal/diff/hunk_test.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -118,6 +119,25 @@ new file mode 100644
 	for _, l := range h.Lines {
 		if l.Type != HunkAdded {
 			t.Errorf("expected all lines to be HunkAdded, got %d", l.Type)
+		}
+	}
+}
+
+func TestParseHunks_CRLFLineEndings(t *testing.T) {
+	raw := "diff --git a/pkg/new.go b/pkg/new.go\r\n" +
+		"--- a/pkg/new.go\r\n" +
+		"+++ b/pkg/new.go\r\n" +
+		"@@ -1,2 +1,2 @@\r\n" +
+		"-old\r\n" +
+		"+new\r\n"
+
+	hunks := ParseHunks(raw)
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	for _, l := range hunks[0].Lines {
+		if strings.HasSuffix(l.Content, "\r") {
+			t.Errorf("hunk line content retains trailing CR: %q", l.Content)
 		}
 	}
 }

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -47,6 +47,7 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 	defer cancel()
 
 	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
 		if m := diffHeaderRe.FindStringSubmatch(line); m != nil {
 			// Flush previous diff
 			if current != nil {

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -272,3 +272,36 @@ index 1234567..89abcde 100644
 		t.Errorf("Insertions = %d, want 1", d.Insertions)
 	}
 }
+
+// TestParseDiffText_CRLFLineEndings guards against CRLF (\r\n) line endings in diffs:
+// trailing carriage returns must be stripped so NewPath is not polluted with '\r',
+// metadata markers like "--- /dev/null" match correctly, and file reading succeeds.
+func TestParseDiffText_CRLFLineEndings(t *testing.T) {
+	diffText := "diff --git a/fresh.go b/fresh.go\r\n" +
+		"new file mode 100644\r\n" +
+		"index 0000000..1234567\r\n" +
+		"--- /dev/null\r\n" +
+		"+++ b/fresh.go\r\n" +
+		"@@ -0,0 +1,2 @@\r\n" +
+		"+line1\r\n" +
+		"+line2\r\n"
+
+	dir := t.TempDir()
+	diffs, err := ParseDiffText(context.Background(), diffText, dir, "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.NewPath != "fresh.go" {
+		t.Errorf("NewPath = %q, want %q", d.NewPath, "fresh.go")
+	}
+	if !d.IsNew {
+		t.Errorf("IsNew = false, want true")
+	}
+	if d.Insertions != 2 {
+		t.Errorf("Insertions = %d, want 2", d.Insertions)
+	}
+}

--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -99,7 +100,7 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 }
 
 func hasTraversalPathComponent(pathspec string) bool {
-	for _, part := range strings.Split(pathspec, "/") {
+	for _, part := range strings.Split(filepath.ToSlash(pathspec), "/") {
 		if part == ".." {
 			return true
 		}

--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -100,7 +99,7 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 }
 
 func hasTraversalPathComponent(pathspec string) bool {
-	for _, part := range strings.Split(filepath.ToSlash(pathspec), "/") {
+	for _, part := range strings.Split(strings.ReplaceAll(pathspec, `\`, "/"), "/") {
 		if part == ".." {
 			return true
 		}

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -599,3 +599,17 @@ func TestBuildGrepArgs_NoIndex(t *testing.T) {
 	assertContains(t, args, "--exclude-standard")
 	assertNotContains(t, args, "--untracked")
 }
+
+func TestCodeSearch_RejectsBackslashPathTraversal(t *testing.T) {
+	p := NewCodeSearch(&FileReader{RepoDir: "/tmp", Ref: ""})
+	result, err := p.Execute(context.Background(), map[string]any{
+		"search_text":   "foo",
+		"file_patterns": []any{"..\\secret", "foo\\..\\bar"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Error: file_patterns must not contain ..") {
+		t.Errorf("expected traversal error, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Description

When unified diff text contains Windows-style CRLF (`\r\n`) line endings (e.g. from Windows environments, CI runners, or repositories with `core.autocrlf=true`), `ParseDiffText` and `ParseHunks` split lines on `\n` without stripping trailing `\r`.

This caused several severe issues:
1. `d.NewPath` retained a trailing `\r` (e.g. `"foo.go\r"`), causing subsequent file reading in `finalizeDiff` to fail with `stat file ...: The filename, directory name, or volume label syntax is incorrect` / `file not found`, leaving `d.NewFileContent` completely empty during review.
2. Strict equality checks for `--- /dev/null` and `+++ /dev/null` failed, resulting in lost `IsNew` and `IsDeleted` metadata.
3. Hunk line content retained trailing `\r`.

Additionally, in `internal/tool/code_search.go`, `hasTraversalPathComponent` only checked `/` separators, allowing Windows-style `..\` path traversal patterns to bypass the check.

### Changes Made:
- In `internal/diff/parser.go` and `internal/diff/hunk.go`: strip trailing `\r` when iterating lines.
- In `internal/tool/code_search.go`: normalize path separators using `filepath.ToSlash` in `hasTraversalPathComponent`.
- Added regression unit tests covering CRLF diff parsing, CRLF hunk parsing, and backslash path traversal in code search.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Added `TestParseDiffText_CRLFLineEndings` in `internal/diff/parser_test.go`
- [x] Added `TestParseHunks_CRLFLineEndings` in `internal/diff/hunk_test.go`
- [x] Added `TestCodeSearch_RejectsBackslashPathTraversal` in `internal/tool/code_search_test.go`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA

## Related Issues

Closes #933
