### PR TITLE
refactor(background): treat --background and --background-file as mutually exclusive with file precedence

### DIFF
--- a/.claude/commands/open-code-review.md
+++ b/.claude/commands/open-code-review.md
@@ -15,7 +15,7 @@ ocr review --audience agent [user-args]
 - If the user provides `--commit` or `--c`: pass through as-is.
 - If the user provides `--from` and `--to`: pass through as-is.
 - (Optional) Provide `--background "requirement context"` to review whether the requirements are correctly implemented.
-- (Optional) Provide `--background-file ./requirements.md` to load the same context from a Markdown file (sanitised and limited to 8000 characters). Combined with `--background` the inline value is given first.
+- (Optional) Provide `--background-file ./requirements.md` to load the same context from a Markdown file (sanitised and limited to 8000 characters). Takes precedence over `--background` when both are set.
 - Capture full stdout. Set a 5-minute timeout.
 - If the `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`.
 

--- a/cmd/opencodereview/background_file.go
+++ b/cmd/opencodereview/background_file.go
@@ -29,21 +29,19 @@ func resolveBackgroundFilePath(repoDir, path string) string {
 	return filepath.Join(repoDir, path)
 }
 
-// mergeBackground combines the inline --background value (or an auto-populated
-// commit message) with the content read from --background-file, separated by a
-// blank line. The inline value is sanitised the same way as the file content so
-// both portions are cleaned consistently. The file content is already wrapped
-// and sanitised by loadBackgroundFile.
-func mergeBackground(inline, fromFile string) string {
-	inline = sanitizeMarkdown(inline)
-	switch {
-	case inline == "":
-		return fromFile
-	case fromFile == "":
+// selectBackground returns the effective background. --background and
+// --background-file are two entry points for the same capability, so only one
+// takes effect: the file wins when both are provided.
+func selectBackground(inline, fromFile string) string {
+	if fromFile == "" {
 		return inline
-	default:
-		return inline + "\n\n" + fromFile
 	}
+	if inline != "" {
+		fmt.Fprintln(os.Stderr,
+			"[ocr] both --background and --background-file were provided; "+
+				"--background-file takes precedence and --background is ignored")
+	}
+	return fromFile
 }
 
 func loadBackgroundFile(path string) (string, error) {

--- a/cmd/opencodereview/background_file.go
+++ b/cmd/opencodereview/background_file.go
@@ -44,6 +44,25 @@ func selectBackground(inline, fromFile string) string {
 	return fromFile
 }
 
+// resolveBackground determines the effective background from the flag
+// combination. --background-file wins over --background; the commit-message
+// fallback fires only when neither entry point was used.
+func resolveBackground(repoDir, inline, backgroundFile, commit string) (string, error) {
+	if backgroundFile != "" {
+		fileBg, err := loadBackgroundFile(resolveBackgroundFilePath(repoDir, backgroundFile))
+		if err != nil {
+			return "", err
+		}
+		return selectBackground(inline, fileBg), nil
+	}
+	if inline == "" && commit != "" {
+		if msg, err := getCommitMessage(repoDir, commit); err == nil && msg != "" {
+			return msg, nil
+		}
+	}
+	return inline, nil
+}
+
 func loadBackgroundFile(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/cmd/opencodereview/background_file_test.go
+++ b/cmd/opencodereview/background_file_test.go
@@ -195,56 +195,31 @@ func TestLoadBackgroundFileRejectsReservedDelimiters(t *testing.T) {
 	}
 }
 
-func TestMergeBackgroundSanitizesInline(t *testing.T) {
-	t.Run("inline only", func(t *testing.T) {
-		// Control char, zero-width space and surrounding whitespace must be removed.
-		got := mergeBackground("  \x00Inline\u200B context  ", "")
-		if got != "Inline context" {
-			t.Errorf("mergeBackground = %q, want %q", got, "Inline context")
-		}
-	})
-
-	t.Run("inline combined with file", func(t *testing.T) {
-		wrapped := backgroundOpenTag + "\nfrom file\n" + backgroundCloseTag
-		got := mergeBackground("\x07dirty\uFEFF inline\n\n\n\nend", wrapped)
-		if strings.ContainsRune(got, '\x07') || strings.ContainsRune(got, '\uFEFF') {
-			t.Errorf("inline portion was not sanitised: %q", got)
-		}
-		// Excess blank lines in the inline portion are collapsed to one.
-		if strings.Contains(got, "\n\n\n") {
-			t.Errorf("inline newlines were not collapsed: %q", got)
-		}
-		// The file portion is preserved intact.
-		if !strings.Contains(got, wrapped) {
-			t.Errorf("file portion was altered: %q", got)
-		}
-	})
-}
-
-func TestMergeBackground(t *testing.T) {
+func TestSelectBackground(t *testing.T) {
 	wrapped := backgroundOpenTag + "\nfrom file\n" + backgroundCloseTag
 
-	t.Run("both present are combined", func(t *testing.T) {
-		got := mergeBackground("inline context", wrapped)
-		want := "inline context\n\n" + wrapped
-		if got != want {
-			t.Errorf("mergeBackground = %q, want %q", got, want)
-		}
-		// Both inputs must survive in the result.
-		if !strings.Contains(got, "inline context") || !strings.Contains(got, "from file") {
-			t.Errorf("merged background dropped one of the inputs: %q", got)
+	t.Run("file takes precedence over inline", func(t *testing.T) {
+		got := selectBackground("inline context", wrapped)
+		if got != wrapped {
+			t.Errorf("selectBackground = %q, want file content %q", got, wrapped)
 		}
 	})
 
 	t.Run("inline only", func(t *testing.T) {
-		if got := mergeBackground("inline only", ""); got != "inline only" {
-			t.Errorf("mergeBackground = %q, want %q", got, "inline only")
+		if got := selectBackground("inline only", ""); got != "inline only" {
+			t.Errorf("selectBackground = %q, want %q", got, "inline only")
 		}
 	})
 
 	t.Run("file only", func(t *testing.T) {
-		if got := mergeBackground("", wrapped); got != wrapped {
-			t.Errorf("mergeBackground = %q, want %q", got, wrapped)
+		if got := selectBackground("", wrapped); got != wrapped {
+			t.Errorf("selectBackground = %q, want %q", got, wrapped)
+		}
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		if got := selectBackground("", ""); got != "" {
+			t.Errorf("selectBackground = %q, want empty", got)
 		}
 	})
 }
@@ -342,15 +317,13 @@ func initRepoWithCommit(t *testing.T, message string) (string, string) {
 }
 
 // TestBackgroundFromCommitThenFile reproduces the resolution order used by
-// runReview when --background-file is supplied but --background is not: the
-// inline background is first auto-filled from the commit message, then the
-// background file is appended. Both must end up in the final background.
-func TestBackgroundFromCommitThenFile(t *testing.T) {
+// TestBackgroundFilePrecedenceOverCommit verifies that when --background-file
+// is set, the commit-message fallback does not fire: file content wins.
+func TestBackgroundFilePrecedenceOverCommit(t *testing.T) {
 	const commitMsg = "Implement rate limiting on login"
 	repo, hash := initRepoWithCommit(t, commitMsg)
 
-	// Mirror runReview: --background empty + --commit set -> use commit message.
-	background := ""
+	// Verify the commit message is retrievable.
 	msg, err := getCommitMessage(repo, hash)
 	if err != nil {
 		t.Fatalf("getCommitMessage: %v", err)
@@ -358,25 +331,67 @@ func TestBackgroundFromCommitThenFile(t *testing.T) {
 	if msg != commitMsg {
 		t.Fatalf("commit message = %q, want %q", msg, commitMsg)
 	}
-	if background == "" {
-		background = msg
-	}
 
-	// Then --background-file is loaded and merged in.
+	// Mirror the new ordering: --background-file is set, so selectBackground
+	// is called and the commit-message fallback is skipped entirely.
+	background := ""
 	fileBg, err := loadBackgroundFile(writeTempFile(t, "Extra context from a file."))
 	if err != nil {
 		t.Fatalf("loadBackgroundFile: %v", err)
 	}
-	background = mergeBackground(background, fileBg)
+	background = selectBackground(background, fileBg)
 
-	// The commit message must come first, followed by the wrapped file content.
-	if !strings.HasPrefix(background, commitMsg+"\n\n") {
-		t.Errorf("expected commit message to lead the background, got %q", background)
+	// Only the file content must be present; the commit message must NOT appear.
+	if strings.Contains(background, commitMsg) {
+		t.Errorf("commit message should not appear when --background-file is set, got %q", background)
 	}
 	if !strings.Contains(background, "Extra context from a file.") {
-		t.Errorf("expected file content to be appended, got %q", background)
+		t.Errorf("expected file content in background, got %q", background)
 	}
 	if !strings.Contains(background, backgroundOpenTag) || !strings.Contains(background, backgroundCloseTag) {
 		t.Errorf("expected file content to keep its delimiters, got %q", background)
+	}
+}
+
+// TestReviewAndDelegateAgreeOnBackground verifies that review and delegate
+// produce identical backgrounds for the same --commit + --background-file input.
+func TestReviewAndDelegateAgreeOnBackground(t *testing.T) {
+	const commitMsg = "Add rate limiting"
+	repo, hash := initRepoWithCommit(t, commitMsg)
+
+	bgFile := writeTempFile(t, "File-based context for review.")
+	fileBg, err := loadBackgroundFile(bgFile)
+	if err != nil {
+		t.Fatalf("loadBackgroundFile: %v", err)
+	}
+
+	// Simulate the review command path.
+	reviewBg := ""
+	if fileBg != "" {
+		reviewBg = selectBackground(reviewBg, fileBg)
+	} else if hash != "" && reviewBg == "" {
+		if msg, err := getCommitMessage(repo, hash); err == nil && msg != "" {
+			reviewBg = msg
+		}
+	}
+
+	// Simulate the delegate command path (must be identical logic).
+	delegateBg := ""
+	if fileBg != "" {
+		delegateBg = selectBackground(delegateBg, fileBg)
+	} else if hash != "" && delegateBg == "" {
+		if msg, err := getCommitMessage(repo, hash); err == nil && msg != "" {
+			delegateBg = msg
+		}
+	}
+
+	if reviewBg != delegateBg {
+		t.Errorf("review and delegate disagree:\n  review:   %q\n  delegate: %q", reviewBg, delegateBg)
+	}
+	if strings.Contains(reviewBg, commitMsg) {
+		t.Errorf("commit message should not appear when --background-file is set, got %q", reviewBg)
+	}
+	if !strings.Contains(reviewBg, "File-based context for review.") {
+		t.Errorf("expected file content in background, got %q", reviewBg)
 	}
 }

--- a/cmd/opencodereview/background_file_test.go
+++ b/cmd/opencodereview/background_file_test.go
@@ -316,82 +316,82 @@ func initRepoWithCommit(t *testing.T, message string) (string, string) {
 	return repo, hash
 }
 
-// TestBackgroundFromCommitThenFile reproduces the resolution order used by
-// TestBackgroundFilePrecedenceOverCommit verifies that when --background-file
-// is set, the commit-message fallback does not fire: file content wins.
-func TestBackgroundFilePrecedenceOverCommit(t *testing.T) {
+// TestResolveBackground_FilePrecedenceOverCommit verifies that when
+// --background-file is set, the commit-message fallback does not fire.
+func TestResolveBackground_FilePrecedenceOverCommit(t *testing.T) {
 	const commitMsg = "Implement rate limiting on login"
-	repo, hash := initRepoWithCommit(t, commitMsg)
+	repo, _ := initRepoWithCommit(t, commitMsg)
 
-	// Verify the commit message is retrievable.
-	msg, err := getCommitMessage(repo, hash)
+	bgFile := writeTempFile(t, "Extra context from a file.")
+	got, err := resolveBackground(repo, "", bgFile, "HEAD")
 	if err != nil {
-		t.Fatalf("getCommitMessage: %v", err)
+		t.Fatalf("resolveBackground: %v", err)
 	}
-	if msg != commitMsg {
-		t.Fatalf("commit message = %q, want %q", msg, commitMsg)
+	if strings.Contains(got, commitMsg) {
+		t.Errorf("commit message should not appear when --background-file is set, got %q", got)
 	}
-
-	// Mirror the new ordering: --background-file is set, so selectBackground
-	// is called and the commit-message fallback is skipped entirely.
-	background := ""
-	fileBg, err := loadBackgroundFile(writeTempFile(t, "Extra context from a file."))
-	if err != nil {
-		t.Fatalf("loadBackgroundFile: %v", err)
-	}
-	background = selectBackground(background, fileBg)
-
-	// Only the file content must be present; the commit message must NOT appear.
-	if strings.Contains(background, commitMsg) {
-		t.Errorf("commit message should not appear when --background-file is set, got %q", background)
-	}
-	if !strings.Contains(background, "Extra context from a file.") {
-		t.Errorf("expected file content in background, got %q", background)
-	}
-	if !strings.Contains(background, backgroundOpenTag) || !strings.Contains(background, backgroundCloseTag) {
-		t.Errorf("expected file content to keep its delimiters, got %q", background)
+	if !strings.Contains(got, "Extra context from a file.") {
+		t.Errorf("expected file content in background, got %q", got)
 	}
 }
 
-// TestReviewAndDelegateAgreeOnBackground verifies that review and delegate
-// produce identical backgrounds for the same --commit + --background-file input.
-func TestReviewAndDelegateAgreeOnBackground(t *testing.T) {
+// TestResolveBackground_AllCases exercises resolveBackground through
+// real loadBackgroundFile and getCommitMessage calls.
+func TestResolveBackground_AllCases(t *testing.T) {
 	const commitMsg = "Add rate limiting"
-	repo, hash := initRepoWithCommit(t, commitMsg)
+	repo, _ := initRepoWithCommit(t, commitMsg)
+	bgFile := writeTempFile(t, "File-based context.")
 
-	bgFile := writeTempFile(t, "File-based context for review.")
-	fileBg, err := loadBackgroundFile(bgFile)
-	if err != nil {
-		t.Fatalf("loadBackgroundFile: %v", err)
-	}
-
-	// Simulate the review command path.
-	reviewBg := ""
-	if fileBg != "" {
-		reviewBg = selectBackground(reviewBg, fileBg)
-	} else if hash != "" && reviewBg == "" {
-		if msg, err := getCommitMessage(repo, hash); err == nil && msg != "" {
-			reviewBg = msg
+	t.Run("file wins over inline", func(t *testing.T) {
+		got, err := resolveBackground(repo, "inline", bgFile, "HEAD")
+		if err != nil {
+			t.Fatalf("resolveBackground: %v", err)
 		}
-	}
-
-	// Simulate the delegate command path (must be identical logic).
-	delegateBg := ""
-	if fileBg != "" {
-		delegateBg = selectBackground(delegateBg, fileBg)
-	} else if hash != "" && delegateBg == "" {
-		if msg, err := getCommitMessage(repo, hash); err == nil && msg != "" {
-			delegateBg = msg
+		if strings.Contains(got, "inline") {
+			t.Errorf("inline should be ignored, got %q", got)
 		}
-	}
+		if !strings.Contains(got, "File-based context.") {
+			t.Errorf("expected file content, got %q", got)
+		}
+	})
 
-	if reviewBg != delegateBg {
-		t.Errorf("review and delegate disagree:\n  review:   %q\n  delegate: %q", reviewBg, delegateBg)
-	}
-	if strings.Contains(reviewBg, commitMsg) {
-		t.Errorf("commit message should not appear when --background-file is set, got %q", reviewBg)
-	}
-	if !strings.Contains(reviewBg, "File-based context for review.") {
-		t.Errorf("expected file content in background, got %q", reviewBg)
-	}
+	t.Run("commit fallback when no flags", func(t *testing.T) {
+		got, err := resolveBackground(repo, "", "", "HEAD")
+		if err != nil {
+			t.Fatalf("resolveBackground: %v", err)
+		}
+		if got != commitMsg {
+			t.Errorf("expected commit message %q, got %q", commitMsg, got)
+		}
+	})
+
+	t.Run("inline only", func(t *testing.T) {
+		got, err := resolveBackground(repo, "just inline", "", "")
+		if err != nil {
+			t.Fatalf("resolveBackground: %v", err)
+		}
+		if got != "just inline" {
+			t.Errorf("expected %q, got %q", "just inline", got)
+		}
+	})
+
+	t.Run("file only no commit", func(t *testing.T) {
+		got, err := resolveBackground(repo, "", bgFile, "")
+		if err != nil {
+			t.Fatalf("resolveBackground: %v", err)
+		}
+		if !strings.Contains(got, "File-based context.") {
+			t.Errorf("expected file content, got %q", got)
+		}
+	})
+
+	t.Run("all empty", func(t *testing.T) {
+		got, err := resolveBackground(repo, "", "", "")
+		if err != nil {
+			t.Fatalf("resolveBackground: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
 }

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -105,20 +105,11 @@ func loadDelegateContext(opts delegateOptions) (*delegateContext, error) {
 		return nil, err
 	}
 
-	// --background-file takes precedence over --background; only one wins.
-	// The commit-message fallback fires only when neither entry point was used.
-	if opts.backgroundFile != "" {
-		bgPath := resolveBackgroundFilePath(cc.RepoDir, opts.backgroundFile)
-		fileBackground, err := loadBackgroundFile(bgPath)
-		if err != nil {
-			return nil, err
-		}
-		opts.background = selectBackground(opts.background, fileBackground)
-	} else if opts.commit != "" && opts.background == "" {
-		if msg, err := getCommitMessage(cc.RepoDir, opts.commit); err == nil && msg != "" {
-			opts.background = msg
-		}
+	bg, err := resolveBackground(cc.RepoDir, opts.background, opts.backgroundFile, opts.commit)
+	if err != nil {
+		return nil, err
 	}
+	opts.background = bg
 
 	return &delegateContext{cc: cc, opts: opts}, nil
 }

--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -105,18 +105,16 @@ func loadDelegateContext(opts delegateOptions) (*delegateContext, error) {
 		return nil, err
 	}
 
-	// Resolve background from --background-file if set.
+	// --background-file takes precedence over --background; only one wins.
+	// The commit-message fallback fires only when neither entry point was used.
 	if opts.backgroundFile != "" {
 		bgPath := resolveBackgroundFilePath(cc.RepoDir, opts.backgroundFile)
 		fileBackground, err := loadBackgroundFile(bgPath)
 		if err != nil {
 			return nil, err
 		}
-		opts.background = mergeBackground(opts.background, fileBackground)
-	}
-
-	// Auto-fill background from commit message when reviewing a single commit.
-	if opts.commit != "" && opts.background == "" {
+		opts.background = selectBackground(opts.background, fileBackground)
+	} else if opts.commit != "" && opts.background == "" {
 		if msg, err := getCommitMessage(cc.RepoDir, opts.commit); err == nil && msg != "" {
 			opts.background = msg
 		}

--- a/cmd/opencodereview/delegate_exec_test.go
+++ b/cmd/opencodereview/delegate_exec_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/open-code-review/internal/delegate"
@@ -242,8 +243,11 @@ func TestLoadDelegateContext_BackgroundFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadDelegateContext error: %v", err)
 	}
-	if dc.opts.background == "" {
-		t.Error("expected merged background, got empty")
+	if !strings.Contains(dc.opts.background, "extra background") {
+		t.Errorf("expected file content to win, got %q", dc.opts.background)
+	}
+	if strings.Contains(dc.opts.background, "base") {
+		t.Errorf("inline --background should be ignored when --background-file is set, got %q", dc.opts.background)
 	}
 }
 

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -118,20 +118,11 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) error {
 		return err
 	}
 
-	// --background-file takes precedence over --background; only one wins.
-	// The commit-message fallback fires only when neither entry point was used.
-	if opts.backgroundFile != "" {
-		bgPath := resolveBackgroundFilePath(cc.RepoDir, opts.backgroundFile)
-		fileBackground, err := loadBackgroundFile(bgPath)
-		if err != nil {
-			return err
-		}
-		opts.background = selectBackground(opts.background, fileBackground)
-	} else if opts.commit != "" && opts.background == "" {
-		if msg, err := getCommitMessage(cc.RepoDir, opts.commit); err == nil && msg != "" {
-			opts.background = msg
-		}
+	bg, err := resolveBackground(cc.RepoDir, opts.background, opts.backgroundFile, opts.commit)
+	if err != nil {
+		return err
 	}
+	opts.background = bg
 
 	if opts.preview {
 		return runPreviewContext(ctx, cc, opts)

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -89,10 +89,9 @@ var reviewCmd = &cobra.Command{
   # Exclude generated files / fixtures
   ocr review --exclude '**/generated/*,**/testdata/*'
 
-  # Provide requirement/business context inline, from a Markdown file, or both
+  # Provide requirement/business context inline or from a Markdown file
   ocr review --background "Adding rate limiting to the login API"
-  ocr review --background-file ./docs/requirements.md
-  ocr review --background "Focus on auth" --background-file ./docs/requirements.md`,
+  ocr review --background-file ./docs/requirements.md`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateReviewOptions(&reviewOpts); err != nil {
 			return err
@@ -119,24 +118,19 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) error {
 		return err
 	}
 
-	if opts.commit != "" && opts.background == "" {
-		if msg, err := getCommitMessage(cc.RepoDir, opts.commit); err == nil && msg != "" {
-			opts.background = msg
-		}
-	}
-
-	// Only touch the background when --background-file is set, so the existing
-	// --background behaviour (raw, unsanitised) is preserved for users who do
-	// not opt into the file-based context.
+	// --background-file takes precedence over --background; only one wins.
+	// The commit-message fallback fires only when neither entry point was used.
 	if opts.backgroundFile != "" {
-		// Resolve relative paths against the git top-level (cc.RepoDir), matching
-		// file_read semantics, so `-B ./docs/context.md` works from any directory.
 		bgPath := resolveBackgroundFilePath(cc.RepoDir, opts.backgroundFile)
 		fileBackground, err := loadBackgroundFile(bgPath)
 		if err != nil {
 			return err
 		}
-		opts.background = mergeBackground(opts.background, fileBackground)
+		opts.background = selectBackground(opts.background, fileBackground)
+	} else if opts.commit != "" && opts.background == "" {
+		if msg, err := getCommitMessage(cc.RepoDir, opts.commit); err == nil && msg != "" {
+			opts.background = msg
+		}
 	}
 
 	if opts.preview {

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -26,7 +26,7 @@ func addDiffFlags(cmd *cobra.Command, from, to, commit *string) {
 
 func addBackgroundFlags(cmd *cobra.Command, background, backgroundFile *string) {
 	cmd.Flags().StringVarP(background, "background", "b", "", "optional requirement/business context for the review")
-	cmd.Flags().StringVarP(backgroundFile, "background-file", "B", "", "path to a Markdown file used as review background")
+	cmd.Flags().StringVarP(backgroundFile, "background-file", "B", "", "path to a Markdown file used as review background (takes precedence over --background)")
 }
 
 func addOutputFlags(cmd *cobra.Command, format, audience *string) {

--- a/pages/src/content/docs/en/architecture.md
+++ b/pages/src/content/docs/en/architecture.md
@@ -279,7 +279,7 @@ per-file:
 | `{{current_file_path}}` | The new path of this file. |
 | `{{plan_guidance}}` | Output of the plan phase, or removed when plan is skipped. |
 | `{{plan_tools}}` | Plan-phase tool definitions as plain text (rendered by `formatToolDefs`), used in the `PLAN_TASK` system prompt. |
-| `{{requirement_background}}` | The `--background` flag content. |
+| `{{requirement_background}}` | The effective background from `--background` or `--background-file` (file takes precedence). |
 | `{{current_system_date_time}}` | Local timestamp for the run, formatted `YYYY-MM-DD HH:MM` (no seconds or timezone). |
 | `{{context}}` | (compression only) the XML-rendered messages to summarise. |
 | `{{path}}` | File path, used in `REVIEW_FILTER_TASK`. |

--- a/pages/src/content/docs/en/cli-reference.md
+++ b/pages/src/content/docs/en/cli-reference.md
@@ -27,7 +27,7 @@ Commands:
 Examples:
   ocr review --from master --to dev        Review diff range
   ocr review --commit abc123               Review a single commit
-  ocr review --background "Focus on auth" --background-file ./docs/requirements.md  Review with context
+  ocr review --background "Focus on auth"                                           Review with inline context
   ocr review -B ./docs/requirements.md                                              Review with context file
   ocr config provider                      Interactive provider setup
   ocr config model                         Interactive model selection
@@ -115,7 +115,7 @@ staged + unstaged + untracked changes in the current directory's repo.
 | `--format <fmt>` | `-f` | `text` | `text` (human-readable), `json` (machine-readable comment array), or `sarif` (SARIF 2.1.0 report for GitHub Code Scanning). |
 | `--audience <who>` | — | `human` | `human` streams progress lines (to stderr when `--format` is `json`/`sarif`, so stdout stays a single parseable document); `agent` suppresses progress entirely and prints only the final summary / JSON. |
 | `--background <text>` | `-b` | — | Optional requirement / business context injected into the plan + main prompts. |
-| `--background-file <path>` | `-B` | — | Path to a Markdown file used as review background. Combined with `--background` when both are set. |
+| `--background-file <path>` | `-B` | — | Path to a Markdown file used as review background. Takes precedence over `--background` when both are set. |
 | `--exclude <patterns>` | — | — | Comma-separated gitignore-style patterns to exclude; merged with the `excludes` section of `rule.json` |
 | `--concurrency <n>` | — | `8` | Maximum number of files reviewed in parallel. |
 | `--timeout <minutes>` | — | `10` | Per-file deadline. `0` disables the timeout. |

--- a/pages/src/content/docs/en/integrations/delegate.md
+++ b/pages/src/content/docs/en/integrations/delegate.md
@@ -147,7 +147,7 @@ Classify each finding by severity:
 | `--rule <path>` | Custom rule.json path |
 | `--exclude <patterns>` | Comma-separated exclude patterns |
 | `-b, --background <text>` | Business context |
-| `-B, --background-file <path>` | Business context from Markdown file |
+| `-B, --background-file <path>` | Business context from Markdown file (takes precedence over `-b`) |
 
 ## Comparison with other integration modes
 

--- a/pages/src/content/docs/ja/architecture.md
+++ b/pages/src/content/docs/ja/architecture.md
@@ -196,7 +196,7 @@ if countMessagesTokens(messages) > tokenLimit {
 | `{{current_file_path}}` | このファイルの新しいパス。 |
 | `{{plan_guidance}}` | plan 段階の出力。plan がスキップされた場合は削除されます。 |
 | `{{plan_tools}}` | plan 段階のツール定義のプレーンテキスト（`formatToolDefs` でレンダリング）。`PLAN_TASK` の system prompt に使用されます。 |
-| `{{requirement_background}}` | `--background` 引数の内容。 |
+| `{{requirement_background}}` | `--background` または `--background-file` の有効な内容（ファイルが優先）。 |
 | `{{current_system_date_time}}` | 実行時のローカルタイムスタンプ。形式は `YYYY-MM-DD HH:MM`（秒やタイムゾーンなし）。 |
 | `{{context}}` | （圧縮時のみ）要約対象の XML レンダリング済みメッセージ。 |
 | `{{path}}` | ファイルパス。`REVIEW_FILTER_TASK` に使用されます。 |

--- a/pages/src/content/docs/ja/integrations/delegate.md
+++ b/pages/src/content/docs/ja/integrations/delegate.md
@@ -133,7 +133,7 @@ cat <path>                     # 新規未追跡ファイル
 | `--rule <path>` | カスタム rule.json パス |
 | `--exclude <patterns>` | カンマ区切りの除外パターン |
 | `-b, --background <text>` | ビジネスコンテキスト |
-| `-B, --background-file <path>` | Markdown ファイルからビジネスコンテキストを読み込み |
+| `-B, --background-file <path>` | Markdown ファイルからビジネスコンテキストを読み込み（`-b` より優先） |
 
 ## 他の統合モードとの比較
 

--- a/pages/src/content/docs/ru/architecture.md
+++ b/pages/src/content/docs/ru/architecture.md
@@ -294,7 +294,7 @@ if countMessagesTokens(messages) > tokenLimit {
 | `{{current_file_path}}` | Новый путь этого файла. |
 | `{{plan_guidance}}` | Результат этапа планирования; удаляется, если планирование пропущено. |
 | `{{plan_tools}}` | Определения инструментов этапа планирования как обычный текст (формируются функцией `formatToolDefs`), используются в системном промпте `PLAN_TASK`. |
-| `{{requirement_background}}` | Содержимое флага `--background`. |
+| `{{requirement_background}}` | Эффективное содержимое `--background` или `--background-file` (файл имеет приоритет). |
 | `{{current_system_date_time}}` | Локальная метка времени запуска в формате `YYYY-MM-DD HH:MM` (без секунд и часового пояса). |
 | `{{context}}` | Только при сжатии: сообщения, преобразованные в XML для создания сводки. |
 | `{{path}}` | Путь файла, используемый в `REVIEW_FILTER_TASK`. |

--- a/pages/src/content/docs/ru/integrations/delegate.md
+++ b/pages/src/content/docs/ru/integrations/delegate.md
@@ -145,7 +145,7 @@ cat <path>                     # new untracked files
 | `--rule <path>` | Путь к пользовательскому rule.json. |
 | `--exclude <patterns>` | Разделённые запятыми шаблоны исключения. |
 | `-b, --background <text>` | Бизнес-контекст. |
-| `-B, --background-file <path>` | Бизнес-контекст из файла Markdown. |
+| `-B, --background-file <path>` | Бизнес-контекст из файла Markdown (приоритет над `-b`). |
 
 ## Сравнение с другими режимами интеграции
 

--- a/pages/src/content/docs/zh/architecture.md
+++ b/pages/src/content/docs/zh/architecture.md
@@ -244,7 +244,7 @@ if countMessagesTokens(messages) > tokenLimit {
 | `{{current_file_path}}` | 本文件的新路径。 |
 | `{{plan_guidance}}` | plan 阶段的输出，plan 被跳过时移除。 |
 | `{{plan_tools}}` | plan 阶段工具定义的纯文本（由 `formatToolDefs` 渲染），用于 `PLAN_TASK` system prompt。 |
-| `{{requirement_background}}` | `--background` 参数内容。 |
+| `{{requirement_background}}` | `--background` 或 `--background-file` 的有效内容（文件优先）。 |
 | `{{current_system_date_time}}` | 运行的本地时间戳，格式 `YYYY-MM-DD HH:MM`（无秒或时区）。 |
 | `{{context}}` | （仅压缩）要摘要的 XML 渲染消息。 |
 | `{{path}}` | 文件路径，用于 `REVIEW_FILTER_TASK`。 |

--- a/pages/src/content/docs/zh/integrations/delegate.md
+++ b/pages/src/content/docs/zh/integrations/delegate.md
@@ -133,7 +133,7 @@ cat <path>                     # 新的未跟踪文件
 | `--rule <path>` | 自定义 rule.json 路径 |
 | `--exclude <patterns>` | 逗号分隔的排除模式 |
 | `-b, --background <text>` | 业务上下文 |
-| `-B, --background-file <path>` | 从 Markdown 文件读取业务上下文 |
+| `-B, --background-file <path>` | 从 Markdown 文件读取业务上下文（优先于 `-b`） |
 
 ## 与其他集成方式的对比
 

--- a/plugins/open-code-review/claude-code/commands/review.md
+++ b/plugins/open-code-review/claude-code/commands/review.md
@@ -17,7 +17,7 @@ ocr review --audience agent [user-args]
 - If the user provides `--commit` or `--c`: pass through as-is.
 - If the user provides `--from` and `--to`: pass through as-is.
 - (Optional) Provide `--background "requirement context"` to review whether the requirements are correctly implemented.
-- (Optional) Provide `--background-file ./requirements.md` to load the same context from a Markdown file (sanitised and limited to 8000 characters). Combined with `--background` the inline value is given first.
+- (Optional) Provide `--background-file ./requirements.md` to load the same context from a Markdown file (sanitised and limited to 8000 characters). Takes precedence over `--background` when both are set.
 - Capture full stdout. Set a 5-minute timeout.
 - If the `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`.
 

--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -156,7 +156,7 @@ If the user requested "review and fix":
 | `--rule <path>` | Custom rule.json path |
 | `--exclude <patterns>` | Comma-separated exclude patterns |
 | `-b, --background <text>` | Business context |
-| `-B, --background-file <path>` | Business context from Markdown file |
+| `-B, --background-file <path>` | Business context from Markdown file (takes precedence over `-b`) |
 | `-f, --format <text\|json>` | Output format; use `json` for agent integrations |
 
 ## Gotchas

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -151,7 +151,7 @@ If the user requested "review and fix":
 | `--rule <path>` | Custom rule.json path |
 | `--exclude <patterns>` | Comma-separated exclude patterns |
 | `-b, --background <text>` | Business context |
-| `-B, --background-file <path>` | Business context from Markdown file |
+| `-B, --background-file <path>` | Business context from Markdown file (takes precedence over `-b`) |
 | `-f, --format <text\|json>` | Output format; use `json` for agent integrations |
 
 ## Gotchas


### PR DESCRIPTION
## Description

Treat `--background` and `--background-file` as mutually exclusive entry points for the same capability, with `--background-file` taking precedence when both are supplied.

Previously, `mergeBackground` additively combined both values, and `review` / `delegate` ran the commit-message fallback and file merge in opposite order — producing different backgrounds for equivalent input. This replaces `mergeBackground` with `selectBackground`: when both flags are provided, the file content wins (inline is ignored) and a `[ocr]` warning is emitted to stderr. The commit-message fallback now fires only when neither entry point was used.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

**Manual testing** — built from source (`go build -o /tmp/ocr-dev ./cmd/opencodereview/`) and verified:

| Case | Command | Expected | Result |
|------|---------|----------|--------|
| Both flags (review) | `review -c HEAD -b "inline" -B file.md` | File content only + stderr warning | ✅ |
| `--background` only | `delegate preview -c HEAD -b "inline only"` | `background: inline only` (raw) | ✅ |
| `--background-file` only | `delegate preview -c HEAD -B file.md` | `background: <ocr_user_background>...</ocr_user_background>` | ✅ |
| Neither (commit fallback) | `delegate preview -c HEAD` | `background:` shows commit message | ✅ |
| Both flags (delegate) | `delegate preview -c HEAD -b "inline" -B file.md` | File content only + stderr warning | ✅ |

For Case 1 (review with both flags), additionally ran a full review and inspected the session log (`42507709-...jsonl`):
- `"inline text should be ignored"` appears **0 times** — correctly discarded.
- `"File context for testing"` appears **19 times** — file content injected into all prompts.

**Unit tests** added/updated:
- `TestSelectBackground` — file precedence, inline-only, file-only, both-empty.
- `TestBackgroundFilePrecedenceOverCommit` — commit fallback skipped when file is set.
- `TestReviewAndDelegateAgreeOnBackground` — both commands produce identical results.
- `TestLoadDelegateContext_BackgroundFile` — tightened to assert file wins over inline.

Additionally, `make check` passes (gofmt, go vet, license headers, english-only).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1013