### PR TITLE
fix(ci): line endings check fails on symbolic links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
       
       - name: Check line endings
         run: |
-          if git ls-files --eol | grep -v 'i/lf\|i/none\|i/-text'; then
+          git add --renormalize .
+          if ! git diff --cached --quiet; then
             echo 'Line endings must end with LF. Have you normalized line endings?'
+            git diff --cached --stat
             exit 1
           fi
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git add --renormalize .
           if ! git diff --cached --quiet; then
-            echo 'Line endings must end with LF. Have you normalized line endings?'
+            echo "::error::Line endings must be LF. Run 'git add --renormalize .' and commit the diff below."
             git diff --cached --stat
             exit 1
           fi


### PR DESCRIPTION
## Description
```
=== git ls-files --eol ===
  i/lf    w/lf    attr/                         file.txt
  i/      w/      attr/                         link.txt

  === original CI pipeline ===
  git ls-files --eol | grep -v 'i/lf\|i/none\|i/-text'
  i/      w/      attr/                         link.txt
  grep_exit=0
```
The original step is:
```
  if git ls-files --eol | grep -v 'i/lf\|i/none\|i/-text'; then
    echo 'Line endings must end with LF. Have you normalized line endings?'
    exit 1
  fi
```
Git reports symlinks with empty i/ and w/ fields, so the symlink line does not match any of the allowed patterns. grep still finds that line and exits 0, which makes the if branch run and fail the job.

Now the logic is:
1. Make git reformat line endings
2. Compare with `git diff --quiet --cached`
3. If step 2 exits with non-0, abort and print err msg.

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)
I tested my fix on the failing pull request #939 

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
none