### PR TITLE
feat(allowlist): add Solidity (.sol) and Vyper (.vy) support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -85,6 +85,10 @@ func TestIsAllowedExt(t *testing.T) {
 		{".THRIFT", true},
 		{".capnp", true},
 		{".CAPNP", true},
+		{".sol", true},
+		{".SOL", true},
+		{".vy", true},
+		{".VY", true},
 		{".txt", false},
 		{".md", false},
 		{".png", false},
@@ -240,6 +244,14 @@ func TestIsExcludedPath(t *testing.T) {
 		{"zig _test suffix", "src/parser_test.zig", true},
 		{"zig non-test", "src/parser.zig", false},
 		{"zig test in filename", "src/testutil.zig", false},
+
+		// Solidity test files (Hardhat test/ dir, Foundry *.t.sol convention)
+		{"solidity foundry test", "src/Counter.t.sol", true},
+		{"solidity foundry test nested", "contracts/test/Vault.t.sol", true},
+		{"solidity hardhat test dir", "test/Counter.sol", true},
+		{"solidity hardhat test nested", "packages/core/test/unit/Vault.sol", true},
+		{"solidity non-test", "src/Counter.sol", false},
+		{"solidity t.sol in filename", "src/contract.sol", false},
 
 		// Snapshot files
 		{"jest snapshot dir", "src/__snapshots__/App.test.js.snap", true},

--- a/internal/config/allowlist/default_exclude_patterns.json
+++ b/internal/config/allowlist/default_exclude_patterns.json
@@ -44,5 +44,7 @@
   "**/*.capnp.go",
   "**/*.capnp.ts",
   "**/*_capnp.rs",
-  "**/*_capnp.py"
+  "**/*_capnp.py",
+  "**/test/**/*.sol",
+  "**/*.t.sol"
 ]

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -94,5 +94,7 @@
   ".libsonnet",
   ".zig",
   ".thrift",
-  ".capnp"
+  ".capnp",
+  ".sol",
+  ".vy"
 ]

--- a/internal/config/rules/rule_docs/solidity.md
+++ b/internal/config/rules/rule_docs/solidity.md
@@ -1,0 +1,39 @@
+> Favor precision over recall: report only issues that are likely to cause incorrect behavior, loss of user funds, or security vulnerabilities. Smart-contract defects are high-stakes and usually irreversible, so prioritize findings with a concrete exploit path over style suggestions. Account for the Solidity version: arithmetic overflow/underflow checks are built into the compiler from 0.8.0 onward, so only flag unchecked blocks, explicit type casts that truncate, or code pinned below 0.8.0.
+
+#### Reentrancy
+- External calls (ETH transfers, calls to untrusted contracts, or token callbacks such as ERC-721 onERC721Received) made before state variables are updated, letting a malicious contract re-enter and drain funds or corrupt state
+- Use of low-level call or delegatecall that forwards all remaining gas without a reentrancy guard (checks-effects-interactions ordering, a nonReentrant modifier, or a pull-payment design)
+- A token balance or accounting value read after an external call that can be manipulated mid-execution, or state written after the interaction instead of before
+
+#### Integer Overflow and Underflow
+- Arithmetic inside an unchecked block, or in a contract pinned below 0.8.0, where an operation can wrap and change a balance, supply, or loop bound
+- Explicit casts or conversions between integer types that silently discard high-order bits and change a value used for accounting or access control
+- Division or modulo by a value that can be zero at runtime
+
+#### Access Control and Authorization
+- Privileged functions (minting, ownership transfer, withdrawal, upgrade, pause) missing an onlyOwner or role check, or checking the wrong role
+- Use of tx.origin for authorization, which is spoofable through a chain of intermediate calls
+- Missing or incorrect checks that let an arbitrary caller become owner/admin, or an ownership transfer to the zero address that permanently orphans the contract
+
+#### Unchecked External Calls and Error Handling
+- A low-level call, staticcall, or delegatecall whose boolean return value is ignored, so a silently failing transfer or call goes unnoticed
+- Use of send or transfer for value movement without checking the return value, or assuming it always succeeds (send forwards only 2300 gas and can fail)
+- delegatecall into an untrusted or user-controlled address, which executes code in the caller's storage context
+- selfdestruct (or the post-0.8.24 replacement) reachable by an unauthorized account
+
+#### Economic and Oracle Safety
+- A hardcoded price or a single on-chain spot price used as an oracle, which is manipulable by flash loans or sandwich attacks
+- Accounting that mints, burns, or transfers tokens without updating the corresponding balance or supply, or that updates them in the wrong order
+- Missing slippage protection on swaps, or a function that lets an arbitrary caller specify the beneficiary or recipient
+
+#### Gas and Denial of Service
+- Unbounded loops over user-controlled arrays that can exceed the block gas limit and permanently lock a function
+- A function that sends ether in a loop where a single failing recipient reverts the whole transaction, allowing griefing
+
+#### Correctness and Storage
+- Uninitialized storage pointers, or storage/memory/calldata location errors that alias two variables to the same slot
+- A fallback or receive function with logic that can be triggered unexpectedly, or a payable function that lets the contract receive ether with no recovery path
+
+#### Signature and Randomness
+- Signature verification that does not protect against replay or malleability, or that recovers the wrong signer
+- Use of block.timestamp or blockhash for randomness, or for any value that must be unpredictable or hard to manipulate

--- a/internal/config/rules/rule_docs/solidity.md
+++ b/internal/config/rules/rule_docs/solidity.md
@@ -17,9 +17,9 @@
 
 #### Unchecked External Calls and Error Handling
 - A low-level call, staticcall, or delegatecall whose boolean return value is ignored, so a silently failing transfer or call goes unnoticed
-- Use of send or transfer for value movement without checking the return value, or assuming it always succeeds (send forwards only 2300 gas and can fail)
+- Ignoring the boolean result of `send`, or relying on `send` or `transfer` succeeding under the fixed 2300-gas stipend; `transfer` reverts on failure and has no return value to check
 - delegatecall into an untrusted or user-controlled address, which executes code in the caller's storage context
-- selfdestruct (or the post-0.8.24 replacement) reachable by an unauthorized account
+- `selfdestruct` reachable by an unauthorized account, or logic that assumes it will delete code and storage on post-Cancun EVMs outside the contract's creation transaction
 
 #### Economic and Oracle Safety
 - A hardcoded price or a single on-chain spot price used as an oracle, which is manipulable by flash loans or sandwich attacks

--- a/internal/config/rules/rule_docs/vyper.md
+++ b/internal/config/rules/rule_docs/vyper.md
@@ -1,16 +1,16 @@
-> Favor precision over recall: report only issues that are likely to cause incorrect behavior, loss of user funds, or security vulnerabilities. Vyper deliberately omits several Solidity footguns: state is written before external calls by default and there is no raw delegatecall, so reentrancy and delegatecall attacks are largely mitigated. Focus on the remaining risks: access control, raw_call misuse, and economic safety. Account for the Vyper version, since built-in arithmetic overflow checks and assert/raise semantics changed across releases.
+> Favor precision over recall: report only issues that are likely to cause incorrect behavior, loss of user funds, or security vulnerabilities. Vyper makes external calls explicit and provides built-in reentrancy protection, but that protection is opt-in through `@nonreentrant` unless the contract uses `#pragma nonreentrancy`. Reentrancy remains possible around unprotected external calls, and `raw_call(..., is_delegate_call=True)` supports delegate calls. Focus on access control, reentrancy, `raw_call` misuse, delegate calls, and economic safety while accounting for the Vyper version.
 
 #### Access Control and Authorization
 - Privileged functions (mint, ownership transfer, withdrawal, upgrade) missing a role or ownership check, or asserting the wrong role
-- Authorization based on tx.origin rather than msg.sender, which is spoofable through a chain of calls
+- Authorization based on `tx.origin` rather than `msg.sender`, which is spoofable through a chain of calls
 
 #### Raw External Calls
-- raw_call with max_outsize=0, so the return value is not checked and a silently failing call goes unnoticed
-- raw_call that forwards unbounded gas or targets a user-controlled address without validating the result
+- `raw_call(..., revert_on_failure=False)` whose returned success flag is ignored, allowing a failed call to go unnoticed; `max_outsize=0` alone is not an error because failures still revert by default
+- `raw_call` that forwards unbounded gas or targets a user-controlled address without validating the result
 - Interface or external call declarations whose ABI, argument types, or return types are inconsistent with the target contract
 
 #### Integer and Value Safety
-- Arithmetic in a version before built-in overflow checks (0.3.4) that can wrap, or unchecked conversion between uint256, int128, and other types that truncates a value used for accounting
+- Use of explicit `unsafe_add`, `unsafe_sub`, `unsafe_mul`, or `unsafe_div` where unchecked arithmetic can corrupt accounting, or a narrowing conversion whose bounds are not validated
 - Division or modulo by a value that can be zero at runtime
 - A payable function that lets the contract receive ether with no accounting or withdrawal path
 
@@ -20,9 +20,9 @@
 - Missing slippage protection on swaps, or a recipient/beneficiary that an arbitrary caller can set
 
 #### Assertions and Control Flow
-- Use of assert for input validation or conditions that can fail on ordinary user input, since assert consumes all remaining gas, where raise would refund unused gas and revert cleanly
+- Use of `assert ..., UNREACHABLE` for a condition that can fail during normal execution, because this form emits `INVALID` and consumes the remaining gas; ordinary `assert` and `raise` both revert and return unused gas
 - Unbounded loops over user-controlled arrays that can exceed the block gas limit
 
 #### Block and Randomness
-- Use of block.timestamp or blockhash for randomness, or for any value that must be unpredictable
+- Use of `block.timestamp` or `blockhash` for randomness, or for any value that must be unpredictable
 - Signature verification that does not protect against replay or malleability

--- a/internal/config/rules/rule_docs/vyper.md
+++ b/internal/config/rules/rule_docs/vyper.md
@@ -10,7 +10,7 @@
 - Interface or external call declarations whose ABI, argument types, or return types are inconsistent with the target contract
 
 #### Integer and Value Safety
-- Use of explicit `unsafe_add`, `unsafe_sub`, `unsafe_mul`, or `unsafe_div` where unchecked arithmetic can corrupt accounting, or a narrowing conversion whose bounds are not validated
+- Use of explicit `unsafe_add`, `unsafe_sub`, `unsafe_mul`, or `unsafe_div` where unchecked arithmetic can corrupt accounting, or a precision-affecting decimal-to-integer conversion whose behavior is not accounted for
 - Division or modulo by a value that can be zero at runtime
 - A payable function that lets the contract receive ether with no accounting or withdrawal path
 
@@ -21,7 +21,7 @@
 
 #### Assertions and Control Flow
 - Use of `assert ..., UNREACHABLE` for a condition that can fail during normal execution, because this form emits `INVALID` and consumes the remaining gas; ordinary `assert` and `raise` both revert and return unused gas
-- Unbounded loops over user-controlled arrays that can exceed the block gas limit
+- Loops or array iteration whose declared upper bound or maximum array length can make worst-case execution exceed the block gas limit
 
 #### Block and Randomness
 - Use of `block.timestamp` or `blockhash` for randomness, or for any value that must be unpredictable

--- a/internal/config/rules/rule_docs/vyper.md
+++ b/internal/config/rules/rule_docs/vyper.md
@@ -1,0 +1,28 @@
+> Favor precision over recall: report only issues that are likely to cause incorrect behavior, loss of user funds, or security vulnerabilities. Vyper deliberately omits several Solidity footguns: state is written before external calls by default and there is no raw delegatecall, so reentrancy and delegatecall attacks are largely mitigated. Focus on the remaining risks: access control, raw_call misuse, and economic safety. Account for the Vyper version, since built-in arithmetic overflow checks and assert/raise semantics changed across releases.
+
+#### Access Control and Authorization
+- Privileged functions (mint, ownership transfer, withdrawal, upgrade) missing a role or ownership check, or asserting the wrong role
+- Authorization based on tx.origin rather than msg.sender, which is spoofable through a chain of calls
+
+#### Raw External Calls
+- raw_call with max_outsize=0, so the return value is not checked and a silently failing call goes unnoticed
+- raw_call that forwards unbounded gas or targets a user-controlled address without validating the result
+- Interface or external call declarations whose ABI, argument types, or return types are inconsistent with the target contract
+
+#### Integer and Value Safety
+- Arithmetic in a version before built-in overflow checks (0.3.4) that can wrap, or unchecked conversion between uint256, int128, and other types that truncates a value used for accounting
+- Division or modulo by a value that can be zero at runtime
+- A payable function that lets the contract receive ether with no accounting or withdrawal path
+
+#### Economic Safety
+- A hardcoded price or single-source spot price used as an oracle, which is manipulable via flash loans or sandwich attacks
+- Mint, burn, or transfer logic that does not update the corresponding balance or supply, or updates it in the wrong order
+- Missing slippage protection on swaps, or a recipient/beneficiary that an arbitrary caller can set
+
+#### Assertions and Control Flow
+- Use of assert for input validation or conditions that can fail on ordinary user input, since assert consumes all remaining gas, where raise would refund unused gas and revert cleanly
+- Unbounded loops over user-controlled arrays that can exceed the block gas limit
+
+#### Block and Randomness
+- Use of block.timestamp or blockhash for randomness, or for any value that must be unpredictable
+- Signature verification that does not protect against replay or malleability

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -41,6 +41,8 @@
     "**/*.{jsonnet,libsonnet}": "jsonnet.md",
     "**/*.zig": "zig.md",
     "**/*.thrift": "thrift.md",
-    "**/*.capnp": "capnp.md"
+    "**/*.capnp": "capnp.md",
+    "**/*.sol": "solidity.md",
+    "**/*.vy": "vyper.md"
   }
 }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -135,6 +135,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"if/common.thrift", "Field IDs and Wire Compatibility"},
 		{"schema/addressbook.capnp", "Ordinals and Wire Compatibility"},
 		{"src/rpc.capnp", "Ordinals and Wire Compatibility"},
+		{"contracts/Token.sol", "Reentrancy"},
+		{"src/Vault.vy", "Access Control"},
 	}
 
 	for _, tt := range tests {

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -182,6 +182,8 @@ matching order:
 | `**/*.{jsonnet,libsonnet}` | `jsonnet.md` — Jsonnet configuration templates and libraries. |
 | `**/*.thrift` | `thrift.md` — Apache Thrift IDL wire compatibility. |
 | `**/*.capnp` | `capnp.md` — Cap'n Proto schema wire compatibility. |
+| `**/*.sol` | `solidity.md` — Solidity smart contracts. |
+| `**/*.vy` | `vyper.md` — Vyper smart contracts. |
 | *(fallback)* | `default.md` |
 
 The resolved rule body becomes the `{{system_rule}}` placeholder in the

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -144,6 +144,8 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{jsonnet,libsonnet}` | `jsonnet.md`: Jsonnet の設定テンプレートとライブラリ。 |
 | `**/*.thrift` | `thrift.md`: Apache Thrift IDL のワイヤ互換性。 |
 | `**/*.capnp` | `capnp.md`: Cap'n Proto スキーマのワイヤ互換性。 |
+| `**/*.sol` | `solidity.md`: Solidity スマートコントラクト。 |
+| `**/*.vy` | `vyper.md`: Vyper スマートコントラクト。 |
 | *(fallback)* | `default.md` |
 
 解決されたルール本文は、plan および main task prompt 内の `{{system_rule}}` プレースホルダーの内容になります。

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -184,6 +184,8 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.{jsonnet,libsonnet}` | `jsonnet.md` — шаблоны конфигурации и библиотеки Jsonnet. |
 | `**/*.thrift` | `thrift.md` — совместимость Apache Thrift IDL на уровне wire. |
 | `**/*.capnp` | `capnp.md` — совместимость схем Cap'n Proto на уровне wire. |
+| `**/*.sol` | `solidity.md` — смарт-контракты Solidity. |
+| `**/*.vy` | `vyper.md` — смарт-контракты Vyper. |
 | *(fallback)* | `default.md` |
 
 Разрешённое тело правила становится значением плейсхолдера `{{system_rule}}`

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -165,6 +165,8 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{jsonnet,libsonnet}` | `jsonnet.md`——Jsonnet 配置模板与库。 |
 | `**/*.thrift` | `thrift.md`——Apache Thrift IDL 线协议兼容性。 |
 | `**/*.capnp` | `capnp.md`——Cap'n Proto schema 线协议兼容性。 |
+| `**/*.sol` | `solidity.md`——Solidity 智能合约。 |
+| `**/*.vy` | `vyper.md`——Vyper 智能合约。 |
 | *(fallback)* | `default.md` |
 
 解析出的规则正文成为 plan 和 main task prompt 中 `{{system_rule}}` 占位符的内容。


### PR DESCRIPTION
## Summary

Implements the **Solidity / Web3** language group from tracking issue #470, adding first-class review support for Solidity (`.sol`) and Vyper (`.vy`) smart contracts.

Closes #1032

## Changes

- **`internal/config/allowlist/supported_file_types.json`** — allowlist `.sol` and `.vy`.
- **`internal/config/allowlist/default_exclude_patterns.json`** — exclude test files using the two dominant conventions: Foundry (`**/*.t.sol`) and Hardhat (`**/test/**/*.sol`).
- **`internal/config/rules/rule_docs/solidity.md`** — new Solidity review rules covering reentrancy, integer overflow/underflow, access control, unchecked external calls, oracle manipulation, gas DoS, storage correctness, and signature/replay safety.
- **`internal/config/rules/rule_docs/vyper.md`** — new Vyper review rules covering access control, `raw_call` misuse, integer/value safety, economic safety, `assert` vs `raise`, and block/randomness misuse.
- **`internal/config/rules/system_rules.json`** — register `**/*.sol` → `solidity.md` and `**/*.vy` → `vyper.md`.
- **Tests** — extend `allowed_ext_test.go` (extension + exclude-path cases) and `system_rules_test.go` (rule resolution cases).

## Testing

- `make test` — passes (all packages, `-race -count=1`).
- `make check` — passes (license check, english check, `go mod tidy`, `gofmt`, `go vet`).

## Notes

First-time contributor — I will sign the Alibaba Open Source CLA via the bot as soon as it prompts.