### PR TITLE
chore(ci): change dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       go-dependencies:
         patterns:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns:
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: npm
     directory: /extensions/vscode
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     ignore:
       # yarn.lock already resolves @types/vscode far above the declared


### PR DESCRIPTION
## Summary

- Change Dependabot update interval from `weekly` to `monthly` for all three ecosystems (gomod, github-actions, npm)
- Reduces PR noise while still keeping dependencies reasonably fresh

## Motivation

Weekly updates generate too many dependency PRs. A monthly cadence strikes a better balance between staying current and minimizing review overhead. Security advisories still trigger immediate PRs regardless of this schedule.