### PR TITLE
docs: fix code of conduct reporting links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,8 +22,8 @@ discussions, chat, and events.
 
 ## Reporting
 
-Report incidents via [GitHub Issues](https://github.com/anthropic-yikun/open-code-review/issues)
-or [GitHub Discussions](https://github.com/anthropic-yikun/open-code-review/discussions).
+Report incidents via [GitHub Issues](https://github.com/alibaba/open-code-review/issues)
+or [GitHub Discussions](https://github.com/alibaba/open-code-review/discussions).
 Include as much detail as possible (what happened, when/where, links, screenshots
 if applicable).
 


### PR DESCRIPTION
## Summary
- replace obsolete Code of Conduct reporting links that point to a non-existent repository
- direct incident reporting to this repository's Issues and Discussions

## Verification
- focused reporting-link acceptance assertions
- verified both replacement GitHub URLs return HTTP 200
- `make check`
- `git diff --check`

No behavior or source code changes.