### PR TITLE
fix(llm): serve GPT-5.6 models via the OpenAI Responses API (#559)

### DIFF
--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -95,11 +95,6 @@ var registry = []Provider{
 		},
 	},
 	{
-		// GPT-5.6 models require the OpenAI Responses API (/v1/responses):
-		// their tool-calling-with-reasoning workflow is rejected by
-		// /v1/chat/completions with a 400 (issue #559). They are served here
-		// under ProtocolOpenAIResponses instead of the "openai" preset so a
-		// user can select them without knowing which API protocol is required.
 		Name:        "openai-responses",
 		DisplayName: "OpenAI Responses API",
 		Protocol:    ProtocolOpenAIResponses,

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const openAIResponsesAPIKeyEnv = "OPENAI_RESPONSES_API_KEY"
+
 // Provider holds the preset configuration for a known LLM provider.
 //
 // Protocol uses the canonical names defined in protocol.go:
@@ -102,7 +104,7 @@ var registry = []Provider{
 		DisplayName: "OpenAI Responses API",
 		Protocol:    ProtocolOpenAIResponses,
 		BaseURL:     "https://api.openai.com/v1",
-		EnvVar:      "OPENAI_API_KEY",
+		EnvVar:      openAIResponsesAPIKeyEnv,
 		Models: []string{
 			"gpt-5.6-sol",
 			"gpt-5.6-terra",

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 )
 
-const openAIResponsesAPIKeyEnv = "OPENAI_RESPONSES_API_KEY"
-
 // Provider holds the preset configuration for a known LLM provider.
 //
 // Protocol uses the canonical names defined in protocol.go:
@@ -99,7 +97,7 @@ var registry = []Provider{
 		DisplayName: "OpenAI Responses API",
 		Protocol:    ProtocolOpenAIResponses,
 		BaseURL:     "https://api.openai.com/v1",
-		EnvVar:      openAIResponsesAPIKeyEnv,
+		EnvVar:      "OPENAI_RESPONSES_API_KEY",
 		Models: []string{
 			"gpt-5.6-sol",
 			"gpt-5.6-terra",

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -87,12 +87,26 @@ var registry = []Provider{
 		BaseURL:     "https://api.openai.com/v1",
 		EnvVar:      "OPENAI_API_KEY",
 		Models: []string{
-			"gpt-5.6-sol",
-			"gpt-5.6-terra",
-			"gpt-5.6-luna",
 			"gpt-5.5",
 			"gpt-5.4",
 			"gpt-5.4-mini",
+		},
+	},
+	{
+		// GPT-5.6 models require the OpenAI Responses API (/v1/responses):
+		// their tool-calling-with-reasoning workflow is rejected by
+		// /v1/chat/completions with a 400 (issue #559). They are served here
+		// under ProtocolOpenAIResponses instead of the "openai" preset so a
+		// user can select them without knowing which API protocol is required.
+		Name:        "openai-responses",
+		DisplayName: "OpenAI Responses API",
+		Protocol:    ProtocolOpenAIResponses,
+		BaseURL:     "https://api.openai.com/v1",
+		EnvVar:      "OPENAI_API_KEY",
+		Models: []string{
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
 		},
 	},
 	{

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -186,6 +186,8 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 }
 
 func TestLookupProvider_OpenAIResponsesDetails(t *testing.T) {
+	const expectedEnvVar = "OPENAI_RESPONSES_API_KEY"
+
 	p, ok := LookupProvider("openai-responses")
 	if !ok {
 		t.Fatal("openai-responses not found")
@@ -196,8 +198,8 @@ func TestLookupProvider_OpenAIResponsesDetails(t *testing.T) {
 	if p.BaseURL != "https://api.openai.com/v1" {
 		t.Errorf("BaseURL = %q, want %q", p.BaseURL, "https://api.openai.com/v1")
 	}
-	if p.EnvVar != "OPENAI_API_KEY" {
-		t.Errorf("EnvVar = %q, want %q", p.EnvVar, "OPENAI_API_KEY")
+	if p.EnvVar != expectedEnvVar {
+		t.Errorf("EnvVar = %q, want %q", p.EnvVar, expectedEnvVar)
 	}
 	if p.AuthHeader != "" {
 		t.Errorf("AuthHeader = %q, want empty (OpenAI-compatible uses Bearer by default)", p.AuthHeader)

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -5,6 +5,7 @@ package llm
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -75,7 +76,7 @@ func TestListProviders_Order(t *testing.T) {
 	if len(providers) < 3 {
 		t.Fatalf("expected at least 3 providers, got %d", len(providers))
 	}
-	expected := []string{"anthropic", "baidu-qianfan", "bedrock", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "gemini", "hy-tokenplan", "iflytek", "kimi", "kimi-global", "litellm", "mimo", "minimax", "minimax-cn", "mistral", "novita", "ollama-cloud", "openai", "siliconflow", "siliconflow-cn", "tencent-tokenhub", "volcengine", "xai", "z-ai", "z-ai-coding"}
+	expected := []string{"anthropic", "baidu-qianfan", "bedrock", "dashscope", "dashscope-tokenplan", "deepseek", "edenai", "gemini", "hy-tokenplan", "iflytek", "kimi", "kimi-global", "litellm", "mimo", "minimax", "minimax-cn", "mistral", "novita", "ollama-cloud", "openai", "openai-responses", "siliconflow", "siliconflow-cn", "tencent-tokenhub", "volcengine", "xai", "z-ai", "z-ai-coding"}
 	if len(providers) != len(expected) {
 		t.Fatalf("expected %d providers, got %d", len(expected), len(providers))
 	}
@@ -167,10 +168,9 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 	if p.AuthHeader != "" {
 		t.Errorf("AuthHeader = %q, want empty", p.AuthHeader)
 	}
+	// GPT-5.6 models are intentionally absent here: they require the Responses
+	// API and live under the "openai-responses" preset (issue #559).
 	expectedModels := []string{
-		"gpt-5.6-sol",
-		"gpt-5.6-terra",
-		"gpt-5.6-luna",
 		"gpt-5.5",
 		"gpt-5.4",
 		"gpt-5.4-mini",
@@ -182,6 +182,66 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 		if p.Models[i] != model {
 			t.Errorf("Models[%d] = %q, want %q", i, p.Models[i], model)
 		}
+	}
+}
+
+func TestLookupProvider_OpenAIResponsesDetails(t *testing.T) {
+	p, ok := LookupProvider("openai-responses")
+	if !ok {
+		t.Fatal("openai-responses not found")
+	}
+	if p.Protocol != ProtocolOpenAIResponses {
+		t.Errorf("Protocol = %q, want %q", p.Protocol, ProtocolOpenAIResponses)
+	}
+	if p.BaseURL != "https://api.openai.com/v1" {
+		t.Errorf("BaseURL = %q, want %q", p.BaseURL, "https://api.openai.com/v1")
+	}
+	if p.EnvVar != "OPENAI_API_KEY" {
+		t.Errorf("EnvVar = %q, want %q", p.EnvVar, "OPENAI_API_KEY")
+	}
+	if p.AuthHeader != "" {
+		t.Errorf("AuthHeader = %q, want empty (OpenAI-compatible uses Bearer by default)", p.AuthHeader)
+	}
+	expectedModels := []string{
+		"gpt-5.6-sol",
+		"gpt-5.6-terra",
+		"gpt-5.6-luna",
+	}
+	if len(p.Models) != len(expectedModels) {
+		t.Fatalf("Models length = %d, want %d", len(p.Models), len(expectedModels))
+	}
+	for i, model := range expectedModels {
+		if p.Models[i] != model {
+			t.Errorf("Models[%d] = %q, want %q", i, p.Models[i], model)
+		}
+	}
+}
+
+// TestGPT56ModelsUseResponsesProtocol guards the fix for issue #559: GPT-5.6
+// models require the OpenAI Responses API (/v1/responses). A built-in provider
+// pointing at api.openai.com must never offer a gpt-5.6 model over Chat
+// Completions, because ocr's tool-calling review workflow then fails with a
+// 400 ("function tools with reasoning_effort are not supported ... in
+// /v1/chat/completions").
+func TestGPT56ModelsUseResponsesProtocol(t *testing.T) {
+	const gpt56Prefix = "gpt-5.6"
+	found := false
+	for _, p := range ListProviders() {
+		if !strings.Contains(p.BaseURL, "api.openai.com") {
+			continue
+		}
+		for _, m := range p.Models {
+			if !strings.HasPrefix(m, gpt56Prefix) {
+				continue
+			}
+			found = true
+			if p.Protocol != ProtocolOpenAIResponses {
+				t.Errorf("provider %q offers %q over %q; GPT-5.6 needs %q", p.Name, m, p.Protocol, ProtocolOpenAIResponses)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no built-in OpenAI provider offers a %q model; expected the openai-responses preset to serve them", gpt56Prefix)
 	}
 }
 

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -47,6 +47,7 @@ environment variable.
 | `anthropic` | anthropic | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
 | `bedrock` | anthropic-bedrock | derived from `aws_region` | — (AWS credential chain) |
 | `openai` | openai | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `openai-responses` | openai-responses | `https://api.openai.com/v1` | `OPENAI_RESPONSES_API_KEY` |
 | `gemini` | openai | `https://generativelanguage.googleapis.com/v1beta/openai` | `GEMINI_API_KEY` |
 | `dashscope` | openai | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_API_KEY` |
 | `dashscope-tokenplan` | openai | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_TOKENPLAN_KEY` |

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -45,6 +45,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `anthropic` | anthropic | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
 | `bedrock` | anthropic-bedrock | `aws_region` から決定 | —（AWS 認証情報チェーン） |
 | `openai` | openai | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `openai-responses` | openai-responses | `https://api.openai.com/v1` | `OPENAI_RESPONSES_API_KEY` |
 | `gemini` | openai | `https://generativelanguage.googleapis.com/v1beta/openai` | `GEMINI_API_KEY` |
 | `dashscope` | openai | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_API_KEY` |
 | `dashscope-tokenplan` | openai | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_TOKENPLAN_KEY` |

--- a/pages/src/content/docs/ru/configuration.md
+++ b/pages/src/content/docs/ru/configuration.md
@@ -50,6 +50,7 @@ API-ключ. Если `providers.<name>.api_key` не задан, OCR испо�
 | `anthropic` | anthropic | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
 | `bedrock` | anthropic-bedrock | определяется `aws_region` | — (цепочка учётных данных AWS) |
 | `openai` | openai | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `openai-responses` | openai-responses | `https://api.openai.com/v1` | `OPENAI_RESPONSES_API_KEY` |
 | `gemini` | openai | `https://generativelanguage.googleapis.com/v1beta/openai` | `GEMINI_API_KEY` |
 | `dashscope` | openai | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_API_KEY` |
 | `dashscope-tokenplan` | openai | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_TOKENPLAN_KEY` |

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -44,6 +44,7 @@ ocr config set providers.anthropic.api_key sk-ant-xxxxxxxxxx
 | `anthropic` | anthropic | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
 | `bedrock` | anthropic-bedrock | 由 `aws_region` 决定 | —（AWS 凭证链） |
 | `openai` | openai | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `openai-responses` | openai-responses | `https://api.openai.com/v1` | `OPENAI_RESPONSES_API_KEY` |
 | `gemini` | openai | `https://generativelanguage.googleapis.com/v1beta/openai` | `GEMINI_API_KEY` |
 | `dashscope` | openai | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_API_KEY` |
 | `dashscope-tokenplan` | openai | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_TOKENPLAN_KEY` |


### PR DESCRIPTION
## Description

The built-in `openai` provider preset lists `gpt-5.6-sol`, `gpt-5.6-terra`, and
`gpt-5.6-luna` but uses the Chat Completions protocol (`/v1/chat/completions`).
Selecting any of these models for `ocr review` completes the planning phase and
then fails on the first tool-using subtask with a 400:

> Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions. Use /v1/responses instead.

The Responses protocol (`ProtocolOpenAIResponses`) already exists in the code,
but no built-in preset paired the GPT-5.6 models with it, and the resolver picks
the protocol strictly from the selected preset (no per-model routing). So every
built-in path to a GPT-5.6 model was broken.

This moves the GPT-5.6 models out of the chat-completions `openai` preset into a
dedicated `openai-responses` preset that uses `ProtocolOpenAIResponses`. A user
can now select a GPT-5.6 model without knowing which OpenAI API protocol is
required. Other `openai` models (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`) are
unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` / `go test -race ./...` passes locally
- [x] Added unit tests, verified RED on the unmodified base and GREEN with the fix

### Test verification (RED → GREEN)

RED — new tests against unmodified `main` (GPT-5.6 still under the chat-completions `openai` preset):

```
--- FAIL: TestListProviders_Order (0.00s)
    providers_test.go:81: expected 26 providers, got 25
--- FAIL: TestLookupProvider_OpenAIDetails (0.00s)
    providers_test.go:179: Models length = 6, want 3
--- FAIL: TestLookupProvider_OpenAIResponsesDetails (0.00s)
    providers_test.go:191: openai-responses not found
--- FAIL: TestGPT56ModelsUseResponsesProtocol (0.00s)
    providers_test.go:239: provider "openai" offers "gpt-5.6-sol" over "openai"; GPT-5.6 needs "openai-responses"
    providers_test.go:239: provider "openai" offers "gpt-5.6-terra" over "openai"; GPT-5.6 needs "openai-responses"
    providers_test.go:239: provider "openai" offers "gpt-5.6-luna" over "openai"; GPT-5.6 needs "openai-responses"
FAIL
```

GREEN — same tests with the fix:

```
--- PASS: TestListProviders_Order (0.00s)
--- PASS: TestLookupProvider_OpenAIDetails (0.00s)
--- PASS: TestLookupProvider_OpenAIResponsesDetails (0.00s)
--- PASS: TestGPT56ModelsUseResponsesProtocol (0.00s)
PASS
ok  	github.com/alibaba/open-code-review/internal/llm	0.019s
```

`TestGPT56ModelsUseResponsesProtocol` is a regression guard: any built-in
provider pointing at `api.openai.com` that offers a `gpt-5.6*` model must use
the Responses protocol.

### Full local suite

Ran the complete local validation suite (mirrors `.github/workflows/ci.yml` in
the pinned `golang:1.26.6` container): `gofmt -s -l .` clean, `go vet ./...`
clean, `go build ./cmd/opencodereview`, and `go test -race -count=1 ./...`:

```
ok  github.com/alibaba/open-code-review/internal/llm   9.144s  coverage: 95.3% of statements
... all packages pass ...
total: (statements) 91.2%
```

Total coverage 91.2% (CI gate is 80%); no pre-existing tests regressed.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA

## Related Issues

Fixes #559

## Review follow-up verification

The built-in `openai-responses` preset now uses the separate `OPENAI_RESPONSES_API_KEY` fallback requested in review. The built-in-provider table was also updated in the English, Chinese, Japanese, and Russian site documentation.

RED — focused test before the production change:

```
EnvVar = "OPENAI_API_KEY", want "OPENAI_RESPONSES_API_KEY"
FAIL github.com/alibaba/open-code-review/internal/llm
```

GREEN — focused test and complete local replay after the change:

```
ok github.com/alibaba/open-code-review/internal/llm
total: (statements) 91.3%
Pages: 8 files / 31 tests passed; lint, typecheck, build, size, and translation sync passed
```

Browser verification: served the production pages build locally, loaded `/docs/configuration` in Chromium, and confirmed `OPENAI_RESPONSES_API_KEY` in the rendered DOM (HTTP 200).

Rebased onto current `main`; conflict resolution preserves the upstream Bedrock and Gemini provider additions.