### PR TITLE
fix(scripts): stop license checks failing on valid headers

### DIFF
--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -40,7 +40,10 @@ is_ignored() {
 has_header() {
   local header
   header="$(head -20 "$1")"
-  echo "$header" | grep -qF "$SPDX_REGEX" && echo "$header" | grep -qE "$COPYRIGHT_REGEX"
+  # Here-string, not `echo |`: grep -q exits on the first match, so echo can die of
+  # SIGPIPE (141) and pipefail turns that into a false "no header", which makes
+  # add_header prepend a second copyright block to a file that already has one.
+  grep -qF "$SPDX_REGEX" <<<"$header" && grep -qE "$COPYRIGHT_REGEX" <<<"$header"
 }
 
 add_header() {

--- a/scripts/verify-license.sh
+++ b/scripts/verify-license.sh
@@ -12,6 +12,7 @@ CURRENT_YEAR=$(date +%Y)
 MIN_YEAR=2026
 SPDX_REGEX="SPDX-License-Identifier: Apache-2.0"
 COPYRIGHT_REGEX="Copyright [0-9]{4} alibaba/open-code-review Contributors"
+YEAR_REGEX="Copyright ([0-9]{4})"
 
 LICENSE_EXTS=(go sh js mjs ts tsx)
 
@@ -50,17 +51,20 @@ while IFS= read -r file; do
 
   header="$(head -20 "$file")"
 
-  if ! echo "$header" | grep -qF "$SPDX_REGEX"; then
+  # Feed $header via here-string, not `echo |`: grep -q exits on the first match,
+  # so echo can die of SIGPIPE (141) and pipefail then reports a valid header as missing.
+  if ! grep -qF "$SPDX_REGEX" <<<"$header"; then
     FAILED+=("$file (missing SPDX identifier)")
     continue
   fi
 
-  if ! echo "$header" | grep -qE "$COPYRIGHT_REGEX"; then
+  if ! grep -qE "$COPYRIGHT_REGEX" <<<"$header"; then
     FAILED+=("$file (missing copyright notice)")
     continue
   fi
 
-  year="$(echo "$header" | grep -oE 'Copyright ([0-9]{4})' | grep -oE '[0-9]{4}' | head -1)"
+  year=""
+  [[ "$header" =~ $YEAR_REGEX ]] && year="${BASH_REMATCH[1]}"
   if [ -z "$year" ] || [ "$year" -lt "$MIN_YEAR" ] || [ "$year" -gt "$CURRENT_YEAR" ]; then
     FAILED+=("$file (invalid year: ${year:-none})")
     continue


### PR DESCRIPTION
## Description

`make license-check` fails intermittently on files whose headers are correct, naming a different file each run.

Both license scripts test the header with `echo "$header" | grep -q ...`. `grep -q` exits the moment it matches, so `echo` can lose the race on the write end and die of SIGPIPE (141). Both scripts run under `set -o pipefail`, which promotes that 141 to the pipeline's status, and `! pipeline` then reads a header that is plainly present as missing.

Measured on `internal/llmloop/compression.go` — a 410-byte header, far under the 64KiB pipe buffer — with the CPU saturated: 4 spurious failures in 3000 iterations of the SPDX pipeline alone. End to end under the same load, `verify-license.sh` failed 5 of 10 runs on current `main` and 0 of 10 with this change.

`has_header()` in `add-license.sh` has the identical race, and there it is worse than a flake. A false negative makes `add_header()` prepend a *second* copyright block to a file that already has one — which is the duplicate SPDX header that had to be removed from `internal/config/testconnection/testconnection.go` during review of #605.

Feeding the header through a here-string removes the second process, so nothing is left to receive SIGPIPE. The year lookup was a `grep | grep | head -1` chain carrying the same exposure (`head -1` exits after one line), so it now uses bash's own regex match and spawns nothing.

### Limitation

This ships without a test. Reproducing the race takes thousands of iterations under CPU saturation, so the test would become the flake it is meant to prevent. The fix is structural rather than probabilistic: with no second process in the pipeline, there is no SIGPIPE to deliver.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

`make check` and `make test` both pass on current `main`.

- Year parity: the new `[[ =~ ]]` match against the old `grep | grep | head -1` chain over 7 inputs, including a 5-digit year, a `CopyrightX` near-miss, no match at all, and two `Copyright` lines in one header. Identical results on all 7.
- Detection is unchanged, checked against a staged probe file: missing SPDX reports `(missing SPDX identifier)`, year 1999 reports `(invalid year: 1999)`, year 2099 reports `(invalid year: 2099)`.
- `make license-add` run twice over a header-less file leaves exactly one `SPDX-License-Identifier` line, and the tree is unchanged on a fully-licensed checkout.
- Both scripts stay pure ASCII, as they are on `main`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

See the Limitation note above on why no test is included.

## Related Issues

None open for this; found while rebasing unrelated PRs, where `license-check` failed on files those branches never touched.
