### PR TITLE
fix(scan): persist safe dedup checkpoints on resume

### DIFF
--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -538,7 +538,7 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 		if err != nil {
 			// ctx cancelled mid-batch: stop scheduling further batches but
 			// still return whatever we've collected so far.
-			a.recordBatchCheckpoints(checkpoints)
+			a.recordBatchCheckpoints(checkpoints, batchStart, nil)
 			return a.args.CommentCollector.Comments(), err
 		}
 
@@ -551,8 +551,8 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 			a.args.CommentWorkerPool.Await()
 		}
 
-		a.maybeRunDedup(ctx, bi, batchStart)
-		a.recordBatchCheckpoints(checkpoints)
+		dedupCheckpoints := a.maybeRunDedup(ctx, bi, batchStart)
+		a.recordBatchCheckpoints(checkpoints, batchStart, dedupCheckpoints)
 
 		// The per-file budget gate inside dispatchBatch tripped — stop
 		// scheduling any remaining batches.
@@ -569,24 +569,32 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 }
 
 type batchCheckpoint struct {
-	item   model.ScanItem
-	reused bool
+	item             model.ScanItem
+	reused           bool
+	originalComments []model.LlmComment
 }
 
-// recordBatchCheckpoints persists the final comments for a batch. It runs
-// after batch dedup so resume replays the same canonical result that the scan
-// returned to the caller.
-func (a *Agent) recordBatchCheckpoints(checkpoints []batchCheckpoint) {
+// recordBatchCheckpoints persists safe per-file comments after batch dedup.
+// New same-file groups use the canonical result. Reused items keep their source
+// checkpoint, and cross-file groups keep raw per-file comments so invalidating
+// one file cannot erase another file's finding on resume.
+func (a *Agent) recordBatchCheckpoints(
+	checkpoints []batchCheckpoint,
+	batchStart int,
+	dedupCheckpoints map[string][]model.LlmComment,
+) {
 	if len(checkpoints) == 0 {
 		return
 	}
 	if a.args.CommentWorkerPool != nil {
 		a.args.CommentWorkerPool.Await()
 	}
+	finalCommentsByPath := groupCommentsByPath(a.args.CommentCollector.Since(batchStart))
 	for _, checkpoint := range checkpoints {
 		fingerprint := a.scanItemFingerprint(checkpoint.item)
-		comments := a.args.CommentCollector.CommentsForPath(checkpoint.item.Path)
+		comments := finalCommentsByPath[checkpoint.item.Path]
 		if checkpoint.reused {
+			comments = checkpoint.originalComments
 			sourceSessionID := ""
 			if a.args.Resume != nil {
 				sourceSessionID = a.args.Resume.SessionID
@@ -595,8 +603,19 @@ func (a *Agent) recordBatchCheckpoints(checkpoints []batchCheckpoint) {
 				fingerprint, sourceSessionID, comments)
 			continue
 		}
+		if dedupCheckpoints != nil {
+			comments = dedupCheckpoints[checkpoint.item.Path]
+		}
 		a.session.RecordReviewItemDone(checkpoint.item.Path, checkpoint.item.Path, checkpoint.item.Path, fingerprint, comments)
 	}
+}
+
+func groupCommentsByPath(comments []model.LlmComment) map[string][]model.LlmComment {
+	byPath := make(map[string][]model.LlmComment)
+	for _, comment := range comments {
+		byPath[comment.Path] = append(byPath[comment.Path], comment)
+	}
+	return byPath
 }
 
 // resolveBatchStrategy reads the strategy from the scan template, defaulting
@@ -640,7 +659,11 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 				a.args.CommentCollector.Add(cm)
 			}
 			checkpointsMu.Lock()
-			checkpoints = append(checkpoints, batchCheckpoint{item: it, reused: true})
+			checkpoints = append(checkpoints, batchCheckpoint{
+				item:             it,
+				reused:           true,
+				originalComments: item.Comments,
+			})
 			checkpointsMu.Unlock()
 			continue
 		}
@@ -904,10 +927,12 @@ func buildSummaryCommentsList(comments []model.LlmComment) string {
 // at least DedupMinComments comments, invokes the DEDUP_TASK LLM to merge
 // near-duplicate findings. On any failure (LLM error / malformed JSON /
 // invalid grouping) the original batch comments are kept unchanged — dedup
-// is a best-effort optimization, never a correctness gate.
-func (a *Agent) maybeRunDedup(ctx context.Context, batchIdx, batchStart int) {
+// is a best-effort optimization, never a correctness gate. The returned map
+// contains safe per-file checkpoints: canonical comments for same-file groups
+// and original comments for cross-file groups.
+func (a *Agent) maybeRunDedup(ctx context.Context, batchIdx, batchStart int) map[string][]model.LlmComment {
 	if !a.dedupEnabled() {
-		return
+		return nil
 	}
 	dt := a.args.Template.DedupTask
 	minN := a.args.Template.DedupMinComments
@@ -917,7 +942,7 @@ func (a *Agent) maybeRunDedup(ctx context.Context, batchIdx, batchStart int) {
 
 	batchComments := a.args.CommentCollector.Since(batchStart)
 	if len(batchComments) < minN {
-		return
+		return nil
 	}
 
 	payload := buildDedupCommentsJSON(batchComments)
@@ -944,22 +969,23 @@ func (a *Agent) maybeRunDedup(ctx context.Context, batchIdx, batchStart int) {
 	if err != nil {
 		rec.SetError(err, time.Since(startTime))
 		fmt.Fprintf(stdout.Writer(), "[ocr] scan dedup failed for batch #%d: %v (keeping originals)\n", batchIdx, err)
-		return
+		return nil
 	}
 	rec.SetResponse(resp, time.Since(startTime))
 	a.runner.RecordUsage(resp.Usage)
 
-	deduped, ok := applyDedupGroups(resp.Content(), batchComments)
+	deduped, dedupCheckpoints, ok := applyDedupGroupsWithCheckpoints(resp.Content(), batchComments)
 	if !ok {
 		fmt.Fprintf(stdout.Writer(), "[ocr] scan dedup batch #%d: malformed groups, keeping originals\n", batchIdx)
-		return
+		return nil
 	}
 	if len(deduped) == len(batchComments) {
 		// No-op result — don't bother rewriting the collector.
-		return
+		return nil
 	}
 	a.args.CommentCollector.ReplaceSince(batchStart, deduped)
 	fmt.Fprintf(stdout.Writer(), "[ocr] scan dedup batch #%d: %d → %d comments\n", batchIdx, len(batchComments), len(deduped))
+	return dedupCheckpoints
 }
 
 // buildDedupCommentsJSON renders the batch comments as a JSON list with
@@ -991,10 +1017,18 @@ func buildDedupCommentsJSON(comments []model.LlmComment) string {
 // when the groups don't cover every input id exactly once (safety: we
 // refuse to silently drop comments we can't account for).
 func applyDedupGroups(rawJSON string, originals []model.LlmComment) ([]model.LlmComment, bool) {
+	comments, _, ok := applyDedupGroupsWithCheckpoints(rawJSON, originals)
+	return comments, ok
+}
+
+func applyDedupGroupsWithCheckpoints(
+	rawJSON string,
+	originals []model.LlmComment,
+) ([]model.LlmComment, map[string][]model.LlmComment, bool) {
 	stripped := llmloop.StripMarkdownFences(rawJSON)
 	stripped = strings.TrimSpace(stripped)
 	if stripped == "" {
-		return nil, false
+		return nil, nil, false
 	}
 	var parsed struct {
 		Groups []struct {
@@ -1003,7 +1037,7 @@ func applyDedupGroups(rawJSON string, originals []model.LlmComment) ([]model.Llm
 		} `json:"groups"`
 	}
 	if err := json.Unmarshal([]byte(stripped), &parsed); err != nil {
-		return nil, false
+		return nil, nil, false
 	}
 
 	idToIdx := make(map[string]int, len(originals))
@@ -1013,34 +1047,48 @@ func applyDedupGroups(rawJSON string, originals []model.LlmComment) ([]model.Llm
 
 	seen := make(map[string]bool, len(originals))
 	var out []model.LlmComment
+	checkpoints := make(map[string][]model.LlmComment)
 	for _, g := range parsed.Groups {
 		if len(g.Members) == 0 {
-			return nil, false
+			return nil, nil, false
 		}
 		canonicalIdx, ok := idToIdx[g.Members[0]]
 		if !ok {
-			return nil, false
+			return nil, nil, false
 		}
+		memberPaths := make(map[string]bool)
+		memberIndices := make([]int, 0, len(g.Members))
 		for _, id := range g.Members {
-			if _, exists := idToIdx[id]; !exists {
-				return nil, false // unknown id
+			idx, exists := idToIdx[id]
+			if !exists {
+				return nil, nil, false // unknown id
 			}
 			if seen[id] {
-				return nil, false // duplicate assignment
+				return nil, nil, false // duplicate assignment
 			}
 			seen[id] = true
+			memberPaths[originals[idx].Path] = true
+			memberIndices = append(memberIndices, idx)
 		}
 		canonical := originals[canonicalIdx]
 		if len(g.Members) > 1 && g.MergedContent != "" {
 			canonical.Content = g.MergedContent
 		}
 		out = append(out, canonical)
+		if len(memberPaths) == 1 {
+			checkpoints[canonical.Path] = append(checkpoints[canonical.Path], canonical)
+			continue
+		}
+		for _, idx := range memberIndices {
+			original := originals[idx]
+			checkpoints[original.Path] = append(checkpoints[original.Path], original)
+		}
 	}
 
 	if len(seen) != len(originals) {
-		return nil, false // some id missing
+		return nil, nil, false // some id missing
 	}
-	return out, true
+	return out, checkpoints, true
 }
 
 // formatPlanGuidance parses the PLAN_TASK JSON output into a markdown

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -533,11 +533,12 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 		// batch and feed them into the per-batch dedup hook.
 		batchStart := a.args.CommentCollector.Snapshot()
 
-		n, budgetHit, err, checkpoints := a.dispatchBatch(ctx, bi, batch)
+		n, budgetHit, checkpoints, err := a.dispatchBatch(ctx, bi, batch)
 		dispatched += n
 		if err != nil {
 			// ctx cancelled mid-batch: stop scheduling further batches but
 			// still return whatever we've collected so far.
+			// Persist completed items so the next resume does not scan them again.
 			a.recordBatchCheckpoints(checkpoints, batchStart, nil)
 			return a.args.CommentCollector.Comments(), err
 		}
@@ -626,8 +627,9 @@ func (a *Agent) resolveBatchStrategy() BatchStrategy {
 
 // dispatchBatch fans out the files of a single batch concurrently and
 // blocks until they all finish (or ctx is cancelled). Returns the number
-// of files dispatched, whether the token budget was hit mid-batch, ctx.Err()
-// if cancelled, and the completed/reused files whose checkpoints need recording.
+// of files dispatched, whether the token budget was hit mid-batch, the
+// completed/reused files whose checkpoints need recording, and ctx.Err()
+// if cancelled.
 //
 // The budget gate is checked per file, right after acquiring the
 // concurrency slot and before launching the subtask: if the tokens already
@@ -635,7 +637,7 @@ func (a *Agent) resolveBatchStrategy() BatchStrategy {
 // budget, the file (and all remaining files in the batch) are skipped.
 // This keeps overrun bounded by roughly one in-flight file per worker,
 // instead of a whole batch as the coarse batch-level gate did.
-func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.ScanItem) (int64, bool, error, []batchCheckpoint) {
+func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.ScanItem) (int64, bool, []batchCheckpoint, error) {
 	concurrency := a.args.MaxConcurrency
 	if concurrency <= 0 {
 		concurrency = 8
@@ -690,7 +692,7 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
-			return dispatched, budgetHit, ctx.Err(), checkpoints
+			return dispatched, budgetHit, checkpoints, ctx.Err()
 		}
 
 		dispatched++
@@ -734,7 +736,7 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 	}
 
 	wg.Wait()
-	return dispatched, budgetHit, nil, checkpoints
+	return dispatched, budgetHit, checkpoints, nil
 }
 
 // executeSubtask runs the scan pipeline for one file:

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -533,16 +533,17 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 		// batch and feed them into the per-batch dedup hook.
 		batchStart := a.args.CommentCollector.Snapshot()
 
-		n, budgetHit, err := a.dispatchBatch(ctx, bi, batch)
+		n, budgetHit, err, checkpoints := a.dispatchBatch(ctx, bi, batch)
 		dispatched += n
 		if err != nil {
 			// ctx cancelled mid-batch: stop scheduling further batches but
 			// still return whatever we've collected so far.
+			a.recordBatchCheckpoints(checkpoints)
 			return a.args.CommentCollector.Comments(), err
 		}
 
 		// Drain async comment workers BEFORE dedup so all of this batch's
-		// comments are visible. recordCompleted has its own Await for
+		// comments are visible. recordBatchCheckpoints has its own Await for
 		// checkpoint correctness; this one keeps the dedup input complete.
 		// CommentWorkerPool.Await is cumulative across batches - that is fine
 		// since batches are sequential here.
@@ -551,6 +552,7 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 		}
 
 		a.maybeRunDedup(ctx, bi, batchStart)
+		a.recordBatchCheckpoints(checkpoints)
 
 		// The per-file budget gate inside dispatchBatch tripped — stop
 		// scheduling any remaining batches.
@@ -566,6 +568,37 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 	return a.args.CommentCollector.Comments(), nil
 }
 
+type batchCheckpoint struct {
+	item   model.ScanItem
+	reused bool
+}
+
+// recordBatchCheckpoints persists the final comments for a batch. It runs
+// after batch dedup so resume replays the same canonical result that the scan
+// returned to the caller.
+func (a *Agent) recordBatchCheckpoints(checkpoints []batchCheckpoint) {
+	if len(checkpoints) == 0 {
+		return
+	}
+	if a.args.CommentWorkerPool != nil {
+		a.args.CommentWorkerPool.Await()
+	}
+	for _, checkpoint := range checkpoints {
+		fingerprint := a.scanItemFingerprint(checkpoint.item)
+		comments := a.args.CommentCollector.CommentsForPath(checkpoint.item.Path)
+		if checkpoint.reused {
+			sourceSessionID := ""
+			if a.args.Resume != nil {
+				sourceSessionID = a.args.Resume.SessionID
+			}
+			a.session.RecordReviewItemReused(checkpoint.item.Path, checkpoint.item.Path, checkpoint.item.Path,
+				fingerprint, sourceSessionID, comments)
+			continue
+		}
+		a.session.RecordReviewItemDone(checkpoint.item.Path, checkpoint.item.Path, checkpoint.item.Path, fingerprint, comments)
+	}
+}
+
 // resolveBatchStrategy reads the strategy from the scan template, defaulting
 // to BatchNone for unrecognized / empty values.
 func (a *Agent) resolveBatchStrategy() BatchStrategy {
@@ -574,8 +607,8 @@ func (a *Agent) resolveBatchStrategy() BatchStrategy {
 
 // dispatchBatch fans out the files of a single batch concurrently and
 // blocks until they all finish (or ctx is cancelled). Returns the number
-// of files dispatched, whether the token budget was hit mid-batch, and
-// ctx.Err() if cancelled.
+// of files dispatched, whether the token budget was hit mid-batch, ctx.Err()
+// if cancelled, and the completed/reused files whose checkpoints need recording.
 //
 // The budget gate is checked per file, right after acquiring the
 // concurrency slot and before launching the subtask: if the tokens already
@@ -583,7 +616,7 @@ func (a *Agent) resolveBatchStrategy() BatchStrategy {
 // budget, the file (and all remaining files in the batch) are skipped.
 // This keeps overrun bounded by roughly one in-flight file per worker,
 // instead of a whole batch as the coarse batch-level gate did.
-func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.ScanItem) (int64, bool, error) {
+func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.ScanItem) (int64, bool, error, []batchCheckpoint) {
 	concurrency := a.args.MaxConcurrency
 	if concurrency <= 0 {
 		concurrency = 8
@@ -592,27 +625,12 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 	timeout := time.Duration(a.args.ConcurrentTaskTimeout) * time.Minute
 
 	var (
-		wg          sync.WaitGroup
-		dispatched  int64
-		budgetHit   bool
-		completedMu sync.Mutex
-		completed   []model.ScanItem
+		wg            sync.WaitGroup
+		dispatched    int64
+		budgetHit     bool
+		checkpointsMu sync.Mutex
+		checkpoints   []batchCheckpoint
 	)
-
-	recordCompleted := func() {
-		// Drain async comment writes before checkpointing completed files.
-		if a.args.CommentWorkerPool != nil {
-			a.args.CommentWorkerPool.Await()
-		}
-		completedMu.Lock()
-		items := append([]model.ScanItem(nil), completed...)
-		completedMu.Unlock()
-		for _, it := range items {
-			fingerprint := a.scanItemFingerprint(it)
-			comments := a.args.CommentCollector.CommentsForPath(it.Path)
-			a.session.RecordReviewItemDone(it.Path, it.Path, it.Path, fingerprint, comments)
-		}
-	}
 
 	for i := range batch {
 		it := batch[i]
@@ -621,7 +639,9 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 			for _, cm := range item.Comments {
 				a.args.CommentCollector.Add(cm)
 			}
-			a.session.RecordReviewItemReused(it.Path, it.Path, it.Path, fingerprint, a.args.Resume.SessionID, item.Comments)
+			checkpointsMu.Lock()
+			checkpoints = append(checkpoints, batchCheckpoint{item: it, reused: true})
+			checkpointsMu.Unlock()
 			continue
 		}
 
@@ -647,8 +667,7 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
-			recordCompleted()
-			return dispatched, budgetHit, ctx.Err()
+			return dispatched, budgetHit, ctx.Err(), checkpoints
 		}
 
 		dispatched++
@@ -685,15 +704,14 @@ func (a *Agent) dispatchBatch(ctx context.Context, batchIdx int, batch []model.S
 				}
 				return
 			}
-			completedMu.Lock()
-			completed = append(completed, it)
-			completedMu.Unlock()
+			checkpointsMu.Lock()
+			checkpoints = append(checkpoints, batchCheckpoint{item: it})
+			checkpointsMu.Unlock()
 		}(it, fingerprint)
 	}
 
 	wg.Wait()
-	recordCompleted()
-	return dispatched, budgetHit, nil
+	return dispatched, budgetHit, nil, checkpoints
 }
 
 // executeSubtask runs the scan pipeline for one file:

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -23,9 +23,11 @@ import (
 type fakeScanClient struct {
 	responses []*llm.ChatResponse
 	idx       int
+	calls     int
 }
 
 func (f *fakeScanClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	f.calls++
 	if f.idx >= len(f.responses) {
 		empty := ""
 		return &llm.ChatResponse{
@@ -860,8 +862,12 @@ func scanTaskDoneResponse() *llm.ChatResponse {
 	}
 }
 
-func scanCodeCommentResponse(content string) *llm.ChatResponse {
-	arguments := fmt.Sprintf(`{"comments":[{"content":%q}]}`, content)
+func scanCodeCommentResponse(contents ...string) *llm.ChatResponse {
+	comments := make([]string, 0, len(contents))
+	for _, content := range contents {
+		comments = append(comments, fmt.Sprintf(`{"content":%q}`, content))
+	}
+	arguments := `{"comments":[` + strings.Join(comments, ",") + `]}`
 	return &llm.ChatResponse{
 		Choices: []llm.Choice{{
 			Message: llm.ResponseMessage{
@@ -884,17 +890,14 @@ func TestDispatchSubtasks_PersistsDedupedCommentsForResume(t *testing.T) {
 	t.Setenv("HOME", testHome)
 	t.Setenv("USERPROFILE", testHome)
 	repoDir := t.TempDir()
-	items := []model.ScanItem{
-		{Path: "a.go", Content: "package a\nfunc f() {}\n", LineCount: 2},
-		{Path: "b.go", Content: "package b\nfunc f() {}\n", LineCount: 2},
-	}
+	items := []model.ScanItem{{Path: "a.go", Content: "package a\nfunc f() {}\n", LineCount: 2}}
 
 	tpl := makeTemplateWithFullScan()
 	tpl.DedupTask = &template.LlmConversation{
 		Messages: []template.ChatMessage{{Role: "user", Content: "dedup {{batch_comments}}"}},
 	}
 	tpl.BatchStrategy = string(BatchByLanguage)
-	tpl.BatchSize = 2
+	tpl.BatchSize = 1
 	tpl.DedupMinComments = 2
 
 	collector := tool.NewCommentCollector()
@@ -903,9 +906,7 @@ func TestDispatchSubtasks_PersistsDedupedCommentsForResume(t *testing.T) {
 	registry.Freeze()
 	dedupContent := `{"groups":[{"members":["c-0","c-1"],"merged_content":"combined finding"}]}`
 	client := &fakeScanClient{responses: []*llm.ChatResponse{
-		scanCodeCommentResponse("duplicate finding 1"),
-		scanTaskDoneResponse(),
-		scanCodeCommentResponse("duplicate finding 2"),
+		scanCodeCommentResponse("duplicate finding 1", "duplicate finding 2"),
 		scanTaskDoneResponse(),
 		{
 			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &dedupContent}}},
@@ -949,11 +950,6 @@ func TestDispatchSubtasks_PersistsDedupedCommentsForResume(t *testing.T) {
 	if !ok || len(firstItem.Comments) != 1 || firstItem.Comments[0].Content != "combined finding" {
 		t.Fatalf("checkpoint for a.go = %+v, want deduped comment", firstItem)
 	}
-	secondItem, ok := state.Item(scanItemFingerprint(items[1]))
-	if !ok || len(secondItem.Comments) != 0 {
-		t.Fatalf("checkpoint for b.go = %+v, want no comments after merge", secondItem)
-	}
-
 	resumedCollector := tool.NewCommentCollector()
 	resumedRegistry := tool.NewRegistry()
 	resumedRegistry.Register(&tool.CodeCommentProvider{Collector: resumedCollector})
@@ -986,11 +982,175 @@ func TestDispatchSubtasks_PersistsDedupedCommentsForResume(t *testing.T) {
 	if len(comments) != 1 || comments[0].Content != "combined finding" {
 		t.Fatalf("resumed comments = %+v, want one deduped comment", comments)
 	}
-	if resumedClient.idx != 0 {
-		t.Fatalf("resumed LLM calls = %d, want 0 after canonical checkpoint", resumedClient.idx)
+	if resumedClient.calls != 0 {
+		t.Fatalf("resumed LLM calls = %d, want 0 after canonical checkpoint", resumedClient.calls)
 	}
 	if err := resumed.Session().Finalize(); err != nil {
 		t.Fatalf("finalize resumed session: %v", err)
+	}
+
+	chainedState, err := session.LoadResumeState(repoDir, resumed.SessionID())
+	if err != nil {
+		t.Fatalf("LoadResumeState chained: %v", err)
+	}
+	chainedItem, ok := chainedState.Item(scanItemFingerprint(items[0]))
+	if !ok || len(chainedItem.Comments) != 1 || chainedItem.Comments[0].Content != "combined finding" {
+		t.Fatalf("chained checkpoint for a.go = %+v, want deduped comment", chainedItem)
+	}
+}
+
+func TestDispatchSubtasks_PreservesReusedCheckpointAfterDedup(t *testing.T) {
+	testHome := t.TempDir()
+	t.Setenv("HOME", testHome)
+	t.Setenv("USERPROFILE", testHome)
+	repoDir := t.TempDir()
+	item := model.ScanItem{Path: "a.go", Content: "package a\n", LineCount: 1}
+	originalComments := []model.LlmComment{
+		{Path: item.Path, Content: "original finding 1"},
+		{Path: item.Path, Content: "original finding 2"},
+	}
+	resume := &session.ResumeState{
+		SessionID:  "previous-session",
+		Model:      "test-model",
+		ReviewMode: session.ReviewModeFullScan,
+		Items: map[string]session.ResumeItem{
+			scanItemFingerprint(item): {
+				FilePath:    item.Path,
+				OldPath:     item.Path,
+				NewPath:     item.Path,
+				Fingerprint: scanItemFingerprint(item),
+				Comments:    originalComments,
+			},
+		},
+	}
+
+	tpl := makeTemplateWithFullScan()
+	tpl.DedupTask = &template.LlmConversation{
+		Messages: []template.ChatMessage{{Role: "user", Content: "dedup {{batch_comments}}"}},
+	}
+	tpl.DedupMinComments = 2
+	dedupContent := `{"groups":[{"members":["c-0","c-1"],"merged_content":"changed by repeated dedup"}]}`
+	client := &fakeScanClient{responses: []*llm.ChatResponse{{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &dedupContent}}},
+		Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+	}}}
+	collector := tool.NewCommentCollector()
+	a := NewAgent(Args{
+		Template:         tpl,
+		LLMClient:        client,
+		Model:            "test-model",
+		CommentCollector: collector,
+		Tools:            tool.NewRegistry(),
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipSummary:      true,
+		RepoDir:          repoDir,
+		Resume:           resume,
+		Session: session.New(repoDir, "main", "test-model", session.SessionOptions{
+			ReviewMode:  session.ReviewModeFullScan,
+			ResumedFrom: resume.SessionID,
+		}),
+	})
+	a.items = []model.ScanItem{item}
+	a.currentDate = "2026-08-21"
+
+	comments, err := a.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("dispatchSubtasks: %v", err)
+	}
+	if len(comments) != 1 || comments[0].Content != "changed by repeated dedup" {
+		t.Fatalf("comments = %+v, want current run's deduped result", comments)
+	}
+	if err := a.Session().Finalize(); err != nil {
+		t.Fatalf("finalize session: %v", err)
+	}
+
+	state, err := session.LoadResumeState(repoDir, a.SessionID())
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	checkpoint, ok := state.Item(scanItemFingerprint(item))
+	if !ok || len(checkpoint.Comments) != 2 ||
+		checkpoint.Comments[0].Content != originalComments[0].Content ||
+		checkpoint.Comments[1].Content != originalComments[1].Content {
+		t.Fatalf("reused checkpoint = %+v, want original comments", checkpoint)
+	}
+}
+
+func TestDispatchSubtasks_PreservesMixedDedupCheckpointProvenance(t *testing.T) {
+	testHome := t.TempDir()
+	t.Setenv("HOME", testHome)
+	t.Setenv("USERPROFILE", testHome)
+	repoDir := t.TempDir()
+	items := []model.ScanItem{
+		{Path: "a.go", Content: "package a\n", LineCount: 1},
+		{Path: "b.go", Content: "package b\n", LineCount: 1},
+	}
+
+	tpl := makeTemplateWithFullScan()
+	tpl.DedupTask = &template.LlmConversation{
+		Messages: []template.ChatMessage{{Role: "user", Content: "dedup {{batch_comments}}"}},
+	}
+	tpl.BatchStrategy = string(BatchByLanguage)
+	tpl.BatchSize = 2
+	tpl.DedupMinComments = 2
+	dedupContent := `{"groups":[{"members":["c-0","c-1"],"merged_content":"same-file finding"},{"members":["c-2","c-3"],"merged_content":"cross-file finding"}]}`
+	client := &fakeScanClient{responses: []*llm.ChatResponse{
+		scanCodeCommentResponse("same-file duplicate 1", "same-file duplicate 2", "cross-file finding from a.go"),
+		scanTaskDoneResponse(),
+		scanCodeCommentResponse("cross-file finding from b.go"),
+		scanTaskDoneResponse(),
+		{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &dedupContent}}},
+			Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+		},
+	}}
+	collector := tool.NewCommentCollector()
+	registry := tool.NewRegistry()
+	registry.Register(&tool.CodeCommentProvider{Collector: collector})
+	registry.Freeze()
+	a := NewAgent(Args{
+		Template:         tpl,
+		LLMClient:        client,
+		Model:            "test-model",
+		Tools:            registry,
+		MainToolDefs:     []llm.ToolDef{{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}}},
+		CommentCollector: collector,
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipSummary:      true,
+		RepoDir:          repoDir,
+		Session: session.New(repoDir, "main", "test-model", session.SessionOptions{
+			ReviewMode: session.ReviewModeFullScan,
+		}),
+	})
+	a.items = items
+	a.currentDate = "2026-08-21"
+
+	comments, err := a.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("dispatchSubtasks: %v", err)
+	}
+	if len(comments) != 2 || comments[0].Content != "same-file finding" || comments[1].Content != "cross-file finding" {
+		t.Fatalf("comments = %+v, want same-file and cross-file canonical results", comments)
+	}
+	if err := a.Session().Finalize(); err != nil {
+		t.Fatalf("finalize session: %v", err)
+	}
+
+	state, err := session.LoadResumeState(repoDir, a.SessionID())
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	aCheckpoint, ok := state.Item(scanItemFingerprint(items[0]))
+	if !ok || len(aCheckpoint.Comments) != 2 ||
+		aCheckpoint.Comments[0].Content != "same-file finding" ||
+		aCheckpoint.Comments[1].Content != "cross-file finding from a.go" {
+		t.Fatalf("checkpoint for a.go = %+v, want canonical same-file and raw cross-file comments", aCheckpoint)
+	}
+	bCheckpoint, ok := state.Item(scanItemFingerprint(items[1]))
+	if !ok || len(bCheckpoint.Comments) != 1 || bCheckpoint.Comments[0].Content != "cross-file finding from b.go" {
+		t.Fatalf("checkpoint for b.go = %+v, want raw cross-file comment", bCheckpoint)
 	}
 }
 

--- a/internal/scan/coverage_test.go
+++ b/internal/scan/coverage_test.go
@@ -5,6 +5,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -856,6 +857,140 @@ func scanTaskDoneResponse() *llm.ChatResponse {
 			},
 		}},
 		Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+	}
+}
+
+func scanCodeCommentResponse(content string) *llm.ChatResponse {
+	arguments := fmt.Sprintf(`{"comments":[{"content":%q}]}`, content)
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{
+			Message: llm.ResponseMessage{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "comment",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "code_comment",
+						Arguments: arguments,
+					},
+				}},
+			},
+		}},
+		Usage: &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+	}
+}
+
+func TestDispatchSubtasks_PersistsDedupedCommentsForResume(t *testing.T) {
+	testHome := t.TempDir()
+	t.Setenv("HOME", testHome)
+	t.Setenv("USERPROFILE", testHome)
+	repoDir := t.TempDir()
+	items := []model.ScanItem{
+		{Path: "a.go", Content: "package a\nfunc f() {}\n", LineCount: 2},
+		{Path: "b.go", Content: "package b\nfunc f() {}\n", LineCount: 2},
+	}
+
+	tpl := makeTemplateWithFullScan()
+	tpl.DedupTask = &template.LlmConversation{
+		Messages: []template.ChatMessage{{Role: "user", Content: "dedup {{batch_comments}}"}},
+	}
+	tpl.BatchStrategy = string(BatchByLanguage)
+	tpl.BatchSize = 2
+	tpl.DedupMinComments = 2
+
+	collector := tool.NewCommentCollector()
+	registry := tool.NewRegistry()
+	registry.Register(&tool.CodeCommentProvider{Collector: collector})
+	registry.Freeze()
+	dedupContent := `{"groups":[{"members":["c-0","c-1"],"merged_content":"combined finding"}]}`
+	client := &fakeScanClient{responses: []*llm.ChatResponse{
+		scanCodeCommentResponse("duplicate finding 1"),
+		scanTaskDoneResponse(),
+		scanCodeCommentResponse("duplicate finding 2"),
+		scanTaskDoneResponse(),
+		{
+			Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &dedupContent}}},
+			Usage:   &llm.UsageInfo{PromptTokens: 10, CompletionTokens: 5},
+		},
+	}}
+	first := NewAgent(Args{
+		Template:         tpl,
+		LLMClient:        client,
+		Model:            "test-model",
+		Tools:            registry,
+		MainToolDefs:     []llm.ToolDef{{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}}},
+		CommentCollector: collector,
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipSummary:      true,
+		RepoDir:          repoDir,
+		Session: session.New(repoDir, "main", "test-model", session.SessionOptions{
+			ReviewMode: session.ReviewModeFullScan,
+		}),
+	})
+	first.items = items
+	first.currentDate = "2026-08-21"
+
+	comments, err := first.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("first dispatchSubtasks: %v", err)
+	}
+	if len(comments) != 1 || comments[0].Content != "combined finding" {
+		t.Fatalf("first comments = %+v, want one deduped comment", comments)
+	}
+	if err := first.Session().Finalize(); err != nil {
+		t.Fatalf("finalize first session: %v", err)
+	}
+
+	state, err := session.LoadResumeState(repoDir, first.SessionID())
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	firstItem, ok := state.Item(scanItemFingerprint(items[0]))
+	if !ok || len(firstItem.Comments) != 1 || firstItem.Comments[0].Content != "combined finding" {
+		t.Fatalf("checkpoint for a.go = %+v, want deduped comment", firstItem)
+	}
+	secondItem, ok := state.Item(scanItemFingerprint(items[1]))
+	if !ok || len(secondItem.Comments) != 0 {
+		t.Fatalf("checkpoint for b.go = %+v, want no comments after merge", secondItem)
+	}
+
+	resumedCollector := tool.NewCommentCollector()
+	resumedRegistry := tool.NewRegistry()
+	resumedRegistry.Register(&tool.CodeCommentProvider{Collector: resumedCollector})
+	resumedRegistry.Freeze()
+	resumedClient := &fakeScanClient{}
+	resumed := NewAgent(Args{
+		Template:         tpl,
+		LLMClient:        resumedClient,
+		Model:            "test-model",
+		Tools:            resumedRegistry,
+		MainToolDefs:     []llm.ToolDef{{Type: "function", Function: llm.FunctionDef{Name: "code_comment"}}},
+		CommentCollector: resumedCollector,
+		MaxConcurrency:   1,
+		SkipPlan:         true,
+		SkipSummary:      true,
+		RepoDir:          repoDir,
+		Resume:           state,
+		Session: session.New(repoDir, "main", "test-model", session.SessionOptions{
+			ReviewMode:  session.ReviewModeFullScan,
+			ResumedFrom: first.SessionID(),
+		}),
+	})
+	resumed.items = items
+	resumed.currentDate = "2026-08-21"
+
+	comments, err = resumed.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("resumed dispatchSubtasks: %v", err)
+	}
+	if len(comments) != 1 || comments[0].Content != "combined finding" {
+		t.Fatalf("resumed comments = %+v, want one deduped comment", comments)
+	}
+	if resumedClient.idx != 0 {
+		t.Fatalf("resumed LLM calls = %d, want 0 after canonical checkpoint", resumedClient.idx)
+	}
+	if err := resumed.Session().Finalize(); err != nil {
+		t.Fatalf("finalize resumed session: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes scan checkpoint timing around batch deduplication. Per-file checkpoints were written before `maybeRunDedup`, so `ocr scan --resume` restored pre-dedup comments and had to invoke the best-effort dedup LLM again.

The repeated call can change the resumed result when batch inputs, configuration, model output, or availability differ from the original run.

Fixes #1034.

## Corrected behavior

Restored comments are included in the resumed batch's dedup input. The earlier PR description incorrectly said resume did not deduplicate them again.

The real problem is that pre-dedup checkpoints make resume depend on an additional LLM call. If that call fails or is disabled, comments merged in the original run can reappear.

## Persistence contract

Dedup can merge findings within one file or across several files, but resume checkpoints are stored per file. A canonical cross-file comment cannot safely be assigned only to its first file: if that file changes later, invalidating its checkpoint could also erase another file's finding.

The safe behavior is:

- newly scanned same-file groups persist their canonical post-dedup comments;
- cross-file groups persist their original comments under each source file;
- reused items preserve the comments from their source session;
- failed or malformed dedup keeps the original comments;
- checkpoint comment lookup is limited to the current batch.

## Implementation

- Defer completed-item checkpoint persistence until the batch settles and dedup finishes.
- Carry completed and reused items out of `dispatchBatch` for checkpointing.
- Preserve source comments for reused items.
- Derive safe per-file checkpoint comments at dedup-group granularity.
- Keep canonical output for same-file groups and raw provenance for cross-file groups.
- Drain asynchronous comment workers before dedup and checkpoint persistence.
- Keep the existing collector output and dedup parsing behavior unchanged.

## Regression tests

The tests cover:

- two same-file comments merged into one persisted checkpoint comment;
- resume reusing that canonical checkpoint without another LLM call;
- chained resume retaining the canonical same-file checkpoint;
- reused items retaining their original source comments;
- mixed same-file and cross-file groups preserving canonicalization and provenance;
- the fake LLM client counting every request, including requests without a preset response.

The minimal reproduction sets `DEDUP_MIN_COMMENTS=2`; the default scan template uses `4`.

## Scope

- Affects full-scan checkpoint and resume behavior only.
- Does not change the dedup prompt or grouping algorithm.
- Does not change non-deduplicated scans or diff-based review modes.
- Does not add a new session record type or change the checkpoint schema.

## Verification

- `make check`
- `make test`
- `make coverage` (91.0% total coverage)
- `make build`
- Targeted scan resume and checkpoint provenance tests

Automated review identified the reused-item provenance problem in the initial patch; the persistence contract above incorporates that feedback.
