### PR TITLE
fix(diff): surface git's own message when a diff command fails

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -181,7 +182,7 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		}
 		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
 		if err != nil {
-			return nil, fmt.Errorf("git diff failed: %w", err)
+			return nil, gitFailure("git diff", out, err)
 		}
 		combined.WriteString(out)
 
@@ -192,14 +193,17 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		// Diffs against the first parent instead, in regular unified format.
 		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "--diff-merges=first-parent", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
 		if err != nil {
-			return nil, fmt.Errorf("git show failed: %w", err)
+			return nil, gitFailure("git show", out, err)
 		}
 		combined.WriteString(out)
 
 	case ModeWorkspace:
+		// On the error path workspaceTrackedDiff returns the failing command's
+		// combined output, so tracked carries git's message here rather than a
+		// usable diff.
 		tracked, err := p.workspaceTrackedDiff(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("workspace tracked diff failed: %w", err)
+			return nil, gitFailure("workspace tracked diff", tracked, err)
 		}
 		combined.WriteString(tracked)
 
@@ -636,4 +640,39 @@ func (p *Provider) runGit(ctx context.Context, args ...string) (string, error) {
 	cmd.Dir = p.repoDir
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// gitDiagLimit bounds how much of git's output is quoted back in an error.
+// Git's own diagnosis is a line or two; the ceiling matters only because
+// runGit returns stdout and stderr combined, so a command that failed partway
+// through can carry a prefix of real diff along with it.
+const gitDiagLimit = 2000
+
+// gitFailure builds an error that carries git's own message.
+//
+// runGit captures stdout and stderr together and every diff-producing caller
+// used to drop that output on the floor, so a failure surfaced as a bare
+// "git show failed: exit status 129" — true, and useless. Diagnosing one then
+// meant asking the reporter to re-run the command by hand to see what git
+// actually said (#972). The exit status alone cannot distinguish an
+// unsupported option from a bad revision or a permission error.
+func gitFailure(op, out string, err error) error {
+	diag := strings.TrimSpace(out)
+	if diag == "" {
+		return fmt.Errorf("%s failed: %w", op, err)
+	}
+	if len(diag) > gitDiagLimit {
+		// Keep the tail: git writes its diagnosis last, after whatever
+		// reached stdout before the failure.
+		diag = diag[len(diag)-gitDiagLimit:]
+		// Cutting by bytes can land mid-rune. Git speaks the user's locale,
+		// so this is not hypothetical — #972 came from a Japanese-language
+		// Windows install. Drop the partial leading rune rather than emit
+		// invalid UTF-8.
+		for len(diag) > 0 && !utf8.RuneStart(diag[0]) {
+			diag = diag[1:]
+		}
+		diag = "..." + diag
+	}
+	return fmt.Errorf("%s failed: %w: %s", op, err, diag)
 }

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -198,9 +198,15 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		combined.WriteString(out)
 
 	case ModeWorkspace:
-		// On the error path workspaceTrackedDiff returns the failing command's
-		// combined output, so tracked carries git's message here rather than a
-		// usable diff.
+		// On the error path workspaceTrackedDiff returns the combined output of
+		// its fallback (`git diff --staged`), so tracked carries git's message
+		// here rather than a usable diff.
+		//
+		// That fallback's message is the one worth surfacing. Reaching it at
+		// all means `git diff HEAD` already failed, and in the case the
+		// fallback exists for — a repository with no commits — it failed with
+		// "bad revision 'HEAD'", which is expected rather than diagnostic.
+		// Only the second failure describes what actually blocked the review.
 		tracked, err := p.workspaceTrackedDiff(ctx)
 		if err != nil {
 			return nil, gitFailure("workspace tracked diff", tracked, err)

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -180,9 +180,9 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		if base == "" {
 			return nil, fmt.Errorf("cannot find merge-base between %s and %s", p.from, p.to)
 		}
-		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
+		out, stderr, err := p.runGitSplit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
 		if err != nil {
-			return nil, gitFailure("git diff", out, err)
+			return nil, gitFailure("git diff", stderr, err)
 		}
 		combined.WriteString(out)
 
@@ -191,25 +191,22 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 		// emits a combined diff ("diff --cc"), which ParseDiffText cannot
 		// parse — the commit would silently yield zero reviewable diffs.
 		// Diffs against the first parent instead, in regular unified format.
-		out, err := p.runGit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "--diff-merges=first-parent", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
+		out, stderr, err := p.runGitSplit(ctx, "-c", "core.quotepath=false", "show", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "--diff-merges=first-parent", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", p.commit)
 		if err != nil {
-			return nil, gitFailure("git show", out, err)
+			return nil, gitFailure("git show", stderr, err)
 		}
 		combined.WriteString(out)
 
 	case ModeWorkspace:
-		// On the error path workspaceTrackedDiff returns the combined output of
-		// its fallback (`git diff --staged`), so tracked carries git's message
-		// here rather than a usable diff.
-		//
-		// That fallback's message is the one worth surfacing. Reaching it at
-		// all means `git diff HEAD` already failed, and in the case the
-		// fallback exists for — a repository with no commits — it failed with
-		// "bad revision 'HEAD'", which is expected rather than diagnostic.
-		// Only the second failure describes what actually blocked the review.
-		tracked, err := p.workspaceTrackedDiff(ctx)
+		// The stderr returned here is the fallback's (`git diff --staged`), and
+		// that is the one worth surfacing. Reaching the fallback at all means
+		// `git diff HEAD` already failed, and in the case the fallback exists
+		// for — a repository with no commits — it failed with "bad revision
+		// 'HEAD'", which is expected rather than diagnostic. Only the second
+		// failure describes what actually blocked the review.
+		tracked, stderr, err := p.workspaceTrackedDiff(ctx)
 		if err != nil {
-			return nil, gitFailure("workspace tracked diff", tracked, err)
+			return nil, gitFailure("workspace tracked diff", stderr, err)
 		}
 		combined.WriteString(tracked)
 
@@ -565,20 +562,23 @@ func firstLine(out string) string {
 	return ""
 }
 
-func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, error) {
-	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", "HEAD", "--")
+// workspaceTrackedDiff returns the tracked-file diff, git's stderr, and the
+// failure if there was one. Stderr is returned separately so the caller can
+// quote it without risking diff content in the error; see runGitSplit.
+func (p *Provider) workspaceTrackedDiff(ctx context.Context) (string, string, error) {
+	out, _, err := p.runGitSplit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", "HEAD", "--")
 	if err == nil && out != "" {
-		return out, nil
+		return out, "", nil
 	}
 	if ctx.Err() != nil {
-		return "", ctx.Err()
+		return "", "", ctx.Err()
 	}
 	// Fall back to the staged diff when `git diff HEAD` errored or was empty. This is
 	// not redundant with the call above: in a repository with no commits yet there is no
 	// HEAD, so `git diff HEAD` fails with "bad revision 'HEAD'", but `git diff --staged`
 	// still surfaces staged changes by diffing the index against the empty tree — the only
 	// way to review a workspace before its first commit.
-	return p.runGit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--staged", "--")
+	return p.runGitSplit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--staged", "--")
 }
 
 func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {
@@ -646,6 +646,46 @@ func (p *Provider) runGit(ctx context.Context, args ...string) (string, error) {
 	cmd.Dir = p.repoDir
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// runGitSplit runs git with stdout and stderr kept apart, for the callers that
+// quote the failure back to the user.
+//
+// runGit's combined output cannot be quoted safely. Git writes the diff to
+// stdout and its diagnosis to stderr, so a command killed mid-write leaves a
+// tail made entirely of diff content — repository source, and whatever that
+// source happens to contain — with no diagnosis anywhere in it. That string
+// does not stay local: reviewResultError hands it to span.RecordError, so it
+// reaches whatever telemetry backend is configured. classifyItemError guards
+// the run manifest against raw error text for the same reason.
+//
+// Stderr carries the diagnosis by construction, since die() writes there, so
+// quoting it alone loses nothing a reader wants and cannot carry diff.
+//
+// Mirrors runGitGrep in internal/tool/code_search.go, cancellation guard
+// included: a killed process reports the signal rather than the reason, and
+// the reason is what the caller needs.
+func (p *Provider) runGitSplit(ctx context.Context, args ...string) (string, string, error) {
+	if p.runner != nil {
+		stdout, stderr, err := p.runner.RunSplit(ctx, p.repoDir, args...)
+		if ctx.Err() != nil && err != nil {
+			return "", "", ctx.Err()
+		}
+		return stdout, stderr, err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = p.repoDir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctx.Err() != nil && err != nil && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
+		return "", "", ctx.Err()
+	}
+	return stdout.String(), stderr.String(), err
 }
 
 // gitDiagLimit bounds how much of git's output is quoted back in an error.

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -688,28 +688,29 @@ func (p *Provider) runGitSplit(ctx context.Context, args ...string) (string, str
 	return stdout.String(), stderr.String(), err
 }
 
-// gitDiagLimit bounds how much of git's output is quoted back in an error.
-// Git's own diagnosis is a line or two; the ceiling matters only because
-// runGit returns stdout and stderr combined, so a command that failed partway
-// through can carry a prefix of real diff along with it.
+// gitDiagLimit bounds how much of git's stderr is quoted back in an error.
+// Git's own diagnosis is a line or two, so the ceiling is a backstop for the
+// pathological case — a flood of warnings ahead of the fatal — rather than the
+// common one.
 const gitDiagLimit = 2000
 
 // gitFailure builds an error that carries git's own message.
 //
-// runGit captures stdout and stderr together and every diff-producing caller
-// used to drop that output on the floor, so a failure surfaced as a bare
-// "git show failed: exit status 129" — true, and useless. Diagnosing one then
-// meant asking the reporter to re-run the command by hand to see what git
-// actually said (#972). The exit status alone cannot distinguish an
-// unsupported option from a bad revision or a permission error.
-func gitFailure(op, out string, err error) error {
-	diag := strings.TrimSpace(out)
+// Every diff-producing caller used to drop git's output on the floor, so a
+// failure surfaced as a bare "git show failed: exit status 129" — true, and
+// useless. Diagnosing one then meant asking the reporter to re-run the command
+// by hand to see what git actually said (#972). The exit status alone cannot
+// distinguish an unsupported option from a bad revision or a permission error.
+//
+// Callers pass stderr, never runGit's combined output; see runGitSplit for why.
+func gitFailure(op, stderr string, err error) error {
+	diag := strings.TrimSpace(stderr)
 	if diag == "" {
 		return fmt.Errorf("%s failed: %w", op, err)
 	}
 	if len(diag) > gitDiagLimit {
-		// Keep the tail: git writes its diagnosis last, after whatever
-		// reached stdout before the failure.
+		// Keep the tail: die() exits the process, so the fatal git ends on is
+		// the last thing it writes, behind any warnings that preceded it.
 		diag = diag[len(diag)-gitDiagLimit:]
 		// Cutting by bytes can land mid-rune. Git speaks the user's locale,
 		// so this is not hypothetical — #972 came from a Japanese-language

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package diff
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/alibaba/open-code-review/internal/gitcmd"
+)
+
+func TestGitFailure(t *testing.T) {
+	baseErr := errors.New("exit status 129")
+
+	t.Run("includes git's own message", func(t *testing.T) {
+		err := gitFailure("git show", "error: unknown option `diff-merges=first-parent'\n", baseErr)
+		got := err.Error()
+		if !strings.Contains(got, "unknown option") {
+			t.Errorf("error %q drops git's message", got)
+		}
+		if !strings.Contains(got, "git show failed") {
+			t.Errorf("error %q lost the operation name", got)
+		}
+		if !strings.Contains(got, "exit status 129") {
+			t.Errorf("error %q lost the exit status", got)
+		}
+	})
+
+	t.Run("wrapped error stays unwrappable", func(t *testing.T) {
+		// Callers up the stack match on the underlying error, so quoting git's
+		// output must not cost them errors.Is.
+		err := gitFailure("git show", "fatal: bad object", baseErr)
+		if !errors.Is(err, baseErr) {
+			t.Error("gitFailure broke the error chain")
+		}
+	})
+
+	t.Run("empty output leaves no dangling separator", func(t *testing.T) {
+		err := gitFailure("git show", "   \n\t ", baseErr)
+		if got := err.Error(); got != "git show failed: exit status 129" {
+			t.Errorf("error = %q, want the bare form with no trailing colon", got)
+		}
+	})
+
+	t.Run("long output keeps the tail", func(t *testing.T) {
+		// runGit returns stdout and stderr combined, so a command that failed
+		// partway through carries real diff ahead of git's diagnosis. The
+		// diagnosis is last, which is the half worth keeping.
+		noise := strings.Repeat("+padding line\n", 400)
+		err := gitFailure("git diff", noise+"fatal: the real problem", baseErr)
+		got := err.Error()
+		if !strings.Contains(got, "fatal: the real problem") {
+			t.Error("truncation dropped the tail, which is where git's diagnosis is")
+		}
+		if !strings.Contains(got, "...") {
+			t.Error("truncated output is not marked as truncated")
+		}
+		if len(got) > gitDiagLimit+200 {
+			t.Errorf("error is %d bytes; truncation is not bounding it", len(got))
+		}
+	})
+
+	t.Run("short output is not truncated", func(t *testing.T) {
+		if got := gitFailure("git show", "fatal: bad object", baseErr).Error(); strings.Contains(got, "...") {
+			t.Errorf("error %q was truncated despite fitting the limit", got)
+		}
+	})
+
+	// Git speaks the user's locale. #972 came from a Japanese-language Windows
+	// install, so truncating by bytes can land in the middle of a rune and turn
+	// a confusing error into an unreadable one.
+	t.Run("multibyte output survives truncation", func(t *testing.T) {
+		msg := strings.Repeat("致命的なエラーが発生しました。", 400) // allow-non-english: multibyte truncation fixture, mirrors the locale in #972
+		err := gitFailure("git show", msg, baseErr)
+		got := err.Error()
+		if !utf8.ValidString(got) {
+			t.Error("truncation produced invalid UTF-8")
+		}
+		if strings.Contains(got, "�") {
+			t.Error("truncation left a replacement character mid-rune")
+		}
+		if !strings.HasSuffix(got, "。") { // allow-non-english: asserts the fixture's trailing rune is intact
+			t.Errorf("error %q does not end on the original tail", got[len(got)-40:])
+		}
+	})
+}
+
+// TestGetDiff_CommitFailureSurfacesGitMessage is the regression test for #972:
+// `git show` failing used to surface as a bare exit status, so neither the
+// reporter nor a maintainer could tell an unsupported option from a bad
+// revision without re-running the command by hand.
+func TestGetDiff_CommitFailureSurfacesGitMessage(t *testing.T) {
+	repo := initRepoWithChange(t)
+	runner := gitcmd.New(2)
+
+	provider := NewCommitProvider(repo, "0b335be72cb7e342c115ff3ffadbe741a4715377", runner)
+
+	_, err := provider.GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail for a commit that does not exist")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "git show failed") {
+		t.Errorf("error %q lost the operation name", got)
+	}
+	// Git words this differently across versions ("bad object", "unknown
+	// revision", "ambiguous argument"), so assert that it said something at
+	// all rather than pinning one phrasing.
+	if !strings.Contains(got, "fatal:") && !strings.Contains(got, "error:") {
+		t.Errorf("error %q carries no message from git; only the exit status survived", got)
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Error("underlying *exec.ExitError is no longer reachable")
+	}
+}

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -199,9 +199,10 @@ func TestGetDiff_CancelledMidWriteReportsCancellation(t *testing.T) {
 	if strings.Contains(got, secret) {
 		t.Errorf("cancelled command leaked stdout into the error:\n%s", got)
 	}
-	// Reporting the cancellation rather than "signal: killed" also lets
-	// classifyItemError see it: it matches on context.DeadlineExceeded to
-	// choose the timeout failure class over the generic provider one.
+	// The leak assertion above holds with or without runGitSplit's cancellation
+	// guard, since quoting stderr alone already keeps stdout out of the error.
+	// This assertion is what pins the guard: drop it and the guard can go too,
+	// leaving "signal: killed" — the mechanism instead of the reason.
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("error %q does not unwrap to the cancellation", got)
 	}

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/alibaba/open-code-review/internal/gitcmd"
@@ -132,15 +134,90 @@ func TestGetDiff_WorkspaceFailureSurfacesFallbackMessage(t *testing.T) {
 	}
 }
 
+// shimGit puts a fake `git` at the front of PATH for the duration of the test.
+func shimGit(t *testing.T, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim relies on a shebang script")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestGetDiff_FailureQuotesStderrNotStdout pins the split that keeps repository
+// content out of the error.
+//
+// Git writes the diff to stdout and its diagnosis to stderr. Quoting the two
+// together means a command that dies mid-write contributes a tail made purely
+// of diff — source code, and whatever that source contains. The string does not
+// stay local either: reviewResultError passes it to span.RecordError, so it
+// reaches the configured telemetry backend.
+func TestGetDiff_FailureQuotesStderrNotStdout(t *testing.T) {
+	const secret = "API_KEY=sk-not-a-real-key-do-not-log"
+
+	// Writes plausible diff to stdout, a diagnosis to stderr, and fails.
+	shimGit(t, "echo '+"+secret+"'\necho 'fatal: shim refused' >&2\nexit 128\n")
+
+	repo := t.TempDir()
+	_, err := NewCommitProvider(repo, "HEAD", nil).GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail")
+	}
+
+	got := err.Error()
+	if strings.Contains(got, secret) {
+		t.Errorf("error carries stdout content:\n%s", got)
+	}
+	if !strings.Contains(got, "shim refused") {
+		t.Errorf("error %q lost the stderr diagnosis", got)
+	}
+}
+
+// TestGetDiff_CancelledMidWriteReportsCancellation covers the case that has no
+// diagnosis to quote at all: a signalled process writes nothing to stderr, so
+// combining the streams left the error made entirely of diff content.
+func TestGetDiff_CancelledMidWriteReportsCancellation(t *testing.T) {
+	const secret = "API_KEY=sk-not-a-real-key-do-not-log"
+
+	// Streams diff to stdout and never exits, so cancellation always lands
+	// inside the write window rather than depending on timing.
+	shimGit(t, "while :; do echo '+"+secret+"'; done\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	repo := t.TempDir()
+	_, err := NewCommitProvider(repo, "HEAD", nil).GetDiff(ctx)
+	if err == nil {
+		t.Fatal("expected GetDiff to fail")
+	}
+
+	got := err.Error()
+	if strings.Contains(got, secret) {
+		t.Errorf("cancelled command leaked stdout into the error:\n%s", got)
+	}
+	// Reporting the cancellation rather than "signal: killed" also lets
+	// classifyItemError see it: it matches on context.DeadlineExceeded to
+	// choose the timeout failure class over the generic provider one.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error %q does not unwrap to the cancellation", got)
+	}
+}
+
 // TestGetDiff_CommitFailureSurfacesGitMessage is the regression test for #972:
 // `git show` failing used to surface as a bare exit status, so neither the
 // reporter nor a maintainer could tell an unsupported option from a bad
 // revision without re-running the command by hand.
 func TestGetDiff_CommitFailureSurfacesGitMessage(t *testing.T) {
+	const missingSHA = "0b335be72cb7e342c115ff3ffadbe741a4715377"
+
 	repo := initRepoWithChange(t)
 	runner := gitcmd.New(2)
 
-	provider := NewCommitProvider(repo, "0b335be72cb7e342c115ff3ffadbe741a4715377", runner)
+	provider := NewCommitProvider(repo, missingSHA, runner)
 
 	_, err := provider.GetDiff(context.Background())
 	if err == nil {
@@ -151,10 +228,15 @@ func TestGetDiff_CommitFailureSurfacesGitMessage(t *testing.T) {
 	if !strings.Contains(got, "git show failed") {
 		t.Errorf("error %q lost the operation name", got)
 	}
-	// Git words this differently across versions ("bad object", "unknown
-	// revision", "ambiguous argument"), so assert that it said something at
-	// all rather than pinning one phrasing.
-	if !strings.Contains(got, "fatal:") && !strings.Contains(got, "error:") {
+	// Anchor on the object name, not on git's prose. Git words this
+	// differently across versions ("bad object", "unknown revision",
+	// "ambiguous argument") and translates all of it: under zh_CN the line
+	// opens with 致命错误, so asserting "fatal:" would pass in CI's English // allow-non-english: names the translated prefix this assertion must not depend on
+	// container and fail for a translated developer. The SHA is the one part
+	// no locale rewrites, and its presence is what proves git's message came
+	// through at all. isNotGitRepoError pairs its English phrase with a
+	// locale-proof check for the same reason.
+	if !strings.Contains(got, missingSHA) {
 		t.Errorf("error %q carries no message from git; only the exit status survived", got)
 	}
 

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -6,7 +6,9 @@ package diff
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -88,6 +90,46 @@ func TestGitFailure(t *testing.T) {
 			t.Errorf("error %q does not end on the original tail", got[len(got)-40:])
 		}
 	})
+}
+
+// TestGetDiff_WorkspaceFailureSurfacesFallbackMessage pins which of the two
+// commands in workspaceTrackedDiff gets to speak when both fail.
+//
+// Reaching the `git diff --staged` fallback means `git diff HEAD` already
+// failed, and in the case the fallback exists for — a repository with no
+// commits — it failed with "bad revision 'HEAD'", which is expected rather
+// than diagnostic. Surfacing both would put that benign message ahead of the
+// one describing what actually blocked the review.
+func TestGetDiff_WorkspaceFailureSurfacesFallbackMessage(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+
+	file := filepath.Join(repo, "sample.txt")
+	if err := os.WriteFile(file, []byte("line1\n"), 0o644); err != nil {
+		t.Fatalf("write sample.txt: %v", err)
+	}
+	runGitTest(t, repo, "add", "sample.txt")
+
+	// No commits yet, so `git diff HEAD` fails; corrupting the index makes the
+	// `--staged` fallback fail too, which is the only way both commands error.
+	if err := os.WriteFile(filepath.Join(repo, ".git", "index"), []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("corrupt index: %v", err)
+	}
+
+	_, err := NewWorkspaceProvider(repo, gitcmd.New(2)).GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail when both tracked-diff commands fail")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "index") {
+		t.Errorf("error %q does not mention the index failure that actually blocked the review", got)
+	}
+	if strings.Contains(got, "bad revision") {
+		t.Errorf("error %q leads with the expected no-HEAD message instead of the real cause", got)
+	}
 }
 
 // TestGetDiff_CommitFailureSurfacesGitMessage is the regression test for #972:


### PR DESCRIPTION
## Description

`GetDiff` runs git through `runGit`, which uses `CombinedOutput()` — so git's diagnosis is captured, and then dropped on the floor at every failure site. What reaches the user is the exit status and nothing else:

```
Error: review failed: load diffs: get diffs: git show failed: exit status 129
```

An exit status cannot distinguish an unsupported option from a bad revision, a corrupt object, or a permission problem. That is the state #972 is stuck in: triaging it required [asking the reporter to re-run the raw git command by hand](https://github.com/alibaba/open-code-review/issues/972#issuecomment-5346330263) just to find out what git said. The information was already in the process's hands at the moment of failure.

This quotes git's output in the error for the three diff-producing paths — range, commit, and workspace-tracked. The same failure now reads:

```
... git show failed: exit status 129: error: unknown option `diff-merges=first-parent'
```

which names the cause, and in that particular case points straight at the Git-version hypothesis the maintainer raised on #972.

### Notes on the implementation

- **Bounded, keeping the tail.** `runGit` returns stdout and stderr combined, so a command that failed partway through carries a prefix of real diff along with the diagnosis. Git writes its diagnosis last, so the tail is the half worth keeping.
- **Cuts on a rune boundary.** Git speaks the user's locale, and #972 came from a Japanese-language Windows install. A byte-wise cut would swap a confusing error for an unreadable one, so the helper walks back to a valid rune start via `utf8.RuneStart`.
- **`%w` is preserved**, so callers matching the underlying `*exec.ExitError` are unaffected.
- **Scope.** The other six `runGit` callers deliberately swallow errors and fall back (returning `""` or `nil`), which is a different contract — they are left alone. Only the paths that already surface an error to the user changed.

This does not fix #972 itself, which still needs the reporter's Git version. It makes that class of report self-diagnosing from the first message instead of costing a round trip.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make test` passes locally (all 23 packages, with `-race`)
- [x] `make check` passes (fmt, vet, license headers, english-only)
- [x] `make coverage` passes at 91.4% (threshold 90%); `gitFailure` is at 100%
- [x] Manual testing (below)

Tests added in `internal/diff/git_error_test.go`:

| Test | Covers |
| --- | --- |
| `TestGetDiff_CommitFailureSurfacesGitMessage` | The regression itself, end to end through `GetDiff`. Asserts git said *something* (`fatal:`/`error:`) rather than pinning one phrasing, since the wording moves between Git versions. Also asserts `*exec.ExitError` is still reachable via `errors.As`. |
| `TestGitFailure/includes git's own message` | The message, operation name and exit status all survive. |
| `TestGitFailure/wrapped error stays unwrappable` | `errors.Is` still reaches the cause. |
| `TestGitFailure/empty output leaves no dangling separator` | Whitespace-only output falls back to the bare form — no trailing `": "`. |
| `TestGitFailure/long output keeps the tail` | Truncation keeps the diagnosis, marks itself, and actually bounds the size. |
| `TestGitFailure/multibyte output survives truncation` | Valid UTF-8 out, no replacement character, tail rune intact. |

The Japanese fixture carries an `allow-non-english:` marker per the AGENTS.md escape hatch, since it exists precisely to exercise a non-ASCII locale.

**Manual verification** with a `git` shim that rejects `--diff-merges=first-parent`, reproducing what a pre-2.31 Git would do:

```
# before
Error: review failed: load diffs: get diffs: git show failed: exit status 129

# after
Error: review failed: load diffs: get diffs: git show failed: exit status 129: error: unknown option `diff-merges=first-parent'
```

I also mutation-checked the regression test by reverting the `git show` call site to its old form; it fails with `error "git show failed: exit status 128" carries no message from git; only the exit status survived`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly — n/a, no user-facing config or CLI surface changed
- [x] I have signed the CLA

## Related Issues

Refs #972 — makes that report self-diagnosing; does not close it, since the root cause still depends on the reporter's Git version.