### PR TITLE
fix(llm): allow opting out of Anthropic prompt-cache breakpoints

### DIFF
--- a/cmd/opencodereview/config_cmd.go
+++ b/cmd/opencodereview/config_cmd.go
@@ -303,6 +303,10 @@ type ProviderEntry struct {
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 	RetryCodes   []int             `json:"retry_codes,omitempty"`
+	// PromptCache is nil when unset, which means enabled. Set it to false for
+	// an Anthropic-compatible gateway that rejects `cache_control` as an
+	// unrecognized field instead of ignoring it.
+	PromptCache *bool `json:"prompt_cache,omitempty"`
 
 	// AWSProfile and AWSRegion pin the credentials and region for providers that
 	// authenticate from the AWS chain (bedrock). Both are optional — without
@@ -353,6 +357,7 @@ type LlmConfig struct {
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 	RetryCodes   []int             `json:"retry_codes,omitempty"`
+	PromptCache  *bool             `json:"prompt_cache,omitempty"` // nil = default true; false = omit cache_control
 }
 
 // TelemetryConfig holds telemetry-specific settings.
@@ -414,6 +419,7 @@ var supportedConfigKeys = []string{
 	"llm.extra_body",
 	"llm.extra_headers",
 	"llm.retry_codes",
+	"llm.prompt_cache",
 	"language",
 	"telemetry.enabled",
 	"telemetry.exporter",
@@ -574,8 +580,14 @@ func setConfigValue(cfg *Config, key, value string) error {
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %s\n", w)
 		}
 		cfg.Llm.RetryCodes = codes
+	case "llm.prompt_cache", "llm.PromptCache":
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid boolean for llm.prompt_cache: %w", err)
+		}
+		cfg.Llm.PromptCache = &b
 	default:
-		return fmt.Errorf("unknown config key: %s\nSupported keys: %s\nProvider fields: api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, aws_region, aws_profile\nProtocol values: anthropic, anthropic-bedrock, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key, strings.Join(supportedConfigKeys, ", "))
+		return fmt.Errorf("unknown config key: %s\nSupported keys: %s\nProvider fields: api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, prompt_cache, aws_region, aws_profile\nProtocol values: anthropic, anthropic-bedrock, openai, openai-responses\nMCP server fields: type, command, args, env, url, headers, tools, setup", key, strings.Join(supportedConfigKeys, ", "))
 	}
 	return nil
 }
@@ -644,6 +656,12 @@ func applyProviderField(providerName string, entry *ProviderEntry, field, key, v
 			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %s\n", w)
 		}
 		entry.RetryCodes = codes
+	case "prompt_cache":
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid boolean for %s: %w", key, err)
+		}
+		entry.PromptCache = &b
 	case "aws_region", "aws_profile":
 		normalized, err := normalizeAWSSetting(field, key, value)
 		if err != nil {
@@ -658,7 +676,7 @@ func applyProviderField(providerName string, entry *ProviderEntry, field, key, v
 			entry.AWSProfile = normalized
 		}
 	default:
-		return fmt.Errorf("unknown provider field %q: supported fields are api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, aws_region, aws_profile", field)
+		return fmt.Errorf("unknown provider field %q: supported fields are api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, prompt_cache, aws_region, aws_profile", field)
 	}
 	return nil
 }

--- a/cmd/opencodereview/config_cmd_test.go
+++ b/cmd/opencodereview/config_cmd_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -1068,8 +1069,8 @@ func TestSetConfigValueUnknownKeyMessage(t *testing.T) {
 		t.Fatal("expected error for unknown key")
 	}
 	want := "unknown config key: bogus.key\n" +
-		"Supported keys: provider, model, max_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_token_cmd, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, llm.retry_codes, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
-		"Provider fields: api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, aws_region, aws_profile\n" +
+		"Supported keys: provider, model, max_tokens, providers.<name>.<field>, custom_providers.<name>.<field>, mcp_servers.<name>.<field>, llm.url, llm.auth_token, llm.auth_token_cmd, llm.auth_header, llm.model, llm.protocol, llm.use_anthropic, llm.extra_body, llm.extra_headers, llm.retry_codes, llm.prompt_cache, language, telemetry.enabled, telemetry.exporter, telemetry.otlp_endpoint, telemetry.content_logging\n" +
+		"Provider fields: api_key, api_key_cmd, url, protocol, model, models, auth_header, extra_body, extra_headers, retry_codes, prompt_cache, aws_region, aws_profile\n" +
 		"Protocol values: anthropic, anthropic-bedrock, openai, openai-responses\n" +
 		"MCP server fields: type, command, args, env, url, headers, tools, setup"
 	if err.Error() != want {
@@ -1598,5 +1599,89 @@ func TestSetConfigValueLlmRetryCodesNoWarningForValidCodes(t *testing.T) {
 	}
 	if len(cfg.Llm.RetryCodes) != 2 {
 		t.Errorf("RetryCodes = %v, want [403 400]", cfg.Llm.RetryCodes)
+	}
+}
+
+func TestSetConfigValuePromptCache(t *testing.T) {
+	// The key is tri-state on disk, so each case checks the pointer as well as
+	// the value: writing `true` must be distinguishable from never setting it,
+	// otherwise `omitempty` would silently drop an explicit re-enable.
+	keys := []struct {
+		name string
+		key  string
+		read func(*Config) *bool
+	}{
+		{
+			name: "llm section",
+			key:  "llm.prompt_cache",
+			read: func(c *Config) *bool { return c.Llm.PromptCache },
+		},
+		{
+			name: "preset provider",
+			key:  "providers.anthropic.prompt_cache",
+			read: func(c *Config) *bool { return c.Providers["anthropic"].PromptCache },
+		},
+		{
+			name: "custom provider",
+			key:  "custom_providers.my-gateway.prompt_cache",
+			read: func(c *Config) *bool { return c.CustomProviders["my-gateway"].PromptCache },
+		},
+	}
+
+	for _, k := range keys {
+		t.Run(k.name, func(t *testing.T) {
+			for _, value := range []string{"false", "0"} {
+				cfg := &Config{}
+				if err := setConfigValue(cfg, k.key, value); err != nil {
+					t.Fatalf("setConfigValue(%s, %s): %v", k.key, value, err)
+				}
+				got := k.read(cfg)
+				if got == nil {
+					t.Fatalf("%s=%s left the field unset", k.key, value)
+				}
+				if *got {
+					t.Errorf("%s=%s stored true, want false", k.key, value)
+				}
+			}
+
+			cfg := &Config{}
+			if err := setConfigValue(cfg, k.key, "true"); err != nil {
+				t.Fatalf("setConfigValue(%s, true): %v", k.key, err)
+			}
+			if got := k.read(cfg); got == nil || !*got {
+				t.Errorf("%s=true stored %v, want an explicit true", k.key, got)
+			}
+
+			if err := setConfigValue(&Config{}, k.key, "sometimes"); err == nil {
+				t.Errorf("%s accepted a non-boolean value", k.key)
+			}
+		})
+	}
+}
+
+// TestSetConfigValuePromptCacheRoundTrip guards the on-disk representation:
+// `prompt_cache` is the field a user reaches for when their gateway rejects
+// cache_control, so it has to survive being written and read back.
+func TestSetConfigValuePromptCacheRoundTrip(t *testing.T) {
+	cfg := &Config{}
+	if err := setConfigValue(cfg, "custom_providers.my-gateway.prompt_cache", "false"); err != nil {
+		t.Fatalf("setConfigValue: %v", err)
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if !strings.Contains(string(data), `"prompt_cache":false`) {
+		t.Fatalf("prompt_cache=false was dropped on write: %s", data)
+	}
+
+	var readBack Config
+	if err := json.Unmarshal(data, &readBack); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	got := readBack.CustomProviders["my-gateway"].PromptCache
+	if got == nil || *got {
+		t.Errorf("prompt_cache read back as %v, want an explicit false", got)
 	}
 }

--- a/cmd/opencodereview/provider_tui.go
+++ b/cmd/opencodereview/provider_tui.go
@@ -1300,6 +1300,12 @@ func cloneProviderEntry(v ProviderEntry) ProviderEntry {
 		AWSProfile: v.AWSProfile,
 		AWSRegion:  v.AWSRegion,
 	}
+	if v.PromptCache != nil {
+		// Copy the value, not the pointer: a shared *bool would let a rollback
+		// path mutate the original entry it is supposed to be restoring.
+		promptCache := *v.PromptCache
+		out.PromptCache = &promptCache
+	}
 	if v.ExtraBody != nil {
 		out.ExtraBody = make(map[string]any, len(v.ExtraBody))
 		for k, val := range v.ExtraBody {

--- a/cmd/opencodereview/provider_tui_funcs_test.go
+++ b/cmd/opencodereview/provider_tui_funcs_test.go
@@ -280,6 +280,7 @@ func TestCloneProviderEntry_NilExtraBody(t *testing.T) {
 // omission. It catches a dropped field, not an aliased one -- DeepEqual
 // compares values, not identity; the sibling tests above cover aliasing.
 func TestCloneProviderEntry_CopiesEveryField(t *testing.T) {
+	promptCache := false
 	orig := ProviderEntry{
 		APIKey:       "key",
 		APIKeyCmd:    "op read op://dev/x/api-key",
@@ -292,6 +293,7 @@ func TestCloneProviderEntry_CopiesEveryField(t *testing.T) {
 		RetryCodes:   []int{403},
 		ExtraBody:    map[string]any{"temperature": 0.7},
 		ExtraHeaders: map[string]string{"X-Trace": "on"},
+		PromptCache:  &promptCache,
 		AWSRegion:    "us-west-2",
 		AWSProfile:   "example-profile",
 	}
@@ -306,6 +308,32 @@ func TestCloneProviderEntry_CopiesEveryField(t *testing.T) {
 
 	if clone := cloneProviderEntry(orig); !reflect.DeepEqual(clone, orig) {
 		t.Errorf("clone dropped a field:\n got %+v\nwant %+v", clone, orig)
+	}
+}
+
+// TestCloneProviderEntry_PromptCacheNotAliased covers the pointer field the
+// DeepEqual check above cannot see through: DeepEqual compares pointees, so a
+// clone that shared the original's *bool would still pass it, and a rollback
+// path would then edit the entry it is restoring.
+func TestCloneProviderEntry_PromptCacheNotAliased(t *testing.T) {
+	promptCache := false
+	orig := ProviderEntry{APIKey: "key", URL: "http://localhost", PromptCache: &promptCache}
+
+	clone := cloneProviderEntry(orig)
+	if clone.PromptCache == nil {
+		t.Fatal("clone dropped PromptCache")
+	}
+	if clone.PromptCache == orig.PromptCache {
+		t.Fatal("clone shares the original's PromptCache pointer")
+	}
+
+	*clone.PromptCache = true
+	if *orig.PromptCache {
+		t.Error("modifying clone should not affect original PromptCache")
+	}
+
+	if nilClone := cloneProviderEntry(ProviderEntry{}); nilClone.PromptCache != nil {
+		t.Error("an unset PromptCache should stay nil, not become an explicit value")
 	}
 }
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -218,6 +218,13 @@ type ClientConfig struct {
 	ExtraBody    map[string]any    // Vendor-specific fields merged into every request body
 	ExtraHeaders map[string]string // Extra HTTP headers sent with every request
 	RetryCodes   []int             // Additional HTTP status codes that trigger retry
+
+	// DisablePromptCache stops the Anthropic protocol from attaching
+	// `cache_control` breakpoints to the request. It exists for
+	// Anthropic-compatible gateways that reject the field as unrecognized
+	// instead of ignoring it; see ResolvedEndpoint.PromptCacheDisabled.
+	DisablePromptCache bool
+
 	// SessionKey is the fallback prompt-cache affinity key
 	// for requests whose context carries none (see ContextWithSessionKey).
 	//
@@ -285,14 +292,17 @@ func retryCodesMiddleware(codes []int) func(*http.Request, func(*http.Request) (
 // ResolvedEndpoint because it belongs to the run, not to the endpoint.
 func NewLLMClient(ep ResolvedEndpoint, collector *RetryCollector) LLMClient {
 	cfg := ClientConfig{
-		URL:            ep.URL,
-		APIKey:         ep.Token,
-		Model:          ep.Model,
-		AuthHeader:     ep.AuthHeader,
-		Timeout:        ep.Timeout,
-		ExtraBody:      ep.ExtraBody,
-		ExtraHeaders:   ep.ExtraHeaders,
-		RetryCodes:     ep.RetryCodes,
+		URL:          ep.URL,
+		APIKey:       ep.Token,
+		Model:        ep.Model,
+		AuthHeader:   ep.AuthHeader,
+		Timeout:      ep.Timeout,
+		ExtraBody:    ep.ExtraBody,
+		ExtraHeaders: ep.ExtraHeaders,
+		RetryCodes:   ep.RetryCodes,
+
+		DisablePromptCache: ep.PromptCacheDisabled,
+
 		retryCollector: collector,
 		AWSProfile:     ep.AWSProfile,
 		AWSRegion:      ep.AWSRegion,
@@ -1190,12 +1200,22 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 		Messages:  messages,
 	}
 
+	// Every `cache_control` marker below is optional to the request's meaning:
+	// dropping them costs the cache discount and nothing else. A gateway that
+	// rejects the field outright leaves no working request at all, so
+	// DisablePromptCache trades the discount for a review that runs.
+	cacheBreakpoints := !c.cfg.DisablePromptCache
+
 	if len(systemBlocks) > 0 {
-		systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
+		if cacheBreakpoints {
+			systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
+		}
 		params.System = systemBlocks
 	}
 	if len(tools) > 0 {
-		tools[len(tools)-1].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		if cacheBreakpoints {
+			tools[len(tools)-1].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		}
 		params.Tools = tools
 		if req.ToolChoice == "required" {
 			params.ToolChoice = anthropic.ToolChoiceUnionParam{
@@ -1205,7 +1225,7 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 	}
 	// Dynamic breakpoint on the latest message so multi-turn history is
 	// cached incrementally: read the full previous prefix, write only the delta.
-	if len(messages) > 0 {
+	if cacheBreakpoints && len(messages) > 0 {
 		last := &messages[len(messages)-1]
 		if len(last.Content) > 0 {
 			if cc := last.Content[len(last.Content)-1].GetCacheControl(); cc != nil {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -227,6 +227,88 @@ func TestBuildAnthropicParams_CacheControl_NoSystem(t *testing.T) {
 	}
 }
 
+// promptCacheRequest exercises all three breakpoints at once: the system
+// prompt, the tool list, and the trailing message.
+func promptCacheRequest() ChatRequest {
+	return ChatRequest{
+		Messages: []Message{
+			{Role: "system", Content: "You are a code reviewer."},
+			{Role: "user", Content: "Review this code."},
+			{Role: "assistant", Content: "", ToolCalls: []ToolCall{
+				{ID: "call_1", Type: "function", Function: FunctionCall{Name: "tool_a", Arguments: `{}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: "tool output"},
+		},
+		Tools: []ToolDef{
+			{Type: "function", Function: FunctionDef{Name: "tool_a", Description: "first tool", Parameters: map[string]any{"type": "object"}}},
+			{Type: "function", Function: FunctionDef{Name: "tool_b", Description: "second tool", Parameters: map[string]any{"type": "object"}}},
+		},
+	}
+}
+
+// TestBuildAnthropicParams_PromptCacheDisabled asserts on the marshalled body
+// rather than the individual params, because the failure this guards against is
+// a gateway rejecting the wire format: "unrecognized field cache_control" (#700).
+// A single leftover breakpoint anywhere in the request is enough to reproduce it.
+func TestBuildAnthropicParams_PromptCacheDisabled(t *testing.T) {
+	req := promptCacheRequest()
+
+	marshal := func(t *testing.T, disable bool) string {
+		t.Helper()
+		client := NewAnthropicClient(ClientConfig{
+			URL:                "https://api.anthropic.com",
+			DisablePromptCache: disable,
+		})
+		params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+		body, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		return string(body)
+	}
+
+	// Guards the negative assertion below from passing vacuously: if the SDK
+	// ever stopped serializing cache_control, the disabled case would look
+	// correct while the default one silently lost its caching.
+	t.Run("enabled by default", func(t *testing.T) {
+		if !strings.Contains(marshal(t, false), "cache_control") {
+			t.Error("default request has no cache_control; prompt caching is expected to stay on unless disabled")
+		}
+	})
+
+	t.Run("no cache_control anywhere when disabled", func(t *testing.T) {
+		if body := marshal(t, true); strings.Contains(body, "cache_control") {
+			t.Errorf("request still carries cache_control when disabled:\n%s", body)
+		}
+	})
+
+	t.Run("request is otherwise unchanged", func(t *testing.T) {
+		client := NewAnthropicClient(ClientConfig{
+			URL:                "https://api.anthropic.com",
+			DisablePromptCache: true,
+		})
+		params, err := client.buildAnthropicParams("claude-sonnet-4-20250514", req)
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+		// Disabling the cache must drop the breakpoints only. Dropping the
+		// system prompt or the tools along with them would turn a billing
+		// optimization into a review that cannot call any tool.
+		if len(params.System) != 1 {
+			t.Errorf("got %d system blocks, want 1", len(params.System))
+		}
+		if len(params.Tools) != 2 {
+			t.Errorf("got %d tools, want 2", len(params.Tools))
+		}
+		if len(params.Messages) == 0 {
+			t.Error("got no messages, want the conversation preserved")
+		}
+	})
+}
+
 func TestBuildAnthropicParams_DynamicCacheBreakpoint(t *testing.T) {
 	client := NewAnthropicClient(ClientConfig{URL: "https://api.anthropic.com"})
 

--- a/internal/llm/main_test.go
+++ b/internal/llm/main_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package llm
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain clears the three globals parseEnvOverrides validates before any test
+// runs.
+//
+// These are unlike the rest of the environment this package reads. The others
+// only contribute a value, so a stray export shifts one assertion at worst. An
+// unparseable one of these aborts ResolveEndpointWithOptions before any
+// resolution strategy runs, so a single bad export on a developer machine or a
+// self-hosted runner fails around a hundred tests that never meant to involve
+// it — with an error naming a variable the test does not mention.
+//
+// clearAllEnv resets them too, for the tests that call it. This is the backstop
+// for the ones that do not: bedrock_test.go and friends build a config file and
+// call ResolveEndpoint directly, and a test added tomorrow is under no
+// obligation to remember either helper.
+//
+// Tests that want one of these set do so with t.Setenv, which takes effect
+// after this and is restored per-test.
+func TestMain(m *testing.M) {
+	for _, k := range []string{envOCRLLMTimeout, envOCRLLMExtraHeaders, envOCRLLMPromptCache} {
+		os.Unsetenv(k)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -33,6 +33,15 @@ type ResolvedEndpoint struct {
 	Timeout    time.Duration
 	RetryCodes []int // additional HTTP status codes that trigger exponential-backoff retry
 
+	// PromptCacheDisabled suppresses the prompt-cache breakpoints OCR adds on
+	// its own initiative — today the Anthropic `cache_control` markers on the
+	// system prompt, the tool list and the latest message. Anthropic-compatible
+	// gateways that validate the request body strictly reject `cache_control`
+	// as an unrecognized field, which fails every review request rather than
+	// just losing the cache discount. Off by default: caching is what makes a
+	// multi-turn review affordable, so it is given up only on request.
+	PromptCacheDisabled bool
+
 	// AmbientAuth marks an endpoint that carries no token and needs no base
 	// URL, because the transport supplies both — AWS SigV4 signing derives the
 	// host from the region and the credentials from the environment's own
@@ -62,8 +71,14 @@ const (
 	// whichever strategy resolves, rather than inside tryOCREnv like other
 	// OCR_LLM_* vars. This lets it override timeout for all resolution paths
 	// (OCR env, config file, provider config, Claude Code env, shell RC).
-	envOCRLLMTimeout   = "OCR_LLM_TIMEOUT"
-	envOCRUseAnthropic = "OCR_USE_ANTHROPIC"
+	envOCRLLMTimeout = "OCR_LLM_TIMEOUT"
+	// envOCRLLMPromptCache is a global override applied the same way as
+	// OCR_LLM_TIMEOUT, so a gateway that rejects `cache_control` can be worked
+	// around without a config file — the deployment that hits this most often
+	// is CI, where the endpoint comes from environment variables alone.
+	// Set it to a false value (0, false) to stop OCR emitting the markers.
+	envOCRLLMPromptCache = "OCR_LLM_PROMPT_CACHE"
+	envOCRUseAnthropic   = "OCR_USE_ANTHROPIC"
 )
 
 // Environment variable names from Claude Code configuration.
@@ -153,15 +168,21 @@ func ResolveEndpointWithOptions(configPath string, opts ResolveOptions) (Resolve
 // strategy resolves the endpoint. Parsed once, up front — see the call site in
 // ResolveEndpointWithOptions for why the timing matters.
 type envOverrides struct {
-	timeout    time.Duration
-	hasTimeout bool
-	headers    map[string]string
+	timeout        time.Duration
+	hasTimeout     bool
+	headers        map[string]string
+	promptCache    bool
+	hasPromptCache bool
 }
 
 func parseEnvOverrides() (envOverrides, error) {
 	var env envOverrides
 	var err error
 	env.timeout, env.hasTimeout, err = parseTimeoutEnv()
+	if err != nil {
+		return envOverrides{}, err
+	}
+	env.promptCache, env.hasPromptCache, err = parsePromptCacheEnv()
 	if err != nil {
 		return envOverrides{}, err
 	}
@@ -183,6 +204,9 @@ func finalizeResolvedEndpoint(source string, ep ResolvedEndpoint, env envOverrid
 	ep.Model = stripModelSuffix(ep.Model)
 	if env.hasTimeout {
 		ep.Timeout = env.timeout
+	}
+	if env.hasPromptCache {
+		ep.PromptCacheDisabled = !env.promptCache
 	}
 	if env.headers != nil {
 		if ep.ExtraHeaders == nil {
@@ -214,6 +238,24 @@ func parseTimeoutEnv() (time.Duration, bool, error) {
 		return 0, false, fmt.Errorf("OCR_LLM_TIMEOUT: %w", err)
 	}
 	return d, true, nil
+}
+
+// parsePromptCacheEnv reads and validates OCR_LLM_PROMPT_CACHE. Returns the
+// parsed value and true if set, or false and false if unset/empty. An
+// unparseable value is an error rather than a silent default, on the same
+// reasoning as parseTimeoutEnv: someone who sets OCR_LLM_PROMPT_CACHE=no is
+// working around a failing endpoint, and quietly ignoring the typo would leave
+// them staring at the same rejection with no idea the knob never took effect.
+func parsePromptCacheEnv() (bool, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(envOCRLLMPromptCache))
+	if raw == "" {
+		return false, false, nil
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, false, fmt.Errorf("%s must be a boolean (true/false, 1/0), got %q", envOCRLLMPromptCache, raw)
+	}
+	return enabled, true, nil
 }
 
 // validateTimeoutSec converts a config-file timeout (in seconds) to time.Duration.
@@ -307,6 +349,7 @@ type llmFileConfig struct {
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 	RetryCodes   []int             `json:"retry_codes,omitempty"`
+	PromptCache  *bool             `json:"prompt_cache,omitempty"` // pointer to distinguish unset from false; nil = enabled
 }
 
 // providerEntryConfig represents a single provider entry in config.json.
@@ -322,6 +365,7 @@ type providerEntryConfig struct {
 	ExtraBody    map[string]any    `json:"extra_body,omitempty"`
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 	RetryCodes   []int             `json:"retry_codes,omitempty"`
+	PromptCache  *bool             `json:"prompt_cache,omitempty"` // pointer to distinguish unset from false; nil = enabled
 
 	// AWSProfile and AWSRegion apply to ambient-auth providers that sign with
 	// SigV4 (currently bedrock). Both are optional: without them the standard
@@ -586,10 +630,19 @@ func tryProviderConfig(cfg configFile, modelOverride string) (ResolvedEndpoint, 
 		ExtraHeaders: extraHeaders,
 		Timeout:      timeout,
 		RetryCodes:   retryCodes,
-		AmbientAuth:  ambientAuth,
-		AWSProfile:   entry.AWSProfile,
-		AWSRegion:    entry.AWSRegion,
+
+		PromptCacheDisabled: promptCacheDisabled(entry.PromptCache),
+		AmbientAuth:         ambientAuth,
+		AWSProfile:          entry.AWSProfile,
+		AWSRegion:           entry.AWSRegion,
 	}, true, nil
+}
+
+// promptCacheDisabled reads the tri-state `prompt_cache` config field. Unset
+// means enabled, matching the behavior of every release before the field
+// existed.
+func promptCacheDisabled(v *bool) bool {
+	return v != nil && !*v
 }
 
 // tryLegacyLlmConfig resolves an endpoint from the legacy llm config block.
@@ -691,6 +744,8 @@ func tryLegacyLlmConfig(cfg configFile, modelOverride string) (ResolvedEndpoint,
 		ExtraHeaders: cfg.Llm.ExtraHeaders,
 		Timeout:      timeout,
 		RetryCodes:   retryCodes,
+
+		PromptCacheDisabled: promptCacheDisabled(cfg.Llm.PromptCache),
 	}, true, nil
 }
 

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -268,6 +268,12 @@ func clearAllEnv(t *testing.T) {
 		"ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL",
 		"ANTHROPIC_API_KEY", "OPENAI_API_KEY",
 		"MINIMAX_GLOBAL_API_KEY", "MINIMAX_API_KEY",
+		// The three globals parseEnvOverrides validates. These matter more
+		// than the rest of the list: the others merely contribute a value, but
+		// an unparseable one of these aborts resolution before any strategy
+		// runs, so a stray export on a developer machine or a self-hosted
+		// runner fails ~100 tests that never meant to involve it.
+		envOCRLLMTimeout, envOCRLLMExtraHeaders, envOCRLLMPromptCache,
 	} {
 		t.Setenv(k, "")
 	}

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -1965,6 +1965,29 @@ func TestNewLLMClient_DefaultTimeout(t *testing.T) {
 	}
 }
 
+// TestNewLLMClient_PromptCacheDisabledForwarded covers the seam between the two
+// halves of this setting: the resolver decides it, the Anthropic client acts on
+// it, and nothing else would notice if NewLLMClient stopped carrying it across.
+func TestNewLLMClient_PromptCacheDisabledForwarded(t *testing.T) {
+	for _, disabled := range []bool{false, true} {
+		ep := ResolvedEndpoint{
+			URL:                 "https://api.example.com",
+			Token:               "test-token",
+			Model:               "test-model",
+			Protocol:            ProtocolAnthropic,
+			PromptCacheDisabled: disabled,
+		}
+
+		client, ok := NewLLMClient(ep, nil).(*AnthropicClient)
+		if !ok {
+			t.Fatalf("expected *AnthropicClient for protocol %q", ep.Protocol)
+		}
+		if client.cfg.DisablePromptCache != disabled {
+			t.Errorf("PromptCacheDisabled=%v produced cfg.DisablePromptCache=%v", disabled, client.cfg.DisablePromptCache)
+		}
+	}
+}
+
 func TestResolveEndpoint_ProviderConfigTimeoutSec(t *testing.T) {
 	clearAllEnv(t)
 
@@ -2620,5 +2643,135 @@ func TestResolveEndpoint_RedundantRetryCodesFiltered(t *testing.T) {
 	}
 	if len(ep.RetryCodes) != 1 || ep.RetryCodes[0] != 403 {
 		t.Errorf("RetryCodes = %v, want [403] (429 should be filtered)", ep.RetryCodes)
+	}
+}
+
+// writePromptCacheConfig writes a config whose Anthropic provider carries the
+// given tri-state prompt_cache value (nil for unset).
+func writePromptCacheConfig(t *testing.T, promptCache *bool) string {
+	t.Helper()
+	cfgFile := filepath.Join(t.TempDir(), "config.json")
+	cfg := configFile{
+		Provider: "gateway",
+		Model:    "m",
+		CustomProviders: map[string]providerEntryConfig{
+			"gateway": {
+				APIKey:      "k",
+				URL:         "http://localhost/v1",
+				Protocol:    "anthropic",
+				Model:       "m",
+				PromptCache: promptCache,
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(cfgFile, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgFile
+}
+
+func TestResolveEndpoint_ProviderPromptCache(t *testing.T) {
+	enabled, disabled := true, false
+
+	tests := []struct {
+		name        string
+		promptCache *bool
+		want        bool
+	}{
+		// Unset is the case that matters for compatibility: every config
+		// written before prompt_cache existed must keep its caching.
+		{name: "unset keeps caching", promptCache: nil, want: false},
+		{name: "true keeps caching", promptCache: &enabled, want: false},
+		{name: "false disables caching", promptCache: &disabled, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envOCRLLMPromptCache, "")
+			ep, err := ResolveEndpoint(writePromptCacheConfig(t, tt.promptCache))
+			if err != nil {
+				t.Fatalf("ResolveEndpoint: %v", err)
+			}
+			if ep.PromptCacheDisabled != tt.want {
+				t.Errorf("PromptCacheDisabled = %v, want %v", ep.PromptCacheDisabled, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEndpoint_LegacyLlmPromptCache(t *testing.T) {
+	t.Setenv(envOCRLLMPromptCache, "")
+
+	cfgFile := filepath.Join(t.TempDir(), "config.json")
+	disabled := false
+	cfg := configFile{
+		Llm: llmFileConfig{
+			URL:         "http://localhost/v1/messages",
+			AuthToken:   "t",
+			Model:       "m",
+			Protocol:    "anthropic",
+			PromptCache: &disabled,
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgFile, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ep, err := ResolveEndpoint(cfgFile)
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if !ep.PromptCacheDisabled {
+		t.Error("PromptCacheDisabled = false, want true from llm.prompt_cache")
+	}
+}
+
+// TestResolveEndpoint_PromptCacheEnvOverride pins the precedence: the env var
+// wins over the config file in both directions, so a CI job can turn caching
+// off for a strict gateway, and back on, without editing config.json.
+func TestResolveEndpoint_PromptCacheEnvOverride(t *testing.T) {
+	enabled, disabled := true, false
+
+	tests := []struct {
+		name        string
+		env         string
+		promptCache *bool
+		want        bool
+	}{
+		{name: "env false overrides config true", env: "false", promptCache: &enabled, want: true},
+		{name: "env true overrides config false", env: "true", promptCache: &disabled, want: false},
+		{name: "env 0 disables an unset config", env: "0", promptCache: nil, want: true},
+		{name: "empty env leaves config alone", env: "", promptCache: &disabled, want: true},
+		{name: "whitespace env leaves config alone", env: "  ", promptCache: &disabled, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envOCRLLMPromptCache, tt.env)
+			ep, err := ResolveEndpoint(writePromptCacheConfig(t, tt.promptCache))
+			if err != nil {
+				t.Fatalf("ResolveEndpoint: %v", err)
+			}
+			if ep.PromptCacheDisabled != tt.want {
+				t.Errorf("PromptCacheDisabled = %v, want %v", ep.PromptCacheDisabled, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEndpoint_InvalidPromptCacheEnv(t *testing.T) {
+	t.Setenv(envOCRLLMPromptCache, "yes-please")
+
+	_, err := ResolveEndpoint(writePromptCacheConfig(t, nil))
+	if err == nil {
+		t.Fatal("expected an error for an unparseable OCR_LLM_PROMPT_CACHE")
+	}
+	if !strings.Contains(err.Error(), envOCRLLMPromptCache) {
+		t.Errorf("error %q does not name the offending variable", err.Error())
 	}
 }

--- a/pages/src/content/docs/en/configuration.md
+++ b/pages/src/content/docs/en/configuration.md
@@ -344,6 +344,35 @@ without patching the source:
 ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
 ```
 
+### Disable prompt caching
+
+OCR marks Anthropic requests with `cache_control` breakpoints so the system
+prompt, the tool list and the conversation prefix are billed at the cached
+rate. Some Anthropic-compatible gateways validate the request body strictly and
+reject the field instead of ignoring it, failing every review:
+
+```
+400 Bad Request {"errorCode":"INVALID_ARGUMENT", ...
+  "unsafeParams":"{unrecognizedProperty=cache_control}",
+  "message":"Request contained an unrecognized field"}
+```
+
+Set `prompt_cache` to `false` to stop OCR sending the markers:
+
+```bash
+ocr config set providers.anthropic.prompt_cache false
+ocr config set custom_providers.my-gateway.prompt_cache false
+ocr config set llm.prompt_cache false
+```
+
+`OCR_LLM_PROMPT_CACHE=false` does the same for whichever configuration OCR
+resolves, which is the shorter route in CI where the endpoint comes from
+environment variables. It overrides the config file in both directions.
+
+Caching is on whenever the key is unset, and turning it off costs money rather
+than correctness: reviews still run, and every request pays full input-token
+price. Leave it alone unless your endpoint actually rejects the field.
+
 ### Session affinity for prompt caching
 
 OCR derives a prompt-cache affinity key for every LLM conversation, scoped

--- a/pages/src/content/docs/ja/configuration.md
+++ b/pages/src/content/docs/ja/configuration.md
@@ -342,6 +342,35 @@ ocr config set providers.<name>.url http://127.0.0.1:15721/v1
 ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
 ```
 
+### プロンプトキャッシュを無効にする
+
+OCR は Anthropic へのリクエストに `cache_control` のブレークポイントを付与し、
+システムプロンプト・ツール一覧・会話のプレフィックスがキャッシュ単価で課金される
+ようにします。Anthropic 互換のゲートウェイの中には、リクエストボディを厳格に検証し、
+このフィールドを無視せず拒否するものがあり、すべてのレビューが失敗します。
+
+```
+400 Bad Request {"errorCode":"INVALID_ARGUMENT", ...
+  "unsafeParams":"{unrecognizedProperty=cache_control}",
+  "message":"Request contained an unrecognized field"}
+```
+
+`prompt_cache` を `false` にすると、OCR はこのマーカーを送信しなくなります。
+
+```bash
+ocr config set providers.anthropic.prompt_cache false
+ocr config set custom_providers.my-gateway.prompt_cache false
+ocr config set llm.prompt_cache false
+```
+
+`OCR_LLM_PROMPT_CACHE=false` は、OCR が解決したどの設定に対しても同じ効果を持ちます。
+エンドポイントを環境変数から与える CI ではこちらのほうが手軽です。設定ファイルの値は
+どちらの方向にも上書きされます。
+
+キーが未設定ならキャッシュは有効です。無効にして失われるのは正しさではなくコストで、
+レビューは変わらず動作し、リクエストごとに入力トークンの全額を支払うだけです。
+エンドポイントが実際にこのフィールドを拒否する場合を除き、変更しないでください。
+
 ### プロンプトキャッシュのセッションアフィニティ
 
 OCR はすべての LLM 会話ごとに、レビューセッションとその中のタスクにスコープされた

--- a/pages/src/content/docs/ru/configuration.md
+++ b/pages/src/content/docs/ru/configuration.md
@@ -363,6 +363,37 @@ ocr config set providers.<name>.url http://127.0.0.1:15721/v1
 ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
 ```
 
+### Отключение кеширования промптов
+
+OCR расставляет в запросах к Anthropic контрольные точки `cache_control`, чтобы
+системный промпт, список инструментов и префикс диалога тарифицировались по
+кеш-ставке. Некоторые Anthropic-совместимые шлюзы строго валидируют тело запроса
+и отклоняют это поле вместо того, чтобы его игнорировать, — тогда падает каждая
+проверка:
+
+```
+400 Bad Request {"errorCode":"INVALID_ARGUMENT", ...
+  "unsafeParams":"{unrecognizedProperty=cache_control}",
+  "message":"Request contained an unrecognized field"}
+```
+
+Установите `prompt_cache` в `false`, чтобы OCR перестал отправлять эти маркеры:
+
+```bash
+ocr config set providers.anthropic.prompt_cache false
+ocr config set custom_providers.my-gateway.prompt_cache false
+ocr config set llm.prompt_cache false
+```
+
+`OCR_LLM_PROMPT_CACHE=false` делает то же самое для любой конфигурации, которую
+разрешит OCR, — это более короткий путь в CI, где эндпоинт задаётся переменными
+окружения. Переменная перекрывает файл конфигурации в обе стороны.
+
+Если ключ не задан, кеширование включено. Его отключение стоит денег, а не
+корректности: проверки продолжают работать, просто каждый запрос оплачивается по
+полной цене входных токенов. Не трогайте этот ключ, пока ваш эндпоинт
+действительно не отклоняет это поле.
+
 ### Аффинити сессии для кеширования промптов
 
 OCR выводит ключ аффинити кеша промптов для каждого диалога с LLM,

--- a/pages/src/content/docs/zh/configuration.md
+++ b/pages/src/content/docs/zh/configuration.md
@@ -315,6 +315,32 @@ ocr config set providers.<name>.url http://127.0.0.1:15721/v1
 ocr config set providers.anthropic.extra_body '{"thinking":{"type":"disabled"}}'
 ```
 
+### 关闭提示词缓存
+
+OCR 会在 Anthropic 请求上打 `cache_control` 断点，让系统提示词、工具列表和对话前缀
+按缓存价计费。部分 Anthropic 兼容网关会严格校验请求体，遇到该字段直接拒绝而不是忽略，
+导致每次评审都失败：
+
+```
+400 Bad Request {"errorCode":"INVALID_ARGUMENT", ...
+  "unsafeParams":"{unrecognizedProperty=cache_control}",
+  "message":"Request contained an unrecognized field"}
+```
+
+把 `prompt_cache` 设为 `false`，OCR 就不再发送这些标记：
+
+```bash
+ocr config set providers.anthropic.prompt_cache false
+ocr config set custom_providers.my-gateway.prompt_cache false
+ocr config set llm.prompt_cache false
+```
+
+`OCR_LLM_PROMPT_CACHE=false` 对最终解析出的配置有同样效果。在端点来自环境变量的
+CI 场景下这条路更短。它会双向覆盖配置文件中的取值。
+
+该键未设置时缓存默认开启；关掉它损失的是钱而不是正确性——评审照常运行，只是每个请求
+都按完整输入 token 计价。除非你的端点确实拒绝该字段，否则不要动它。
+
 ### 提示词缓存的会话亲和性
 
 OCR 为每个 LLM 对话派生一个提示词缓存亲和性密钥，作用域为评审会话及其中的任务（`<会话 ID>-<任务类型>-<作用域哈希>`）。提示词缓存按前缀匹配，因此按对话划分密钥可让每个不断增长的对话（如某个文件的评审工具循环）稳定路由到同一缓存节点，而不是把整次运行压在一个热点密钥上；密钥中的会话 ID 前缀可将供应商侧缓存日志与 `ocr session` 记录对应。


### PR DESCRIPTION
## Description

OCR unconditionally attaches `cache_control` breakpoints to three places in every Anthropic request: the last system block, the last tool, and the trailing message. Anthropic-compatible gateways that validate the request body strictly reject the field as an unrecognized property instead of ignoring it, so **every** review request fails:

```
400 Bad Request {"errorCode":"INVALID_ARGUMENT", ...
  "unsafeParams":"{unrecognizedProperty=cache_control}",
  "message":"Request contained an unrecognized field"}
```

`ocr llm test` still passes against such a gateway, because that request carries no breakpoint — which is what makes the failure confusing to diagnose. Until now the only fix was patching the source.

This adds a tri-state `prompt_cache` key:

```bash
ocr config set providers.anthropic.prompt_cache false
ocr config set custom_providers.my-gateway.prompt_cache false
ocr config set llm.prompt_cache false
```

plus `OCR_LLM_PROMPT_CACHE=false` as a global override, applied the same way as `OCR_LLM_TIMEOUT` — it reaches every resolution path, which matters in CI where the endpoint comes from environment variables alone and there is no config file to edit. It overrides the config file in both directions.

Design notes:

- **Unset means enabled.** `*bool` rather than `bool` so a config written before this key existed is indistinguishable from one that explicitly opts in, and `omitempty` cannot silently drop an explicit re-enable.
- **Cost, not correctness.** Every `cache_control` marker is optional to the request's meaning, so disabling it gives up the cache discount and nothing else — reviews still run, tools still work. That is the trade the flag makes deliberate.
- **An unparseable `OCR_LLM_PROMPT_CACHE` is an error**, not a silent default. Anyone setting it is working around a failing endpoint; ignoring a typo would leave them staring at the same 400 with no clue the knob never applied.
- **Anthropic protocol only**, since it is the only path that emits these markers on its own. The OpenAI `prompt_cache_key` route is user-supplied via `extra_body` and already opt-in.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (all 23 packages, with `-race`)
- [x] `make check` passes (fmt, vet, license headers, english-only)
- [x] `make coverage` passes at 91.4% (threshold 90%)
- [x] Manual testing (described below)

Unit tests added:

| Test | Covers |
| --- | --- |
| `TestBuildAnthropicParams_PromptCacheDisabled` | Asserts on the **marshalled request body**, since the bug is about the wire format — one leftover breakpoint anywhere reproduces it. Includes a positive control so the negative assertion cannot pass vacuously, and a check that the system prompt, tools and messages all survive. |
| `TestResolveEndpoint_ProviderPromptCache` | Tri-state resolution; the `nil` case pins backward compatibility. |
| `TestResolveEndpoint_LegacyLlmPromptCache` | The legacy `llm` section. |
| `TestResolveEndpoint_PromptCacheEnvOverride` | Env precedence in both directions, plus empty/whitespace being treated as unset. |
| `TestResolveEndpoint_InvalidPromptCacheEnv` | Unparseable value errors and names the variable. |
| `TestNewLLMClient_PromptCacheDisabledForwarded` | The `ResolvedEndpoint` → `ClientConfig` seam, which nothing else would notice breaking. |
| `TestSetConfigValuePromptCache` / `...RoundTrip` | All three config keys, invalid input, and survival across a marshal/unmarshal cycle. |
| `TestCloneProviderEntry_PromptCacheNotAliased` | The TUI clone. `DeepEqual` compares pointees, so it would pass on a shared pointer; without a deep copy a rollback path would mutate the entry it is restoring. |

`TestCloneProviderEntry_CopiesEveryField` caught the new field automatically and its fixture was updated — that guard works exactly as its comment promises.

**Manual end-to-end**, against a local server that mimics the gateway in #700 by returning 400 whenever the body contains `cache_control`:

```
=== WITHOUT the flag (reproduces #700) ===
Error: llm request failed: POST "http://127.0.0.1:8899/v1/messages": 400 Bad Request
{"type":"error","error":{"type":"invalid_request_error",
 "message":"Request contained an unrecognized field: cache_control"}}

=== WITH prompt caching disabled ===
✓ Connection test successful

=== WITH an invalid value ===
Error: resolve LLM endpoint: OCR_LLM_PROMPT_CACHE must be a boolean (true/false, 1/0), got "maybe"
```

I also mutation-checked the main test by forcing `cacheBreakpoints := true`; it fails as expected and prints the offending body.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly — `configuration.md` in all four locales (`en`, `zh`, `ja`, `ru`)
- [ ] I have signed the CLA — will sign as soon as the bot posts

## Related Issues

closes #700