### PR TITLE
refactor(skill): simplify review flow, use native severity

### DIFF
--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -67,6 +67,8 @@ ocr review --audience agent --background "business context here" [user-args]
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
 - **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
 
+**On failure:** If `ocr review` exits non-zero (e.g. an LLM connection error), do not retry blindly — consult the Troubleshooting section below for the matching fix before re-running.
+
 ### Step 3: Report
 
 OCR output includes structured `severity` (critical / high / medium / low) and `category` (bug / security / performance / maintainability / test / style / documentation / other) on each comment. Present results grouped by severity, discarding `low` severity items that are likely false positives or nitpicks.

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -124,7 +124,7 @@ Present results grouped by severity using this template:
   > Recommendation: How to fix (if applicable)
 ```
 
-If no issues found, simply state: "Review complete — no issues found in N files."
+If no critical, high, or medium severity issues remain after filtering, state: "Review complete — no critical, high, or medium issues found in N files."
 
 **Handling mispositioned comments:**
 
@@ -203,18 +203,15 @@ npm install -g @alibaba-group/open-code-review
 
 **`ocr review` fails with LLM connection error**
 
-The user must configure an LLM. Guide them with one of these options:
+Prompt the user to configure an LLM provider.
 
-**Option A — Environment variables (highest priority, recommended for CI):**
+Interactive setup (recommended):
 
 ```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
+ocr config provider
 ```
 
-**Option B — Persistent config:**
+Manual setup (alternative):
 
 ```bash
 ocr config set llm.url https://api.anthropic.com/v1/messages

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -28,46 +28,6 @@ materialize the plugin subtree.
 
 A skill for invoking [open-code-review](https://github.com/alibaba/open-code-review) (`ocr`) — an open-source AI code review CLI that reads Git diffs and generates structured, line-level review comments.
 
-## Prerequisites check
-
-Before starting a review, verify the environment:
-
-```bash
-# 1. Check the CLI is installed
-which ocr || echo "NOT INSTALLED"
-
-# 2. Verify LLM connectivity
-ocr llm test
-```
-
-If `ocr` is not installed, install it first:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
-If `ocr llm test` fails, the user must configure an LLM. Guide them with one of these options:
-
-**Option A — Environment variables (highest priority, recommended for CI):**
-
-```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
-```
-
-**Option B — Persistent config:**
-
-```bash
-ocr config set llm.url https://api.anthropic.com/v1/messages
-ocr config set llm.auth_token <api-key>
-ocr config set llm.model claude-opus-4-6
-ocr config set llm.use_anthropic true
-```
-
-Stop here and ask the user to provide credentials — never invent or hardcode API keys.
-
 ## Workflow
 
 ### Step 1: Gather Business Context
@@ -214,7 +174,7 @@ ocr rules check src/main/java/com/example/Foo.java
 
 ## Gotchas
 
-- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. Always run `ocr llm test` before the first review.
+- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. See the Troubleshooting section below if this happens.
 - **Working directory matters** — `ocr review` operates on the Git repo at the current directory. Use `--repo /path/to/repo` to run from elsewhere.
 - **Untracked files are reviewed in workspace mode** — running bare `ocr review` includes staged, unstaged, *and* untracked changes. Stage selectively if you want narrower scope.
 - **Large diffs may hit token limits** — files with very large diffs may be truncated. The default `MAX_TOKENS` is 58888 per request.
@@ -231,6 +191,40 @@ After the review completes, verify success by checking:
 3. Warnings (if any) are displayed in stderr
 
 If errors occurred, check the stderr warnings for details about which files failed and why.
+
+## Troubleshooting
+
+**`ocr: command not found`**
+
+Install the CLI:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+**`ocr review` fails with LLM connection error**
+
+The user must configure an LLM. Guide them with one of these options:
+
+**Option A — Environment variables (highest priority, recommended for CI):**
+
+```bash
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=<api-key>
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true
+```
+
+**Option B — Persistent config:**
+
+```bash
+ocr config set llm.url https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token <api-key>
+ocr config set llm.model claude-opus-4-6
+ocr config set llm.use_anthropic true
+```
+
+Verify connectivity with `ocr llm test`. Stop here and ask the user to provide credentials — never invent or hardcode API keys.
 
 ## References
 

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -65,6 +65,7 @@ ocr review --audience agent --background "business context here" [user-args]
 **Output mode:**
 
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
+- **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
 
 ### Step 3: Report
 
@@ -176,6 +177,7 @@ ocr rules check src/main/java/com/example/Foo.java
 - **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
 - **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
 - **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
+- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Redirect output to a file and read it in full.
 
 ## Validation
 

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -66,15 +66,9 @@ ocr review --audience agent --background "business context here" [user-args]
 
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
 
-### Step 3: Classify and Report
+### Step 3: Report
 
-For each comment from the review output, classify by priority and report all issues to the user:
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Likely false positives, lacking sufficient context, nitpicks, or meaningless suggestions
-
-Report all comments grouped by priority level.
+OCR output includes structured `severity` (critical / high / medium / low) and `category` (bug / security / performance / maintainability / test / style / documentation / other) on each comment. Present results grouped by severity, discarding `low` severity items that are likely false positives or nitpicks.
 
 ### Step 4: Fix
 
@@ -85,48 +79,49 @@ Before applying fixes, check whether the user requested automatic fixes:
 
 When fixing issues and suggestions:
 
-- Focus on High and Medium priority items
+- Focus on critical, high, and medium severity items
 - Apply fixes directly to the code when safe and well-defined
 - For complex fixes requiring manual intervention, clearly describe what needs to be done
 - Always verify fixes with the user before committing
 
 ## Output Format
 
-Each comment contains:
+Each comment in OCR's output contains:
 
 - `path`: File path
 - `content`: Review comment text
 - `start_line` / `end_line`: Line range (both 0 means positioning failed)
+- `category`: Issue category (bug, security, performance, maintainability, test, style, documentation, other)
+- `severity`: Issue severity (critical, high, medium, low)
 - `suggestion_code`: Optional fix suggestion
 - `existing_code`: Optional original code snippet
 - `thinking`: Optional LLM reasoning process
 
-After filtering comments by priority, present results using this template:
+Present results grouped by severity using this template:
 
 ```markdown
 ## Code Review Results
 
 **Files reviewed**: N
-**Issues found**: X high priority / Y medium priority
+**Issues found**: X critical, Y high, Z medium
 
-### High Priority
+### Critical
 
-- **`path/to/file.java:42`** — Brief description
+- **`path/to/file.java:42`** [bug] — Brief description
   > Recommendation: How to fix
 
-### Medium Priority
+### High
 
-- **`path/to/file.ts:88`** — Brief description
+- **`path/to/file.java:26`** [bug] — Brief description
+  > Recommendation: How to fix
+
+### Medium
+
+- **`path/to/file.ts:88`** [performance] — Brief description
   > Recommendation: How to fix (if applicable)
 ```
 
-If the review found no issues after filtering, simply state: "Review complete — no issues found in N files."
-
-**Priority classification:**
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Discarded silently (likely false positives, lacking context, nitpicks, or meaningless suggestions)
+If no issues found, simply state: "Review complete — no issues found in N files."
 
 **Handling mispositioned comments:**
 

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -62,6 +62,8 @@ ocr review --audience agent --background "business context here" [user-args]
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
 - **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
 
+**On failure:** If `ocr review` exits non-zero (e.g. an LLM connection error), do not retry blindly — consult the Troubleshooting section below for the matching fix before re-running.
+
 ### Step 3: Report
 
 OCR output includes structured `severity` (critical / high / medium / low) and `category` (bug / security / performance / maintainability / test / style / documentation / other) on each comment. Present results grouped by severity, discarding `low` severity items that are likely false positives or nitpicks.

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -23,46 +23,6 @@ metadata:
 
 A skill for invoking [open-code-review](https://github.com/alibaba/open-code-review) (`ocr`) — an open-source AI code review CLI that reads Git diffs and generates structured, line-level review comments.
 
-## Prerequisites check
-
-Before starting a review, verify the environment:
-
-```bash
-# 1. Check the CLI is installed
-which ocr || echo "NOT INSTALLED"
-
-# 2. Verify LLM connectivity
-ocr llm test
-```
-
-If `ocr` is not installed, install it first:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
-If `ocr llm test` fails, the user must configure an LLM. Guide them with one of these options:
-
-**Option A — Environment variables (highest priority, recommended for CI):**
-
-```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
-```
-
-**Option B — Persistent config:**
-
-```bash
-ocr config set llm.url https://api.anthropic.com/v1/messages
-ocr config set llm.auth_token <api-key>
-ocr config set llm.model claude-opus-4-6
-ocr config set llm.use_anthropic true
-```
-
-Stop here and ask the user to provide credentials — never invent or hardcode API keys.
-
 ## Workflow
 
 ### Step 1: Gather Business Context
@@ -102,15 +62,9 @@ ocr review --audience agent --background "business context here" [user-args]
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
 - **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
 
-### Step 3: Classify and Report
+### Step 3: Report
 
-For each comment from the review output, classify by priority and report all issues to the user:
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Likely false positives, lacking sufficient context, nitpicks, or meaningless suggestions
-
-Report all comments grouped by priority level.
+OCR output includes structured `severity` (critical / high / medium / low) and `category` (bug / security / performance / maintainability / test / style / documentation / other) on each comment. Present results grouped by severity, discarding `low` severity items that are likely false positives or nitpicks.
 
 ### Step 4: Fix
 
@@ -121,48 +75,49 @@ Before applying fixes, check whether the user requested automatic fixes:
 
 When fixing issues and suggestions:
 
-- Focus on High and Medium priority items
+- Focus on critical, high, and medium severity items
 - Apply fixes directly to the code when safe and well-defined
 - For complex fixes requiring manual intervention, clearly describe what needs to be done
 - Always verify fixes with the user before committing
 
 ## Output Format
 
-Each comment contains:
+Each comment in OCR's output contains:
 
 - `path`: File path
 - `content`: Review comment text
 - `start_line` / `end_line`: Line range (both 0 means positioning failed)
+- `category`: Issue category (bug, security, performance, maintainability, test, style, documentation, other)
+- `severity`: Issue severity (critical, high, medium, low)
 - `suggestion_code`: Optional fix suggestion
 - `existing_code`: Optional original code snippet
 - `thinking`: Optional LLM reasoning process
 
-After filtering comments by priority, present results using this template:
+Present results grouped by severity using this template:
 
 ```markdown
 ## Code Review Results
 
 **Files reviewed**: N
-**Issues found**: X high priority / Y medium priority
+**Issues found**: X critical, Y high, Z medium
 
-### High Priority
+### Critical
 
-- **`path/to/file.java:42`** — Brief description
+- **`path/to/file.java:42`** [bug] — Brief description
   > Recommendation: How to fix
 
-### Medium Priority
+### High
 
-- **`path/to/file.ts:88`** — Brief description
+- **`path/to/file.java:26`** [bug] — Brief description
+  > Recommendation: How to fix
+
+### Medium
+
+- **`path/to/file.ts:88`** [performance] — Brief description
   > Recommendation: How to fix (if applicable)
 ```
 
-If the review found no issues after filtering, simply state: "Review complete — no issues found in N files."
-
-**Priority classification:**
-
-- **High**: Obvious bugs, security issues, clear mistakes, or well-founded suggestions with precise fix proposals
-- **Medium**: Reasonable concerns but context-dependent, style/performance suggestions, or fixes that require manual implementation
-- **Low**: Discarded silently (likely false positives, lacking context, nitpicks, or meaningless suggestions)
+If no issues found, simply state: "Review complete — no issues found in N files."
 
 **Handling mispositioned comments:**
 
@@ -210,7 +165,7 @@ ocr rules check src/main/java/com/example/Foo.java
 
 ## Gotchas
 
-- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. Always run `ocr llm test` before the first review.
+- **LLM must be configured first** — `ocr review` will fail loudly if no LLM is reachable. See the Troubleshooting section below if this happens.
 - **Working directory matters** — `ocr review` operates on the Git repo at the current directory. Use `--repo /path/to/repo` to run from elsewhere.
 - **Untracked files are reviewed in workspace mode** — running bare `ocr review` includes staged, unstaged, *and* untracked changes. Stage selectively if you want narrower scope.
 - **Large diffs may hit token limits** — files with very large diffs may be truncated. The default `MAX_TOKENS` is 58888 per request.
@@ -228,6 +183,40 @@ After the review completes, verify success by checking:
 3. Warnings (if any) are displayed in stderr
 
 If errors occurred, check the stderr warnings for details about which files failed and why.
+
+## Troubleshooting
+
+**`ocr: command not found`**
+
+Install the CLI:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
+**`ocr review` fails with LLM connection error**
+
+The user must configure an LLM. Guide them with one of these options:
+
+**Option A — Environment variables (highest priority, recommended for CI):**
+
+```bash
+export OCR_LLM_URL=https://api.anthropic.com/v1/messages
+export OCR_LLM_TOKEN=<api-key>
+export OCR_LLM_MODEL=claude-opus-4-6
+export OCR_USE_ANTHROPIC=true
+```
+
+**Option B — Persistent config:**
+
+```bash
+ocr config set llm.url https://api.anthropic.com/v1/messages
+ocr config set llm.auth_token <api-key>
+ocr config set llm.model claude-opus-4-6
+ocr config set llm.use_anthropic true
+```
+
+Verify connectivity with `ocr llm test`. Stop here and ask the user to provide credentials — never invent or hardcode API keys.
 
 ## References
 

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -119,7 +119,7 @@ Present results grouped by severity using this template:
   > Recommendation: How to fix (if applicable)
 ```
 
-If no issues found, simply state: "Review complete — no issues found in N files."
+If no critical, high, or medium severity issues remain after filtering, state: "Review complete — no critical, high, or medium issues found in N files."
 
 **Handling mispositioned comments:**
 
@@ -198,18 +198,15 @@ npm install -g @alibaba-group/open-code-review
 
 **`ocr review` fails with LLM connection error**
 
-The user must configure an LLM. Guide them with one of these options:
+Prompt the user to configure an LLM provider.
 
-**Option A — Environment variables (highest priority, recommended for CI):**
+Interactive setup (recommended):
 
 ```bash
-export OCR_LLM_URL=https://api.anthropic.com/v1/messages
-export OCR_LLM_TOKEN=<api-key>
-export OCR_LLM_MODEL=claude-opus-4-6
-export OCR_USE_ANTHROPIC=true
+ocr config provider
 ```
 
-**Option B — Persistent config:**
+Manual setup (alternative):
 
 ```bash
 ocr config set llm.url https://api.anthropic.com/v1/messages


### PR DESCRIPTION
## Description

This PR simplifies the `open-code-review` skill and aligns it with the current OCR version. The skill was written for an older OCR that did not emit structured `severity`/`category` on comments and required the agent to verify its environment before each run. These are now redundant — OCR emits `severity`/`category` as required fields, and `ocr review` fails fast when no LLM is configured.

### What changed

**1. Move prerequisites check out of the main workflow**
- Removed the upfront `which ocr` / `ocr llm test` block. These are low-frequency, one-time setup actions, and `ocr review` already fails fast on a missing CLI or unreachable LLM.
- Added a **Troubleshooting** section at the end holding the install and LLM-config guidance, consulted only on failure.

**2. Use native OCR severity/category instead of manual classification**
- Step 3 no longer asks the agent to classify comments into High/Medium/Low itself — OCR's `code_comment` tool already emits these. The agent now groups results by the native `severity` and discards `low` items.
- Output Format: added `category`/`severity` to the field list; the report template is now grouped by severity (critical/high/medium). Removed the duplicated "Priority classification" block. Retained the `thinking` field and the "Handling mispositioned comments" guidance (still needed as a fallback when OCR's internal re-location also fails).

**3. Route command failures to Troubleshooting**
- Step 2 had no failure directive, so the agent did not consult Troubleshooting when `ocr review` failed (e.g. LLM connection error). Added an "On failure" pointer so the agent looks up the matching fix before retrying.

**4. Sync canonical and plugin skill copies**
- Applied the same refactor to the canonical `skills/open-code-review/SKILL.md` (the plugin copy mirrors it).
- Back-filled the output-truncation guidance (previously added to canonical but missed by the plugin copy) into the plugin copy. The two files now diverge only by the plugin's self-descriptive mirror notice.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

A/B tested the skill instruction change (markdown only, no Go code change). Environment: Claude Opus 4.6.

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Manual testing:
- **A/B comparison**: the old skill ran `which ocr` + `ocr llm test` before every review; the new skill starts the review directly.
- **New skill, `ocr` uninstalled**: no upfront check; failed mid-review and triggered the inline install hint. As expected.
- **New skill, LLM unconfigured**: no upfront `ocr llm test`; failed mid-review and guided the user to configure via Troubleshooting. As expected.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`) — N/A (markdown only)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works — N/A (no code change)
- [ ] New and existing unit tests pass locally with my changes — N/A (no code change)
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

None
