### PR TITLE
test(llm): cover tool_choice mapping for all three provider protocols

### DIFF
--- a/internal/llm/client_params_test.go
+++ b/internal/llm/client_params_test.go
@@ -70,6 +70,45 @@ func TestBuildOpenAIParams_Minimal(t *testing.T) {
 	}
 }
 
+// TestBuildOpenAIParams_ToolChoice locks the tool_choice mapping the review-filter
+// task depends on (agent.go sets ChatRequest.ToolChoice="required" so the model
+// cannot silently skip both filterTools). openai.ChatCompletionToolChoiceOptionUnionParam
+// serializes OfAuto inline as a bare string, so this is the field that must carry
+// "required" onto the wire — and only when tools are actually attached.
+func TestBuildOpenAIParams_ToolChoice(t *testing.T) {
+	tool := ToolDef{Function: FunctionDef{Name: "f", Description: "d", Parameters: map[string]any{"type": "object"}}}
+	c := &OpenAIClient{}
+
+	tests := []struct {
+		name       string
+		tools      []ToolDef
+		toolChoice string
+		wantSet    bool
+		wantValue  string
+	}{
+		{name: "required with tools", tools: []ToolDef{tool}, toolChoice: "required", wantSet: true, wantValue: "required"},
+		{name: "auto with tools", tools: []ToolDef{tool}, toolChoice: "auto", wantSet: true, wantValue: "auto"},
+		{name: "empty with tools leaves provider default", tools: []ToolDef{tool}, toolChoice: "", wantSet: false},
+		{name: "required without tools is dropped", tools: nil, toolChoice: "required", wantSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := c.buildOpenAIParams("gpt-x", ChatRequest{
+				Messages:   []Message{{Role: "user", Content: "hi"}},
+				Tools:      tt.tools,
+				ToolChoice: tt.toolChoice,
+			})
+			if got := params.ToolChoice.OfAuto.Valid(); got != tt.wantSet {
+				t.Fatalf("tool_choice set = %v, want %v", got, tt.wantSet)
+			}
+			if tt.wantSet && params.ToolChoice.OfAuto.Value != tt.wantValue {
+				t.Errorf("tool_choice = %q, want %q", params.ToolChoice.OfAuto.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
 // TestBuildAnthropicParams_AllRoles exercises every message-role branch (system,
 // tool-result flushing, assistant with/without tool calls, user string and
 // content-block content) plus tools/system cache-control and temperature.
@@ -158,6 +197,45 @@ func TestBuildAnthropicParams_DefaultMaxTokens(t *testing.T) {
 	}
 	if params.Temperature.Valid() {
 		t.Error("expected temperature unset")
+	}
+}
+
+// TestBuildAnthropicParams_ToolChoice locks the tool_choice mapping the
+// review-filter task depends on. Anthropic has no bare "required" mode — the
+// client must translate ChatRequest.ToolChoice="required" into
+// ToolChoiceAnyParam ({"type":"any"}), and only when tools are attached.
+// Any other value (including "auto") is intentionally left untranslated,
+// since Anthropic's own default already behaves like "auto".
+func TestBuildAnthropicParams_ToolChoice(t *testing.T) {
+	tool := ToolDef{Function: FunctionDef{Name: "f", Description: "d", Parameters: map[string]any{"type": "object"}}}
+	c := &AnthropicClient{}
+
+	tests := []struct {
+		name       string
+		tools      []ToolDef
+		toolChoice string
+		wantAny    bool
+	}{
+		{name: "required with tools maps to any", tools: []ToolDef{tool}, toolChoice: "required", wantAny: true},
+		{name: "auto with tools is not translated", tools: []ToolDef{tool}, toolChoice: "auto", wantAny: false},
+		{name: "empty with tools leaves provider default", tools: []ToolDef{tool}, toolChoice: "", wantAny: false},
+		{name: "required without tools is dropped", tools: nil, toolChoice: "required", wantAny: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := c.buildAnthropicParams("claude-x", ChatRequest{
+				Messages:   []Message{{Role: "user", Content: "hi"}},
+				Tools:      tt.tools,
+				ToolChoice: tt.toolChoice,
+			})
+			if err != nil {
+				t.Fatalf("buildAnthropicParams returned error: %v", err)
+			}
+			if got := params.ToolChoice.OfAny != nil; got != tt.wantAny {
+				t.Fatalf("tool_choice.OfAny set = %v, want %v", got, tt.wantAny)
+			}
+		})
 	}
 }
 

--- a/internal/llm/responses_client_test.go
+++ b/internal/llm/responses_client_test.go
@@ -232,6 +232,44 @@ func TestBuildResponsesParams_Tools(t *testing.T) {
 	}
 }
 
+// TestBuildResponsesParams_ToolChoice locks the tool_choice mapping the
+// review-filter task depends on. ChatRequest.ToolChoice="required" must become
+// responses.ToolChoiceOptionsRequired on the wire, and only when tools are
+// attached. Any other value (including "auto") is intentionally left
+// untranslated, matching the Anthropic client's behavior.
+func TestBuildResponsesParams_ToolChoice(t *testing.T) {
+	client := NewOpenAIResponsesClient(ClientConfig{URL: "https://api.openai.com/v1"})
+	tool := ToolDef{Function: FunctionDef{Name: "f", Description: "d", Parameters: map[string]any{"type": "object"}}}
+
+	tests := []struct {
+		name       string
+		tools      []ToolDef
+		toolChoice string
+		wantSet    bool
+	}{
+		{name: "required with tools", tools: []ToolDef{tool}, toolChoice: "required", wantSet: true},
+		{name: "auto with tools is not translated", tools: []ToolDef{tool}, toolChoice: "auto", wantSet: false},
+		{name: "empty with tools leaves provider default", tools: []ToolDef{tool}, toolChoice: "", wantSet: false},
+		{name: "required without tools is dropped", tools: nil, toolChoice: "required", wantSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := client.buildResponsesParams("gpt-5.4", ChatRequest{
+				Messages:   []Message{{Role: "user", Content: "hi"}},
+				Tools:      tt.tools,
+				ToolChoice: tt.toolChoice,
+			})
+			if got := params.ToolChoice.OfToolChoiceMode.Valid(); got != tt.wantSet {
+				t.Fatalf("tool_choice set = %v, want %v", got, tt.wantSet)
+			}
+			if tt.wantSet && params.ToolChoice.OfToolChoiceMode.Value != responses.ToolChoiceOptionsRequired {
+				t.Errorf("tool_choice = %q, want %q", params.ToolChoice.OfToolChoiceMode.Value, responses.ToolChoiceOptionsRequired)
+			}
+		})
+	}
+}
+
 func TestBuildResponsesParams_StoreAndCacheKey(t *testing.T) {
 	client := NewOpenAIResponsesClient(ClientConfig{URL: "https://api.openai.com/v1"})
 


### PR DESCRIPTION
## Summary

- Add tests for `buildOpenAIParams` (Chat Completions), `buildAnthropicParams` (Anthropic Messages), and `buildResponsesParams` (OpenAI Responses) that assert how `ChatRequest.ToolChoice = "required"` is translated into each provider's own tool-forcing representation.
- Each test also covers the "not applicable" cases: an unmapped value like `"auto"`, an empty `ToolChoice`, and `"required"` with no tools attached (the mapping is gated on `len(tools) > 0` in all three clients).

## Why

The review-filter task (`internal/agent`) relies on `ToolChoice: "required"` so the model is forced to call one of `report_incorrect_comments` / `approve_all_comments` rather than answering in free text. Each protocol translates that string differently:

- Chat Completions: bare string `"required"` on `ToolChoice.OfAuto`
- Anthropic: `{"type":"any"}` via `ToolChoiceAnyParam`
- Responses API: `ToolChoiceOptionsRequired` on `ToolChoice.OfToolChoiceMode`

None of these three mappings had direct test coverage, so a refactor touching any of them could silently break the "must call a tool" guarantee without any CI signal.

## Test plan

- [x] `go test ./internal/llm/... -run ToolChoice -v` — all new subtests pass
- [x] `go build ./...`
- [x] `go vet ./internal/llm/...`
- [x] `go test ./internal/llm/...` — full package suite passes