### PR TITLE
feat(allowlist): add Zig support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -75,6 +75,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".JSONNET", true},
 		{".libsonnet", true},
 		{".LIBSONNET", true},
+		{".zig", true},
+		{".ZIG", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -200,6 +202,12 @@ func TestIsExcludedPath(t *testing.T) {
 		{"jsonnet non-vendor env", "environments/prod/main.jsonnet", false},
 		{"go under vendor still reviewed", "vendor/github.com/pkg/errors/errors.go", false},
 		{"php under vendor still reviewed", "vendor/monolog/monolog/src/Logger.php", false},
+		// Zig test files
+		{"zig test directory", "test/parser.zig", true},
+		{"zig nested test directory", "src/test/unit/parser.zig", true},
+		{"zig _test suffix", "src/parser_test.zig", true},
+		{"zig non-test", "src/parser.zig", false},
+		{"zig test in filename", "src/testutil.zig", false},
 
 		// Snapshot files
 		{"jest snapshot dir", "src/__snapshots__/App.test.js.snap", true},

--- a/internal/config/allowlist/default_exclude_patterns.json
+++ b/internal/config/allowlist/default_exclude_patterns.json
@@ -34,5 +34,7 @@
   "**/*Tests.swift",
   "**/Tests/**/*.swift",
   "**/tests/**/*.elm",
-  "**/vendor/**/*.{jsonnet,libsonnet}"
+  "**/vendor/**/*.{jsonnet,libsonnet}",
+  "**/test/**/*.zig",
+  "**/*_test.zig"
 ]

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -90,5 +90,6 @@
   ".po",
   ".pot",
   ".jsonnet",
-  ".libsonnet"
+  ".libsonnet",
+  ".zig"
 ]

--- a/internal/config/rules/rule_docs/zig.md
+++ b/internal/config/rules/rule_docs/zig.md
@@ -1,0 +1,35 @@
+> Favor precision over recall: report only issues that are likely to cause incorrect behavior, memory unsafety, security vulnerabilities, or material performance problems. Do not report formatting handled by `zig fmt`, and account for the project's Zig version, build mode (`Debug`, `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall`), and active `comptime` configuration before raising compatibility findings.
+
+#### Memory Safety and Illegal Behavior
+- Slices, pointers, or `[]const u8` views that outlive the storage they refer to, especially addresses derived from stack locals, temporaries, or a buffer that is reused or freed
+- Detectable illegal behavior — out-of-bounds indexing, integer overflow, `@intCast`/`@truncate` narrowing that loses value, null-unwrap of an optional, or invalid `@ptrCast`/`@alignCast` — reachable in `ReleaseFast` or `ReleaseSmall`, where safety checks are disabled and the same code becomes silent undefined behavior
+- Reads of `undefined` memory, or use of a value before it is fully initialized
+- `@ptrCast`, `@alignCast`, `@bitCast`, or pointer arithmetic without a locally established type, alignment, provenance, and lifetime invariant
+- Do not report ordinary value copies or bounds-checked access in `Debug`/`ReleaseSafe` without evidence of a real lifetime or aliasing defect
+
+#### Allocators and Resource Cleanup
+- Memory obtained from an `Allocator` without a matching `free`/`destroy`, or freed with a different allocator than the one that allocated it
+- Resources acquired without a corresponding `defer` or `errdefer`, so an early `return` or error path leaks them or leaves partial state
+- `errdefer` missing on a value that is cleaned up only on the success path, causing a leak when a later step in the same function fails
+- Double-free or use-after-free from a `deinit` that runs on an already-released or aliased object
+- Ignoring the result of an allocation or a fallible call at a boundary where failure changes correctness
+
+#### Errors, Optionals, and Control Flow
+- Error unions discarded with `catch unreachable`, `catch undefined`, or `_ =` where the error is actually reachable at runtime
+- `orelse unreachable` or `.?` on an optional that can legitimately be null for untrusted or runtime input
+- `unreachable` or `@panic` used for ordinary invalid input in reusable library or server code, especially where it becomes illegal behavior in release-unsafe modes
+- `switch` on an error set or tagged union that silently handles unrelated cases with `else` and hides a newly added variant
+- Assertions (`std.debug.assert`) used to validate untrusted input, since they are compiled out in release-unsafe builds
+
+#### Comptime, Generics, and Build Code
+- `comptime` code or `@This()`-based generics that read mutable external state and make builds non-reproducible without an explicit requirement
+- Type-parameter functions that assume capabilities (fields, methods, layout) a caller's type may not provide, producing confusing compile errors instead of a checked constraint
+- `build.zig` steps that fetch, execute, or trust untrusted input, or that hardcode absolute paths and platform assumptions
+- Do not report ordinary `comptime` use when the generated behavior is clear and inputs are validated
+
+#### Concurrency and C Interop
+- Shared mutable state accessed from multiple threads without a `std.Thread.Mutex`, atomic, or established single-owner design
+- Locks held across blocking operations or callbacks, creating deadlock or starvation risk
+- `extern`/`export` declarations or `callconv` annotations with incompatible types, struct layout, nullability, or ownership relative to the C side
+- C strings or buffers consumed without validating length, null termination, encoding, and lifetime
+- User-controlled data passed to process spawning, path access, SQL construction, or deserialization without validation, and secrets embedded in source, logs, or error messages

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -37,6 +37,7 @@
     "**/*.{nim,nims,nimble}": "nim.md",
     "**/*.swift": "swift.md",
     "**/*.elm": "elm.md",
-    "**/*.{jsonnet,libsonnet}": "jsonnet.md"
+    "**/*.{jsonnet,libsonnet}": "jsonnet.md",
+    "**/*.zig": "zig.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -125,6 +125,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"lib/config.libsonnet", "Late Binding"},
 		{"environments/prod/main.jsonnet", "Late Binding"},
 		{"jsonnet/kube-prometheus/components/grafana.libsonnet", "Late Binding"},
+		{"src/main.zig", "Illegal Behavior"},
+		{"build.zig", "Illegal Behavior"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Adds built-in Zig support to the review allowlist so `.zig` changes are reviewed with a Zig-specific ruleset instead of being skipped (extension not recognized) or falling back to the generic `default.md` checklist. This is the Zig language-group sub-issue tracked under #470.

- `internal/config/allowlist/supported_file_types.json` — recognize `.zig`
- `internal/config/allowlist/default_exclude_patterns.json` — exclude conventional Zig tests: `**/test/**/*.zig` and `**/*_test.zig`
- `internal/config/rules/rule_docs/zig.md` — new precision-focused Zig review rules (memory safety / illegal behavior across build modes, allocators + `defer`/`errdefer` cleanup, error unions & optionals, comptime/generics/`build.zig`, concurrency & C interop)
- `internal/config/rules/system_rules.json` — map `**/*.zig` → `zig.md`
- extension, test-exclusion, and rule-resolution tests

Note on the exclude patterns: the tracking issue suggested `**/test/*.zig`, but this PR uses the nested `**/test/**/*.zig` for consistency with the already-merged Julia (`**/test/**/*.jl`) and Haskell (`**/test/**/*.hs`) patterns, so tests under `src/test/unit/*.zig` are also excluded. `**/*_test.zig` covers the suffix convention.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Full local CI replay in the pinned `golang:1.26.6` container: `gofmt -s -l .` clean, `go vet ./...` clean, `go build ./cmd/opencodereview`, `go test -race -count=1 ./...` all green (total coverage 91.2%), `go mod tidy` leaves `go.mod`/`go.sum` unchanged.

### RED → GREEN

New tests fail on the unmodified base (before the allowlist/rule additions):

```
--- FAIL: TestIsAllowedExt/.zig
    allowed_ext_test.go: IsAllowedExt(".zig") = false, want true
--- FAIL: TestIsExcludedPath/zig_test_directory
    allowed_ext_test.go: IsExcludedPath("test/parser.zig") = false, want true
--- FAIL: TestIsExcludedPath/zig__test_suffix
    allowed_ext_test.go: IsExcludedPath("src/parser_test.zig") = false, want true
--- FAIL: TestResolve_DefaultRules/src/main.zig
    system_rules_test.go: Resolve("src/main.zig"): expected rule containing "Illegal Behavior", got "#### Correctness ..."
FAIL	github.com/alibaba/open-code-review/internal/config/allowlist
FAIL	github.com/alibaba/open-code-review/internal/config/rules
```

Same tests pass after the change:

```
ok  	github.com/alibaba/open-code-review/internal/config/allowlist	0.007s
ok  	github.com/alibaba/open-code-review/internal/config/rules	0.056s
```

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #472
