### PR TITLE
fix(llm): preserve opaque tool-call fields

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -125,9 +125,10 @@ type Choice struct {
 
 // ToolCall represents a function call requested by the model.
 type ToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"`
-	Function FunctionCall `json:"function"`
+	ID          string                     `json:"id"`
+	Type        string                     `json:"type"`
+	Function    FunctionCall               `json:"function"`
+	ExtraFields map[string]json.RawMessage `json:"-"`
 }
 
 // FunctionCall holds the name and arguments of a tool call.
@@ -613,14 +614,25 @@ func (c *OpenAIClient) buildOpenAIParams(model string, req ChatRequest) openai.C
 					asst.Content.OfString = openai.String(content)
 				}
 				for _, tc := range msg.ToolCalls {
-					asst.ToolCalls = append(asst.ToolCalls, openai.ChatCompletionMessageToolCallUnionParam{
-						OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-							ID: tc.ID,
-							Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-								Name:      tc.Function.Name,
-								Arguments: tc.Function.Arguments,
-							},
+					functionCall := openai.ChatCompletionMessageFunctionToolCallParam{
+						ID: tc.ID,
+						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+							Name:      tc.Function.Name,
+							Arguments: tc.Function.Arguments,
 						},
+					}
+					if len(tc.ExtraFields) > 0 {
+						extraFields := make(map[string]any, len(tc.ExtraFields))
+						for name, raw := range tc.ExtraFields {
+							if name == "id" || name == "type" || name == "function" || !json.Valid(raw) {
+								continue
+							}
+							extraFields[name] = raw
+						}
+						functionCall.SetExtraFields(extraFields)
+					}
+					asst.ToolCalls = append(asst.ToolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+						OfFunction: &functionCall,
 					})
 				}
 				messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
@@ -682,9 +694,19 @@ func (c *OpenAIClient) mapOpenAIResponse(sdkResp *openai.ChatCompletion) *ChatRe
 	for _, ch := range sdkResp.Choices {
 		var toolCalls []ToolCall
 		for _, tc := range ch.Message.ToolCalls {
+			var extraFields map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.RawJSON()), &extraFields); err == nil {
+				delete(extraFields, "id")
+				delete(extraFields, "type")
+				delete(extraFields, "function")
+				if len(extraFields) == 0 {
+					extraFields = nil
+				}
+			}
 			toolCalls = append(toolCalls, ToolCall{
-				ID:   tc.ID,
-				Type: tc.Type,
+				ID:          tc.ID,
+				Type:        tc.Type,
+				ExtraFields: extraFields,
 				Function: FunctionCall{
 					Name:      tc.Function.Name,
 					Arguments: tc.Function.Arguments,

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -914,6 +914,90 @@ func TestOpenAIClient_NonStreamingRequestDropsStreamField(t *testing.T) {
 	}
 }
 
+func TestOpenAIClient_PreservesToolCallExtraFieldsAcrossTurns(t *testing.T) {
+	var requestNumber atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := requestNumber.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if current == 1 {
+			_, _ = fmt.Fprint(w, `{
+				"id":"chatcmpl-tools",
+				"object":"chat.completion",
+				"model":"gemini-compatible",
+				"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{
+					"id":"call_read",
+					"type":"function",
+					"function":{"name":"file_read","arguments":"{\"path\":\"main.go\"}"},
+					"extra_content":{"google":{"thought_signature":"opaque-signature"}}
+				}]},"finish_reason":"tool_calls"}]
+			}`)
+			return
+		}
+
+		var body struct {
+			Messages []struct {
+				Role      string           `json:"role"`
+				ToolCalls []map[string]any `json:"tool_calls"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode second request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if len(body.Messages) < 2 || len(body.Messages[1].ToolCalls) != 1 {
+			t.Errorf("second request messages = %#v, want assistant tool call", body.Messages)
+			http.Error(w, "missing tool call", http.StatusBadRequest)
+			return
+		}
+		extraContent, ok := body.Messages[1].ToolCalls[0]["extra_content"].(map[string]any)
+		if !ok {
+			t.Errorf("extra_content = %#v, want object", body.Messages[1].ToolCalls[0]["extra_content"])
+			http.Error(w, "missing extra_content", http.StatusBadRequest)
+			return
+		}
+		google, ok := extraContent["google"].(map[string]any)
+		if !ok || google["thought_signature"] != "opaque-signature" {
+			t.Errorf("extra_content.google = %#v, want opaque thought signature", extraContent["google"])
+			http.Error(w, "missing thought signature", http.StatusBadRequest)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{
+			"id":"chatcmpl-done",
+			"object":"chat.completion",
+			"model":"gemini-compatible",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1",
+		APIKey: "test-key",
+		Model:  "gemini-compatible",
+	})
+	first, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "read main.go"}},
+	})
+	if err != nil {
+		t.Fatalf("first completion: %v", err)
+	}
+
+	second, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{
+			{Role: "user", Content: "read main.go"},
+			NewToolCallMessage(first.Content(), first.ToolCalls()),
+			NewToolResultMessage("call_read", "package main"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("second completion: %v", err)
+	}
+	if got := second.Content(); got != "done" {
+		t.Fatalf("second completion content = %q, want done", got)
+	}
+}
+
 func TestOpenAIClient_StreamingToolCall(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeOpenAISSE(t, w,


### PR DESCRIPTION
Description
Preserve unknown JSON fields returned on OpenAI-compatible function tool calls and echo them on later assistant-history turns through the OpenAI SDK's supported SetExtraFields mechanism.

OpenAI-compatible Gemini endpoint puts a required thought signature under tool_calls[].extra_content. OCR previously reduced every returned tool call to id, type, and function, so a repository tool succeeded on turn one and the provider rejected turn two with HTTP 400. The fix is provider-independent: opaque extension fields survive the response-to-request round trip, while OCR continues to own id, type, and function; invalid JSON is not forwarded; and the fields remain excluded from normal OCR JSON/session serialization.

Type of Change
 Bug fix (non-breaking change that fixes an issue)
 
How Has This Been Tested?
 make test passes locally
 Manual testing (describe below)

Tests and validation:

go test -count=1 ./internal/llm -skip 'TestShellRCFiles|TestTryShellRC' passes. The skipped tests are existing Unix-home assumptions that fail under Windows because os.UserHomeDir does not follow the test's HOME override.
go vet ./... passes.
Added an HTTP-level regression test: a fake OpenAI-compatible server returns nested opaque extra_content on turn one and rejects turn two unless OCR echoes it unchanged.
Built the patched OCR binary and ran a real three-file review against Vertex AI's official OpenAI-compatible Gemini endpoint. Before this patch, all three files failed on request two with HTTP 400 and coverage was 0/3. With this patch, coverage was 3/3, the review completed, and it found the planted defect. Two additional identical runs also completed 3/3, proving the transport/tool loop is stable.
Ran OCR's required self-review command against this diff; it completed with no findings.
The full Windows suite still contains unrelated permission/Unix-shell failures, and the race target requires a CGO toolchain not present on this host. CI remains the authoritative full race run.
ocr scan no longer generates 400 errors

Checklist
 My code follows the project's coding style (go fmt, go vet)
 I have performed a self-review of my code
 I have added tests that prove my fix is effective or my feature works
 New and existing focused unit tests pass locally with my changes
 
Related Issues
Closes https://github.com/alibaba/open-code-review/issues/947