### PR TITLE
fix(pages): serve 404 pages on non-existent GET requests but render no React Route

### DIFF
--- a/pages/src/App.test.tsx
+++ b/pages/src/App.test.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+import { LanguageProvider } from './i18n';
+
+function installLocalStorageMock() {
+  let store: Record<string, string> = {};
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      get length() {
+        return Object.keys(store).length;
+      },
+    } as Storage,
+  });
+}
+
+describe('App', () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    window.localStorage.clear();
+    window.scrollTo = () => {};
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the not-found page for an unmatched URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/ewe.html']}>
+        <LanguageProvider>
+          <App />
+        </LanguageProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Page not found' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Back to Home' })).toBeTruthy();
+  });
+});

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -9,6 +9,7 @@ import { useTransitionedLocation } from './hooks/useTransitionedLocation';
 import { useTranslation } from './i18n';
 import FeaturesPage from './pages/FeaturesPage';
 import FeaturesRoutePage from './pages/FeaturesRoutePage';
+import NotFoundPage from './pages/NotFoundPage';
 
 const BenchmarkPage = React.lazy(() => import(/* webpackChunkName: "benchmark-page" */ './pages/BenchmarkPage'));
 const QuickStartPage = React.lazy(() => import(/* webpackChunkName: "quickstart-page" */ './pages/QuickStartPage'));
@@ -92,6 +93,7 @@ const App: React.FC = () => {
             <Route path="/docs/:slug" element={<DocsPage />} />
             <Route path="/blog" element={<BlogPage />} />
             <Route path="/blog/:slug" element={<BlogPage />} />
+            <Route path="*" element={<LandingPage><NotFoundPage /></LandingPage>} />
           </Routes>
         </Suspense>
       </ErrorBoundary>

--- a/pages/src/i18n/en.ts
+++ b/pages/src/i18n/en.ts
@@ -31,6 +31,11 @@ export const en = {
   'error.pageLoadFailed': 'Failed to load this page.',
   'error.reload': 'Reload',
 
+  // Not found
+  'notFound.title': 'Page not found',
+  'notFound.description': 'The page you are looking for does not exist or has moved.',
+  'notFound.backHome': 'Back to Home',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': 'INTERNAL ACTIVE USERS',

--- a/pages/src/i18n/ja.ts
+++ b/pages/src/i18n/ja.ts
@@ -33,6 +33,11 @@ export const ja: TranslationKeys = {
   'error.pageLoadFailed': 'ページの読み込みに失敗しました。',
   'error.reload': '再読み込み',
 
+  // Not found
+  'notFound.title': 'ページが見つかりません',
+  'notFound.description': 'お探しのページは存在しないか、移動した可能性があります。',
+  'notFound.backHome': 'ホームに戻る',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': '社内アクティブユーザー',

--- a/pages/src/i18n/ru.ts
+++ b/pages/src/i18n/ru.ts
@@ -33,6 +33,11 @@ export const ru: TranslationKeys = {
   'error.pageLoadFailed': 'Не удалось загрузить страницу.',
   'error.reload': 'Обновить',
 
+  // Not found
+  'notFound.title': 'Страница не найдена',
+  'notFound.description': 'Запрошенная страница не существует или была перемещена.',
+  'notFound.backHome': 'На главную',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': 'ВНУТРЕННИЕ АКТИВНЫЕ ПОЛЬЗОВАТЕЛИ',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -33,6 +33,11 @@ export const zh: TranslationKeys = {
   'error.pageLoadFailed': '页面加载失败。',
   'error.reload': '重新加载',
 
+  // Not found
+  'notFound.title': '喵呜，页面找不到了',
+  'notFound.description': '您访问的页面不存在或已被移动。',
+  'notFound.backHome': '返回首页',
+
   // Highlights
   'highlights.stat1Value': '20K+',
   'highlights.stat1Label': '内部活跃用户',

--- a/pages/src/i18n/zh.ts
+++ b/pages/src/i18n/zh.ts
@@ -34,7 +34,7 @@ export const zh: TranslationKeys = {
   'error.reload': '重新加载',
 
   // Not found
-  'notFound.title': '喵呜，页面找不到了',
+  'notFound.title': '页面找不到了',
   'notFound.description': '您访问的页面不存在或已被移动。',
   'notFound.backHome': '返回首页',
 

--- a/pages/src/pages/NotFoundPage.test.tsx
+++ b/pages/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import NotFoundPage from './NotFoundPage';
+import { LanguageProvider } from '../i18n';
+import type { Language } from '../i18n/types';
+
+function installLocalStorageMock() {
+  let store: Record<string, string> = {};
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      get length() {
+        return Object.keys(store).length;
+      },
+    } as Storage,
+  });
+}
+
+function renderNotFound(language: Language) {
+  if (language !== 'en') {
+    window.localStorage.setItem('ocr-lang', language);
+  }
+
+  return render(
+    <MemoryRouter initialEntries={['/missing']}>
+      <LanguageProvider>
+        <Routes>
+          <Route path="/" element={<div>home page</div>} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </LanguageProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('NotFoundPage', () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    window.localStorage.clear();
+    window.scrollTo = () => {};
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the not-found message and returns home', () => {
+    renderNotFound('en');
+
+    expect(screen.getByRole('heading', { name: 'Page not found' })).toBeTruthy();
+    expect(
+      screen.getByText('The page you are looking for does not exist or has moved.'),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Home' }));
+    expect(screen.getByText('home page')).toBeTruthy();
+  });
+
+  it.each([
+    ['en', 'Page not found'],
+    ['zh', '页面未找到'], // allow-non-english: translation assertion
+    ['ja', 'ページが見つかりません'], // allow-non-english: translation assertion
+    ['ru', 'Страница не найдена'], // allow-non-english: translation assertion
+  ] as [Language, string][])('renders the %s translation', (language, expectedTitle) => {
+    renderNotFound(language);
+    expect(screen.getByRole('heading', { name: expectedTitle })).toBeTruthy();
+  });
+});

--- a/pages/src/pages/NotFoundPage.test.tsx
+++ b/pages/src/pages/NotFoundPage.test.tsx
@@ -7,7 +7,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import NotFoundPage from './NotFoundPage';
 import { LanguageProvider } from '../i18n';
-import type { Language } from '../i18n/types';
+import { en } from '../i18n/en';
+import { zh } from '../i18n/zh';
+import { ja } from '../i18n/ja';
+import { ru } from '../i18n/ru';
+import type { Language, TranslationKeys } from '../i18n/types';
+
+const translations: Record<Language, TranslationKeys> = { en, zh, ja, ru };
 
 function installLocalStorageMock() {
   let store: Record<string, string> = {};
@@ -72,13 +78,10 @@ describe('NotFoundPage', () => {
     expect(screen.getByText('home page')).toBeTruthy();
   });
 
-  it.each([
-    ['en', 'Page not found'],
-    ['zh', '页面未找到'], // allow-non-english: translation assertion
-    ['ja', 'ページが見つかりません'], // allow-non-english: translation assertion
-    ['ru', 'Страница не найдена'], // allow-non-english: translation assertion
-  ] as [Language, string][])('renders the %s translation', (language, expectedTitle) => {
+  it.each(
+    (Object.keys(translations) as Language[]).map((language) => [language, translations[language]] as const),
+  )('renders the %s translation', (language, table) => {
     renderNotFound(language);
-    expect(screen.getByRole('heading', { name: expectedTitle })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: table['notFound.title'] })).toBeTruthy();
   });
 });

--- a/pages/src/pages/NotFoundPage.tsx
+++ b/pages/src/pages/NotFoundPage.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Footer from '../components/Footer';
+import { useTranslation } from '../i18n';
+
+const NotFoundPage: React.FC = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        paddingTop: 72,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '80px 24px',
+        }}
+      >
+        <div
+          style={{
+            width: '100%',
+            maxWidth: 480,
+            textAlign: 'center',
+            color: '#ffffff',
+          }}
+        >
+          <h1
+            style={{
+              margin: '0 0 16px',
+              fontSize: 48,
+              fontWeight: 700,
+              lineHeight: 1.1,
+            }}
+          >
+            {t('notFound.title')}
+          </h1>
+          <p
+            style={{
+              margin: '0 0 32px',
+              fontSize: 16,
+              lineHeight: 1.6,
+              color: 'rgba(255,255,255,0.65)',
+            }}
+          >
+            {t('notFound.description')}
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            style={{
+              border: 0,
+              borderRadius: 8,
+              padding: '12px 22px',
+              background: '#ffffff',
+              color: '#000000',
+              fontSize: 15,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            {t('notFound.backHome')}
+          </button>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/pages/webpack.config.cjs
+++ b/pages/webpack.config.cjs
@@ -88,7 +88,10 @@ module.exports = {
     ],
     historyApiFallback: {
       index: '/index.html',
-      rewrites: [{ from: /^\/\_p\/\d+\//, to: '/index.html' }]
+      rewrites: [
+        { from: /^\/\_p\/\d+\//, to: '/index.html' },
+        { from: /\.html$/, to: '/index.html' }
+      ]
     }
   },
   plugins: [


### PR DESCRIPTION
## Description
Unknown deployed paths such as /ewe.html currently serve the 404.html app shell but render no React route, leaving #root empty and the CSS boot spinner spinning indefinitely. So, even if the console said the requested source is not found, the circle keeps spinning forever.
<img width="2024" height="1151" alt="Screenshot 2026-08-16 at 10 02 24 PM" src="https://github.com/user-attachments/assets/de8d8407-3a2f-49ba-9437-284b20caa231" />

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)
`npm run typecheck`
`npm run lint`
`npm test`
`npm run build`

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
none yet