### PR TITLE
fix(diff): strip CRLF trailing carriage returns in diff parsing

### DIFF
--- a/internal/diff/hunk.go
+++ b/internal/diff/hunk.go
@@ -42,6 +42,13 @@ func ParseHunks(rawDiffText string) []Hunk {
 	var hunks []Hunk
 	var current *Hunk
 
+	// Strip a trailing "\r" left behind when the raw text uses CRLF line
+	// endings, so hunk headers and content lines match cleanly and
+	// HunkLine.Content does not retain a stray "\r".
+	for i, line := range lines {
+		lines[i] = strings.TrimSuffix(line, "\r")
+	}
+
 	for _, line := range lines {
 		if m := hunkHeaderRe.FindStringSubmatch(line); m != nil {
 			// Flush previous hunk

--- a/internal/diff/hunk_test.go
+++ b/internal/diff/hunk_test.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -119,5 +120,36 @@ new file mode 100644
 		if l.Type != HunkAdded {
 			t.Errorf("expected all lines to be HunkAdded, got %d", l.Type)
 		}
+	}
+}
+
+// TestParseHunks_CRLFLineEndings guards against issue #933: CRLF-terminated
+// diff text left a trailing "\r" on every split line, corrupting
+// HunkLine.Content and (via the header regex not matching a line ending in
+// "\r") potentially dropping hunk boundaries.
+func TestParseHunks_CRLFLineEndings(t *testing.T) {
+	raw := "diff --git a/handler.go b/handler.go\r\n" +
+		"--- a/handler.go\r\n" +
+		"+++ b/handler.go\r\n" +
+		"@@ -10,3 +10,3 @@\r\n" +
+		" ctx := r.Context()\r\n" +
+		"-log.Print(\"old\")\r\n" +
+		"+log.Printf(\"new\")"
+
+	hunks := ParseHunks(raw)
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	h := hunks[0]
+	if len(h.Lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(h.Lines))
+	}
+	for i, l := range h.Lines {
+		if strings.Contains(l.Content, "\r") {
+			t.Errorf("line[%d].Content = %q, must not retain a trailing \r", i, l.Content)
+		}
+	}
+	if h.Lines[2].Content != `log.Printf("new")` {
+		t.Errorf("line[2].Content = %q, want %q", h.Lines[2].Content, `log.Printf("new")`)
 	}
 }

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -35,6 +35,14 @@ func ParseDiffText(ctx context.Context, diffText string, repoDir string, ref str
 	var diffs []model.Diff
 	var current *model.Diff
 	var buf strings.Builder
+	// Diff text may use CRLF line endings (core.autocrlf=true, or diffs
+	// captured on Windows). Strip a trailing "\r" left behind by splitting
+	// on "\n" alone so headers like "diff --git a/x b/y\r" and markers like
+	// "--- /dev/null\r" match cleanly instead of being treated as content
+	// or losing their file path / metadata significance.
+	for i, line := range lines {
+		lines[i] = strings.TrimSuffix(line, "\r")
+	}
 	// inHunk tracks whether the current line sits inside a "@@" hunk of the
 	// current file's section. Only hunk content lines carry a leading
 	// "+"/"-"/" " marker, so insertion/deletion counting and the binary

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -5,6 +5,8 @@ package diff
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -270,5 +272,47 @@ index 1234567..89abcde 100644
 	}
 	if d.Insertions != 1 {
 		t.Errorf("Insertions = %d, want 1", d.Insertions)
+	}
+}
+
+// TestParseDiffText_CRLFLineEndings guards against issue #933: when the diff
+// text uses CRLF ("\r\n") line endings (e.g. core.autocrlf=true, or diffs
+// captured on Windows), splitting on "\n" alone leaves a trailing "\r" on
+// every line. That stray "\r" was polluting NewPath (breaking the on-disk
+// read in finalizeDiff), and defeating the "--- /dev/null" / "+++ /dev/null"
+// exact-string checks used to detect new/deleted files.
+func TestParseDiffText_CRLFLineEndings(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "fresh.go"), []byte("line1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	diffText := "diff --git a/fresh.go b/fresh.go\r\n" +
+		"new file mode 100644\r\n" +
+		"index 0000000..1234567\r\n" +
+		"--- /dev/null\r\n" +
+		"+++ b/fresh.go\r\n" +
+		"@@ -0,0 +1,1 @@\r\n" +
+		"+line1\r\n"
+
+	diffs, err := ParseDiffText(context.Background(), diffText, repoDir, "", nil)
+	if err != nil {
+		t.Fatalf("ParseDiffText: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.NewPath != "fresh.go" {
+		t.Errorf("NewPath = %q, want %q (trailing \r must be stripped)", d.NewPath, "fresh.go")
+	}
+	if !d.IsNew {
+		t.Error("IsNew = false, want true (\"--- /dev/null\r\" must still match)")
+	}
+	if d.NewFileContent != "line1\n" {
+		t.Errorf("NewFileContent = %q, want %q (read must succeed against the clean path)", d.NewFileContent, "line1\n")
+	}
+	if strings.Contains(d.Diff, "\r") {
+		t.Errorf("stored diff text still contains \r:\n%q", d.Diff)
 	}
 }

--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -99,7 +99,11 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 }
 
 func hasTraversalPathComponent(pathspec string) bool {
-	for _, part := range strings.Split(pathspec, "/") {
+	// Check both separators: a pathspec may use Windows-style backslashes
+	// (e.g. "..\\secret") even on a non-Windows host, and splitting only on
+	// "/" would let such a component through unchecked.
+	normalized := strings.ReplaceAll(pathspec, "\\", "/")
+	for _, part := range strings.Split(normalized, "/") {
 		if part == ".." {
 			return true
 		}

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -460,6 +460,11 @@ func TestCodeSearchProvider_Execute_RejectsTraversalPattern(t *testing.T) {
 		{name: "leading parent", pattern: "../pkg", want: "Error: file_patterns must not contain .."},
 		{name: "middle parent", pattern: "pkg/../internal", want: "Error: file_patterns must not contain .."},
 		{name: "trailing parent", pattern: "pkg/..", want: "Error: file_patterns must not contain .."},
+		// Windows-style backslash separators must be rejected too, since a
+		// pathspec like "..\secret" bypasses a "/"-only split check even on
+		// a non-Windows host.
+		{name: "leading parent backslash", pattern: "..\\pkg", want: "Error: file_patterns must not contain .."},
+		{name: "middle parent backslash", pattern: "pkg\\..\\internal", want: "Error: file_patterns must not contain .."},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

`ParseDiffText` and `ParseHunks` in `internal/diff` split unified diff text on `"\n"` only. When the diff text carries CRLF (`\r\n`) line endings — e.g. `core.autocrlf=true`, or a diff captured on Windows — every split line retains a trailing `\r`. This corrupts parsing in several ways:

- `diffHeaderRe`'s `b/(.+)` capture pollutes `NewPath` with a trailing `\r` (e.g. `"file.go\r"`), which then fails the on-disk / `git show` read used to populate `NewFileContent`.
- The exact-string checks `line == "--- /dev/null"` / `"+++ /dev/null"` no longer match, so `IsNew` / `IsDeleted` metadata is silently lost.
- `HunkLine.Content` in `ParseHunks` retains the stray `\r`.

Fix: strip the trailing `\r` from every line immediately after the `"\n"` split, in both `ParseDiffText` (`internal/diff/parser.go`) and `ParseHunks` (`internal/diff/hunk.go`), before any header/marker matching runs.

Also included, as suggested in the issue: `hasTraversalPathComponent` in `internal/tool/code_search.go` only checked `/`-separated path components, so a Windows-style `..\secret` traversal attempt in a `file_patterns` value was not rejected. It now normalizes `\` to `/` before checking components.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (`go test -race -count=1` across all non-extensions packages)
- [x] Added `TestParseDiffText_CRLFLineEndings` reproducing the issue's exact repro (CRLF diff adding a new file `fresh.go`), asserting `NewPath`, `IsNew`, and `NewFileContent` are all correct and the stored diff text no longer contains `\r`.
- [x] Added `TestParseHunks_CRLFLineEndings` asserting hunk line content has no trailing `\r`.
- [x] Added two traversal-check cases (`"..\pkg"`, `"pkg\..\internal"`) to the existing `TestCodeSearchProvider_Execute_RejectsTraversalPattern` table.
- [x] `gofmt -s -l`, `go vet`, `scripts/verify-license.sh`, and `scripts/verify-english-only.go` all pass on the changed files.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (not applicable — internal parsing fix, no user-facing docs)
- [ ] I have signed the CLA (will sign when the CLA bot comments)

## Related Issues

Fixes #933