### PR TITLE
feat(review): expose filtered comments in JSON output

### DIFF
--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -281,18 +281,23 @@ type jsonLLMIdentity struct {
 }
 
 type jsonOutput struct {
-	Status         string               `json:"status"`
-	LLM            *jsonLLMIdentity     `json:"llm,omitempty"`
-	TraceID        string               `json:"trace_id,omitempty"`
-	Message        string               `json:"message,omitempty"`
-	Summary        *jsonSummary         `json:"summary,omitempty"`
-	ToolCalls      *jsonToolCalls       `json:"tool_calls"`
-	Comments       []model.LlmComment   `json:"comments"`
-	Warnings       []agent.AgentWarning `json:"warnings,omitempty"`
-	ProjectSummary string               `json:"project_summary,omitempty"`
-	Resume         *agent.ResumeInfo    `json:"resume,omitempty"`
-	SessionID      string               `json:"session_id,omitempty"`
-	Manifest       *session.RunManifest `json:"manifest,omitempty"`
+	Status    string             `json:"status"`
+	LLM       *jsonLLMIdentity   `json:"llm,omitempty"`
+	TraceID   string             `json:"trace_id,omitempty"`
+	Message   string             `json:"message,omitempty"`
+	Summary   *jsonSummary       `json:"summary,omitempty"`
+	ToolCalls *jsonToolCalls     `json:"tool_calls"`
+	Comments  []model.LlmComment `json:"comments"`
+	// FilteredComments are the comments the review filter removed, reported next
+	// to the ones that survived so a dropped finding stays visible. Omitted when
+	// nothing was removed, which also covers runs where the filter never ran
+	// (--no-filter, LLM error, scan mode).
+	FilteredComments []agent.FilteredComment `json:"filtered_comments,omitempty"`
+	Warnings         []agent.AgentWarning    `json:"warnings,omitempty"`
+	ProjectSummary   string                  `json:"project_summary,omitempty"`
+	Resume           *agent.ResumeInfo       `json:"resume,omitempty"`
+	SessionID        string                  `json:"session_id,omitempty"`
+	Manifest         *session.RunManifest    `json:"manifest,omitempty"`
 	// RetryReport is the frozen LLM retry report (ocr.llm-retry-report/v1).
 	// Reuses llm.RetryReport's own field/tag definitions rather than mirroring
 	// them here, and sits last with omitempty so a first-try-success run emits
@@ -317,13 +322,14 @@ func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 	filesReviewed, inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens int64,
 	duration time.Duration, projectSummary string, toolCalls map[string]int64, traceID string, resumeInfo *agent.ResumeInfo, sessionID string,
 	manifest *session.RunManifest, budgetExceeded bool, llmIdentity *jsonLLMIdentity,
-	retryReport *llm.RetryReport) error {
+	retryReport *llm.RetryReport, filteredComments []agent.FilteredComment) error {
 	publishedWarnings := warningsForOutput(warnings, manifest)
 	out := jsonOutput{
-		Status:   "success",
-		LLM:      llmIdentity,
-		TraceID:  traceID,
-		Comments: comments,
+		Status:           "success",
+		LLM:              llmIdentity,
+		TraceID:          traceID,
+		Comments:         comments,
+		FilteredComments: filteredComments,
 		Summary: &jsonSummary{
 			FilesReviewed:    filesReviewed,
 			Comments:         int64(len(comments)),

--- a/cmd/opencodereview/output_helpers_test.go
+++ b/cmd/opencodereview/output_helpers_test.go
@@ -173,7 +173,7 @@ func TestOutputJSONWithWarnings_NoCommentsSubtaskError(t *testing.T) {
 	os.Stdout = w
 
 	warnings := []agent.AgentWarning{{Type: "subtask_error", File: "x.go", Message: "fail"}}
-	err := outputJSONWithWarnings(nil, warnings, 1, 10, 5, 15, 0, 0, time.Second, "", nil, "abc123trace", nil, "", nil, false, nil, nil)
+	err := outputJSONWithWarnings(nil, warnings, 1, 10, 5, 15, 0, 0, time.Second, "", nil, "abc123trace", nil, "", nil, false, nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 
@@ -279,6 +279,68 @@ func TestOutputJSON_NoComments(t *testing.T) {
 	}
 }
 
+// TestOutputJSONWithWarnings_FilteredComments pins the published contract: a
+// removed comment reaches filtered_comments with its reason and resolved line
+// numbers, and the field disappears entirely when nothing was removed.
+func TestOutputJSONWithWarnings_FilteredComments(t *testing.T) {
+	const rawDiff = `diff --git a/b.go b/b.go
+--- a/b.go
++++ b/b.go
+@@ -10,7 +10,7 @@ func handle() {
+     ctx := context.Background()
+-    log.Print("old")
++    log.Printf("new")
+     err := process(ctx)`
+
+	// Line numbers deliberately left at 0, the way the model usually reports them:
+	// the output path must resolve them from existing_code before publishing.
+	filtered := resolveFilteredLines(
+		[]agent.FilteredComment{{
+			LlmComment: model.LlmComment{Path: "b.go", Content: "dropped", ExistingCode: `log.Print("old")`},
+			Reason:     "c-1: the method it flags is not in this diff",
+		}},
+		[]model.Diff{{NewPath: "b.go", Diff: rawDiff}},
+	)
+
+	emit := func(f []agent.FilteredComment) (jsonOutput, string) {
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		err := outputJSONWithWarnings(nil, nil, 1, 0, 0, 0, 0, 0, time.Second, "", nil, "", nil, "", nil, false, nil, nil, f)
+		_ = w.Close()
+		os.Stdout = old
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		var out jsonOutput
+		if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return out, buf.String()
+	}
+
+	out, _ := emit(filtered)
+	if len(out.FilteredComments) != 1 {
+		t.Fatalf("filtered_comments len = %d, want 1", len(out.FilteredComments))
+	}
+	got := out.FilteredComments[0]
+	if got.Content != "dropped" {
+		t.Errorf("content = %q, want dropped", got.Content)
+	}
+	if got.Reason != "c-1: the method it flags is not in this diff" {
+		t.Errorf("reason = %q, want the c-1 analysis entry", got.Reason)
+	}
+	if got.StartLine != 11 || got.EndLine != 11 {
+		t.Errorf("lines = %d..%d, want 11..11 resolved from existing_code", got.StartLine, got.EndLine)
+	}
+
+	if _, raw := emit(nil); strings.Contains(raw, "filtered_comments") {
+		t.Errorf("filtered_comments should be omitted when nothing was removed, got:\n%s", raw)
+	}
+}
+
 func TestOutputJSONWithWarnings(t *testing.T) {
 	old := os.Stdout
 	r, w, _ := os.Pipe()
@@ -286,7 +348,7 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 
 	comments := []model.LlmComment{{Path: "b.go", Content: "test"}}
 	warnings := []agent.AgentWarning{{Type: "subtask_error", File: "c.go", Message: "failed"}}
-	err := outputJSONWithWarnings(comments, warnings, 5, 100, 50, 150, 10, 5, 3*time.Second, "summary", map[string]int64{"file_read": 3}, "trace-xyz-789", nil, "", nil, false, nil, nil)
+	err := outputJSONWithWarnings(comments, warnings, 5, 100, 50, 150, 10, 5, 3*time.Second, "summary", map[string]int64{"file_read": 3}, "trace-xyz-789", nil, "", nil, false, nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 
@@ -324,7 +386,7 @@ func TestOutputJSONWithWarnings_NoCommentsNoErrors(t *testing.T) {
 	os.Stdout = w
 
 	warnings := []agent.AgentWarning{{Type: "warning", Message: "something"}}
-	err := outputJSONWithWarnings(nil, warnings, 2, 50, 20, 70, 0, 0, time.Second, "", nil, "", nil, "", nil, false, nil, nil)
+	err := outputJSONWithWarnings(nil, warnings, 2, 50, 20, 70, 0, 0, time.Second, "", nil, "", nil, "", nil, false, nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -350,6 +350,35 @@ type resumeInfoProvider interface {
 	ResumeInfo() *agent.ResumeInfo
 }
 
+// filteredCommentsProvider is implemented by the review agent only. Scan runs no
+// comment-level filter, so it has nothing to report and stays off this interface.
+type filteredCommentsProvider interface {
+	FilteredComments() []agent.FilteredComment
+}
+
+// resolveFilteredLines applies to removed comments the same line-number
+// resolution emitRunResult applies to the surviving ones. It is not optional
+// polish: the model usually omits start_line/end_line — that is why the resolver
+// exists at all — so without this a filtered comment is published with line 0 and
+// the reader cannot locate the finding that was dropped.
+func resolveFilteredLines(filtered []agent.FilteredComment, diffs []model.Diff) []agent.FilteredComment {
+	if len(filtered) == 0 {
+		return nil
+	}
+	inner := make([]model.LlmComment, len(filtered))
+	for i, fc := range filtered {
+		inner[i] = fc.LlmComment
+	}
+	// ResolveLineNumbers preserves length and order, so index i still identifies
+	// the comment whose Reason sits at filtered[i].
+	inner = diff.ResolveLineNumbers(inner, diffs)
+	out := make([]agent.FilteredComment, len(filtered))
+	for i := range filtered {
+		out[i] = agent.FilteredComment{LlmComment: inner[i], Reason: filtered[i].Reason}
+	}
+	return out
+}
+
 // emitRunResult is the post-LLM-run finalization shared by `ocr review` and
 // `ocr scan`: resolves comment line numbers, records telemetry, restores
 // stdout early for agent-text audiences so the summary is visible, prints
@@ -421,10 +450,14 @@ func emitRunResult(
 		if p, ok := ag.(resumeInfoProvider); ok {
 			resumeInfo = p.ResumeInfo()
 		}
+		var filtered []agent.FilteredComment
+		if p, ok := ag.(filteredCommentsProvider); ok {
+			filtered = resolveFilteredLines(p.FilteredComments(), ag.Diffs())
+		}
 		return outputJSONWithWarnings(comments, ag.Warnings(), ag.FilesReviewed(),
 			ag.TotalInputTokens(), ag.TotalOutputTokens(), ag.TotalTokensUsed(),
 			ag.TotalCacheReadTokens(), ag.TotalCacheWriteTokens(), duration,
-			ag.ProjectSummary(), ag.ToolCalls(), traceID, resumeInfo, ag.SessionID(), manifest, ag.BudgetExceeded(), llmIdentity, retryReport)
+			ag.ProjectSummary(), ag.ToolCalls(), traceID, resumeInfo, ag.SessionID(), manifest, ag.BudgetExceeded(), llmIdentity, retryReport, filtered)
 	}
 	if outputFormat == "sarif" {
 		return outputSARIF(comments, Version, ag.Warnings(), manifest)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"regexp"
 	"runtime/debug"
 	"slices"
 	"sort"
@@ -196,10 +197,29 @@ type Agent struct {
 	// and consumed by finalizeManifest to fill the manifest input/repository.
 	inputResolution    diff.InputResolution
 	repoRemoteIdentity string
+
+	// filteredComments accumulates the comments the review filter removed, so a
+	// dropped finding is reported rather than vanishing. executeReviewFilter
+	// appends from concurrent file subtasks, so every access takes filteredMu.
+	filteredMu       sync.Mutex
+	filteredComments []FilteredComment
 }
 
 // ResumeInfo summarizes file-level reuse for a resumed review.
 type ResumeInfo = session.ResumeInfo
+
+// FilteredComment is one comment the review filter removed, carrying the
+// original finding plus the filter's own reasoning for dropping it.
+//
+// Reason is best-effort and often absent: it is recovered from the filter tool
+// call's free-text "analysis" entries, which are the model's reasoning scratchpad
+// rather than a structured field. It stays empty when no entry could be matched to
+// this comment, and always when the provider has no tool support and the run fell
+// back to text parsing.
+type FilteredComment struct {
+	model.LlmComment
+	Reason string `json:"reason,omitempty"`
+}
 
 // New creates a new Agent from the given arguments.
 func New(args Args) *Agent {
@@ -434,6 +454,19 @@ func (a *Agent) ResumeInfo() *ResumeInfo {
 	}
 	info := *a.resumeInfo
 	return &info
+}
+
+// FilteredComments returns a copy of the comments the review filter removed.
+// Nil when the filter removed nothing, was disabled, or never ran.
+func (a *Agent) FilteredComments() []FilteredComment {
+	a.filteredMu.Lock()
+	defer a.filteredMu.Unlock()
+	if len(a.filteredComments) == 0 {
+		return nil
+	}
+	out := make([]FilteredComment, len(a.filteredComments))
+	copy(out, a.filteredComments)
+	return out
 }
 
 // FilesReviewed returns the number of dispatchable files included in this review.
@@ -1463,8 +1496,10 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 	rec.SetResponse(resp, duration)
 	a.runner.RecordUsage(resp.Usage)
 
-	indices := parseFilterToolCalls(resp.ToolCalls(), len(comments))
+	indices, analysis := parseFilterToolCalls(resp.ToolCalls(), len(comments))
 	if indices == nil {
+		// Text fallback for providers without tool support: it carries ids only, so
+		// the removed comments end up with no reason attached.
 		indices = parseFilterResponse(resp.Content(), len(comments))
 	}
 	telemetry.SetAttr(span, "comments.filtered", len(indices))
@@ -1476,7 +1511,7 @@ func (a *Agent) executeReviewFilter(ctx context.Context, d model.Diff, newPath s
 		return
 	}
 
-	a.args.CommentCollector.RemoveByPathAndIndices(newPath, indices)
+	a.recordFilteredComments(a.args.CommentCollector.RemoveByPathAndIndices(newPath, indices), analysis)
 	telemetry.Event(ctx, "review_filter.completed",
 		attribute.String("file.path", newPath),
 		attribute.Int("total_comments", len(comments)),
@@ -1504,10 +1539,17 @@ func buildFilterCommentsJSON(comments []model.LlmComment) string {
 }
 
 // parseFilterToolCalls extracts comment indices from the filter tool call response.
-// Returns nil if no matching tool call is found, allowing fallback to text-based parsing.
-// Returns an empty map (non-nil) for approve_all_comments or an empty comment_ids list.
-func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
+// Returns nil indices if no matching tool call is found, allowing fallback to
+// text-based parsing. Returns an empty map (non-nil) for approve_all_comments or an
+// empty comment_ids list.
+//
+// The second return value is the raw "analysis" entries the model wrote before
+// committing to comment_ids. They are its reasoning scratchpad, not a structured
+// field: callers may mine them for a per-comment reason but must tolerate any shape.
+// It is nil for approve_all_comments, which removes nothing and so needs no reason.
+func parseFilterToolCalls(calls []llm.ToolCall, total int) (map[int]struct{}, []string) {
 	var indices map[int]struct{}
+	var analysis []string
 	for _, call := range calls {
 		switch call.Function.Name {
 		case "approve_all_comments":
@@ -1516,6 +1558,7 @@ func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
 			}
 		case "report_incorrect_comments":
 			var args struct {
+				Analysis   []string `json:"analysis"`
 				CommentIDs []string `json:"comment_ids"`
 			}
 			if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
@@ -1525,6 +1568,7 @@ func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
 			if indices == nil {
 				indices = make(map[int]struct{})
 			}
+			analysis = append(analysis, args.Analysis...)
 			for _, id := range args.CommentIDs {
 				var idx int
 				if _, err := fmt.Sscanf(id, "c-%d", &idx); err == nil && idx >= 0 && idx < total {
@@ -1533,7 +1577,65 @@ func parseFilterToolCalls(calls []llm.ToolCall, total int) map[int]struct{} {
 			}
 		}
 	}
-	return indices
+	return indices, analysis
+}
+
+// filterAnalysisIDRe pulls the leading comment id out of one free-text analysis
+// entry, tolerating list markers or quotes before it. The trailing (?:\D|$) is a
+// digit boundary: without it "c-1" would also claim an entry written about c-10.
+var filterAnalysisIDRe = regexp.MustCompile(`(?i)^[^a-z0-9]*c-(\d+)(?:\D|$)`)
+
+// filterReasonsByIndex maps each removed comment's per-path index to the analysis
+// entry that discusses it. Entries whose id cannot be read, or that belong to a
+// comment the filter kept, are skipped; the first entry for an index wins. The
+// result is best-effort and may cover only some — or none — of removed.
+func filterReasonsByIndex(analysis []string, removed map[int]model.LlmComment) map[int]string {
+	var out map[int]string
+	for _, entry := range analysis {
+		m := filterAnalysisIDRe.FindStringSubmatch(entry)
+		if m == nil {
+			continue
+		}
+		idx, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if _, ok := removed[idx]; !ok {
+			continue
+		}
+		if _, dup := out[idx]; dup {
+			continue
+		}
+		if out == nil {
+			out = make(map[int]string, len(removed))
+		}
+		out[idx] = strings.TrimSpace(entry)
+	}
+	return out
+}
+
+// recordFilteredComments stores the comments the filter removed alongside its
+// reasoning, so a dropped finding is still reported. Entries are appended in
+// per-path index order to keep output stable across runs.
+func (a *Agent) recordFilteredComments(removed map[int]model.LlmComment, analysis []string) {
+	if len(removed) == 0 {
+		return
+	}
+	reasons := filterReasonsByIndex(analysis, removed)
+	idxs := make([]int, 0, len(removed))
+	for idx := range removed {
+		idxs = append(idxs, idx)
+	}
+	sort.Ints(idxs)
+
+	a.filteredMu.Lock()
+	defer a.filteredMu.Unlock()
+	for _, idx := range idxs {
+		a.filteredComments = append(a.filteredComments, FilteredComment{
+			LlmComment: removed[idx],
+			Reason:     reasons[idx],
+		})
+	}
 }
 
 // parseFilterResponse extracts comment indices from the LLM filter response.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -294,7 +294,7 @@ func TestParseFilterToolCalls(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseFilterToolCalls(tt.calls, tt.total)
+			got, _ := parseFilterToolCalls(tt.calls, tt.total)
 			if tt.wantSet == nil {
 				if got != nil {
 					t.Errorf("expected nil, got %v", got)
@@ -307,6 +307,43 @@ func TestParseFilterToolCalls(t *testing.T) {
 			for idx := range tt.wantSet {
 				if _, ok := got[idx]; !ok {
 					t.Errorf("missing index %d in result", idx)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterReasonsByIndex(t *testing.T) {
+	removed := map[int]model.LlmComment{1: {Content: "one"}, 10: {Content: "ten"}}
+
+	tests := []struct {
+		name     string
+		analysis []string
+		want     map[int]string
+	}{
+		{
+			// The digit boundary is the whole reason for the regex: a plain "c-1"
+			// prefix match would also claim the entry written about c-10.
+			name:     "matches on a digit boundary, colon optional",
+			analysis: []string{"- c-10 is refuted by line 4", "c-1: one's reason"},
+			want:     map[int]string{1: "c-1: one's reason", 10: "- c-10 is refuted by line 4"},
+		},
+		{
+			name:     "skips kept ids and unreadable entries",
+			analysis: []string{"c-2: kept, so not a removal reason", "no id here", "c-1: real"},
+			want:     map[int]string{1: "c-1: real"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterReasonsByIndex(tt.analysis, removed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for idx, want := range tt.want {
+				if got[idx] != want {
+					t.Errorf("index %d: got %q, want %q", idx, got[idx], want)
 				}
 			}
 		})

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -278,7 +278,7 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 						Type: "function",
 						Function: llm.FunctionCall{
 							Name:      "report_incorrect_comments",
-							Arguments: `{"comment_ids":["c-1"]}`,
+							Arguments: `{"analysis":["c-0: real, keep it","c-1: the field it flags is not in this diff"],"comment_ids":["c-1"]}`,
 						},
 					}},
 				},
@@ -317,6 +317,17 @@ func TestExecuteReviewFilter_RemovesComments(t *testing.T) {
 		if c.Content == "remove this" {
 			t.Error("filtered comment should have been removed")
 		}
+	}
+
+	filtered := a.FilteredComments()
+	if len(filtered) != 1 {
+		t.Fatalf("FilteredComments len = %d, want 1: %v", len(filtered), filtered)
+	}
+	if filtered[0].Content != "remove this" {
+		t.Errorf("filtered content = %q, want %q", filtered[0].Content, "remove this")
+	}
+	if filtered[0].Reason != "c-1: the field it flags is not in this diff" {
+		t.Errorf("filtered reason = %q, want the c-1 analysis entry", filtered[0].Reason)
 	}
 }
 

--- a/internal/tool/comment_collector.go
+++ b/internal/tool/comment_collector.go
@@ -93,14 +93,22 @@ func (c *CommentCollector) ReplaceSince(start int, replacements []model.LlmComme
 
 // RemoveByPathAndIndices removes comments for a given path whose per-path index
 // (0-based position among all comments with that path) is in the indices set.
-func (c *CommentCollector) RemoveByPathAndIndices(path string, indices map[int]struct{}) {
+// It returns the removed comments, keyed by that same per-path index, so a caller
+// can report what was dropped instead of losing it silently. The returned map is
+// nil when nothing matched.
+func (c *CommentCollector) RemoveByPathAndIndices(path string, indices map[int]struct{}) map[int]model.LlmComment {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	var removed map[int]model.LlmComment
 	kept := c.comments[:0]
 	pathIdx := 0
 	for _, cm := range c.comments {
 		if cm.Path == path {
 			if _, remove := indices[pathIdx]; remove {
+				if removed == nil {
+					removed = make(map[int]model.LlmComment, len(indices))
+				}
+				removed[pathIdx] = cm
 				pathIdx++
 				continue
 			}
@@ -113,4 +121,5 @@ func (c *CommentCollector) RemoveByPathAndIndices(path string, indices map[int]s
 		tail[i] = model.LlmComment{}
 	}
 	c.comments = kept
+	return removed
 }

--- a/internal/tool/comment_collector_test.go
+++ b/internal/tool/comment_collector_test.go
@@ -127,7 +127,10 @@ func TestCommentCollector_RemoveByPathAndIndices(t *testing.T) {
 	c.Add(cm("a.go", "a2"))
 	c.Add(cm("b.go", "b1"))
 
-	c.RemoveByPathAndIndices("a.go", map[int]struct{}{0: {}, 2: {}})
+	removed := c.RemoveByPathAndIndices("a.go", map[int]struct{}{0: {}, 2: {}})
+	if removed[0].Content != "a0" || removed[2].Content != "a2" {
+		t.Errorf("removed = %v, want per-path indices 0=a0 and 2=a2", removed)
+	}
 
 	got := c.Comments()
 	if len(got) != 3 {

--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -275,6 +275,16 @@ ocr review --format json --audience agent
       "suggestion_code": "mu.Lock(); defer mu.Unlock(); m[k] = v",
       "thinking": "Looking at line 42, the map …"
     }
+  ],
+  "filtered_comments": [
+    {
+      "path": "src/foo.go",
+      "content": "validate() never checks the nil case.",
+      "start_line": 88,
+      "end_line": 88,
+      "existing_code": "return validate(cfg)",
+      "reason": "c-1: validate() is not part of this diff, so the claim cannot be checked against it"
+    }
   ]
 }
 ```
@@ -288,6 +298,7 @@ Top-level fields:
 | `message` | Optional. Human-readable summary, e.g. `"No comments generated. Looks good to me."`. |
 | `summary` | Optional. Run aggregates: `files_reviewed`, `comments`, `total_tokens`, `input_tokens`, `output_tokens`, `cache_read_tokens` (omitempty), `cache_write_tokens` (omitempty), `elapsed`. Omitted for `skipped` runs. |
 | `comments` | Always present, possibly empty. Per-comment fields are the ones in the example above. |
+| `filtered_comments` | Optional. The comments `REVIEW_FILTER_TASK` removed as provably incorrect, so a dropped finding stays reviewable. Same per-comment fields as `comments`, plus `reason` — the filter's own explanation, recovered from its free-text analysis. `reason` is best-effort and may be absent (always so on providers without tool support). Omitted when nothing was removed, which also covers runs where the filter never ran (`--no-filter`, or an LLM error during filtering). Present only in this JSON output; it is not written to the session record, so `ocr session comments` and the viewer do not show it. |
 | `warnings` | Optional. Present when one or more sub-agents failed; each entry describes the affected file and the error. |
 | `session_id` | Optional. Present on persisted review runs; pass this to `ocr review --resume <session-id>` when retrying compatible range or commit reviews. |
 | `resume` | Optional. Present on resumed runs with `resumed_from`, `reused_files`, `rerun_files`, `previous_model`, and `current_model`. |

--- a/pages/src/content/docs/ja/cli-reference.md
+++ b/pages/src/content/docs/ja/cli-reference.md
@@ -258,6 +258,16 @@ ocr review --format json --audience agent
       "suggestion_code": "mu.Lock(); defer mu.Unlock(); m[k] = v",
       "thinking": "Looking at line 42, the map …"
     }
+  ],
+  "filtered_comments": [
+    {
+      "path": "src/foo.go",
+      "content": "validate() never checks the nil case.",
+      "start_line": 88,
+      "end_line": 88,
+      "existing_code": "return validate(cfg)",
+      "reason": "c-1: validate() is not part of this diff, so the claim cannot be checked against it"
+    }
   ]
 }
 ```
@@ -271,6 +281,7 @@ ocr review --format json --audience agent
 | `message` | 任意。人間が読みやすいサマリー（例: `"No comments generated. Looks good to me."`）。 |
 | `summary` | 任意。実行の集計: `files_reviewed`、`comments`、`total_tokens`、`input_tokens`、`output_tokens`、`cache_read_tokens`（omitempty）、`cache_write_tokens`（omitempty）、`elapsed`。`skipped` の実行時は省略されます。 |
 | `comments` | 常に存在しますが、空の場合があります。各コメントのフィールドは上記の例のとおりです。 |
+| `filtered_comments` | 任意。`REVIEW_FILTER_TASK` が明らかに誤りと判断して削除したコメントで、破棄された指摘も確認できるようにするためのものです。各フィールドは `comments` と同じで、加えて `reason`（フィルター自身の説明。自由記述の analysis から抽出したもの）が付きます。`reason` はベストエフォートのため欠ける場合があります（tool 呼び出しに対応していない provider では常に欠けます）。何も削除されなかった場合は省略され、フィルターが実行されなかった場合（`--no-filter`、またはフィルター中の LLM エラー）も同様です。この JSON 出力にのみ存在し、session レコードには書き込まれないため、`ocr session comments` とビューアーには表示されません。 |
 | `warnings` | 任意。1 つ以上のサブエージェントが失敗した場合に存在します。各項目は影響を受けたファイルとエラーを記述します。 |
 | `session_id` | 任意。永続化されたレビュー実行に含まれます。互換性のある範囲または単一 commit レビューを再試行する際に `ocr review --resume <session-id>` へ渡せます。 |
 | `resume` | 任意。再開した実行で存在し、`resumed_from`、`reused_files`、`rerun_files`、`previous_model`、`current_model` を含みます。 |

--- a/pages/src/content/docs/ru/cli-reference.md
+++ b/pages/src/content/docs/ru/cli-reference.md
@@ -259,6 +259,16 @@ ocr review --format json --audience agent
       "suggestion_code": "mu.Lock(); defer mu.Unlock(); m[k] = v",
       "thinking": "Looking at line 42, the map …"
     }
+  ],
+  "filtered_comments": [
+    {
+      "path": "src/foo.go",
+      "content": "validate() never checks the nil case.",
+      "start_line": 88,
+      "end_line": 88,
+      "existing_code": "return validate(cfg)",
+      "reason": "c-1: validate() is not part of this diff, so the claim cannot be checked against it"
+    }
   ]
 }
 ```
@@ -271,6 +281,7 @@ ocr review --format json --audience agent
 | `message` | Необязательно. Сводка для чтения человеком, например, `"No comments generated. Looks good to me."`. |
 | `summary` | Необязательно. Сводные показатели запуска: `files_reviewed`, `comments`, `total_tokens`, `input_tokens`, `output_tokens`, `cache_read_tokens` (omitempty), `cache_write_tokens` (omitempty), `elapsed`. Отсутствует у запусков со статусом `skipped`. |
 | `comments` | Присутствует всегда, но может быть пустым. Поля комментария показаны в примере выше. |
+| `filtered_comments` | Необязательно. Комментарии, удалённые `REVIEW_FILTER_TASK` как доказуемо неверные, — чтобы отброшенную находку всё же можно было проверить. Поля те же, что и у `comments`, плюс `reason` — объяснение самого фильтра, извлечённое из его свободного текста analysis. `reason` заполняется по возможности и может отсутствовать (у провайдеров без поддержки вызова инструментов — всегда). Поле отсутствует, когда ничего не было удалено, включая запуски, где фильтр не выполнялся (`--no-filter` или ошибка LLM во время фильтрации). Присутствует только в этом JSON-выводе и не записывается в запись сессии, поэтому `ocr session comments` и просмотрщик его не показывают. |
 | `warnings` | Необязательно. Присутствует, если один или несколько субагентов завершились с ошибкой; каждая запись описывает затронутый файл и ошибку. |
 | `session_id` | Необязательно. Присутствует у сохранённых запусков ревью; передайте его в `ocr review --resume <session-id>`, чтобы повторить совместимое ревью диапазона или коммита. |
 | `resume` | Необязательно. Присутствует у возобновлённых запусков и содержит `resumed_from`, `reused_files`, `rerun_files`, `previous_model` и `current_model`. |

--- a/pages/src/content/docs/zh/cli-reference.md
+++ b/pages/src/content/docs/zh/cli-reference.md
@@ -258,6 +258,16 @@ ocr review --format json --audience agent
       "suggestion_code": "mu.Lock(); defer mu.Unlock(); m[k] = v",
       "thinking": "Looking at line 42, the map …"
     }
+  ],
+  "filtered_comments": [
+    {
+      "path": "src/foo.go",
+      "content": "validate() never checks the nil case.",
+      "start_line": 88,
+      "end_line": 88,
+      "existing_code": "return validate(cfg)",
+      "reason": "c-1: validate() is not part of this diff, so the claim cannot be checked against it"
+    }
   ]
 }
 ```
@@ -271,6 +281,7 @@ ocr review --format json --audience agent
 | `message` | 可选。人类可读摘要，如 `"No comments generated. Looks good to me."`。 |
 | `summary` | 可选。运行聚合：`files_reviewed`、`comments`、`total_tokens`、`input_tokens`、`output_tokens`、`cache_read_tokens`（omitempty）、`cache_write_tokens`（omitempty）、`elapsed`。`skipped` 运行时省略。 |
 | `comments` | 总是存在，可能为空。每条评论的字段如上例。 |
+| `filtered_comments` | 可选。被 `REVIEW_FILTER_TASK` 判定为确凿错误而移除的评论，使被丢弃的结论仍可复核。字段与 `comments` 相同，另加 `reason` —— 过滤器自身的说明，从其自由文本分析中提取。`reason` 为尽力而为，可能缺失（在不支持 tool 调用的 provider 上必然缺失）。未移除任何评论时省略该字段，过滤器未运行（`--no-filter`，或过滤期间 LLM 报错）的情况同样如此。仅存在于本次 JSON 输出，不写入 session 记录，因此 `ocr session comments` 与 viewer 不会显示。 |
 | `warnings` | 可选。当一个或多个子 agent 失败时存在；每条描述受影响文件与错误。 |
 | `session_id` | 可选。持久化的评审运行会包含该字段；重试兼容的区间或单 commit 评审时可传给 `ocr review --resume <session-id>`。 |
 | `resume` | 可选。恢复运行时存在，包含 `resumed_from`、`reused_files`、`rerun_files`、`previous_model` 和 `current_model`。 |


### PR DESCRIPTION
## Description

`REVIEW_FILTER_TASK` removes comments that the diff proves to be incorrect. These comments are currently removed from the collector and disappear from the final result, making filter decisions difficult to inspect.

This PR preserves removed comments and exposes them through an optional top-level `filtered_comments` field in JSON output. Each entry contains:

- the original review comment
- resolved line numbers
- the filter's reasoning when available

The field is omitted when no comments are removed. Existing `comments` semantics, summary counts, publishing behavior, and session persistence remain unchanged. Filtered comments are available only in the current JSON output and are not returned by `ocr session comments` or the viewer.

The JSON output contract is documented in all supported languages.

## Type of Change

- [x] New feature
- [x] Documentation update

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Added unit tests for collection, reason handling, line resolution, and JSON output

## Checklist

- [x] Self-reviewed
- [x] Tests added and passing
- [x] Documentation updated

## Related Issues

N/A