### PR TITLE
fix(review): honor lower max-tools overrides

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/alibaba/open-code-review/internal/agent"
+	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/diff"
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/mcp"
@@ -125,6 +126,7 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 	if err != nil {
 		return err
 	}
+	applyReviewMaxToolsOverride(cc.Template, opts.maxTools)
 	applyCLIExcludes(cc, splitPaths(opts.excludes))
 
 	// Security (#112): reject ref-option injection before any git invocation.
@@ -306,6 +308,12 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 		return errors.Join(resultErr, emitErr)
 	}
 	return emitErr
+}
+
+func applyReviewMaxToolsOverride(tpl *template.Template, maxTools int) {
+	if maxTools > 0 {
+		tpl.MaxToolRequestTimes = maxTools
+	}
 }
 
 func reviewResultError(runErr error, manifest *session.RunManifest) error {

--- a/cmd/opencodereview/review_cmd_test.go
+++ b/cmd/opencodereview/review_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,20 +17,26 @@ import (
 
 func TestApplyReviewMaxToolsOverride(t *testing.T) {
 	tests := []struct {
-		name     string
-		maxTools int
-		want     int
+		name        string
+		cliMaxTools int
+		want        int
 	}{
-		{name: "template default", maxTools: 0, want: 30},
-		{name: "lower override", maxTools: 10, want: 10},
-		{name: "middle override", maxTools: 20, want: 20},
-		{name: "higher override", maxTools: 40, want: 40},
+		{name: "template default", cliMaxTools: 0, want: 100},
+		{name: "below minimum clamps", cliMaxTools: 30, want: 50},
+		{name: "lower override", cliMaxTools: 50, want: 50},
+		{name: "middle override", cliMaxTools: 75, want: 75},
+		{name: "equal override", cliMaxTools: 100, want: 100},
+		{name: "higher override", cliMaxTools: 125, want: 125},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tpl := &template.Template{MaxToolRequestTimes: 30}
-			applyReviewMaxToolsOverride(tpl, tt.maxTools)
+			opts, err := parseReviewFlags([]string{"--max-tools", strconv.Itoa(tt.cliMaxTools)})
+			if err != nil {
+				t.Fatalf("parseReviewFlags: %v", err)
+			}
+			tpl := &template.Template{MaxToolRequestTimes: 100}
+			applyReviewMaxToolsOverride(tpl, opts.maxTools)
 			if tpl.MaxToolRequestTimes != tt.want {
 				t.Errorf("MaxToolRequestTimes = %d, want %d", tpl.MaxToolRequestTimes, tt.want)
 			}

--- a/cmd/opencodereview/review_cmd_test.go
+++ b/cmd/opencodereview/review_cmd_test.go
@@ -10,8 +10,32 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/session"
 )
+
+func TestApplyReviewMaxToolsOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxTools int
+		want     int
+	}{
+		{name: "template default", maxTools: 0, want: 30},
+		{name: "lower override", maxTools: 10, want: 10},
+		{name: "middle override", maxTools: 20, want: 20},
+		{name: "higher override", maxTools: 40, want: 40},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tpl := &template.Template{MaxToolRequestTimes: 30}
+			applyReviewMaxToolsOverride(tpl, tt.maxTools)
+			if tpl.MaxToolRequestTimes != tt.want {
+				t.Errorf("MaxToolRequestTimes = %d, want %d", tpl.MaxToolRequestTimes, tt.want)
+			}
+		})
+	}
+}
 
 func TestValidateReviewRefsRejectsOptionLikeCommit(t *testing.T) {
 	err := validateReviewRefs(t.TempDir(), reviewOptions{commit: "-O./pwn.sh"})


### PR DESCRIPTION
## Summary
- make validated positive review --max-tools values override the embedded template default
- preserve the scan command's existing raise-only behavior
- cover the parsed CLI default, clamp-to-50, lower, equal, and higher review overrides against the current 100-round template default

Closes #935.

## Verification
- git diff --check
- required ocr review --audience agent: the earlier source change completed with zero findings
- GitHub CI on the updated exact head