### PR TITLE
feat(cli): clarify LLM request failures by review stage

### DIFF
--- a/cmd/opencodereview/emit_run_result_test.go
+++ b/cmd/opencodereview/emit_run_result_test.go
@@ -623,7 +623,7 @@ func TestEmitRunResult_TextReportOrder(t *testing.T) {
 	if summary < 0 || report > summary {
 		t.Errorf("report must precede the project summary\n%s", got)
 	}
-	if !strings.Contains(got, "rejected by provider (HTTP 402) → failed") {
+	if !strings.Contains(got, "rejected by provider (HTTP 402) -> failed") {
 		t.Errorf("per-request lines missing: %s", got)
 	}
 }

--- a/cmd/opencodereview/emit_run_result_test.go
+++ b/cmd/opencodereview/emit_run_result_test.go
@@ -615,7 +615,7 @@ func TestEmitRunResult_TextReportOrder(t *testing.T) {
 			t.Fatalf("emitRunResult: %v", err)
 		}
 	})
-	report := strings.Index(got, "LLM retry report:")
+	report := strings.Index(got, "LLM retry report summary:")
 	summary := strings.Index(got, "PROJECT-SUMMARY-MARKER")
 	if report < 0 {
 		t.Fatalf("report missing from text output: %s", got)
@@ -623,7 +623,7 @@ func TestEmitRunResult_TextReportOrder(t *testing.T) {
 	if summary < 0 || report > summary {
 		t.Errorf("report must precede the project summary\n%s", got)
 	}
-	if !strings.Contains(got, "- config.go / main_task #1: provider(402) -> failed") {
+	if !strings.Contains(got, "rejected by provider (HTTP 402) → failed") {
 		t.Errorf("per-request lines missing: %s", got)
 	}
 }
@@ -635,7 +635,7 @@ func TestEmitRunResult_TextOmitsReportWhenNil(t *testing.T) {
 			t.Fatalf("emitRunResult: %v", err)
 		}
 	})
-	if strings.Contains(got, "LLM retry report") {
+	if strings.Contains(got, "LLM retry report summary") {
 		t.Errorf("nil report must print nothing, got %s", got)
 	}
 }
@@ -649,7 +649,7 @@ func TestEmitRunResult_JSONHasNoReportText(t *testing.T) {
 			t.Fatalf("emitRunResult: %v", err)
 		}
 	})
-	if strings.Contains(got, "LLM retry report:") {
+	if strings.Contains(got, "LLM retry report summary:") {
 		t.Errorf("JSON mode must not emit the terminal summary: %s", got)
 	}
 	dec := json.NewDecoder(strings.NewReader(got))
@@ -685,7 +685,7 @@ func TestEmitFailureUsage_TextCarriesRetryReport(t *testing.T) {
 		emitFailureUsage(ag, time.Second, "text", nil, retryReportFixture())
 	})
 	usage := strings.Index(got, "[ocr] usage on failure:")
-	report := strings.Index(got, "LLM retry report:")
+	report := strings.Index(got, "LLM retry report summary:")
 	if usage < 0 || report < 0 || usage > report {
 		t.Errorf("report must follow the usage line on stderr:\n%s", got)
 	}
@@ -696,7 +696,7 @@ func TestEmitFailureUsage_NilReportUnchanged(t *testing.T) {
 	got := captureStderr(t, func() {
 		emitFailureUsage(ag, time.Second, "text", nil, nil)
 	})
-	if strings.Contains(got, "LLM retry report") {
+	if strings.Contains(got, "LLM retry report summary") {
 		t.Errorf("nil report must print nothing, got %q", got)
 	}
 }
@@ -714,10 +714,10 @@ func TestEmitRunResult_TextReportWithWarnings(t *testing.T) {
 			t.Fatalf("emitRunResult: %v", err)
 		}
 	})
-	if !strings.Contains(got, "LLM retry report:") {
+	if !strings.Contains(got, "LLM retry report summary:") {
 		t.Errorf("report missing: %s", got)
 	}
-	if strings.Count(got, "LLM retry report:") != 1 {
+	if strings.Count(got, "LLM retry report summary:") != 1 {
 		t.Errorf("report emitted more than once: %s", got)
 	}
 }

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -448,9 +448,12 @@ func outputRetryReportText(w io.Writer, rep *llm.RetryReport) {
 		}
 	}
 
-	fmt.Fprintf(w, "\nLLM retry report summary: %d of %d %s affected — %s\n",
-		len(rep.Requests), rep.TotalRequests, plural(rep.TotalRequests, "request"),
-		strings.Join(parts, ", "))
+	fmt.Fprintf(w, "\nLLM retry report summary: %d of %d %s affected",
+		len(rep.Requests), rep.TotalRequests, plural(rep.TotalRequests, "request"))
+	if len(parts) > 0 {
+		fmt.Fprintf(w, " — %s", strings.Join(parts, ", "))
+	}
+	fmt.Fprintln(w)
 
 	for _, g := range groups {
 		header := fmt.Sprintf("%s (%d %s", g.title,
@@ -458,7 +461,7 @@ func outputRetryReportText(w io.Writer, rep *llm.RetryReport) {
 		fmt.Fprintf(w, "\n%s):\n", header)
 		for i, r := range g.requests {
 			if i == retryGroupListLimit {
-				fmt.Fprintf(w, "  ... and %d more\n", len(g.requests)-i)
+				fmt.Fprintf(w, "- ... and %d more\n", len(g.requests)-i)
 				break
 			}
 			fmt.Fprintf(w, "- %s — %s\n", sanitizeTerminal(r.FilePath), retryAttemptChain(r))

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -451,7 +451,7 @@ func outputRetryReportText(w io.Writer, rep *llm.RetryReport) {
 	fmt.Fprintf(w, "\nLLM retry report summary: %d of %d %s affected",
 		len(rep.Requests), rep.TotalRequests, plural(rep.TotalRequests, "request"))
 	if len(parts) > 0 {
-		fmt.Fprintf(w, " — %s", strings.Join(parts, ", "))
+		fmt.Fprintf(w, " -- %s", strings.Join(parts, ", "))
 	}
 	fmt.Fprintln(w)
 
@@ -464,7 +464,7 @@ func outputRetryReportText(w io.Writer, rep *llm.RetryReport) {
 				fmt.Fprintf(w, "- ... and %d more\n", len(g.requests)-i)
 				break
 			}
-			fmt.Fprintf(w, "- %s — %s\n", sanitizeTerminal(r.FilePath), retryAttemptChain(r))
+			fmt.Fprintf(w, "- %s: %s\n", sanitizeTerminal(r.FilePath), retryAttemptChain(r))
 		}
 	}
 
@@ -537,7 +537,7 @@ func retryAttemptChain(r llm.RequestReport) string {
 		(r.Outcome == llm.OutcomeCancelled && !lastCancelled) {
 		parts = append(parts, string(r.Outcome))
 	}
-	return strings.Join(parts, " → ")
+	return strings.Join(parts, " -> ")
 }
 
 func retryErrorPhrase(a llm.AttemptRecord) string {

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -389,62 +390,187 @@ func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 	return enc.Encode(out)
 }
 
-// outputRetryReportText renders the frozen retry report as the terminal
-// summary. It is a run result, not a warning, so it goes to the same writer as
-// the review result rather than to stderr; JSON mode never calls this (stdout
-// must stay a single JSON document).
-//
-// Nothing here is free text from a provider: only stable classes, numeric
-// status codes, the file path and the task type — no API keys, headers,
-// bodies, prompts, URLs or raw SDK error strings. Every request in the report
-// is listed; the report already only contains requests that erred or retried,
-// so there is no separate terminal truncation contract to reason about.
+// retryStages maps internal task types to concise terminal labels. The slice
+// order is also the display order.
+var retryStages = []struct {
+	taskType session.TaskType
+	title    string
+}{
+	{session.PlanTask, "Review planning"},
+	{session.MainTask, "Core review"},
+	{session.MemoryCompressionTask, "Context compaction"},
+	{session.ReLocationTask, "Comment re-location"},
+	{session.ReviewFilterTask, "Comment filtering"},
+}
+
+// Keep the terminal concise; JSON retains every request.
+const retryGroupListLimit = 5
+
+// retryGroup is one review-stage bucket of listed requests.
+type retryGroup struct {
+	rank     int
+	title    string
+	requests []llm.RequestReport
+}
+
+func retryOutcomeInfo(o llm.Outcome) (summary string, rank int) {
+	switch o {
+	case llm.OutcomeFailed:
+		return "failed", 0
+	case llm.OutcomeCancelled:
+		return "cancelled", 1
+	case llm.OutcomeRecovered:
+		return "recovered after retry", 2
+	default:
+		return "retried at provider request", 3
+	}
+}
+
+// outputRetryReportText groups noteworthy requests by review stage. It
+// renders only stable classes and status codes; raw provider errors stay out.
 func outputRetryReportText(w io.Writer, rep *llm.RetryReport) {
 	if rep == nil {
 		return
 	}
-	retryWord := "retries"
-	if rep.TotalRetries == 1 {
-		retryWord = "retry"
-	}
-	fmt.Fprintf(w, "\nLLM retry report: %d/%d requests retried, %d %s, %d recovered, %d failed, %d cancelled\n",
-		rep.RetriedRequests, rep.TotalRequests, rep.TotalRetries, retryWord,
-		rep.RecoveredRequests, rep.FailedRequests, rep.CancelledRequests)
-	for _, r := range rep.Requests {
-		fmt.Fprintf(w, "- %s / %s #%d: %s\n",
-			sanitizeTerminal(r.FilePath), sanitizeTerminal(r.TaskType),
-			r.RequestNo, retryAttemptChain(r))
-	}
-}
+	groups := groupRetryRequests(rep.Requests)
 
-// retryAttemptChain renders one logical request's attempts as
-// "rate_limited(429) -> overloaded(529) -> success".
-//
-// A trailing request-level outcome is appended for failed and, when the last
-// attempt does not already say so, cancelled. A recovered or succeeded request
-// already ends in a "success" attempt, so repeating the outcome there would be
-// noise, whereas a request that never succeeded would otherwise end on its last
-// error with no sign of how it finished. cancelled in particular is a routine
-// outcome (background memory compression is deliberately abandoned at the end
-// of every file), so it must be visibly distinct from a provider failure.
-func retryAttemptChain(r llm.RequestReport) string {
-	parts := make([]string, 0, len(r.Attempts)+1)
-	for _, a := range r.Attempts {
-		switch {
-		case a.Outcome == llm.AttemptSuccess:
-			parts = append(parts, "success")
-		case a.StatusCode > 0:
-			parts = append(parts, fmt.Sprintf("%s(%d)", a.ErrorClass, a.StatusCode))
-		default:
-			parts = append(parts, string(a.ErrorClass))
+	// The counts come from the listed requests, not from the report aggregates, so the
+	// summary line can never disagree with the entries printed under it.
+	byOutcome := make(map[llm.Outcome]int, 3)
+	for _, r := range rep.Requests {
+		byOutcome[r.Outcome]++
+	}
+	parts := make([]string, 0, 4)
+	for _, o := range []llm.Outcome{llm.OutcomeFailed, llm.OutcomeCancelled, llm.OutcomeRecovered, llm.OutcomeSucceeded} {
+		if n := byOutcome[o]; n > 0 {
+			summary, _ := retryOutcomeInfo(o)
+			parts = append(parts, fmt.Sprintf("%d %s %s", n, plural(n, "request"), summary))
 		}
 	}
+
+	fmt.Fprintf(w, "\nLLM retry report summary: %d of %d %s affected — %s\n",
+		len(rep.Requests), rep.TotalRequests, plural(rep.TotalRequests, "request"),
+		strings.Join(parts, ", "))
+
+	for _, g := range groups {
+		header := fmt.Sprintf("%s (%d %s", g.title,
+			len(g.requests), plural(len(g.requests), "request"))
+		fmt.Fprintf(w, "\n%s):\n", header)
+		for i, r := range g.requests {
+			if i == retryGroupListLimit {
+				fmt.Fprintf(w, "  ... and %d more\n", len(g.requests)-i)
+				break
+			}
+			fmt.Fprintf(w, "- %s — %s\n", sanitizeTerminal(r.FilePath), retryAttemptChain(r))
+		}
+	}
+
+	fmt.Fprintf(w, "\nPer-attempt detail: --format json (retry_report).\n")
+}
+
+// groupRetryRequests buckets by review stage, then sorts for stable output.
+func groupRetryRequests(requests []llm.RequestReport) []*retryGroup {
+	byStage := make(map[string]*retryGroup)
+	for _, r := range requests {
+		g := byStage[r.TaskType]
+		if g == nil {
+			title, rank := retryStageInfo(r.TaskType)
+			g = &retryGroup{rank: rank, title: title}
+			byStage[r.TaskType] = g
+		}
+		g.requests = append(g.requests, r)
+	}
+
+	groups := make([]*retryGroup, 0, len(byStage))
+	for _, g := range byStage {
+		sort.Slice(g.requests, func(i, j int) bool {
+			_, ri := retryOutcomeInfo(g.requests[i].Outcome)
+			_, rj := retryOutcomeInfo(g.requests[j].Outcome)
+			if ri != rj {
+				return ri < rj
+			}
+			if g.requests[i].FilePath != g.requests[j].FilePath {
+				return g.requests[i].FilePath < g.requests[j].FilePath
+			}
+			return g.requests[i].RequestNo < g.requests[j].RequestNo
+		})
+		groups = append(groups, g)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].rank != groups[j].rank {
+			return groups[i].rank < groups[j].rank
+		}
+		return groups[i].title < groups[j].title
+	})
+	return groups
+}
+
+func retryStageInfo(taskType string) (title string, rank int) {
+	for i, stage := range retryStages {
+		if string(stage.taskType) == taskType {
+			return stage.title, i
+		}
+	}
+	return sanitizeTerminal(taskType), len(retryStages)
+}
+
+// retryAttemptChain renders one logical request as a short human-readable chain.
+func retryAttemptChain(r llm.RequestReport) string {
+	parts := make([]string, 0, len(r.Attempts)+1)
+	for i, a := range r.Attempts {
+		if a.Outcome == llm.AttemptSuccess {
+			if i < len(r.Attempts)-1 {
+				parts = append(parts, "succeeded (provider asked to retry)")
+				continue
+			}
+			parts = append(parts, "succeeded")
+			continue
+		}
+		parts = append(parts, retryErrorPhrase(a))
+	}
+	lastCancelled := len(r.Attempts) > 0 &&
+		r.Attempts[len(r.Attempts)-1].ErrorClass == llm.ErrorClassCancelled
 	if r.Outcome == llm.OutcomeFailed ||
-		(r.Outcome == llm.OutcomeCancelled &&
-			(len(parts) == 0 || parts[len(parts)-1] != string(llm.OutcomeCancelled))) {
+		(r.Outcome == llm.OutcomeCancelled && !lastCancelled) {
 		parts = append(parts, string(r.Outcome))
 	}
-	return strings.Join(parts, " -> ")
+	return strings.Join(parts, " → ")
+}
+
+func retryErrorPhrase(a llm.AttemptRecord) string {
+	var phrase string
+	switch a.ErrorClass {
+	case llm.ErrorClassRateLimited:
+		phrase = "rate limited"
+	case llm.ErrorClassOverloaded:
+		phrase = "provider overloaded"
+	case llm.ErrorClassAuthentication:
+		phrase = "authentication rejected"
+	case llm.ErrorClassTimeout:
+		phrase = "timed out"
+	case llm.ErrorClassNetwork:
+		phrase = "network error"
+	case llm.ErrorClassProvider:
+		phrase = "provider error"
+		if a.StatusCode > 0 && a.StatusCode < 500 {
+			phrase = "rejected by provider"
+		}
+	case llm.ErrorClassCancelled:
+		phrase = "cancelled"
+	default:
+		phrase = "unclassified error"
+	}
+	if a.StatusCode > 0 {
+		phrase = fmt.Sprintf("%s (HTTP %d)", phrase, a.StatusCode)
+	}
+	return phrase
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }
 
 func manifestMessage(manifest *session.RunManifest, findings int) string {

--- a/cmd/opencodereview/retry_report_e2e_test.go
+++ b/cmd/opencodereview/retry_report_e2e_test.go
@@ -45,7 +45,7 @@ func TestReviewE2E_CleanRunEmitsNoRetryReport(t *testing.T) {
 	if strings.Contains(out, "retry_report") {
 		t.Errorf("a first-try-success run must not emit retry_report:\n%s", out)
 	}
-	if strings.Contains(errOut, "LLM retry report") {
+	if strings.Contains(errOut, "LLM retry report summary") {
 		t.Errorf("nothing should reach the failure exit either:\n%s", errOut)
 	}
 }
@@ -141,17 +141,17 @@ func TestReviewE2E_RetryReportReachesTextExit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("partial coverage must exit 0: %v\nstderr: %s", err, errOut)
 	}
-	if !strings.Contains(out, "LLM retry report:") {
+	if !strings.Contains(out, "LLM retry report summary:") {
 		t.Fatalf("terminal summary missing from stdout:\n%s", out)
 	}
-	if !strings.Contains(out, "rate_limited(429) -> success") {
+	if !strings.Contains(out, "rate limited (HTTP 429) → succeeded") {
 		t.Errorf("attempt chain missing from the terminal summary:\n%s", out)
 	}
-	if !strings.Contains(out, "provider(402) -> failed") {
+	if !strings.Contains(out, "rejected by provider (HTTP 402) → failed") {
 		t.Errorf("failed request missing from the terminal summary:\n%s", out)
 	}
 	// The summary is a run result, so it must not be duplicated onto stderr.
-	if strings.Contains(errOut, "LLM retry report") {
+	if strings.Contains(errOut, "LLM retry report summary") {
 		t.Errorf("report must not also appear on stderr:\n%s", errOut)
 	}
 	// It must carry no secret material: the token, the endpoint URL and raw
@@ -209,10 +209,10 @@ func TestReviewE2E_AllFilesFailTextPublishesReportOnce(t *testing.T) {
 	if err == nil {
 		t.Fatal("a fully failed review must exit non-zero")
 	}
-	if !strings.Contains(out, "LLM retry report:") {
+	if !strings.Contains(out, "LLM retry report summary:") {
 		t.Fatalf("report missing from stdout:\n%s", out)
 	}
-	if strings.Contains(errOut, "LLM retry report:") {
+	if strings.Contains(errOut, "LLM retry report summary:") {
 		t.Errorf("report duplicated onto stderr:\n%s", errOut)
 	}
 	if !strings.Contains(errOut, "[ocr] usage on failure:") {

--- a/cmd/opencodereview/retry_report_e2e_test.go
+++ b/cmd/opencodereview/retry_report_e2e_test.go
@@ -144,10 +144,10 @@ func TestReviewE2E_RetryReportReachesTextExit(t *testing.T) {
 	if !strings.Contains(out, "LLM retry report summary:") {
 		t.Fatalf("terminal summary missing from stdout:\n%s", out)
 	}
-	if !strings.Contains(out, "rate limited (HTTP 429) → succeeded") {
+	if !strings.Contains(out, "rate limited (HTTP 429) -> succeeded") {
 		t.Errorf("attempt chain missing from the terminal summary:\n%s", out)
 	}
-	if !strings.Contains(out, "rejected by provider (HTTP 402) → failed") {
+	if !strings.Contains(out, "rejected by provider (HTTP 402) -> failed") {
 		t.Errorf("failed request missing from the terminal summary:\n%s", out)
 	}
 	// The summary is a run result, so it must not be duplicated onto stderr.

--- a/cmd/opencodereview/retry_report_render_test.go
+++ b/cmd/opencodereview/retry_report_render_test.go
@@ -62,11 +62,11 @@ func retryReportFixture() *llm.RetryReport {
 // task_type/request_no identity the JSON report carries stays out of the
 // terminal.
 const wantRetryReportText = `
-LLM retry report summary: 2 of 12 requests affected — 1 request failed, 1 request recovered after retry
+LLM retry report summary: 2 of 12 requests affected -- 1 request failed, 1 request recovered after retry
 
 Core review (2 requests):
-- config.go — rejected by provider (HTTP 402) → failed
-- payment.go — rate limited (HTTP 429) → provider overloaded (HTTP 529) → succeeded
+- config.go: rejected by provider (HTTP 402) -> failed
+- payment.go: rate limited (HTTP 429) -> provider overloaded (HTTP 529) -> succeeded
 
 Per-attempt detail: --format json (retry_report).
 `
@@ -161,9 +161,9 @@ func TestOutputRetryReportText_SucceededAfterRetry(t *testing.T) {
 	}
 	// "retried", not "recovered": no attempt failed, so nothing was recovered
 	// from — the same distinction the JSON report's recovered_requests keeps.
-	want := "\nLLM retry report summary: 1 of 1 request affected — 1 request retried at provider request\n" +
+	want := "\nLLM retry report summary: 1 of 1 request affected -- 1 request retried at provider request\n" +
 		"\nCore review (1 request):\n" +
-		"- payment.go — succeeded (provider asked to retry) → succeeded\n" +
+		"- payment.go: succeeded (provider asked to retry) -> succeeded\n" +
 		"\nPer-attempt detail: --format json (retry_report).\n"
 	var buf bytes.Buffer
 	outputRetryReportText(&buf, rep)
@@ -187,9 +187,9 @@ func TestOutputRetryReportText_CancelledIsShown(t *testing.T) {
 			Attempts:         []llm.AttemptRecord{{Number: 1, Outcome: llm.AttemptSuccess}},
 		}},
 	}
-	want := "\nLLM retry report summary: 1 of 1 request affected — 1 request cancelled\n" +
+	want := "\nLLM retry report summary: 1 of 1 request affected -- 1 request cancelled\n" +
 		"\nContext compaction (1 request):\n" +
-		"- payment.go — succeeded → cancelled\n" +
+		"- payment.go: succeeded -> cancelled\n" +
 		"\nPer-attempt detail: --format json (retry_report).\n"
 	var buf bytes.Buffer
 	outputRetryReportText(&buf, rep)
@@ -220,7 +220,7 @@ func TestRetryAttemptChain_NoStatusCode(t *testing.T) {
 			{Number: 1, Outcome: llm.AttemptError, ErrorClass: llm.ErrorClassNetwork, FailurePhase: llm.FailurePhaseTransport},
 		},
 	}
-	if got, want := retryAttemptChain(r), "network error → failed"; got != want {
+	if got, want := retryAttemptChain(r), "network error -> failed"; got != want {
 		t.Errorf("chain = %q, want %q", got, want)
 	}
 }
@@ -380,7 +380,7 @@ func TestRetryReport_TerminalAndJSONReadSameFrozenResult(t *testing.T) {
 		t.Fatal("retry_report missing")
 	}
 
-	wantHeader := "LLM retry report summary: 2 of 2 requests affected — 1 request failed, 1 request recovered after retry"
+	wantHeader := "LLM retry report summary: 2 of 2 requests affected -- 1 request failed, 1 request recovered after retry"
 	if !strings.Contains(text.String(), wantHeader) {
 		t.Errorf("terminal header = %q, want it to contain %q", text.String(), wantHeader)
 	}

--- a/cmd/opencodereview/retry_report_render_test.go
+++ b/cmd/opencodereview/retry_report_render_test.go
@@ -57,11 +57,17 @@ func retryReportFixture() *llm.RetryReport {
 }
 
 // The expected rendering is fixed, so the text contract is asserted whole
-// rather than by substring.
+// rather than by substring. Failures list before recoveries, and the internal
+// task_type/request_no identity the JSON report carries stays out of the
+// terminal.
 const wantRetryReportText = `
-LLM retry report: 1/12 requests retried, 2 retries, 1 recovered, 1 failed, 0 cancelled
-- payment.go / main_task #2: rate_limited(429) -> overloaded(529) -> success
-- config.go / main_task #1: provider(402) -> failed
+LLM retry report summary: 2 of 12 requests affected — 1 request failed, 1 request recovered after retry
+
+Core review (2 requests):
+- config.go — rejected by provider (HTTP 402) → failed
+- payment.go — rate limited (HTTP 429) → provider overloaded (HTTP 529) → succeeded
+
+Per-attempt detail: --format json (retry_report).
 `
 
 func TestOutputRetryReportText_RecoveredAndFailed(t *testing.T) {
@@ -80,13 +86,33 @@ func TestOutputRetryReportText_NilWritesNothing(t *testing.T) {
 	}
 }
 
-func TestOutputRetryReportText_SingularRetry(t *testing.T) {
-	rep := retryReportFixture()
-	rep.TotalRetries = 1
+// Counted nouns are singular at one and plural above it.
+func TestOutputRetryReportText_PluralAgreement(t *testing.T) {
 	var buf bytes.Buffer
+	outputRetryReportText(&buf, retryReportFixture())
+	got := buf.String()
+	for _, want := range []string{"2 of 12 requests affected", "(1 request)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+
+	rep := retryReportFixture()
+	rep.Requests = append(rep.Requests, llm.RequestReport{
+		LogicalRequestID: "ccc",
+		Model:            "claude-test",
+		FilePath:         "billing.go",
+		TaskType:         "main_task",
+		RequestNo:        1,
+		Outcome:          llm.OutcomeFailed,
+		Attempts: []llm.AttemptRecord{
+			{Number: 1, Outcome: llm.AttemptError, ErrorClass: llm.ErrorClassProvider, FailurePhase: llm.FailurePhaseHTTP, StatusCode: 402},
+		},
+	})
+	buf.Reset()
 	outputRetryReportText(&buf, rep)
-	if !strings.Contains(buf.String(), "1 retry,") {
-		t.Errorf("total_retries=1 must read %q, got %q", "1 retry,", buf.String())
+	if got := buf.String(); !strings.Contains(got, "(2 requests)") {
+		t.Errorf("two failures must read %q, got:\n%s", "(2 requests)", got)
 	}
 }
 
@@ -113,8 +139,12 @@ func TestOutputRetryReportText_SucceededAfterRetry(t *testing.T) {
 			},
 		}},
 	}
-	want := "\nLLM retry report: 1/1 requests retried, 1 retry, 0 recovered, 0 failed, 0 cancelled\n" +
-		"- payment.go / main_task #2: success -> success\n"
+	// "retried", not "recovered": no attempt failed, so nothing was recovered
+	// from — the same distinction the JSON report's recovered_requests keeps.
+	want := "\nLLM retry report summary: 1 of 1 request affected — 1 request retried at provider request\n" +
+		"\nCore review (1 request):\n" +
+		"- payment.go — succeeded (provider asked to retry) → succeeded\n" +
+		"\nPer-attempt detail: --format json (retry_report).\n"
 	var buf bytes.Buffer
 	outputRetryReportText(&buf, rep)
 	if got := buf.String(); got != want {
@@ -122,9 +152,7 @@ func TestOutputRetryReportText_SucceededAfterRetry(t *testing.T) {
 	}
 }
 
-// A cancelled request keeps its clean attempt and is told apart from a provider
-// failure only by the trailing outcome, so that suffix is part of the contract.
-func TestOutputRetryReportText_CancelledSuffix(t *testing.T) {
+func TestOutputRetryReportText_CancelledIsShown(t *testing.T) {
 	rep := &llm.RetryReport{
 		SchemaVersion:     llm.RetryReportSchemaVersion,
 		TotalRequests:     1,
@@ -139,8 +167,10 @@ func TestOutputRetryReportText_CancelledSuffix(t *testing.T) {
 			Attempts:         []llm.AttemptRecord{{Number: 1, Outcome: llm.AttemptSuccess}},
 		}},
 	}
-	want := "\nLLM retry report: 0/1 requests retried, 0 retries, 0 recovered, 0 failed, 1 cancelled\n" +
-		"- payment.go / memory_compression_task #1: success -> cancelled\n"
+	want := "\nLLM retry report summary: 1 of 1 request affected — 1 request cancelled\n" +
+		"\nContext compaction (1 request):\n" +
+		"- payment.go — succeeded → cancelled\n" +
+		"\nPer-attempt detail: --format json (retry_report).\n"
 	var buf bytes.Buffer
 	outputRetryReportText(&buf, rep)
 	if got := buf.String(); got != want {
@@ -170,7 +200,7 @@ func TestRetryAttemptChain_NoStatusCode(t *testing.T) {
 			{Number: 1, Outcome: llm.AttemptError, ErrorClass: llm.ErrorClassNetwork, FailurePhase: llm.FailurePhaseTransport},
 		},
 	}
-	if got, want := retryAttemptChain(r), "network -> failed"; got != want {
+	if got, want := retryAttemptChain(r), "network error → failed"; got != want {
 		t.Errorf("chain = %q, want %q", got, want)
 	}
 }
@@ -304,7 +334,7 @@ func TestRetryReport_TerminalAndJSONReadSameFrozenResult(t *testing.T) {
 		t.Fatal("retry_report missing")
 	}
 
-	wantHeader := "LLM retry report: 1/2 requests retried, 1 retry, 1 recovered, 1 failed, 0 cancelled"
+	wantHeader := "LLM retry report summary: 2 of 2 requests affected — 1 request failed, 1 request recovered after retry"
 	if !strings.Contains(text.String(), wantHeader) {
 		t.Errorf("terminal header = %q, want it to contain %q", text.String(), wantHeader)
 	}

--- a/cmd/opencodereview/retry_report_render_test.go
+++ b/cmd/opencodereview/retry_report_render_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -83,6 +84,17 @@ func TestOutputRetryReportText_NilWritesNothing(t *testing.T) {
 	outputRetryReportText(&buf, nil)
 	if buf.Len() != 0 {
 		t.Errorf("nil report must write nothing, got %q", buf.String())
+	}
+}
+
+func TestOutputRetryReportText_EmptyRequestsHasNoDanglingSummary(t *testing.T) {
+	rep := &llm.RetryReport{TotalRequests: 12}
+	var buf bytes.Buffer
+	outputRetryReportText(&buf, rep)
+	want := "\nLLM retry report summary: 0 of 12 requests affected\n" +
+		"\nPer-attempt detail: --format json (retry_report).\n"
+	if got := buf.String(); got != want {
+		t.Errorf("text report mismatch\n got: %q\nwant: %q", got, want)
 	}
 }
 
@@ -221,6 +233,32 @@ func TestOutputRetryReportText_SanitizesControlChars(t *testing.T) {
 	outputRetryReportText(&buf, rep)
 	if strings.ContainsAny(buf.String(), "\x1b\x07") {
 		t.Errorf("control characters must be stripped, got %q", buf.String())
+	}
+}
+
+func TestOutputRetryReportText_TruncatesStageList(t *testing.T) {
+	rep := &llm.RetryReport{TotalRequests: retryGroupListLimit + 2}
+	for i := 0; i < retryGroupListLimit+2; i++ {
+		rep.Requests = append(rep.Requests, llm.RequestReport{
+			FilePath:  fmt.Sprintf("file-%d.go", i),
+			TaskType:  string(session.MainTask),
+			RequestNo: i + 1,
+			Outcome:   llm.OutcomeFailed,
+			Attempts: []llm.AttemptRecord{{
+				Number: 1, Outcome: llm.AttemptError,
+				ErrorClass: llm.ErrorClassProvider, FailurePhase: llm.FailurePhaseHTTP,
+			}},
+		})
+	}
+
+	var buf bytes.Buffer
+	outputRetryReportText(&buf, rep)
+	got := buf.String()
+	if n := strings.Count(got, "\n- file-"); n != retryGroupListLimit {
+		t.Errorf("listed %d requests, want %d:\n%s", n, retryGroupListLimit, got)
+	}
+	if want := "\n- ... and 2 more\n"; !strings.Contains(got, want) {
+		t.Errorf("missing aligned truncation line %q:\n%s", want, got)
 	}
 }
 

--- a/cmd/opencodereview/retry_report_render_test.go
+++ b/cmd/opencodereview/retry_report_render_test.go
@@ -91,7 +91,12 @@ func TestOutputRetryReportText_PluralAgreement(t *testing.T) {
 	var buf bytes.Buffer
 	outputRetryReportText(&buf, retryReportFixture())
 	got := buf.String()
-	for _, want := range []string{"2 of 12 requests affected", "(1 request)"} {
+	for _, want := range []string{
+		"2 of 12 requests affected",
+		"1 request failed",
+		"1 request recovered after retry",
+		"Core review (2 requests)",
+	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in:\n%s", want, got)
 		}
@@ -111,8 +116,11 @@ func TestOutputRetryReportText_PluralAgreement(t *testing.T) {
 	})
 	buf.Reset()
 	outputRetryReportText(&buf, rep)
-	if got := buf.String(); !strings.Contains(got, "(2 requests)") {
-		t.Errorf("two failures must read %q, got:\n%s", "(2 requests)", got)
+	got = buf.String()
+	for _, want := range []string{"2 requests failed", "Core review (3 requests)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

The text retry report currently exposes internal `task_type` and `request_no` values in a flat request list. It also uses summaries such as `2 failed`, which can be mistaken for failed review items rather than failed LLM requests.

This PR improves the human-readable report by:

- making request-level outcomes explicit, such as `2 requests failed`;
- grouping noteworthy requests only by human-readable review stage;
- displaying failed and recovered requests together within each stage;
- rendering each request on one line with its path and attempt chain;
- retaining HTTP status codes and readable error classifications;
- listing failures before recovered requests and limiting each stage to five entries.

Example:

```text
LLM retry report summary: 3 of 50 requests affected — 2 requests failed, 1 request recovered after retry

Core review (1 request):
- internal/agent/agent.go — rate limited (HTTP 429) → succeeded

Comment filtering (2 requests):
- internal/agent/agent.go — rejected by provider (HTTP 400) → failed
- cmd/opencodereview/shared.go — rejected by provider (HTTP 400) → failed

Per-attempt detail: --format json (retry_report).
```

This makes it clear that the overall review may still be complete even when auxiliary LLM requests fail.

This is a rendering-only change. The review result, retry report schema, manifest wording, JSON fields, warnings, retry behavior, exit status, and SARIF output remain unchanged. Full per-attempt data remains available through `--format json`.

The terminal heading and layout intentionally change from the flat `LLM retry report:` format to grouped sections under `LLM retry report summary:`. Machine consumers should continue using the JSON report.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] `make check` passes locally

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that cover the updated rendering
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required because no machine-readable contract changed

## Related Issues

Related to #786
