### PR TITLE
Fix/gitlab multiline comments and suggestions

### DIFF
--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -1193,7 +1193,6 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
     routed = []
     for comment in comments:
         path = comment.get("path", "")
-        path_sha1 = hashlib.sha1(path.encode("utf-8")).hexdigest()
         start_line = comment.get("start_line", 0)
         end_line = comment.get("end_line", 0)
         # Inline posting needs a valid end_line (it becomes the GitLab position's
@@ -1253,6 +1252,8 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
     for it in inline_items:
         comment = it["comment"]
         path = comment.get("path", "")
+        path_sha1 = hashlib.sha1(path.encode("utf-8")).hexdigest()
+        start_line = comment.get("start_line", 0)
         end_line = comment.get("end_line", 0)
         if not path or not end_line:
             failed_comments.append({"comment": comment, "reason": NO_LINE_REASON})

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -1252,9 +1252,8 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
     for it in inline_items:
         comment = it["comment"]
         path = comment.get("path", "")
-        path_sha1 = hashlib.sha1(path.encode("utf-8")).hexdigest()
-        start_line = comment.get("start_line", 0)
         end_line = comment.get("end_line", 0)
+        span = comment_span(comment)
         if not path or not end_line:
             failed_comments.append({"comment": comment, "reason": NO_LINE_REASON})
             continue
@@ -1271,20 +1270,24 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
                 "base_sha": diff_refs["base_sha"],
                 "start_sha": diff_refs["start_sha"],
                 "head_sha": diff_refs["head_sha"],
-                "line_range": {
-                    "start": {
-                        "line_code": f"{path_sha1}_0_{start_line}",
-                        "type": "new",
-                        "new_line": start_line,
-                    },
-                    "end": {
-                        "line_code": f"{path_sha1}_0_{end_line}",
-                        "type": "new",
-                        "new_line": end_line,
-                    },
-                },
             },
         }
+        if span is not None and span["multiline"]:
+            path_sha1 = hashlib.sha1(path.encode("utf-8")).hexdigest()
+            discussion["position"]["line_range"] = {
+                "start": {
+                    "line_code": f"{path_sha1}_0_{span['start']}",
+                    "type": "new",
+                    "old_line": None,
+                    "new_line": span["start"],
+                },
+                "end": {
+                    "line_code": f"{path_sha1}_0_{span['end']}",
+                    "type": "new",
+                    "old_line": None,
+                    "new_line": span["end"],
+                },
+            }
         resp = poster.post_discussion(discussion, comment_id=it["id"])
         if resp.get("success"):
             stats["inline"] += 1

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -272,7 +272,7 @@ def format_comment(comment, comment_id=None):
     existing = comment.get("existing_code", "")
     if suggestion and existing:
         span = comment_span(comment)
-        suggestion_offset = span["end"] - span["start"] if span is not None else 0
+        suggestion_offset = span["end"] - span["start"] if span is not None and span["multiline"] else 0
         body += "\n\n**Suggestion:**\n"
         body += "```suggestion:-%d+0\n%s\n```" % (suggestion_offset, suggestion)
     return body

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -36,6 +36,7 @@ Standard library only (json, urllib) so it runs on any stock python3 image.
 """
 
 import argparse
+import hashlib
 import json
 import os
 import random
@@ -1190,6 +1191,7 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
     routed = []
     for comment in comments:
         path = comment.get("path", "")
+        path_sha1 = hashlib.sha1(path.encode("utf-8")).hexdigest()
         start_line = comment.get("start_line", 0)
         end_line = comment.get("end_line", 0)
         # Inline posting needs a valid end_line (it becomes the GitLab position's
@@ -1266,6 +1268,18 @@ def publish(result, diff_refs, poster, config, sleep=_sleep):
                 "base_sha": diff_refs["base_sha"],
                 "start_sha": diff_refs["start_sha"],
                 "head_sha": diff_refs["head_sha"],
+                "line_range": {
+                    "start": {
+                        "line_code": f"{path_sha1}_0_{start_line}",
+                        "type": "new",
+                        "new_line": start_line,
+                    },
+                    "end": {
+                        "line_code": f"{path_sha1}_0_{end_line}",
+                        "type": "new",
+                        "new_line": end_line,
+                    },
+                },
             },
         }
         resp = poster.post_discussion(discussion, comment_id=it["id"])

--- a/examples/gitlab_ci/post_review.py
+++ b/examples/gitlab_ci/post_review.py
@@ -271,8 +271,10 @@ def format_comment(comment, comment_id=None):
     suggestion = comment.get("suggestion_code", "")
     existing = comment.get("existing_code", "")
     if suggestion and existing:
+        span = comment_span(comment)
+        suggestion_offset = span["end"] - span["start"] if span is not None else 0
         body += "\n\n**Suggestion:**\n"
-        body += "```suggestion:-0+0\n%s\n```" % suggestion
+        body += "```suggestion:-%d+0\n%s\n```" % (suggestion_offset, suggestion)
     return body
 
 

--- a/examples/gitlab_ci/post_review_test.py
+++ b/examples/gitlab_ci/post_review_test.py
@@ -16,6 +16,7 @@ Test seams:
      canned ``HTTPError`` sequences.
 """
 
+import hashlib
 import io
 import json
 import os
@@ -381,7 +382,7 @@ class SafeFenceTest(unittest.TestCase):
 
 class PublishTest(unittest.TestCase):
     def test_inline_success_and_summary(self):
-        stats, rec = run_publish({"comments": [comment()]})
+        stats, rec = run_publish({"comments": [comment(start_line=5, end_line=10)]})
         self.assertEqual(stats["inline"], 1)
         self.assertEqual(stats["failed"], 0)
         self.assertEqual(len(rec.disc_calls), 1)
@@ -390,6 +391,13 @@ class PublishTest(unittest.TestCase):
         inline = rec.disc_calls[0]
         self.assertEqual(inline["position"]["new_path"], "main.py")
         self.assertEqual(inline["position"]["new_line"], 10)
+        line_range = inline["position"]["line_range"]
+        expected_path_sha1 = hashlib.sha1(b"main.py").hexdigest()
+        self.assertEqual(line_range["start"]["line_code"], f"{expected_path_sha1}_0_5")
+        self.assertEqual(line_range["start"]["new_line"], 5)
+        self.assertEqual(line_range["end"]["line_code"], f"{expected_path_sha1}_0_10")
+        self.assertEqual(line_range["end"]["new_line"], 10)
+
         self.assertIn("possible issue", inline["body"])
         self.assertIn("**1** issue(s)", rec.final_summary_body)
         self.assertIn("Successfully posted inline: 1 comment(s)", rec.final_summary_body)

--- a/examples/gitlab_ci/post_review_test.py
+++ b/examples/gitlab_ci/post_review_test.py
@@ -231,6 +231,24 @@ class FormatCommentTest(unittest.TestCase):
         self.assertIn("```suggestion:-0+0\nx = 2\n```", body)
         self.assertIn("**Suggestion:**", body)
 
+    def test_with_multiline_suggestion(self):
+        body = pr.format_comment(comment(content="fix this", existing_code="x = 1\ny = 2", suggestion_code="x = 2\ny = 3", start_line=5, end_line=6))
+        self.assertIn("fix this", body)
+        self.assertIn("```suggestion:-1+0\nx = 2\ny = 3\n```", body)
+        self.assertIn("**Suggestion:**", body)
+
+    def test_with_multiline_suggestion_no_start_line(self):
+        body = pr.format_comment(comment(content="fix this", existing_code="x = 1\ny = 2", suggestion_code="x = 2\ny = 3", start_line=None, end_line=5))
+        self.assertIn("fix this", body)
+        self.assertIn("```suggestion:-0+0\nx = 2\ny = 3\n```", body)
+        self.assertIn("**Suggestion:**", body)
+
+    def test_with_multiline_suggestion_no_end_line(self):
+        body = pr.format_comment(comment(content="fix this", existing_code="x = 1\ny = 2", suggestion_code="x = 2\ny = 3", start_line=5, end_line=None))
+        self.assertIn("fix this", body)
+        self.assertIn("```suggestion:-0+0\nx = 2\ny = 3\n```", body)
+        self.assertIn("**Suggestion:**", body)
+
     def test_suggestion_without_existing(self):
         body = pr.format_comment(comment(content="fix this", suggestion_code="x = 2"))
         self.assertNotIn("```suggestion", body)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
Fixes the GitLab CI post_review example so that multiline discussions are correctly shown in the UI, currently the discussion is only associated with the end_line. Also fixes the suggestions so that the correct before and after state is shown so that you are able to use the "Apply Suggestion" in the UI, currently only the last line of the before state is shown causing the "Apply Suggestion" not to function properly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing (describe below)

The unit tests `post_review_test.py` has been updated to reflect the changes made and are passing. I have also used the new version against GitLab to validate that the changes are showing the correct behaviour in the UI.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA
