### PR TITLE
fix(scan): join background memory compression before session finalization

### DIFF
--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -118,8 +118,8 @@ func NewRunner(deps Deps) *Runner {
 // ultimately depends on the LLM client honouring context cancellation, and no
 // additional deadline is imposed here: the job already carries its own
 // timeout.
-// Scan does not currently call this because it freezes no retry report; its
-// analogous session-finalization race is outside this change.
+// Both diff-review and scan modes call this prior to session finalization so
+// background compression goroutines are joined before session_end is written.
 func (r *Runner) WaitBackground() {
 	r.bg.Wait()
 }

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -372,6 +372,12 @@ func (a *Agent) Run(ctx context.Context) ([]model.LlmComment, error) {
 	// Project-level summary runs after all batches; never blocks return.
 	a.maybeRunProjectSummary(ctx, comments)
 
+	// Join background memory compression before anything finalizes the session.
+	// Those jobs are cancelled rather than awaited when a conversation ends, so
+	// their LLM request can still be in flight here; joining them ensures no
+	// background goroutine is left leaking or writing to a finalized session.
+	a.runner.WaitBackground()
+
 	// A persistence failure is a delivery error in its own right: when the scan
 	// also failed, both facts are reported (errors.Join) rather than letting the
 	// dispatch error hide the fact that session_end never reached disk.

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -416,6 +416,12 @@ func (c *blockingScanCompressionClient) CompletionsWithCtx(ctx context.Context, 
 		}, nil
 	}
 
+	// Round 2+: wait until the background compression goroutine has reached
+	// the mock (closed c.started) before returning task_done. This eliminates
+	// the race where the main loop finishes before compression starts,
+	// ensuring WaitBackground is the only thing holding Run open.
+	<-c.started
+
 	doneContent := ""
 	return &llm.ChatResponse{
 		Choices: []llm.Choice{{
@@ -489,11 +495,15 @@ func TestScanAgent_WaitBackground_NoLeakOnRun(t *testing.T) {
 		t.Fatal("timed out waiting for background compression to start")
 	}
 
-	// Verify that a.Run has NOT returned yet (held by a.runner.WaitBackground())
+	// Verify that a.Run has NOT returned yet (held by a.runner.WaitBackground()).
+	// Use a timeout rather than default: the main goroutine's entire post-loop
+	// cleanup (RunPerFile return → dispatchSubtasks → Finalize) completes in
+	// under 1ms on any machine, so 200ms is a generous upper bound. If Run
+	// returns within this window, WaitBackground is not holding it.
 	select {
 	case res := <-done:
 		t.Fatalf("a.Run returned prematurely before background compression was released: err=%v", res.err)
-	default:
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	// Release compression and wait for Run to finish

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -359,3 +359,16 @@ func TestTokenCountersDelegateToRunner(t *testing.T) {
 	}
 	_ = llmloop.AgentWarning{} // keep llmloop import meaningful
 }
+
+func TestScanAgent_WaitBackground_NoLeakOnRun(t *testing.T) {
+	client := &identityProbeClient{reply: "no findings"}
+	a := newProbeAgent(t, makeTemplateWithFullScan(), client, nil)
+	a.args.RepoDir = t.TempDir() // empty dir so 0 files discovered -> clean skip
+	comments, err := a.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(comments) != 0 {
+		t.Fatalf("expected 0 comments, got %d", len(comments))
+	}
+}

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -4,8 +4,13 @@
 package scan
 
 import (
+	"context"
+	"encoding/json"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/llm"
@@ -360,15 +365,190 @@ func TestTokenCountersDelegateToRunner(t *testing.T) {
 	_ = llmloop.AgentWarning{} // keep llmloop import meaningful
 }
 
-func TestScanAgent_WaitBackground_NoLeakOnRun(t *testing.T) {
-	client := &identityProbeClient{reply: "no findings"}
-	a := newProbeAgent(t, makeTemplateWithFullScan(), client, nil)
-	a.args.RepoDir = t.TempDir() // empty dir so 0 files discovered -> clean skip
-	comments, err := a.Run(t.Context())
-	if err != nil {
-		t.Fatalf("Run: %v", err)
+type blockingScanCompressionClient struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	mu      sync.Mutex
+	round   int
+}
+
+func newBlockingScanCompressionClient() *blockingScanCompressionClient {
+	return &blockingScanCompressionClient{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
 	}
-	if len(comments) != 0 {
-		t.Fatalf("expected 0 comments, got %d", len(comments))
+}
+
+func (c *blockingScanCompressionClient) CompletionsWithCtx(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	if len(req.Tools) == 0 {
+		c.once.Do(func() { close(c.started) })
+		select {
+		case <-c.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		summary := "compressed summary"
+		return &llm.ChatResponse{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &summary}}},
+			Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+		}, nil
+	}
+
+	c.mu.Lock()
+	c.round++
+	r := c.round
+	c.mu.Unlock()
+
+	if r == 1 {
+		content := strings.Repeat("word ", 650)
+		return &llm.ChatResponse{
+			Choices: []llm.Choice{{
+				Message: llm.ResponseMessage{
+					Content: &content,
+					ToolCalls: []llm.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      "code_comment",
+							Arguments: `{"comments":[{"path":"main.go","line":1,"content":"finding"}]}`,
+						},
+					}},
+				},
+			}},
+			Usage: &llm.UsageInfo{PromptTokens: 100, CompletionTokens: 50},
+		}, nil
+	}
+
+	doneContent := ""
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{
+			Message: llm.ResponseMessage{
+				Content: &doneContent,
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call_done",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "task_done",
+						Arguments: `{"state":"DONE"}`,
+					},
+				}},
+			},
+		}},
+		Usage: &llm.UsageInfo{PromptTokens: 20, CompletionTokens: 10},
+	}, nil
+}
+
+func TestScanAgent_WaitBackground_NoLeakOnRun(t *testing.T) {
+	repo := initTestRepo(t)
+	writeFile(t, repo, "main.go", []byte("package main\n\nfunc main() {}\n"))
+	gitCommit(t, repo, "init")
+
+	tpl := makeTemplateWithFullScan()
+	tpl.MaxTokens = 1000
+	tpl.MemoryCompressionTask = template.LlmConversation{
+		Messages: []template.ChatMessage{
+			{Role: "system", Content: "compress {{context}}"},
+		},
+	}
+
+	client := newBlockingScanCompressionClient()
+	sess := session.New(repo, "main", "test-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeFullScan,
+	})
+
+	a := NewAgent(Args{
+		RepoDir:          repo,
+		Template:         tpl,
+		LLMClient:        client,
+		Model:            "test-model",
+		CommentCollector: tool.NewCommentCollector(),
+		Tools:            tool.NewRegistry(),
+		MainToolDefs: []llm.ToolDef{
+			{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}},
+			{Type: "function", Function: llm.FunctionDef{Name: "task_done"}},
+		},
+		SkipPlan:         true,
+		SkipDedup:        true,
+		SkipSummary:      true,
+		MaxConcurrency:   1,
+		Session:          sess,
+	})
+
+	type runResult struct {
+		comments []model.LlmComment
+		err      error
+	}
+	done := make(chan runResult, 1)
+
+	go func() {
+		comments, err := a.Run(context.Background())
+		done <- runResult{comments: comments, err: err}
+	}()
+
+	// Wait until background compression starts and blocks
+	select {
+	case <-client.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for background compression to start")
+	}
+
+	// Verify that a.Run has NOT returned yet (held by a.runner.WaitBackground())
+	select {
+	case res := <-done:
+		t.Fatalf("a.Run returned prematurely before background compression was released: err=%v", res.err)
+	default:
+	}
+
+	// Release compression and wait for Run to finish
+	close(client.release)
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("Run: %v", res.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a.Run to finish")
+	}
+
+	// Verify session JSONL file:
+	// 1. memory_compression_task llm_request is recorded
+	// 2. session_end is the final record
+	path, err := session.SessionFilePath(repo, sess.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty session JSONL")
+	}
+
+	var hasCompressionRequest bool
+	for _, l := range lines {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(l), &rec); err != nil {
+			t.Fatalf("unmarshal line %q: %v", l, err)
+		}
+		if rec["type"] == "llm_request" && rec["taskType"] == string(session.MemoryCompressionTask) {
+			hasCompressionRequest = true
+		}
+	}
+
+	if !hasCompressionRequest {
+		t.Errorf("session JSONL missing memory_compression_task llm_request; contents:\n%s", string(data))
+	}
+
+	var lastRec map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &lastRec); err != nil {
+		t.Fatalf("unmarshal last line %q: %v", lines[len(lines)-1], err)
+	}
+	if lastRec["type"] != "session_end" {
+		t.Errorf("last session JSONL record type = %q, want session_end", lastRec["type"])
 	}
 }

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -383,11 +383,7 @@ func newBlockingScanCompressionClient() *blockingScanCompressionClient {
 func (c *blockingScanCompressionClient) CompletionsWithCtx(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
 	if len(req.Tools) == 0 {
 		c.once.Do(func() { close(c.started) })
-		select {
-		case <-c.release:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+		<-c.release
 		summary := "compressed summary"
 		return &llm.ChatResponse{
 			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &summary}}},

--- a/internal/scan/agent_test.go
+++ b/internal/scan/agent_test.go
@@ -468,11 +468,11 @@ func TestScanAgent_WaitBackground_NoLeakOnRun(t *testing.T) {
 			{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}},
 			{Type: "function", Function: llm.FunctionDef{Name: "task_done"}},
 		},
-		SkipPlan:         true,
-		SkipDedup:        true,
-		SkipSummary:      true,
-		MaxConcurrency:   1,
-		Session:          sess,
+		SkipPlan:       true,
+		SkipDedup:      true,
+		SkipSummary:    true,
+		MaxConcurrency: 1,
+		Session:        sess,
 	})
 
 	type runResult struct {


### PR DESCRIPTION
### Problem Description
Fixes #1025

In full-scan mode (`scan.Agent`), subtasks share `llmloop.Runner` for per-file reviews. When a conversation exceeds the memory compression soft threshold (60%), `triggerAsyncCompression` spawns background goroutines registered via `r.bg.Add(1)`.

While `internal/agent/agent.go:385` (`Agent.Run` in diff-review mode) explicitly calls `a.runner.WaitBackground()` before `a.session.Finalize()`, `internal/scan/agent.go` omitted this join barrier. As a result, background compression jobs could outlive the main scan lifecycle and attempt to write records after `session.Finalize()` closes the session file writer.

### Key Implementation Changes
- **`internal/scan/agent.go`**: Call `a.runner.WaitBackground()` in `scan.Agent.Run` prior to calling `a.session.Finalize()`, ensuring full parity with `internal/agent/agent.go`.
- **`internal/scan/agent_test.go`**: Add `TestScanAgent_WaitBackground_NoLeakOnRun` unit regression test.

### Verification & Empirical Evidence
- `go test ./internal/scan/... -v` passes cleanly.
- `go test ./internal/llmloop/... ./internal/agent/...` passes cleanly.
- All unit and integration tests verified locally.
