### PR TITLE
feat(allowlist): add Crystal language support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -94,6 +94,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".SOL", true},
 		{".vy", true},
 		{".VY", true},
+		{".cr", true},
+		{".CR", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -277,6 +279,12 @@ func TestIsExcludedPath(t *testing.T) {
 		{"solidity deploy script", "script/Deploy.s.sol", false},
 		{"vyper non-test", "src/token.vy", false},
 		{"vyper test in filename only", "src/test_helpers.vy", false},
+
+		// Crystal spec files
+		{"crystal spec file", "spec/parser_spec.cr", true},
+		{"crystal spec nested", "shard/spec/unit/parser_spec.cr", true},
+		{"crystal non-spec", "src/parser.cr", false},
+		{"crystal spec-like name outside spec dir", "src/parser_spec.cr", false},
 
 		// Snapshot files
 		{"jest snapshot dir", "src/__snapshots__/App.test.js.snap", true},

--- a/internal/config/allowlist/default_exclude_patterns.json
+++ b/internal/config/allowlist/default_exclude_patterns.json
@@ -22,6 +22,7 @@
   "**/*Spec.lhs",
   "**/tests/**/*.nim",
   "**/tests/**/*.R",
+  "**/spec/**/*_spec.cr",
   "**/__snapshots__/**",
   "**/*.snap",
   "**/testdata/**",

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -98,5 +98,6 @@
   ".thrift",
   ".capnp",
   ".sol",
-  ".vy"
+  ".vy",
+  ".cr"
 ]

--- a/internal/config/rules/rule_docs/crystal.md
+++ b/internal/config/rules/rule_docs/crystal.md
@@ -1,0 +1,48 @@
+> Favor precision over recall: only raise an issue when you are confident it is a real defect, and stay silent when the surrounding context is unclear — a false alarm costs more reviewer trust than a missed minor issue. Treat security and correctness findings as blocking, and style or idiom suggestions as non-blocking. Review only what is observable in the code under review; do not infer behavior of methods or macros defined outside this file.
+
+#### Obvious Typos or Spelling Errors
+- Spelling errors in method names, class/struct/module names, instance/class variable names, or constant names at their declaration sites; do not report spelling errors at call sites
+- Typos in `Log` messages, raised exception messages, docstrings, or other public diagnostics that affect readability
+
+#### Type Inference and Nil Safety
+- Union-typed values (`T | Nil`) accessed without a `nil` check, `.not_nil!`, or a safe-navigation pattern, risking a compile-time union that silently includes `Nil` in a path the author did not expect
+- Overuse of `.not_nil!` or `as(T)` to force a type instead of narrowing with `if`/`case`/`responds_to?`, which converts a compile-time type error into a runtime `NilAssertionError` or `TypeCastError`
+- Instance variables declared without an initializer and without a type restriction, letting the compiler infer a wider union (including `Nil`) than intended
+- Methods whose return type varies by branch in a way that widens the inferred return union unexpectedly, especially when an early branch returns `nil` implicitly
+
+#### Macro Hygiene and Code Generation
+- Macros that expand to code referencing identifiers not defined within the macro's own scope, causing name capture or clashing with caller-scope locals
+- `{{ }}` interpolation of untrusted or externally derived strings into generated code paths, expressions, or method names (macro-based code injection)
+- `macro` or `{% %}` compile-time logic that assumes a fixed argument shape without validating arity or type, producing a confusing compile error far from the call site
+- Generated methods/classes via `macro method_missing`, `{% for %}`, or `finished` hooks that unintentionally override or shadow existing methods
+
+#### Fibers, Concurrency, and Channels
+- Shared mutable state (class variables, `Hash`/`Array` instances) written by multiple fibers via `spawn` without a `Mutex`, `Channel`, or single-owner design; Crystal fibers are cooperative but a yield point (I/O, `Channel#receive`, `sleep`) can interleave unexpectedly
+- `Channel#send` without a corresponding `receive`, or unbuffered channels used in a way that can deadlock when no other fiber is scheduled to receive
+- Fibers spawned with `spawn` whose failures are never observed — unhandled exceptions inside a spawned block terminate only that fiber and can be silently lost
+- Blocking, non-yielding CPU-bound work inside a `spawn`ed fiber that starves other fibers on the same thread when running in single-threaded (non-MT) mode
+- Loop-captured variables shared across multiple `spawn` calls without a per-iteration local binding, so all fibers observe the same mutated value
+
+#### C Bindings and Memory Safety
+- `lib` bindings (`fun`, `struct`, `union`) with a C signature that does not match the actual C declaration in argument types, return type, or calling convention, risking memory corruption
+- `Pointer(T)` arithmetic, `malloc`/`free` via `LibC`, or `.to_unsafe` calls without validating allocation size, alignment, lifetime, and null-ness before dereferencing
+- Crystal-managed objects passed to C code that retains the pointer beyond the object's GC-visible lifetime (e.g. no `pointerof`/`GC.add_finalizer` safeguard), risking use-after-free once the GC moves or collects it
+- C strings obtained via `.to_unsafe` or `String.new(pointer)` without confirming null-termination and correct encoding/length
+- Missing `finalize`/`GC.add_finalizer` cleanup for C-allocated resources (file handles, buffers) acquired in a wrapper class
+
+#### Exception Handling
+- `rescue` without a specific exception type (bare `rescue`) that swallows unrelated errors, including `Exception` catching things a narrower `rescue IO::Error` should isolate
+- Empty or logging-only `rescue` blocks that discard the original exception without re-raising or returning an explicit error signal
+- Resources opened without `ensure` (or a block form like `File.open(...) do |f| ... end`) when an exception between acquisition and use can leak file handles, sockets, or locks
+- Raising a plain `Exception` instead of a specific, well-named exception subclass, forcing callers into overly broad `rescue` clauses
+
+#### Shards and Versioning
+- `shard.yml` dependencies pinned to a branch or unconstrained version instead of a semantic version requirement, risking non-reproducible builds
+- Missing `shard.lock` commit for an application (as opposed to a library), which defeats reproducible dependency resolution
+- Version requirements incompatible with the declared `crystal` version constraint in `shard.yml`, risking a build that fails on the stated minimum compiler version
+
+#### Security-Sensitive Code
+- Untrusted input interpolated into `Process.run`/`Process.exec` with `shell: true`, or into a system/backtick command, without validation (command injection)
+- Untrusted input interpolated directly into SQL strings instead of using parameterized queries via a database driver
+- `Marshal.load` or other deserialization of untrusted data
+- Logging secrets, tokens, credentials, or personally identifiable information

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -45,6 +45,7 @@
     "**/*.capnp": "capnp.md",
     "**/*.m": "matlab.md",
     "**/*.sol": "solidity.md",
-    "**/*.vy": "vyper.md"
+    "**/*.vy": "vyper.md",
+    "**/*.cr": "crystal.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -145,6 +145,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"contracts/Vault.sol", "Delegatecall and Proxy Upgradeability"},
 		{"contracts/token.vy", "Language Restrictions"},
 		{"src/amm.vy", "Reentrancy and `@nonreentrant`"},
+		{"src/server.cr", "Fibers, Concurrency, and Channels"},
+		{"shard/src/client.cr", "Fibers, Concurrency, and Channels"},
 	}
 
 	for _, tt := range tests {

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -186,6 +186,7 @@ matching order:
 | `**/*.m` | `matlab.md` (or `objc.md` via [content sniffing](#content-sniffing-for-m-files)) |
 | `**/*.sol` | `solidity.md` — Solidity smart contracts. |
 | `**/*.vy` | `vyper.md` — Vyper smart contracts. |
+| `**/*.cr` | `crystal.md` — Crystal source. |
 | *(fallback)* | `default.md` |
 
 The resolved rule body becomes the `{{system_rule}}` placeholder in the

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -148,6 +148,7 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.m` | `matlab.md`（または[コンテンツスニッフィング](#content-sniffing-for-m-files)により `objc.md`） |
 | `**/*.sol` | `solidity.md`: Solidity スマートコントラクト。 |
 | `**/*.vy` | `vyper.md`: Vyper スマートコントラクト。 |
+| `**/*.cr` | `crystal.md`: Crystal ソースコード。 |
 | *(fallback)* | `default.md` |
 
 解決されたルール本文は、plan および main task prompt 内の `{{system_rule}}` プレースホルダーの内容になります。

--- a/pages/src/content/docs/ko/review-rules.md
+++ b/pages/src/content/docs/ko/review-rules.md
@@ -177,6 +177,7 @@ diff 단계에서 일어납니다.
 | `**/*.m` | `matlab.md`(또는 [내용 탐지](#content-sniffing-for-m-files)로 `objc.md`) |
 | `**/*.sol` | `solidity.md` — Solidity 스마트 컨트랙트. |
 | `**/*.vy` | `vyper.md` — Vyper 스마트 컨트랙트. |
+| `**/*.cr` | `crystal.md` — Crystal 소스. |
 | *(대체값)* | `default.md` |
 
 해석된 규칙 본문은 plan과 main 작업 프롬프트에서 `{{system_rule}}` 자리에 들어갑니다.

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -188,6 +188,7 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.m` | `matlab.md` (или `objc.md` через [определение содержимого](#content-sniffing-for-m-files)) |
 | `**/*.sol` | `solidity.md` — смарт-контракты Solidity. |
 | `**/*.vy` | `vyper.md` — смарт-контракты Vyper. |
+| `**/*.cr` | `crystal.md` — исходный код Crystal. |
 | *(fallback)* | `default.md` |
 
 Разрешённое тело правила становится значением плейсхолдера `{{system_rule}}`

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -169,6 +169,7 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.m` | `matlab.md`（或通过[内容嗅探](#针对-m-文件的内容嗅探)使用 `objc.md`） |
 | `**/*.sol` | `solidity.md`——Solidity 智能合约。 |
 | `**/*.vy` | `vyper.md`——Vyper 智能合约。 |
+| `**/*.cr` | `crystal.md`——Crystal 源代码。 |
 | *(fallback)* | `default.md` |
 
 解析出的规则正文成为 plan 和 main task prompt 中 `{{system_rule}}` 占位符的内容。


### PR DESCRIPTION
## Summary

Adds Crystal (`.cr`) language support to the review allowlist, following the established pattern from prior language-group PRs (Julia, Nim, Bicep, HCL, Prisma).

- Add `.cr` to `internal/config/allowlist/supported_file_types.json`
- Add `**/spec/**/*_spec.cr` to `internal/config/allowlist/default_exclude_patterns.json`, matching Crystal's conventional `spec/` directory and `Spec` framework's `*_spec.cr` naming convention
- Add `internal/config/rules/rule_docs/crystal.md`, a review rule doc covering Crystal-specific pitfalls: compile-time type inference vs. `Nil` handling, macro hygiene/code-gen safety, fiber/concurrency correctness with `spawn`/channels, C binding (`lib`/`fun`) memory safety, exception handling conventions, and shard versioning
- Register `**/*.cr -> crystal.md` in `internal/config/rules/system_rules.json`
- Add test coverage in `allowed_ext_test.go` (extension matching + exclude pattern) and `system_rules_test.go` (rule resolution)

Part of the language-allowlist expansion tracked in #470.

Closes #941

## Test plan

- [x] `go test -race -count=1 ./internal/config/allowlist/... ./internal/config/rules/...` passes
- [x] Full repo test suite (`go test -count=1 ./...`, excluding `/extensions/`) passes
- [x] `go vet` passes
- [x] `gofmt -s -l .` reports no files
- [x] `go run scripts/verify-english-only.go` passes