### PR TITLE
fix(vscode): list merge commit files

### DIFF
--- a/extensions/vscode/src/extension/services/GitService.ts
+++ b/extensions/vscode/src/extension/services/GitService.ts
@@ -241,7 +241,14 @@ export class GitService {
     const root = await this.repoRoot();
     if (!root || !sha) return [];
     try {
-      const out = await runGit(root, ['show', '--name-status', '--format=', sha]);
+      const out = await runGit(root, [
+        'show',
+        '--diff-merges=first-parent',
+        '--name-status',
+        '--format=',
+        '--end-of-options',
+        sha,
+      ]);
       const files = parseNameStatus(out);
       this.trace(`getCommitFiles(${sha}): files=${files.length}`);
       return files;

--- a/extensions/vscode/src/extension/services/__tests__/GitService.test.ts
+++ b/extensions/vscode/src/extension/services/__tests__/GitService.test.ts
@@ -39,4 +39,30 @@ describe('GitService workspace files', () => {
       { path: 'untracked.ts', status: 'added' },
     ]);
   });
+
+  it('lists merge commit files relative to the first parent', async () => {
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repoRoot });
+
+    await writeFile(path.join(repoRoot, 'base.ts'), 'export const base = true;\n');
+    await execFileAsync('git', ['add', 'base.ts'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    await execFileAsync('git', ['branch', '-M', 'main'], { cwd: repoRoot });
+
+    await execFileAsync('git', ['checkout', '-q', '-b', 'feature'], { cwd: repoRoot });
+    await writeFile(path.join(repoRoot, 'feature.ts'), 'export const feature = true;\n');
+    await execFileAsync('git', ['add', 'feature.ts'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-q', '-m', 'feature'], { cwd: repoRoot });
+
+    await execFileAsync('git', ['checkout', '-q', 'main'], { cwd: repoRoot });
+    await writeFile(path.join(repoRoot, 'main.ts'), 'export const main = true;\n');
+    await execFileAsync('git', ['add', 'main.ts'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-q', '-m', 'main'], { cwd: repoRoot });
+    await execFileAsync('git', ['merge', '--no-ff', '-q', 'feature', '-m', 'merge'], { cwd: repoRoot });
+
+    const mergeSha = (await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })).stdout.trim();
+    const files = await new GitService().getCommitFiles(mergeSha);
+
+    expect(files).toEqual([{ path: 'feature.ts', status: 'added' }]);
+  });
 });


### PR DESCRIPTION
## Description

Fix the VS Code Commit mode pending file list for merge commits.

## Problem / Reproduction

### Affected scenario

When a user selects a merge commit in the VS Code Open Code Review Sidebar's
Commit mode, the Pending Files list is empty. The user cannot start a review
from that list even though the merge commit contains changes.

### Reproduction

Using repository baseline `4b6874b` and the existing merge commit `0f0f899`:

1. Run the command currently used by the VS Code adapter:

   ```bash
   git show --name-status --format= 0f0f899
   ```

   It produces no file entries because Git uses combined diff output for the
   merge commit by default.

2. Run the first-parent equivalent:

   ```bash
   git show --diff-merges=first-parent --name-status --format= --end-of-options 0f0f899
   ```

   It returns the merge commit's changed files, including:
   `README.ja-JP.md`, `README.ko-KR.md`, `README.md`, `README.ru-RU.md`,
   `README.zh-CN.md`, and `imgs/logo-core.svg`.

The same behavior is visible in VS Code by opening the Sidebar, switching to
Commit mode, selecting `0f0f899`, and observing an empty Pending Files list.

### Root cause

`GitService.getCommitFiles()` used Git's default combined diff semantics for
merge commits. The Go core already uses first-parent semantics, and
`openDiff()` compares a commit with `commit^`, so the VS Code file list must use
the same contract.

## Fix

`GitService.getCommitFiles()` now uses `--diff-merges=first-parent` and
`--end-of-options`, matching the Go core and `openDiff()` semantics. Ordinary
commit behavior is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing with a deterministic temporary Git repository containing a real `--no-ff` merge commit

The regression test creates a base commit, diverging feature and main
branches, and a real merge commit. It asserts that
`getCommitFiles(mergeSha)` returns `feature.ts` with status `added`.

Validation completed:

- `extensions/vscode`: `npm test -- --runInBand` — 101 tests passed
- `extensions/vscode`: `npm run compile`
- `make check`
- `make test`
- `make build`
- `ocr review --audience agent` — 0 findings

## Checklist

- [x] My code follows the project's coding style (`make check` passed)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation update is not applicable
- [x] I have signed the CLA

## Related Issues

Related to #450: the Go core first-parent merge diff fix. This PR aligns the
independent VS Code adapter implementation.
