### PR TITLE
chore(examples): add explicit --audience agent to codeup_ci and action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -276,7 +276,7 @@ runs:
         OCR_RULE: ${{ inputs.rule }}
       shell: bash
       run: |
-        ARGS=(--from "${MERGE_BASE}" --to "${HEAD_SHA}" --format json)
+        ARGS=(--from "${MERGE_BASE}" --to "${HEAD_SHA}" --audience agent --format json)
         [ -n "$OCR_REVIEW_CONCURRENCY" ] && ARGS+=(--concurrency "$OCR_REVIEW_CONCURRENCY")
         [ -n "$OCR_BACKGROUND" ] && ARGS+=(--background "$OCR_BACKGROUND")
         [ -n "$OCR_RULE" ] && ARGS+=(--rule "$OCR_RULE")

--- a/examples/codeup_ci/post_review.py
+++ b/examples/codeup_ci/post_review.py
@@ -70,7 +70,7 @@ def run_ocr_review(from_ref: str | None = None, to_ref: str | None = None,
                     extra_args: list[str] | None = None,
                     timeout: int = 1800) -> dict:
     """Run `ocr review --format json` and return the parsed JSON output."""
-    cmd = ["ocr", "review", "--format", "json"]
+    cmd = ["ocr", "review", "--audience", "agent", "--format", "json"]
     if from_ref and to_ref:
         cmd += ["--from", from_ref, "--to", to_ref]
     if extra_args:

--- a/examples/codeup_ci/post_review_test.py
+++ b/examples/codeup_ci/post_review_test.py
@@ -26,7 +26,7 @@ class RunOcrReviewTests(unittest.TestCase):
         self.assertEqual(result, {"comments": []})
         run_mock.assert_called_once()
         cmd = run_mock.call_args[0][0]
-        self.assertEqual(cmd, ["ocr", "review", "--format", "json"])
+        self.assertEqual(cmd, ["ocr", "review", "--audience", "agent", "--format", "json"])
 
     def test_from_to_ref_are_passed_through(self):
         fake_proc = mock.Mock(returncode=0, stdout='{"comments": []}', stderr="")


### PR DESCRIPTION
## Description

Since PR #929 made `human` the default audience and redirected `[ocr]` progress lines to stderr, the two non-interactive CI call sites that omitted `--audience` now emit progress noise on stderr. Add `--audience agent` to match the other four examples.

- `examples/codeup_ci/post_review.py`: add `--audience agent` to `cmd`
- `action.yml`: add `--audience agent` to `ARGS` (also covers `github_actions`)
- `examples/codeup_ci/post_review_test.py`: update exact `cmd` assertion

Exit-code handling, JSON parsing, and comment-posting logic are unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

`python3 -m unittest post_review_test` in `examples/codeup_ci/`: 27 tests pass, including the updated exact `cmd` assertion.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1003