### PR TITLE
fix(llmloop): propagate grace-round task_done completion

### DIFF
--- a/internal/llmloop/grace_round_completion_test.go
+++ b/internal/llmloop/grace_round_completion_test.go
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package llmloop
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/config/template"
+	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/model"
+	"github.com/alibaba/open-code-review/internal/session"
+	"github.com/alibaba/open-code-review/internal/tool"
+)
+
+// These tests cover grace-round completion propagation: a model that makes
+// context-tool calls and then emits task_done in the grace round must be
+// recorded as completed, mirroring the main loop's semantics.
+
+// graceRoundTestDeps builds Deps for grace-round tests. Tests that need to
+// cancel mid-round mutate the returned Deps before building the Runner, for
+// example installing a DiffLookup hook that cancels the context while
+// code_comment resolves its comments.
+func graceRoundTestDeps(client llm.LLMClient, maxRounds int) Deps {
+	collector := tool.NewCommentCollector()
+	reg := tool.NewRegistry()
+	reg.Register(&fakeFileReadProvider{result: "package main\n"})
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+	return Deps{
+		LLMClient:        client,
+		Model:            "fake",
+		Template:         template.Template{MaxTokens: 100000, MaxToolRequestTimes: maxRounds},
+		Tools:            reg,
+		CommentCollector: collector,
+		MainToolDefs: []llm.ToolDef{
+			{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}},
+			{Type: "function", Function: llm.FunctionDef{Name: "task_done"}},
+			{Type: "function", Function: llm.FunctionDef{Name: "file_read"}},
+		},
+		Session: session.New("/tmp/test-repo", "main", "fake", session.SessionOptions{}),
+	}
+}
+
+// Scenario A (the regression): the model spends all its rounds on
+// context tools (file_read), then — given one last chance in the grace
+// round — correctly calls task_done with state DONE. The completion must
+// propagate: RunPerFile reports completed=true with StopNone, so callers
+// record a reusable checkpoint instead of translating the run into
+// "main_task did not complete before stopping".
+func TestRunPerFile_GraceRoundTaskDoneCompletes(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		// Round 1: context tool call (budget = 1, exhausted after this).
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		// Grace round: model calls task_done DONE.
+		taskDoneResponseWithArguments(`{"state":"DONE"}`),
+	}}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, stop, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	t.Logf("Scenario A: completed=%v stop=%v llmCalls=%d", completed, stop, client.calls)
+
+	// Sanity: the grace round did run and task_done was issued there.
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round with task_done)", client.calls)
+	}
+	// Regression: an explicit task_done(DONE) in the grace round must
+	// complete the run, mirroring the main loop's semantics.
+	if !completed {
+		t.Fatal("grace-round task_done(DONE) must propagate: RunPerFile returned completed=false")
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone on grace-round completion", stop)
+	}
+}
+
+// graceRoundDoneThenCommentResponse builds a grace-round response whose
+// task_done(DONE) arrives BEFORE a code_comment: the loop must keep
+// executing the remaining calls in the round so the late comment still
+// lands, mirroring the main loop's ordering semantics.
+func graceRoundDoneThenCommentResponse() *llm.ChatResponse {
+	content := ""
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{
+			Content: &content,
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "call_done",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "task_done",
+						Arguments: `{"state":"DONE"}`,
+					},
+				},
+				{
+					ID:   "call_comment",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "code_comment",
+						Arguments: `{"comments":[{"content":"late finding","existing_code":"x"}]}`,
+					},
+				},
+			},
+		}}},
+		Model: "fake",
+		Usage: &llm.UsageInfo{PromptTokens: 30, CompletionTokens: 10},
+	}
+}
+
+// TestRunPerFile_GraceRoundCommentAfterTaskDoneStillLands locks the
+// same-round ordering semantics: a code_comment issued in the same grace
+// round as task_done(DONE) still lands, and the run still completes.
+func TestRunPerFile_GraceRoundCommentAfterTaskDoneStillLands(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		// Round 1: context tool call (budget = 1, exhausted after this).
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		// Grace round: task_done first, then a late code_comment.
+		graceRoundDoneThenCommentResponse(),
+	}}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, _, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if !completed {
+		t.Fatal("grace-round task_done(DONE) must complete the run")
+	}
+	comments := runner.CollectPendingComments()
+	if len(comments) != 1 {
+		t.Fatalf("comments = %d, want 1 (the late grace-round comment must land)", len(comments))
+	}
+	if comments[0].Content != "late finding" {
+		t.Errorf("comment content = %q, want %q", comments[0].Content, "late finding")
+	}
+}
+
+// graceRoundFailedThenCommentResponse builds a grace-round response whose
+// task_done(FAILED) arrives BEFORE a code_comment: the failure must return
+// immediately without executing the remaining calls, mirroring the main
+// loop's ordering semantics.
+func graceRoundFailedThenCommentResponse() *llm.ChatResponse {
+	content := ""
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{
+			Content: &content,
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "call_failed",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "task_done",
+						Arguments: `{"state":"FAILED"}`,
+					},
+				},
+				{
+					ID:   "call_comment",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "code_comment",
+						Arguments: `{"comments":[{"content":"must not land","existing_code":"x"}]}`,
+					},
+				},
+			},
+		}}},
+		Model: "fake",
+		Usage: &llm.UsageInfo{PromptTokens: 30, CompletionTokens: 10},
+	}
+}
+
+// TestRunPerFile_GraceRoundTaskDoneFailedSurfaces locks the failure
+// semantics: a model-declared task_done(FAILED) in the grace round
+// surfaces as a task failure error (not budget exhaustion), and the
+// failure returns immediately so later calls in the round do not execute.
+func TestRunPerFile_GraceRoundTaskDoneFailedSurfaces(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		// Round 1: context tool call (budget = 1, exhausted after this).
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		// Grace round: task_done(FAILED) first, then a comment that must
+		// not execute.
+		graceRoundFailedThenCommentResponse(),
+	}}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, stop, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("grace-round task_done(FAILED) must not complete the run")
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone on task failure", stop)
+	}
+	if err == nil {
+		t.Fatal("grace-round task_done(FAILED) must surface as a task failure error")
+	}
+	if !errors.Is(err, ErrTaskFailed) {
+		t.Errorf("err = %v, must wrap ErrTaskFailed", err)
+	}
+	if !strings.Contains(err.Error(), "task failed") {
+		t.Errorf("err = %v, want a task failure error", err)
+	}
+	if comments := runner.CollectPendingComments(); len(comments) != 0 {
+		t.Fatalf("comments = %d, want 0 (calls after FAILED must not execute)", len(comments))
+	}
+}
+
+// graceErrorClient serves the main round normally, then fails the grace
+// round with an LLM outage.
+type graceErrorClient struct {
+	calls int
+}
+
+func (c *graceErrorClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	c.calls++
+	if c.calls == 1 {
+		return fileReadToolCallResponse("call_1", `{"path":"main.go"}`), nil
+	}
+	return nil, errors.New("grace round outage")
+}
+
+// TestRunPerFile_GraceRoundLLMErrorSwallowed locks the asymmetric error
+// handling: a grace-round LLM outage is logged and swallowed, so the file
+// keeps its budget-exhaustion record instead of surfacing a transient
+// network error as the primary failure cause.
+func TestRunPerFile_GraceRoundLLMErrorSwallowed(t *testing.T) {
+	client := &graceErrorClient{}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, stop, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("grace-round LLM outage must not complete the run")
+	}
+	if err != nil {
+		t.Fatalf("grace-round LLM outage must be swallowed, got err: %v", err)
+	}
+	if stop != StopMaxRounds {
+		t.Fatalf("stop = %v, want StopMaxRounds (budget exhaustion stays the recorded cause)", stop)
+	}
+}
+
+// cancellingErrorClient serves the main round normally, then cancels the
+// run's context and fails the grace-round LLM call, simulating a Ctrl-C
+// that interrupts the request in flight.
+type cancellingErrorClient struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (c *cancellingErrorClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	c.calls++
+	if c.calls == 1 {
+		return fileReadToolCallResponse("call_1", `{"path":"main.go"}`), nil
+	}
+	c.cancel()
+	return nil, errors.New("request interrupted")
+}
+
+// TestRunPerFile_GraceRoundCancelledDuringLLMCall closes the cancellation
+// window inside the grace-round LLM call itself: the request fails because
+// the context was cancelled mid-flight. The cancellation must surface as
+// context.Canceled so callers classify the item as FailureCancelled — it
+// must not be swallowed as a transient LLM outage.
+func TestRunPerFile_GraceRoundCancelledDuringLLMCall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &cancellingErrorClient{cancel: cancel}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, stop, err := runner.RunPerFile(
+		ctx,
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("a cancelled run must never be recorded as completed")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("grace-round cancellation during the LLM call must surface as context.Canceled, got: %v", err)
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone (an error carries no stop cause)", stop)
+	}
+}
+
+// cancellingClient serves the main round normally, then cancels the run's
+// context at the instant the grace-round response arrives, simulating a
+// Ctrl-C that lands while the response is in flight.
+type cancellingClient struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (c *cancellingClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	c.calls++
+	if c.calls == 1 {
+		return fileReadToolCallResponse("call_1", `{"path":"main.go"}`), nil
+	}
+	c.cancel()
+	return taskDoneResponseWithArguments(`{"state":"DONE"}`), nil
+}
+
+// TestRunPerFile_GraceRoundCancelledAfterResponseDiscarded closes the last
+// cancellation window around the grace round: the context is cancelled after
+// the response arrives but before its tool calls execute. The response must
+// be discarded without executing it, and the cancellation must surface as
+// context.Canceled — mirroring the main loop, so callers classify the item
+// as FailureCancelled instead of FailureBudget.
+func TestRunPerFile_GraceRoundCancelledAfterResponseDiscarded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &cancellingClient{cancel: cancel}
+	runner := NewRunner(graceRoundTestDeps(client, 1))
+
+	completed, stop, err := runner.RunPerFile(
+		ctx,
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("a cancelled run must never be recorded as completed")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("grace-round cancellation must surface as context.Canceled, got: %v", err)
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone (an error carries no stop cause)", stop)
+	}
+}
+
+// graceRoundCommentThenDoneResponse builds a grace-round response whose
+// code_comment arrives BEFORE task_done(DONE), with distinct call IDs.
+func graceRoundCommentThenDoneResponse() *llm.ChatResponse {
+	content := ""
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{
+			Content: &content,
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "call_comment",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "code_comment",
+						Arguments: `{"comments":[{"content":"finding","existing_code":"x"}]}`,
+					},
+				},
+				{
+					ID:   "call_done",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "task_done",
+						Arguments: `{"state":"DONE"}`,
+					},
+				},
+			},
+		}}},
+		Model: "fake",
+		Usage: &llm.UsageInfo{PromptTokens: 30, CompletionTokens: 10},
+	}
+}
+
+// cancellingDiffLookup returns a DiffLookup hook that cancels the run's
+// context the moment code_comment resolves a comment, simulating a Ctrl-C
+// that lands while a grace-round tool call executes.
+func cancellingDiffLookup(cancel context.CancelFunc) func(string) *model.Diff {
+	return func(string) *model.Diff {
+		cancel()
+		return nil
+	}
+}
+
+// TestRunPerFile_GraceRoundCancelledBetweenToolCalls closes the cancellation
+// window inside the grace-round tool loop: the context is cancelled while
+// the round's first call (code_comment) executes, and the task_done(DONE)
+// that follows must not complete the run. Without the per-call check, the
+// completion would propagate and callers would checkpoint a cancelled file
+// as reusable.
+func TestRunPerFile_GraceRoundCancelledBetweenToolCalls(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		// Round 1: context tool call (budget = 1, exhausted after this).
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		// Grace round: code_comment (cancels the context), then task_done.
+		graceRoundCommentThenDoneResponse(),
+	}}
+	deps := graceRoundTestDeps(client, 1)
+	deps.DiffLookup = cancellingDiffLookup(cancel)
+	runner := NewRunner(deps)
+
+	completed, stop, err := runner.RunPerFile(
+		ctx,
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("task_done(DONE) after a mid-round cancellation must not complete the run")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("grace-round cancellation must surface as context.Canceled, got: %v", err)
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone (an error carries no stop cause)", stop)
+	}
+}
+
+// TestRunPerFile_GraceRoundCancelledInFinalCallDiscardsCompletion closes the
+// last cancellation window: task_done(DONE) executes, then the context is
+// cancelled while the round's final call (code_comment) executes. The
+// already-observed completion must be discarded, so a cancelled run is never
+// recorded as completed.
+func TestRunPerFile_GraceRoundCancelledInFinalCallDiscardsCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		// Round 1: context tool call (budget = 1, exhausted after this).
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		// Grace round: task_done first, then code_comment (cancels the context).
+		graceRoundDoneThenCommentResponse(),
+	}}
+	deps := graceRoundTestDeps(client, 1)
+	deps.DiffLookup = cancellingDiffLookup(cancel)
+	runner := NewRunner(deps)
+
+	completed, stop, err := runner.RunPerFile(
+		ctx,
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if client.calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (1 main round + 1 grace round)", client.calls)
+	}
+	if completed {
+		t.Fatal("a completion observed before a mid-round cancellation must be discarded")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("grace-round cancellation must surface as context.Canceled, got: %v", err)
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone (an error carries no stop cause)", stop)
+	}
+}
+
+// Scenario B (the "empty final response" case): the model answers with
+// plain text and no tool call at all. Each such round burns budget with a
+// retry nudge; once budget is gone the grace round gets a second text-only
+// reply. Nothing ever completes the task.
+func TestRunPerFile_EmptyResponsesNeverComplete(t *testing.T) {
+	textOnly := func() *llm.ChatResponse {
+		content := "I have finished reviewing this file."
+		return &llm.ChatResponse{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &content}}},
+			Model:   "fake",
+			Usage:   &llm.UsageInfo{PromptTokens: 5, CompletionTokens: 5},
+		}
+	}
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		textOnly(), textOnly(), textOnly(), textOnly(),
+	}}
+	runner := NewRunner(graceRoundTestDeps(client, 2))
+
+	completed, stop, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	t.Logf("Scenario B: completed=%v stop=%v llmCalls=%d", completed, stop, client.calls)
+
+	if completed {
+		t.Fatal("text-only run must never complete")
+	}
+	if stop != StopMaxRounds {
+		t.Fatalf("stop = %v, want StopMaxRounds", stop)
+	}
+	t.Log("Scenario B OK: text-only model burns all rounds, grace round returns no tool call, run stays incomplete")
+}
+
+// Scenario C (control group, same shape as Scenario A but in a normal
+// round): task_done(DONE) in a regular round completes the run. This
+// isolates grace-round behavior from the normal-round completion path.
+func TestRunPerFile_TaskDoneInNormalRoundCompletes(t *testing.T) {
+	client := &fakeClient{responses: []*llm.ChatResponse{
+		fileReadToolCallResponse("call_1", `{"path":"main.go"}`),
+		taskDoneResponseWithArguments(`{"state":"DONE"}`),
+	}}
+	runner := NewRunner(graceRoundTestDeps(client, 5))
+
+	completed, _, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	if err != nil {
+		t.Fatalf("RunPerFile: %v", err)
+	}
+	if !completed {
+		t.Fatal("control failed: task_done in a normal round must complete")
+	}
+	t.Log("Control OK: task_done(DONE) in a normal round completes the run")
+}

--- a/internal/llmloop/grace_round_protocol_test.go
+++ b/internal/llmloop/grace_round_protocol_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package llmloop
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/llm"
+)
+
+// Cross-protocol reproduction: each supported wire format (openai chat
+// completions, anthropic messages, openai responses) is driven end-to-end
+// through a REAL protocol client against an httptest server, so the full path
+// wire format -> protocol parsing -> shared RunPerFile loop -> grace round
+// is exercised. The scripted conversation mirrors the live Ark failure:
+// round 1 spends the budget on a context tool call (file_read), and the
+// grace round answers with an explicit task_done(DONE).
+
+type protocolFixture struct {
+	name         string
+	newClient    func(url string) llm.LLMClient
+	fileReadBody string
+	taskDoneBody string
+}
+
+func protocolFixtures() []protocolFixture {
+	return []protocolFixture{
+		{
+			name: "openai_chat_completions",
+			newClient: func(url string) llm.LLMClient {
+				return llm.NewOpenAIClient(llm.ClientConfig{URL: url, APIKey: "test", Model: "fake"})
+			},
+			fileReadBody: `{
+				"id":"chatcmpl_1","object":"chat.completion","created":1700000000,"model":"fake",
+				"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_1","type":"function","function":{"name":"file_read","arguments":"{\"path\":\"main.go\"}"}}
+				]},"finish_reason":"tool_calls"}],
+				"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}
+			}`,
+			taskDoneBody: `{
+				"id":"chatcmpl_2","object":"chat.completion","created":1700000000,"model":"fake",
+				"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_2","type":"function","function":{"name":"task_done","arguments":"{\"state\":\"DONE\"}"}}
+				]},"finish_reason":"tool_calls"}],
+				"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}
+			}`,
+		},
+		{
+			name: "anthropic_messages",
+			newClient: func(url string) llm.LLMClient {
+				return llm.NewAnthropicClient(llm.ClientConfig{URL: url, APIKey: "test", Model: "claude-test"})
+			},
+			fileReadBody: `{
+				"id":"msg_1","type":"message","role":"assistant","model":"claude-test",
+				"content":[{"type":"tool_use","id":"toolu_1","name":"file_read","input":{"path":"main.go"}}],
+				"stop_reason":"tool_use",
+				"usage":{"input_tokens":5,"output_tokens":5}
+			}`,
+			taskDoneBody: `{
+				"id":"msg_2","type":"message","role":"assistant","model":"claude-test",
+				"content":[{"type":"tool_use","id":"toolu_2","name":"task_done","input":{"state":"DONE"}}],
+				"stop_reason":"tool_use",
+				"usage":{"input_tokens":5,"output_tokens":5}
+			}`,
+		},
+		{
+			name: "openai_responses",
+			newClient: func(url string) llm.LLMClient {
+				return llm.NewOpenAIResponsesClient(llm.ClientConfig{URL: url, APIKey: "test", Model: "gpt-5.4"})
+			},
+			fileReadBody: `{
+				"id":"resp_1","object":"response","model":"gpt-5.4","status":"completed",
+				"output":[{"type":"function_call","call_id":"call_1","name":"file_read","arguments":"{\"path\":\"main.go\"}"}],
+				"usage":{"input_tokens":5,"output_tokens":5,"total_tokens":10}
+			}`,
+			taskDoneBody: `{
+				"id":"resp_2","object":"response","model":"gpt-5.4","status":"completed",
+				"output":[{"type":"function_call","call_id":"call_2","name":"task_done","arguments":"{\"state\":\"DONE\"}"}],
+				"usage":{"input_tokens":5,"output_tokens":5,"total_tokens":10}
+			}`,
+		},
+	}
+}
+
+// scriptedProtocolServer serves body per request: first hit gets first,
+// later hits get rest (repeating the last one).
+func scriptedProtocolServer(t *testing.T, first, rest string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		body := rest
+		if n == 1 {
+			body = first
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// protocolRunResult captures what a scripted protocol run observed, so the
+// all-protocols tests can assert on it without repeating the plumbing.
+type protocolRunResult struct {
+	completed bool
+	stop      MainLoopStop
+	err       error
+	hits      int32
+}
+
+// runOverProtocol drives one protocol fixture through RunPerFile against a
+// scripted server: the first hit answers a file_read (burning round 1) and
+// later hits answer task_done(DONE). maxRounds decides where that task_done
+// lands: 1 pushes it into the grace round, more leaves it in a normal round.
+func runOverProtocol(t *testing.T, p protocolFixture, maxRounds int) protocolRunResult {
+	t.Helper()
+	srv, hits := scriptedProtocolServer(t, p.fileReadBody, p.taskDoneBody)
+	runner := NewRunner(graceRoundTestDeps(p.newClient(srv.URL), maxRounds))
+	completed, stop, err := runner.RunPerFile(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage("user", "review")},
+		"main.go",
+	)
+	return protocolRunResult{completed: completed, stop: stop, err: err, hits: hits.Load()}
+}
+
+// TestRunPerFile_GraceRoundTaskDonePropagates_AllProtocols drives every
+// supported wire format through the regression scenario: budget exhausted
+// by a context tool call, then an explicit task_done(DONE) in the grace
+// round. The tool call is parsed and executed on every protocol, and its
+// completion must propagate on every protocol — the semantics live in the
+// shared loop, so every response format benefits from the fix.
+func TestRunPerFile_GraceRoundTaskDonePropagates_AllProtocols(t *testing.T) {
+	for _, p := range protocolFixtures() {
+		t.Run(p.name, func(t *testing.T) {
+			got := runOverProtocol(t, p, 1)
+			if got.err != nil {
+				t.Fatalf("RunPerFile: %v", got.err)
+			}
+
+			// Both rounds must have happened: the context-tool round and the
+			// grace round whose task_done was answered over this wire format.
+			if got.hits != 2 {
+				t.Fatalf("server hits = %d, want 2 (1 main round + 1 grace round)", got.hits)
+			}
+			if got.stop != StopNone {
+				t.Fatalf("stop = %v, want StopNone on grace-round completion", got.stop)
+			}
+			if !got.completed {
+				t.Fatalf("grace-round task_done(DONE) must propagate on %s: RunPerFile returned completed=false", p.name)
+			}
+		})
+	}
+}
+
+// TestRunPerFile_TaskDoneNormalRound_AllProtocols is the control group:
+// the same task_done(DONE), issued in a normal round with budget to spare,
+// completes the run on every wire format. This proves each protocol's
+// parsing path is sound — the dropped completion is a loop-level defect,
+// not a per-format parsing defect.
+func TestRunPerFile_TaskDoneNormalRound_AllProtocols(t *testing.T) {
+	for _, p := range protocolFixtures() {
+		t.Run(p.name, func(t *testing.T) {
+			got := runOverProtocol(t, p, 5)
+			if got.err != nil {
+				t.Fatalf("RunPerFile: %v", got.err)
+			}
+			if got.hits != 2 {
+				t.Fatalf("server hits = %d, want 2", got.hits)
+			}
+			if !got.completed {
+				t.Fatalf("control failed on %s: task_done in a normal round must complete", p.name)
+			}
+		})
+	}
+}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -6,6 +6,7 @@ package llmloop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,13 @@ import (
 	"github.com/alibaba/open-code-review/internal/tool"
 	"github.com/google/uuid"
 )
+
+// ErrTaskFailed is the sentinel wrapped by the task-failure error returned
+// when the model declares task_done(FAILED), in both the main loop and the
+// grace round. Callers can distinguish a model-declared failure from other
+// errors with errors.Is(err, ErrTaskFailed); the error text is unchanged
+// ("task failed: <model-provided detail>").
+var ErrTaskFailed = errors.New("task failed")
 
 // Deps bundles all per-call dependencies the Runner needs. Both
 // internal/agent (diff review) and internal/scan (full-file scan) build a
@@ -327,7 +335,12 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 		for _, call := range calls {
 			cp := r.executeToolCall(ctx, newPath, call, rec, thinking)
 			if cp.Failed {
-				return false, StopNone, fmt.Errorf("task failed: %s", cp.Data)
+				// A model-declared failure stops the round immediately: any
+				// calls issued after task_done(FAILED) do not execute. This
+				// is intentionally asymmetric with task_done(DONE), which
+				// keeps executing the remaining calls so comments issued
+				// alongside it still land.
+				return false, StopNone, fmt.Errorf("%w: %s", ErrTaskFailed, cp.Data)
 			} else if cp.Completed {
 				results = append(results, tool.ToolCallResult{
 					ToolCallID: call.ID,
@@ -376,18 +389,31 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 
 	if stop == StopMaxRounds {
 		fmt.Fprintf(stdout.Writer(), "[ocr] Max tool requests reached for %s.\n", newPath)
-		r.runGraceRound(ctx, messages, newPath, sessionID)
+		completed, err := r.runGraceRound(ctx, messages, newPath, sessionID)
+		if err != nil {
+			return false, StopNone, err
+		}
+		if completed {
+			return true, StopNone, nil
+		}
 	}
 	return false, stop, nil
 }
 
 // runGraceRound performs one final LLM call after the tool-request budget is
 // exhausted, giving the model a chance to submit any findings it identified
-// but did not yet report via code_comment.
-func (r *Runner) runGraceRound(ctx context.Context, messages []llm.Message, newPath string, sessionID string) {
+// but did not yet report via code_comment. It mirrors the main loop's
+// terminal semantics: a task_done(DONE) executed in this round completes the
+// file (RunPerFile reports completed=true so callers record a reusable
+// checkpoint), a task_done(FAILED) returns a task-failure error, and a
+// cancelled context returns ctx.Err() so callers classify the item as
+// FailureCancelled rather than FailureBudget. Every other outcome leaves the
+// run incomplete with budget exhaustion as the stop cause; only transient
+// LLM errors are swallowed so a network blip cannot mask the budget stop.
+func (r *Runner) runGraceRound(ctx context.Context, messages []llm.Message, newPath string, sessionID string) (bool, error) {
 	graceDefs := graceRoundToolDefs(r.deps.MainToolDefs)
 	if len(graceDefs) == 0 {
-		return
+		return false, nil
 	}
 
 	messages = append(messages, llm.NewTextMessage("user",
@@ -398,7 +424,7 @@ func (r *Runner) runGraceRound(ctx context.Context, messages []llm.Message, newP
 
 	if ctx.Err() != nil {
 		fmt.Fprintf(stdout.Writer(), "[ocr] Grace round skipped for %s: context cancelled\n", newPath)
-		return
+		return false, ctx.Err()
 	}
 
 	resp, err := r.deps.LLMClient.CompletionsWithCtx(ctx, llm.ChatRequest{
@@ -409,8 +435,14 @@ func (r *Runner) runGraceRound(ctx context.Context, messages []llm.Message, newP
 		SessionID: sessionID,
 	})
 	if err != nil {
+		// Cancellation is a user intent, not a transient outage: surface it
+		// like the main loop does instead of swallowing it below.
+		if ctx.Err() != nil {
+			fmt.Fprintf(stdout.Writer(), "[ocr] Grace round cancelled for %s: %v\n", newPath, ctx.Err())
+			return false, ctx.Err()
+		}
 		fmt.Fprintf(stdout.Writer(), "[ocr] Grace round LLM error for %s: %v\n", newPath, err)
-		return
+		return false, nil
 	}
 
 	if resp.Usage != nil {
@@ -422,16 +454,56 @@ func (r *Runner) runGraceRound(ctx context.Context, messages []llm.Message, newP
 
 	calls := resp.ToolCalls()
 	if len(calls) == 0 {
-		return
+		return false, nil
+	}
+
+	// Cancellation wins over grace-round completion: if the context was
+	// cancelled while the response was in flight, discard the response
+	// without executing it, so a cancelled run is never recorded as
+	// completed, and return ctx.Err() so the item is classified as
+	// cancelled rather than budget-exhausted.
+	if ctx.Err() != nil {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Grace round response discarded for %s: context cancelled\n", newPath)
+		return false, ctx.Err()
 	}
 
 	fs := r.deps.Session.GetOrCreateFileSession(newPath)
 	rec := fs.AppendTaskRecord(session.MainTask, append([]llm.Message(nil), messages...))
 	rec.SetResponse(resp, 0)
 	thinking := resp.ReasoningContent()
+	completed := false
 	for _, call := range calls {
-		r.executeToolCall(ctx, newPath, call, rec, thinking)
+		// Cancellation wins over grace-round completion: a Ctrl-C that lands
+		// between the round's tool calls must stop the round, so a later
+		// task_done(DONE) never completes a run that was already cancelled.
+		if ctx.Err() != nil {
+			fmt.Fprintf(stdout.Writer(), "[ocr] Grace round aborted for %s: context cancelled\n", newPath)
+			return false, ctx.Err()
+		}
+		cp := r.executeToolCall(ctx, newPath, call, rec, thinking)
+		if cp.Failed {
+			// Mirror the main loop: a model-declared failure surfaces as a
+			// task failure error, returning without executing the rest of
+			// the round. Intentionally asymmetric with the Completed branch
+			// below: task_done(FAILED) stops the round dead, while
+			// task_done(DONE) keeps executing so comments issued alongside
+			// it still land.
+			return false, fmt.Errorf("%w: %s", ErrTaskFailed, cp.Data)
+		}
+		if cp.Completed {
+			// Mirror the main loop: keep executing the remaining calls in
+			// the round so comments issued alongside task_done still land.
+			completed = true
+		}
 	}
+	// Final cancellation check: a Ctrl-C that lands during the round's last
+	// tool call must still discard the completion observed above, so a
+	// cancelled run is never recorded as completed.
+	if ctx.Err() != nil {
+		fmt.Fprintf(stdout.Writer(), "[ocr] Grace round completion discarded for %s: context cancelled\n", newPath)
+		return false, ctx.Err()
+	}
+	return completed, nil
 }
 
 // graceRoundToolDefs returns the subset of tool definitions containing only

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -6,6 +6,7 @@ package llmloop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -182,6 +183,9 @@ func TestRunPerFile_TaskDoneFailed(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "task_done reported FAILED") {
 		t.Fatalf("expected task_done FAILED error, got %v", err)
+	}
+	if !errors.Is(err, ErrTaskFailed) {
+		t.Fatalf("task_done FAILED error must wrap ErrTaskFailed, got %v", err)
 	}
 	if completed {
 		t.Fatal("task_done FAILED must not complete RunPerFile")
@@ -732,9 +736,15 @@ func TestRunPerFile_GraceRoundSkippedWhenContextCancelled(t *testing.T) {
 	runner = NewRunner(deps)
 
 	msgs := []llm.Message{llm.NewTextMessage("user", "review")}
-	_, stop, _ := runner.RunPerFile(ctx, msgs, "main.go")
-	if stop != StopMaxRounds {
-		t.Fatalf("stop = %v, want StopMaxRounds", stop)
+	completed, stop, err := runner.RunPerFile(ctx, msgs, "main.go")
+	if completed {
+		t.Fatal("a cancelled run must never be recorded as completed")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("grace-round skip on cancellation must surface as context.Canceled, got: %v", err)
+	}
+	if stop != StopNone {
+		t.Fatalf("stop = %v, want StopNone (an error carries no stop cause)", stop)
 	}
 	// Grace round should have been skipped (only 1 LLM call total)
 	if cancelClient.calls != 1 {

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -700,6 +700,123 @@ func TestDispatchSubtasks_ResumeSkipsCompletedFiles(t *testing.T) {
 	}
 }
 
+// TestDispatchSubtasks_GraceRoundCompletionIsCheckpointedAndReused protects
+// the full scan-to-resume contract: after a context-tool call exhausts the
+// per-file budget, task_done(DONE) in the grace round must persist a
+// review_item_done checkpoint that a later scan reuses without another LLM
+// request. If grace-round completion stops propagating from llmloop, the
+// first scan records a failure instead and the resumed scan reruns the file.
+func TestDispatchSubtasks_GraceRoundCompletionIsCheckpointedAndReused(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := t.TempDir()
+	item := model.ScanItem{Path: "target.go", Content: "package target\n", LineCount: 1}
+	collector := tool.NewCommentCollector()
+	tools := tool.NewRegistry()
+	tools.Register(&tool.CodeCommentProvider{Collector: collector})
+	tools.Freeze()
+
+	content := ""
+	firstClient := &fakeScanClient{responses: []*llm.ChatResponse{
+		{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{
+				Content: &content,
+				ToolCalls: []llm.ToolCall{{
+					ID: "comment", Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "code_comment",
+						Arguments: `{"comments":[{"content":"grace finding","existing_code":"package target"}]}`,
+					},
+				}},
+			}}},
+			Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+		},
+		scanTaskDoneResponse(),
+	}}
+
+	tpl := makeTemplateWithFullScan()
+	tpl.MaxTokens = 100000
+	tpl.MaxToolRequestTimes = 1
+	previous := session.New(repo, "main", "test", session.SessionOptions{ReviewMode: session.ReviewModeFullScan})
+	first := NewAgent(Args{
+		RepoDir:          repo,
+		Template:         tpl,
+		LLMClient:        firstClient,
+		Model:            "test",
+		CommentCollector: collector,
+		Tools:            tools,
+		MainToolDefs: []llm.ToolDef{
+			{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}},
+			{Type: "function", Function: llm.FunctionDef{Name: "task_done"}},
+		},
+		MaxConcurrency: 1,
+		SkipPlan:       true,
+		SkipDedup:      true,
+		SkipSummary:    true,
+		Session:        previous,
+	})
+	first.items = []model.ScanItem{item}
+	first.currentDate = "2026-08-20"
+
+	if _, err := first.dispatchSubtasks(context.Background()); err != nil {
+		t.Fatalf("first dispatchSubtasks: %v", err)
+	}
+	if firstClient.idx != 2 {
+		t.Fatalf("first LLM calls = %d, want 2 (context round plus grace round)", firstClient.idx)
+	}
+	if err := previous.Finalize(); err != nil {
+		t.Fatalf("finalize previous session: %v", err)
+	}
+
+	resume, err := session.LoadResumeState(repo, previous.SessionID)
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	fingerprint := scanItemFingerprint(item)
+	checkpoint, ok := resume.Item(fingerprint)
+	if !ok {
+		t.Fatalf("resume state missing grace-completed item %q", item.Path)
+	}
+	if len(checkpoint.Comments) != 1 || checkpoint.Comments[0].Content != "grace finding" {
+		t.Fatalf("checkpoint comments = %+v, want the grace-round finding", checkpoint.Comments)
+	}
+
+	resumedClient := &fakeScanClient{}
+	resumed := NewAgent(Args{
+		RepoDir:          repo,
+		Template:         tpl,
+		LLMClient:        resumedClient,
+		Model:            "test",
+		CommentCollector: tool.NewCommentCollector(),
+		Tools:            tool.NewRegistry(),
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipDedup:        true,
+		SkipSummary:      true,
+		Resume:           resume,
+		Session: session.New(repo, "main", "test", session.SessionOptions{
+			ReviewMode:  session.ReviewModeFullScan,
+			ResumedFrom: previous.SessionID,
+		}),
+	})
+	resumed.items = []model.ScanItem{item}
+	resumed.currentDate = "2026-08-20"
+
+	comments, err := resumed.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("resumed dispatchSubtasks: %v", err)
+	}
+	if resumedClient.idx != 0 {
+		t.Fatalf("resumed LLM calls = %d, want 0 for a reused grace-completed item", resumedClient.idx)
+	}
+	if len(comments) != 1 || comments[0].Content != "grace finding" {
+		t.Fatalf("resumed comments = %+v, want the checkpointed grace-round finding", comments)
+	}
+	info := resumed.ResumeInfo()
+	if info == nil || info.ReusedFiles != 1 || info.RerunFiles != 0 {
+		t.Fatalf("ResumeInfo = %+v, want 1 reused / 0 rerun", info)
+	}
+}
+
 func TestDispatchSubtasks_AllFailed(t *testing.T) {
 	client := &errorScanClient{err: context.DeadlineExceeded}
 


### PR DESCRIPTION
## Description

When the tool-request budget is exhausted, `RunPerFile` runs one grace round, giving the model a final chance to submit findings.

Previously, the grace round discarded the result of `task_done`: a model that spent its normal rounds on context tools and then correctly called `task_done(DONE)` in the grace round was still recorded as incomplete. Callers therefore kept the misleading `main_task did not complete before stopping` result instead of recording a reusable checkpoint.

The grace round now mirrors the main loop's terminal semantics:

- **`task_done(DONE)` completes the run.** `RunPerFile` returns `completed=true` with `StopNone`; remaining calls in the same round still execute, so accompanying `code_comment` calls land.
- **`task_done(FAILED)` returns a task-failure error.** The round stops immediately and does not execute subsequent calls, intentionally matching the main loop's DONE/FAILED asymmetry.
- **Cancellation returns `ctx.Err()` at every grace-round window.** Callers classify it as `FailureCancelled`, consistently with the main loop and run-level cancellation handling.
- **Transient LLM errors remain swallowed**, so a network failure in this best-effort round does not mask the original budget stop.
- **Task-failure errors wrap `ErrTaskFailed`**, allowing callers to identify them with `errors.Is` while preserving the existing error text.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Unit tests in `internal/llmloop`:

- `TestRunPerFile_GraceRoundTaskDoneCompletes` — the core regression: `task_done(DONE)` in the grace round completes the run.
- `TestRunPerFile_GraceRoundCommentAfterTaskDoneStillLands` / `TestRunPerFile_GraceRoundTaskDoneFailedSurfaces` — same-round ordering semantics for DONE and FAILED, including the `ErrTaskFailed` sentinel.
- `TestRunPerFile_GraceRoundLLMErrorSwallowed` — a transient LLM outage keeps budget exhaustion as the stop cause.
- `TestRunPerFile_GraceRoundCancelled{DuringLLMCall,AfterResponseDiscarded,BetweenToolCalls,InFinalCallDiscardsCompletion}` and `TestRunPerFile_GraceRoundSkippedWhenContextCancelled` — each grace-round cancellation window surfaces `context.Canceled`.
- `grace_round_protocol_test.go` — propagation verified over the OpenAI chat-completions, Anthropic messages, and OpenAI responses wire formats, with normal-round control groups.

Manual verification used real LLM runs against a scratch Git repository with a staged Go diff containing a swallowed-error bug:

- **Before/after comparison.** Built binaries from the pre-fix `v1.9.8` baseline and this branch. For a deterministic grace-round trigger, each binary used a local test-only template change setting `MAX_TOOL_REQUEST_TIMES=1`; that change is not part of this PR. Both binaries ran `ocr review --audience agent --no-filter` against the same repository.
  - Before: `Review failed: 0 finding(s); 1 of 1 selected item(s) failed` — the grace round's `task_done(DONE)` was dropped, and the misleading error told the user to "check your LLM configuration and API key".
  - After: `Review complete: 1 finding(s) across 1 selected item(s)` — the `code_comment` submitted in the grace round landed, correctly flagging the swallowed error with a suggested fix; completion propagated instead of failing the item.
- **Cancellation.** Re-ran the review and sent SIGINT mid-run. The summary reported `Review failed (cancelled)` and the per-item retry report recorded `server.go / main_task #1: cancelled`; item-level and run-level attribution agree rather than classifying the item as budget exhaustion. The precise grace-round cancellation windows are covered by unit tests because LLM latency jitter makes them hard to trigger deterministically in a live run.

Downstream coverage: the new scan integration test verifies checkpoint persistence and resume reuse. Existing `internal/agent` and `internal/scan` suites also pass.

Additional local verification:

- `go test -race` on `internal/llmloop` passes.
- `make check` passes locally.
- `make coverage` passes, meeting the repository's 90% threshold.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1018
