### PR TITLE
feat(config): make completion output token limit configurable

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -149,10 +149,13 @@ func runConfigUnset(key string) error {
 	if key == "max_tokens" {
 		return unsetMaxTokens(configPath)
 	}
+	if key == "max_completion_tokens" {
+		return unsetMaxCompletionTokens(configPath)
+	}
 
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) != 2 || parts[1] == "" {
-		return fmt.Errorf("unset supports provider, max_tokens, custom_providers.<name>, and mcp_servers.<name>")
+		return fmt.Errorf("unset supports provider, max_tokens, max_completion_tokens, custom_providers.<name>, and mcp_servers.<name>")
 	}
 
 	switch parts[0] {
@@ -161,7 +164,7 @@ func runConfigUnset(key string) error {
 	case "mcp_servers":
 		return unsetMCPServer(configPath, parts[1])
 	default:
-		return fmt.Errorf("unset supports provider, max_tokens, custom_providers.<name>, and mcp_servers.<name>")
+		return fmt.Errorf("unset supports provider, max_tokens, max_completion_tokens, custom_providers.<name>, and mcp_servers.<name>")
 	}
 }
 
@@ -177,6 +180,21 @@ func unsetMaxTokens(configPath string) error {
 	}
 
 	fmt.Println("Cleared max_tokens; using the embedded template default.")
+	return nil
+}
+
+func unsetMaxCompletionTokens(configPath string) error {
+	cfg, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	cfg.MaxCompletionTokens = 0
+	if err := saveConfig(configPath, cfg); err != nil {
+		return err
+	}
+
+	fmt.Println("Cleared max_completion_tokens; using the embedded template default.")
 	return nil
 }
 
@@ -311,15 +329,16 @@ type MCPServerConfig struct {
 
 // Config represents the user-level configuration file (~/.opencodereview/config.json).
 type Config struct {
-	Provider        string                     `json:"provider,omitempty"`
-	Model           string                     `json:"model,omitempty"`
-	MaxTokens       int                        `json:"max_tokens,omitempty"`
-	Providers       map[string]ProviderEntry   `json:"providers,omitempty"`
-	CustomProviders map[string]ProviderEntry   `json:"custom_providers,omitempty"`
-	Llm             LlmConfig                  `json:"llm,omitempty"`
-	Language        string                     `json:"language,omitempty"`
-	Telemetry       *TelemetryConfig           `json:"telemetry,omitempty"`
-	MCPServers      map[string]MCPServerConfig `json:"mcp_servers,omitempty"`
+	Provider            string                     `json:"provider,omitempty"`
+	Model               string                     `json:"model,omitempty"`
+	MaxTokens           int                        `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int                        `json:"max_completion_tokens,omitempty"`
+	Providers           map[string]ProviderEntry   `json:"providers,omitempty"`
+	CustomProviders     map[string]ProviderEntry   `json:"custom_providers,omitempty"`
+	Llm                 LlmConfig                  `json:"llm,omitempty"`
+	Language            string                     `json:"language,omitempty"`
+	Telemetry           *TelemetryConfig           `json:"telemetry,omitempty"`
+	MCPServers          map[string]MCPServerConfig `json:"mcp_servers,omitempty"`
 }
 
 type LlmConfig struct {
@@ -381,6 +400,7 @@ var supportedConfigKeys = []string{
 	"provider",
 	"model",
 	"max_tokens",
+	"max_completion_tokens",
 	"providers.<name>.<field>",
 	"custom_providers.<name>.<field>",
 	"mcp_servers.<name>.<field>",
@@ -459,6 +479,12 @@ func setConfigValue(cfg *Config, key, value string) error {
 			return fmt.Errorf("invalid max_tokens %q: must be a positive integer", value)
 		}
 		cfg.MaxTokens = maxTokens
+	case "max_completion_tokens":
+		maxCompletionTokens, err := strconv.Atoi(value)
+		if err != nil || maxCompletionTokens <= 0 {
+			return fmt.Errorf("invalid max_completion_tokens %q: must be a positive integer", value)
+		}
+		cfg.MaxCompletionTokens = maxCompletionTokens
 	case "llm.url", "llm.URL":
 		cfg.Llm.URL = value
 	case "llm.auth_token", "llm.AuthToken":

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -114,6 +114,43 @@ func TestMaxTokensConfigRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSetConfigValueMaxCompletionTokens(t *testing.T) {
+	cfg := &Config{}
+
+	if err := setConfigValue(cfg, "max_completion_tokens", "16384"); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+	if cfg.MaxCompletionTokens != 16384 {
+		t.Errorf("MaxCompletionTokens = %d, want 16384", cfg.MaxCompletionTokens)
+	}
+}
+
+func TestSetConfigValueMaxCompletionTokensRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"0", "-1", "not-a-number"} {
+		t.Run(value, func(t *testing.T) {
+			if err := setConfigValue(&Config{}, "max_completion_tokens", value); err == nil {
+				t.Fatalf("expected max_completion_tokens=%q to be rejected", value)
+			}
+		})
+	}
+}
+
+func TestMaxCompletionTokensConfigRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := &Config{MaxCompletionTokens: 16384}
+
+	if err := saveConfig(path, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	loaded, err := LoadAppConfig(path)
+	if err != nil {
+		t.Fatalf("LoadAppConfig: %v", err)
+	}
+	if loaded.MaxCompletionTokens != 16384 {
+		t.Errorf("MaxCompletionTokens = %d, want 16384", loaded.MaxCompletionTokens)
+	}
+}
+
 func TestSetConfigValueModelWithProvider(t *testing.T) {
 	cfg := &Config{
 		Provider: "anthropic",
@@ -448,6 +485,33 @@ func TestUnsetMaxTokens(t *testing.T) {
 	}
 	if strings.Contains(string(data), "max_tokens") {
 		t.Errorf("max_tokens should be omitted after unset: %s", data)
+	}
+	loaded, err := loadOrCreateConfig(configPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if loaded.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic", loaded.Provider)
+	}
+}
+
+func TestUnsetMaxCompletionTokens(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	cfg := &Config{Provider: "anthropic", MaxCompletionTokens: 16384}
+	if err := saveConfig(configPath, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	if err := unsetMaxCompletionTokens(configPath); err != nil {
+		t.Fatalf("unsetMaxCompletionTokens: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "max_completion_tokens") {
+		t.Errorf("max_completion_tokens should be omitted after unset: %s", data)
 	}
 	loaded, err := loadOrCreateConfig(configPath)
 	if err != nil {
@@ -1018,7 +1082,7 @@ func TestSetConfigValueUnknownKeyMessage(t *testing.T) {
 		t.Fatal("expected error for unknown key")
 	}
 	want := "unknown config key: bogus.key\n" +
-		"Supported keys: provider, model, max_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, llm.retry_codes, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
+		"Supported keys: provider, model, max_tokens, max_completion_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, llm.retry_codes, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
 		"Provider fields: api_key, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes\n" +
 		"Protocol values: anthropic, openai, openai-responses\n" +
 		"MCP server fields: type, command, args, env, url, headers, tools, setup"

--- a/cmd/opencodereview/config_runset_test.go
+++ b/cmd/opencodereview/config_runset_test.go
@@ -58,6 +58,32 @@ func TestRunConfigSetPersists(t *testing.T) {
 
 // TestRunConfigUnsetPaths drives runConfigUnset across its dispatch branches.
 func TestRunConfigUnsetPaths(t *testing.T) {
+	t.Run("unset max completion tokens", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		configPath, err := defaultConfigPath()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := saveConfig(configPath, &Config{MaxCompletionTokens: 16384}); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		out := captureStdout(t, func() {
+			if err := runConfigUnset("max_completion_tokens"); err != nil {
+				t.Fatalf("runConfigUnset: %v", err)
+			}
+		})
+		if !strings.Contains(out, "Cleared max_completion_tokens") {
+			t.Errorf("stdout = %q", out)
+		}
+		cfg, err := loadOrCreateConfig(configPath)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if cfg.MaxCompletionTokens != 0 {
+			t.Errorf("MaxCompletionTokens = %d, want 0", cfg.MaxCompletionTokens)
+		}
+	})
+
 	t.Run("unset active provider clears provider and model", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		configPath, err := defaultConfigPath()

--- a/cmd/opencodereview/flags_test.go
+++ b/cmd/opencodereview/flags_test.go
@@ -120,6 +120,23 @@ func TestParseReviewFlags_MaxTokensParsed(t *testing.T) {
 	}
 }
 
+func TestParseReviewFlags_NegativeMaxCompletionTokens(t *testing.T) {
+	_, err := parseReviewFlags([]string{"--max-completion-tokens", "-1"})
+	if err == nil {
+		t.Fatal("expected error for negative max-completion-tokens")
+	}
+}
+
+func TestParseReviewFlags_MaxCompletionTokensParsed(t *testing.T) {
+	opts, err := parseReviewFlags([]string{"--max-completion-tokens", "16384"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.maxCompletionTokens != 16384 {
+		t.Errorf("maxCompletionTokens = %d, want 16384", opts.maxCompletionTokens)
+	}
+}
+
 func TestParseReviewFlags_BudgetFlagsDefaultZero(t *testing.T) {
 	opts, err := parseReviewFlags([]string{"--from", "main", "--to", "dev"})
 	if err != nil {

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -27,28 +27,29 @@ import (
 )
 
 type reviewOptions struct {
-	toolConfigPath  string
-	rulePath        string
-	repoDir         string
-	from            string
-	to              string
-	commit          string
-	resume          string
-	excludes        string
-	outputFormat    string
-	audience        string
-	background      string
-	backgroundFile  string
-	provider        string
-	model           string
-	concurrency     int
-	perFileTimeout  int
-	maxTools        int
-	maxGitProcs     int
-	maxTokens       int
-	maxTokensBudget int
-	noFilter        bool
-	preview         bool
+	toolConfigPath      string
+	rulePath            string
+	repoDir             string
+	from                string
+	to                  string
+	commit              string
+	resume              string
+	excludes            string
+	outputFormat        string
+	audience            string
+	background          string
+	backgroundFile      string
+	provider            string
+	model               string
+	concurrency         int
+	perFileTimeout      int
+	maxTools            int
+	maxGitProcs         int
+	maxTokens           int
+	maxCompletionTokens int
+	maxTokensBudget     int
+	noFilter            bool
+	preview             bool
 }
 
 var reviewOpts reviewOptions
@@ -155,12 +156,19 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) error {
 	if err != nil {
 		return err
 	}
-	cc.Template.MaxCompletionTokens = cc.Template.MaxTokens
+	embeddedCompletionTokens := cc.Template.MaxTokens
 	maxTokens, err := resolveMaxTokens(cc.Template.MaxTokens, rt.AppCfg, opts.maxTokens)
 	if err != nil {
 		return err
 	}
 	cc.Template.MaxTokens = maxTokens
+	maxCompletionTokens, err := resolveMaxCompletionTokens(
+		embeddedCompletionTokens, rt.AppCfg, opts.maxCompletionTokens,
+	)
+	if err != nil {
+		return err
+	}
+	cc.Template.MaxCompletionTokens = maxCompletionTokens
 
 	// Strictly before agent.New, so a rejected resume persists nothing. The sealed
 	// input it returns pins the run to the very commits this check passed on, so

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -23,28 +23,29 @@ import (
 )
 
 type scanOptions struct {
-	toolConfigPath  string
-	rulePath        string
-	repoDir         string
-	paths           string
-	excludes        string
-	outputFormat    string
-	audience        string
-	background      string
-	concurrency     int
-	perFileTimeout  int
-	maxTools        int
-	maxGitProcs     int
-	preview         bool
-	noPlan          bool
-	noDedup         bool
-	noSummary       bool
-	batch           string
-	maxTokens       int
-	maxTokensBudget int
-	provider        string
-	model           string
-	resume          string
+	toolConfigPath      string
+	rulePath            string
+	repoDir             string
+	paths               string
+	excludes            string
+	outputFormat        string
+	audience            string
+	background          string
+	concurrency         int
+	perFileTimeout      int
+	maxTools            int
+	maxGitProcs         int
+	preview             bool
+	noPlan              bool
+	noDedup             bool
+	noSummary           bool
+	batch               string
+	maxTokens           int
+	maxCompletionTokens int
+	maxTokensBudget     int
+	provider            string
+	model               string
+	resume              string
 }
 
 var scanOpts scanOptions
@@ -154,12 +155,19 @@ func executeScan(opts scanOptions) error {
 	if err != nil {
 		return err
 	}
-	scanTpl.MaxCompletionTokens = scanTpl.MaxTokens
+	embeddedCompletionTokens := scanTpl.MaxTokens
 	maxTokens, err := resolveMaxTokens(scanTpl.MaxTokens, rt.AppCfg, opts.maxTokens)
 	if err != nil {
 		return err
 	}
 	scanTpl.MaxTokens = maxTokens
+	maxCompletionTokens, err := resolveMaxCompletionTokens(
+		embeddedCompletionTokens, rt.AppCfg, opts.maxCompletionTokens,
+	)
+	if err != nil {
+		return err
+	}
+	scanTpl.MaxCompletionTokens = maxCompletionTokens
 	llmIdentity := &jsonLLMIdentity{
 		Provider: rt.Provider,
 		Model:    rt.Model,

--- a/cmd/opencodereview/scan_cmd_test.go
+++ b/cmd/opencodereview/scan_cmd_test.go
@@ -162,6 +162,26 @@ func TestParseScanFlags_RejectsNegativeMaxTokens(t *testing.T) {
 	}
 }
 
+func TestParseScanFlags_RejectsNegativeMaxCompletionTokens(t *testing.T) {
+	_, err := parseScanFlags([]string{"--max-completion-tokens", "-100"})
+	if err == nil {
+		t.Fatal("expected error for negative --max-completion-tokens")
+	}
+	if !strings.Contains(err.Error(), "--max-completion-tokens") {
+		t.Errorf("error message = %q; want it to mention --max-completion-tokens", err.Error())
+	}
+}
+
+func TestParseScanFlags_MaxCompletionTokensParsed(t *testing.T) {
+	opts, err := parseScanFlags([]string{"--max-completion-tokens", "16384"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.maxCompletionTokens != 16384 {
+		t.Errorf("maxCompletionTokens = %d, want 16384", opts.maxCompletionTokens)
+	}
+}
+
 func TestParseScanFlags_BooleanFlags(t *testing.T) {
 	opts, err := parseScanFlags([]string{"--no-plan", "--no-dedup", "--no-summary", "--preview"})
 	if err != nil {

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -60,6 +60,24 @@ func resolveMaxTokens(templateDefault int, cfg *Config, cliOverride int) (int, e
 	return cfg.MaxTokens, nil
 }
 
+// resolveMaxCompletionTokens applies the independent per-request output cap.
+// It intentionally does not affect prompt compression or preflight thresholds.
+func resolveMaxCompletionTokens(templateDefault int, cfg *Config, cliOverride int) (int, error) {
+	if cliOverride < 0 {
+		return 0, fmt.Errorf("--max-completion-tokens must be a non-negative integer")
+	}
+	if cliOverride > 0 {
+		return cliOverride, nil
+	}
+	if cfg == nil || cfg.MaxCompletionTokens == 0 {
+		return templateDefault, nil
+	}
+	if cfg.MaxCompletionTokens < 0 {
+		return 0, fmt.Errorf("invalid max_completion_tokens in app config: must be a positive integer")
+	}
+	return cfg.MaxCompletionTokens, nil
+}
+
 // loadCommonContext validates the working directory, loads the embedded
 // template, raises MaxToolRequestTimes when maxTools exceeds the default,
 // resolves the absolute repo path, loads system review rules, and creates

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -40,12 +40,16 @@ func addExcludeFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVar(target, "exclude", "", "comma-separated gitignore-style patterns to exclude; merged with rule.json excludes")
 }
 
-func addConcurrencyFlags(cmd *cobra.Command, concurrency, timeout, maxTools, maxGitProcs, maxTokens, maxTokensBudget *int) {
+func addConcurrencyFlags(
+	cmd *cobra.Command,
+	concurrency, timeout, maxTools, maxGitProcs, maxTokens, maxCompletionTokens, maxTokensBudget *int,
+) {
 	cmd.Flags().IntVar(concurrency, "concurrency", 8, "max concurrent file reviews")
 	cmd.Flags().IntVar(timeout, "timeout", 10, "concurrent task timeout in minutes")
 	cmd.Flags().IntVar(maxTools, "max-tools", 0, "max tool call rounds per file (0 = template default; min 10)")
 	cmd.Flags().IntVar(maxGitProcs, "max-git-procs", 16, "max concurrent git subprocesses")
 	cmd.Flags().IntVar(maxTokens, "max-tokens", 0, "per-file prompt token ceiling (0 = configured or template default)")
+	cmd.Flags().IntVar(maxCompletionTokens, "max-completion-tokens", 0, "per-request completion token ceiling (0 = configured or template default)")
 	cmd.Flags().IntVar(maxTokensBudget, "max-tokens-budget", 0, "cap total token usage (input+output) for this review; dispatch stops once exceeded and skipped files are reported as failed(budget). Partial results are published and review exits 0; it exits non-zero only if every selected item failed (0 = unlimited)")
 }
 
@@ -126,6 +130,9 @@ func validateReviewOptions(opts *reviewOptions) error {
 	if opts.maxTokens < 0 {
 		return fmt.Errorf("--max-tokens must be a non-negative integer (0 means use configured or template default)")
 	}
+	if opts.maxCompletionTokens < 0 {
+		return fmt.Errorf("--max-completion-tokens must be a non-negative integer (0 means use configured or template default)")
+	}
 	if opts.maxTokensBudget < 0 {
 		return fmt.Errorf("--max-tokens-budget must be a non-negative integer (0 means unlimited)")
 	}
@@ -144,6 +151,9 @@ func validateScanOptions(opts *scanOptions) error {
 	}
 	if opts.maxTokens < 0 {
 		return fmt.Errorf("--max-tokens must be a non-negative integer (0 means use configured or template default)")
+	}
+	if opts.maxCompletionTokens < 0 {
+		return fmt.Errorf("--max-completion-tokens must be a non-negative integer (0 means use configured or template default)")
 	}
 	if opts.preview && opts.resume != "" {
 		return fmt.Errorf("--preview and --resume cannot be used together")
@@ -174,7 +184,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	cmd.RegisterFlagCompletionFunc("resume", completeSessionIDs)
 	addExcludeFlag(cmd, &opts.excludes)
 	addOutputFlags(cmd, &opts.outputFormat, &opts.audience)
-	addConcurrencyFlags(cmd, &opts.concurrency, &opts.perFileTimeout, &opts.maxTools, &opts.maxGitProcs, &opts.maxTokens, &opts.maxTokensBudget)
+	addConcurrencyFlags(cmd, &opts.concurrency, &opts.perFileTimeout, &opts.maxTools, &opts.maxGitProcs, &opts.maxTokens, &opts.maxCompletionTokens, &opts.maxTokensBudget)
 	addBackgroundFlags(cmd, &opts.background, &opts.backgroundFile)
 	addProviderFlag(cmd, &opts.provider)
 	addModelFlag(cmd, &opts.model)
@@ -195,6 +205,7 @@ func registerScanFlags(cmd *cobra.Command, opts *scanOptions) {
 	cmd.Flags().IntVar(&opts.maxTools, "max-tools", 0, "max tool call rounds per file; only takes effect when greater than template default")
 	cmd.Flags().IntVar(&opts.maxGitProcs, "max-git-procs", 16, "max concurrent git subprocesses")
 	cmd.Flags().IntVar(&opts.maxTokens, "max-tokens", 0, "per-file prompt token ceiling (0 = configured or template default)")
+	cmd.Flags().IntVar(&opts.maxCompletionTokens, "max-completion-tokens", 0, "per-request completion token ceiling (0 = configured or template default)")
 	cmd.Flags().IntVar(&opts.maxTokensBudget, "max-tokens-budget", 0, "cap total token usage; dispatch stops once exceeded (0 = unlimited)")
 	cmd.Flags().StringVarP(&opts.background, "background", "b", "", "optional requirement/business context for the scan")
 	cmd.Flags().BoolVarP(&opts.preview, "preview", "p", false, "preview which files will be scanned without running the LLM")

--- a/cmd/opencodereview/shared_test.go
+++ b/cmd/opencodereview/shared_test.go
@@ -42,6 +42,36 @@ func TestResolveMaxTokensPrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveMaxCompletionTokensPrecedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		cliOverride int
+		template    int
+		want        int
+		wantErr     bool
+	}{
+		{name: "template default", template: 58888, want: 58888},
+		{name: "zero config is unset", cfg: &Config{}, template: 58888, want: 58888},
+		{name: "saved config", cfg: &Config{MaxCompletionTokens: 16384}, template: 58888, want: 16384},
+		{name: "cli overrides config", cfg: &Config{MaxCompletionTokens: 16384}, cliOverride: 8192, template: 58888, want: 8192},
+		{name: "negative config", cfg: &Config{MaxCompletionTokens: -1}, template: 58888, wantErr: true},
+		{name: "negative cli", cliOverride: -1, template: 58888, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveMaxCompletionTokens(tt.template, tt.cfg, tt.cliOverride)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveMaxCompletionTokens() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("resolveMaxCompletionTokens() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyCLIExcludes_Empty(t *testing.T) {
 	cc := &commonContext{FileFilter: &rules.FileFilter{Exclude: []string{"a"}}}
 	applyCLIExcludes(cc, nil)

--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -104,6 +104,7 @@ staged + unstaged + untracked changes in the current directory's repo.
 | `--rule <path>` | — | — | Path to a custom JSON review rule file. Overrides the project-level and global `rule.json`. |
 | `--max-tools <n>` | — | template default | Max tool-call rounds per file. `0` uses the template default (`30`); values 1–9 are clamped up to `10`; any value `≥ 10` overrides the template default (even if smaller than `30`). |
 | `--max-tokens <n>` | — | config or template default | Per-file prompt token ceiling. Overrides the saved `max_tokens` setting for this run. |
+| `--max-completion-tokens <n>` | — | config or template default | Per-request completion/output token ceiling. Overrides the saved `max_completion_tokens` setting for this run. |
 | `--max-tokens-budget <n>` | — | `0` (unlimited) | Cap total input + output token usage for the review. Dispatch stops once the budget is exceeded and partial results are still published. |
 | `--provider <name>` | — | — | Select a configured provider for this run. Names under both `providers` and `custom_providers` are accepted. |
 | `--model <name>` | — | — | Override the resolved LLM model for this run (e.g., `claude-opus-4-6`). |

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -195,6 +195,30 @@ independent of both the model's output-token cap and `--max-tokens-budget`,
 which caps total token use for a run. Restore the embedded default with
 `ocr config unset max_tokens`.
 
+### Completion output limit
+
+Some providers expose models whose maximum completion is smaller than OCR's
+embedded task-template default. Set `max_completion_tokens` to cap each LLM
+response independently of the per-file prompt ceiling:
+
+```bash
+ocr config set max_completion_tokens 16384
+```
+
+The setting applies to both `ocr review` and `ocr scan`. Use
+`--max-completion-tokens` for a one-off override:
+
+```bash
+ocr review --max-completion-tokens 16384
+ocr scan --max-completion-tokens 16384
+```
+
+The per-run flag takes precedence over `max_completion_tokens`; when neither is
+set, OCR uses the embedded task-template default. This limit controls only the
+maximum output requested from the provider. It does not change prompt
+compression, preflight context checks, or `--max-tokens-budget`. Restore the
+embedded default with `ocr config unset max_completion_tokens`.
+
 ### Verify connectivity
 
 ```bash


### PR DESCRIPTION
## In Plain English

People trying to use OpenCodeReview with lower-cost review models could not start a review because it asked every model for a larger response than some models allow. Those reviews failed before any code was examined, even though the models were otherwise compatible. Reviewers can now match the response size to the model they selected without shrinking the code context or changing the existing behavior for everyone else.

## Description

Adds an independent completion/output token limit for review and scan runs:

- `--max-completion-tokens` for one-run overrides
- persisted `max_completion_tokens` configuration
- `ocr config unset max_completion_tokens` to restore the embedded default
- precedence of CLI override, then saved configuration, then embedded template default

This deliberately leaves `max_tokens`, prompt compression, preflight context checks, and the existing unset behavior unchanged. Documentation and unit coverage are included for flags, configuration round-tripping, precedence, and unset behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Validation completed:

- Focused completion-limit tests pass.
- `go vet ./...` passes.
- License-header and English-only checks pass.
- The Windows binary builds and exposes the new flag in `ocr review --help`.
- A real Azure OpenAI-compatible GPT-4o mini review that previously failed before examining any file completed all three selected files with a 16,384-token output cap.
- A real Vertex Llama 4 Scout review that previously failed before examining any file completed both selected files with an 8,192-token output cap.

The full command-package test run is degraded on Windows by existing platform-specific failures and an existing output-capture test timeout; Linux PR CI remains the authoritative full-suite result.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #949
