### PR TITLE
fix(llm): extract raw response payload for Google Gemini 400 Bad Request errors

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -664,7 +664,7 @@ func extractOpenAIErrorDetails(err error) (*openAIErrorDetails, bool) {
 	}
 
 	if raw := apiErr.RawJSON(); raw != "" {
-		details.RawBody = strings.TrimSpace(raw)
+		details.RawBody = limitErrorBodyForLog(raw)
 	} else if apiErr.Response != nil && apiErr.Response.Body != nil {
 		bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
 		_ = apiErr.Response.Body.Close()

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -272,20 +272,14 @@ func retryCodesMiddleware(codes []int) func(*http.Request, func(*http.Request) (
 	}
 }
 
-// limitErrorResponseBody bounds provider error payloads before the OpenAI SDK
-// reads them into memory. The wrapper delegates Close to the transport body.
-func limitErrorResponseBody(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
-	resp, err := next(req)
-	if resp != nil && resp.StatusCode >= http.StatusBadRequest && resp.Body != nil {
-		resp.Body = struct {
-			io.Reader
-			io.Closer
-		}{
-			Reader: io.LimitReader(resp.Body, maxErrorBodyBytes),
-			Closer: resp.Body,
-		}
+// limitErrorBodyForLog bounds the payload included in terminal and session logs
+// without truncating the HTTP response before the SDK parses it.
+func limitErrorBodyForLog(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if len(raw) <= maxErrorBodyBytes {
+		return raw
 	}
-	return resp, err
+	return strings.ToValidUTF8(raw[:maxErrorBodyBytes], "\uFFFD") + "... (truncated)"
 }
 
 // --- Factory ---

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -421,7 +421,6 @@ func NewOpenAIClient(cfg ClientConfig) *OpenAIClient {
 		openaiopt.WithMaxRetries(5),
 		openaiopt.WithHeader("User-Agent", userAgent("")),
 		openaiopt.WithRequestTimeout(cfg.Timeout),
-		openaiopt.WithMiddleware(limitErrorResponseBody),
 	}
 	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
 		opts = append(opts, openaiopt.WithMiddleware(mw))

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -43,6 +43,8 @@ var AppVersion = "dev"
 // shrink it, same as keyCmdTimeout.
 var bedrockConfigLoadTimeout = 60 * time.Second
 
+const maxErrorBodyBytes = 64 * 1024
+
 func userAgent(provider string) string {
 	ua := "open-code-review/" + AppVersion
 	if provider != "" {
@@ -270,6 +272,22 @@ func retryCodesMiddleware(codes []int) func(*http.Request, func(*http.Request) (
 	}
 }
 
+// limitErrorResponseBody bounds provider error payloads before the OpenAI SDK
+// reads them into memory. The wrapper delegates Close to the transport body.
+func limitErrorResponseBody(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+	resp, err := next(req)
+	if resp != nil && resp.StatusCode >= http.StatusBadRequest && resp.Body != nil {
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: io.LimitReader(resp.Body, maxErrorBodyBytes),
+			Closer: resp.Body,
+		}
+	}
+	return resp, err
+}
+
 // --- Factory ---
 
 // NewLLMClient creates the appropriate client based on the resolved endpoint protocol.
@@ -409,6 +427,7 @@ func NewOpenAIClient(cfg ClientConfig) *OpenAIClient {
 		openaiopt.WithMaxRetries(5),
 		openaiopt.WithHeader("User-Agent", userAgent("")),
 		openaiopt.WithRequestTimeout(cfg.Timeout),
+		openaiopt.WithMiddleware(limitErrorResponseBody),
 	}
 	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
 		opts = append(opts, openaiopt.WithMiddleware(mw))
@@ -630,6 +649,7 @@ func formatOpenAIError(provider, model string, err error) error {
 			rawBody = strings.TrimSpace(raw)
 		} else if apiErr.Response != nil && apiErr.Response.Body != nil {
 			bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
+			_ = apiErr.Response.Body.Close()
 			apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 			rawBody = strings.TrimSpace(string(bodyBytes))
 		}
@@ -666,7 +686,7 @@ func formatOpenAIError(provider, model string, err error) error {
 			parts = append(parts, fmt.Sprintf("response body: %s", rawBody))
 		}
 
-		if len(parts) > 1 || rawBody != "" {
+		if len(parts) > 0 {
 			return fmt.Errorf("%s: %w", strings.Join(parts, ", "), err)
 		}
 	}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -534,7 +534,7 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 		}
 	}
 	if err != nil {
-		return nil, formatOpenAIError(c.cfg.Provider, model, err)
+		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, model, err)
 	}
 
 	return c.mapOpenAIResponse(sdkResp), nil
@@ -557,7 +557,7 @@ func (c *OpenAIClient) completionsStreaming(ctx context.Context, params openai.C
 	if err != nil {
 		class, phase := classifyStreamError(err)
 		reviseAttempt(ctx, c.cfg.retryCollector, class, phase)
-		return nil, formatOpenAIError(c.cfg.Provider, string(params.Model), err)
+		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, string(params.Model), err)
 	}
 	return resp, nil
 }
@@ -634,73 +634,105 @@ func (c *OpenAIClient) completionsStreamingInner(ctx context.Context, params ope
 	return resp, nil
 }
 
-// formatOpenAIError extracts structured error details from an OpenAI SDK error
-// (*openai.Error, which embeds *apierror.Error), including HTTP status, code,
-// message, and the raw JSON response payload (crucial for providers like
-// Google Gemini whose 400 Bad Request details live in custom nested JSON fields).
-func formatOpenAIError(provider, model string, err error) error {
+// openAIErrorDetails captures unmarshaled and raw fields from an *openai.Error.
+type openAIErrorDetails struct {
+	Status   int
+	Message  string
+	Code     string
+	Type     string
+	RawBody  string
+	Original error
+}
+
+// extractOpenAIErrorDetails unwraps an *openai.Error (embedding *apierror.Error),
+// capturing the HTTP status, message, error code, error type, and raw JSON or text body.
+// If the response body was unread, it reads, closes, and restores the body stream.
+// Returns false if err does not unwrap to an *openai.Error.
+func extractOpenAIErrorDetails(err error) (*openAIErrorDetails, bool) {
 	if err == nil {
-		return nil
+		return nil, false
 	}
 	var apiErr *openai.Error
-	if errors.As(err, &apiErr) {
-		var rawBody string
-		if raw := apiErr.RawJSON(); raw != "" {
-			rawBody = strings.TrimSpace(raw)
-		} else if apiErr.Response != nil && apiErr.Response.Body != nil {
-			bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
-			_ = apiErr.Response.Body.Close()
-			apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-			rawBody = strings.TrimSpace(string(bodyBytes))
-		}
+	if !errors.As(err, &apiErr) {
+		return nil, false
+	}
 
-		status := apiErr.StatusCode
-		if status == 0 && apiErr.Response != nil {
-			status = apiErr.Response.StatusCode
-		}
-		statusText := http.StatusText(status)
+	details := &openAIErrorDetails{
+		Status:   apiErr.StatusCode,
+		Message:  apiErr.Message,
+		Code:     apiErr.Code,
+		Type:     apiErr.Type,
+		Original: err,
+	}
 
-		pName := providerDisplayName(provider)
+	if details.Status == 0 && apiErr.Response != nil {
+		details.Status = apiErr.Response.StatusCode
+	}
 
-		var parts []string
-		if status > 0 {
-			if statusText != "" {
-				parts = append(parts, fmt.Sprintf("%s error (HTTP %d %s, model: %s)", pName, status, statusText, model))
-			} else {
-				parts = append(parts, fmt.Sprintf("%s error (HTTP %d, model: %s)", pName, status, model))
-			}
+	if raw := apiErr.RawJSON(); raw != "" {
+		details.RawBody = strings.TrimSpace(raw)
+	} else if apiErr.Response != nil && apiErr.Response.Body != nil {
+		bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
+		_ = apiErr.Response.Body.Close()
+		apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		details.RawBody = strings.TrimSpace(string(bodyBytes))
+	}
+
+	return details, true
+}
+
+// formatGeminiError formats structured error details for Google Gemini endpoints
+// (whose 400 Bad Request details live in custom nested JSON fields like google.rpc.ErrorInfo).
+// Non-Gemini providers return the original error unmodified.
+func formatGeminiError(provider, url, model string, err error) error {
+	if err == nil || !isGemini(provider, url) {
+		return err
+	}
+
+	details, ok := extractOpenAIErrorDetails(err)
+	if !ok {
+		return err
+	}
+
+	statusText := http.StatusText(details.Status)
+	var parts []string
+	if details.Status > 0 {
+		if statusText != "" {
+			parts = append(parts, fmt.Sprintf("Google Gemini API error (HTTP %d %s, model: %s)", details.Status, statusText, model))
 		} else {
-			parts = append(parts, fmt.Sprintf("%s error (model: %s)", pName, model))
+			parts = append(parts, fmt.Sprintf("Google Gemini API error (HTTP %d, model: %s)", details.Status, model))
 		}
+	} else {
+		parts = append(parts, fmt.Sprintf("Google Gemini API error (model: %s)", model))
+	}
 
-		if apiErr.Message != "" {
-			parts = append(parts, fmt.Sprintf("message: %s", apiErr.Message))
-		}
-		if apiErr.Code != "" {
-			parts = append(parts, fmt.Sprintf("code: %s", apiErr.Code))
-		}
-		if apiErr.Type != "" {
-			parts = append(parts, fmt.Sprintf("type: %s", apiErr.Type))
-		}
-		if rawBody != "" && rawBody != apiErr.Message {
-			parts = append(parts, fmt.Sprintf("response body: %s", rawBody))
-		}
+	if details.Message != "" {
+		parts = append(parts, fmt.Sprintf("message: %s", details.Message))
+	}
+	if details.Code != "" {
+		parts = append(parts, fmt.Sprintf("code: %s", details.Code))
+	}
+	if details.Type != "" {
+		parts = append(parts, fmt.Sprintf("type: %s", details.Type))
+	}
+	if details.RawBody != "" && details.RawBody != details.Message {
+		parts = append(parts, fmt.Sprintf("response body: %s", details.RawBody))
+	}
 
-		if len(parts) > 0 {
-			return fmt.Errorf("%s: %w", strings.Join(parts, ", "), err)
-		}
+	if len(parts) > 0 {
+		return fmt.Errorf("%s: %w", strings.Join(parts, ", "), err)
 	}
 	return err
 }
 
-func providerDisplayName(provider string) string {
-	if p, ok := LookupProvider(provider); ok && p.DisplayName != "" {
-		return p.DisplayName
+func isGemini(provider, url string) bool {
+	if strings.EqualFold(provider, "gemini") {
+		return true
 	}
-	if provider != "" {
-		return provider
+	if strings.Contains(strings.ToLower(url), "generativelanguage.googleapis.com") {
+		return true
 	}
-	return "LLM"
+	return false
 }
 
 // buildOpenAIParams converts the shared ChatRequest into OpenAI SDK parameters.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -10,6 +10,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -210,6 +211,7 @@ type FunctionDef struct {
 
 // ClientConfig holds configuration for connecting to an LLM service.
 type ClientConfig struct {
+	Provider     string            // Known provider name (e.g. "gemini", "openai") or empty
 	URL          string            // Full API endpoint URL
 	APIKey       string            // Bearer token / API key
 	Model        string            // Default model override
@@ -285,6 +287,7 @@ func retryCodesMiddleware(codes []int) func(*http.Request, func(*http.Request) (
 // ResolvedEndpoint because it belongs to the run, not to the endpoint.
 func NewLLMClient(ep ResolvedEndpoint, collector *RetryCollector) LLMClient {
 	cfg := ClientConfig{
+		Provider:       ep.Provider,
 		URL:            ep.URL,
 		APIKey:         ep.Token,
 		Model:          ep.Model,
@@ -512,7 +515,7 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 		}
 	}
 	if err != nil {
-		return nil, err
+		return nil, formatOpenAIError(c.cfg.Provider, model, err)
 	}
 
 	return c.mapOpenAIResponse(sdkResp), nil
@@ -535,7 +538,7 @@ func (c *OpenAIClient) completionsStreaming(ctx context.Context, params openai.C
 	if err != nil {
 		class, phase := classifyStreamError(err)
 		reviseAttempt(ctx, c.cfg.retryCollector, class, phase)
-		return nil, err
+		return nil, formatOpenAIError(c.cfg.Provider, string(params.Model), err)
 	}
 	return resp, nil
 }
@@ -610,6 +613,74 @@ func (c *OpenAIClient) completionsStreamingInner(ctx context.Context, params ope
 	}
 
 	return resp, nil
+}
+
+// formatOpenAIError extracts structured error details from an OpenAI SDK error
+// (*openai.Error, which embeds *apierror.Error), including HTTP status, code,
+// message, and the raw JSON response payload (crucial for providers like
+// Google Gemini whose 400 Bad Request details live in custom nested JSON fields).
+func formatOpenAIError(provider, model string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *openai.Error
+	if errors.As(err, &apiErr) {
+		var rawBody string
+		if raw := apiErr.RawJSON(); raw != "" {
+			rawBody = strings.TrimSpace(raw)
+		} else if apiErr.Response != nil && apiErr.Response.Body != nil {
+			bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
+			apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+			rawBody = strings.TrimSpace(string(bodyBytes))
+		}
+
+		status := apiErr.StatusCode
+		if status == 0 && apiErr.Response != nil {
+			status = apiErr.Response.StatusCode
+		}
+		statusText := http.StatusText(status)
+
+		pName := providerDisplayName(provider)
+
+		var parts []string
+		if status > 0 {
+			if statusText != "" {
+				parts = append(parts, fmt.Sprintf("%s error (HTTP %d %s, model: %s)", pName, status, statusText, model))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s error (HTTP %d, model: %s)", pName, status, model))
+			}
+		} else {
+			parts = append(parts, fmt.Sprintf("%s error (model: %s)", pName, model))
+		}
+
+		if apiErr.Message != "" {
+			parts = append(parts, fmt.Sprintf("message: %s", apiErr.Message))
+		}
+		if apiErr.Code != "" {
+			parts = append(parts, fmt.Sprintf("code: %s", apiErr.Code))
+		}
+		if apiErr.Type != "" {
+			parts = append(parts, fmt.Sprintf("type: %s", apiErr.Type))
+		}
+		if rawBody != "" && rawBody != apiErr.Message {
+			parts = append(parts, fmt.Sprintf("response body: %s", rawBody))
+		}
+
+		if len(parts) > 1 || rawBody != "" {
+			return fmt.Errorf("%s: %w", strings.Join(parts, ", "), err)
+		}
+	}
+	return err
+}
+
+func providerDisplayName(provider string) string {
+	if p, ok := LookupProvider(provider); ok && p.DisplayName != "" {
+		return p.DisplayName
+	}
+	if provider != "" {
+		return provider
+	}
+	return "LLM"
 }
 
 // buildOpenAIParams converts the shared ChatRequest into OpenAI SDK parameters.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -669,7 +669,7 @@ func extractOpenAIErrorDetails(err error) (*openAIErrorDetails, bool) {
 		bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
 		_ = apiErr.Response.Body.Close()
 		apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		details.RawBody = strings.TrimSpace(string(bodyBytes))
+		details.RawBody = limitErrorBodyForLog(string(bodyBytes))
 	}
 
 	return details, true

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -213,7 +213,6 @@ type FunctionDef struct {
 
 // ClientConfig holds configuration for connecting to an LLM service.
 type ClientConfig struct {
-	Provider     string            // Known provider name (e.g. "gemini", "openai") or empty
 	URL          string            // Full API endpoint URL
 	APIKey       string            // Bearer token / API key
 	Model        string            // Default model override
@@ -299,7 +298,6 @@ func limitErrorBodyForLog(raw string) string {
 // ResolvedEndpoint because it belongs to the run, not to the endpoint.
 func NewLLMClient(ep ResolvedEndpoint, collector *RetryCollector) LLMClient {
 	cfg := ClientConfig{
-		Provider:       ep.Provider,
 		URL:            ep.URL,
 		APIKey:         ep.Token,
 		Model:          ep.Model,
@@ -527,7 +525,7 @@ func (c *OpenAIClient) CompletionsWithCtx(ctx context.Context, req ChatRequest) 
 		}
 	}
 	if err != nil {
-		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, model, err)
+		return nil, enrichOpenAIError(err)
 	}
 
 	return c.mapOpenAIResponse(sdkResp), nil
@@ -550,7 +548,7 @@ func (c *OpenAIClient) completionsStreaming(ctx context.Context, params openai.C
 	if err != nil {
 		class, phase := classifyStreamError(err)
 		reviseAttempt(ctx, c.cfg.retryCollector, class, phase)
-		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, string(params.Model), err)
+		return nil, enrichOpenAIError(err)
 	}
 	return resp, nil
 }
@@ -627,105 +625,30 @@ func (c *OpenAIClient) completionsStreamingInner(ctx context.Context, params ope
 	return resp, nil
 }
 
-// openAIErrorDetails captures unmarshaled and raw fields from an *openai.Error.
-type openAIErrorDetails struct {
-	Status   int
-	Message  string
-	Code     string
-	Type     string
-	RawBody  string
-	Original error
-}
-
-// extractOpenAIErrorDetails unwraps an *openai.Error (embedding *apierror.Error),
-// capturing the HTTP status, message, error code, error type, and raw JSON or text body.
-// If the response body was unread, it reads, closes, and restores the body stream.
-// Returns false if err does not unwrap to an *openai.Error.
-func extractOpenAIErrorDetails(err error) (*openAIErrorDetails, bool) {
+// enrichOpenAIError adds a restored error response body when the OpenAI SDK
+// could not extract one. It leaves standard OpenAI error payloads unchanged.
+func enrichOpenAIError(err error) error {
 	if err == nil {
-		return nil, false
+		return nil
 	}
 	var apiErr *openai.Error
 	if !errors.As(err, &apiErr) {
-		return nil, false
+		return err
 	}
-
-	details := &openAIErrorDetails{
-		Status:   apiErr.StatusCode,
-		Message:  apiErr.Message,
-		Code:     apiErr.Code,
-		Type:     apiErr.Type,
-		Original: err,
-	}
-
-	if details.Status == 0 && apiErr.Response != nil {
-		details.Status = apiErr.Response.StatusCode
-	}
-
-	if raw := apiErr.RawJSON(); raw != "" {
-		details.RawBody = limitErrorBodyForLog(raw)
-	} else if apiErr.Response != nil && apiErr.Response.Body != nil {
-		bodyBytes, _ := io.ReadAll(apiErr.Response.Body)
-		_ = apiErr.Response.Body.Close()
-		apiErr.Response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		details.RawBody = limitErrorBodyForLog(string(bodyBytes))
-	}
-
-	return details, true
-}
-
-// formatGeminiError formats structured error details for Google Gemini endpoints
-// (whose 400 Bad Request details live in custom nested JSON fields like google.rpc.ErrorInfo).
-// Non-Gemini providers return the original error unmodified.
-func formatGeminiError(provider, url, model string, err error) error {
-	if err == nil || !isGemini(provider, url) {
+	if strings.TrimSpace(apiErr.RawJSON()) != "" || apiErr.Response == nil || apiErr.Response.Body == nil {
 		return err
 	}
 
-	details, ok := extractOpenAIErrorDetails(err)
-	if !ok {
+	body, readErr := io.ReadAll(apiErr.Response.Body)
+	_ = apiErr.Response.Body.Close()
+	apiErr.Response.Body = io.NopCloser(bytes.NewReader(body))
+	if readErr != nil {
 		return err
 	}
-
-	statusText := http.StatusText(details.Status)
-	var parts []string
-	if details.Status > 0 {
-		if statusText != "" {
-			parts = append(parts, fmt.Sprintf("Google Gemini API error (HTTP %d %s, model: %s)", details.Status, statusText, model))
-		} else {
-			parts = append(parts, fmt.Sprintf("Google Gemini API error (HTTP %d, model: %s)", details.Status, model))
-		}
-	} else {
-		parts = append(parts, fmt.Sprintf("Google Gemini API error (model: %s)", model))
-	}
-
-	if details.Message != "" {
-		parts = append(parts, fmt.Sprintf("message: %s", details.Message))
-	}
-	if details.Code != "" {
-		parts = append(parts, fmt.Sprintf("code: %s", details.Code))
-	}
-	if details.Type != "" {
-		parts = append(parts, fmt.Sprintf("type: %s", details.Type))
-	}
-	if details.RawBody != "" && details.RawBody != details.Message {
-		parts = append(parts, fmt.Sprintf("response body: %s", details.RawBody))
-	}
-
-	if len(parts) > 0 {
-		return fmt.Errorf("%s: %w", strings.Join(parts, ", "), err)
+	if body := limitErrorBodyForLog(string(body)); body != "" {
+		return fmt.Errorf("OpenAI-compatible API error response body: %s: %w", body, err)
 	}
 	return err
-}
-
-func isGemini(provider, url string) bool {
-	if strings.EqualFold(provider, "gemini") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(url), "generativelanguage.googleapis.com") {
-		return true
-	}
-	return false
 }
 
 // buildOpenAIParams converts the shared ChatRequest into OpenAI SDK parameters.

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1992,7 +1992,7 @@ func TestIsGemini(t *testing.T) {
 }
 
 func TestFormatGeminiError_Gemini400BadRequest(t *testing.T) {
-	geminiErrBody := `{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}`
+	geminiErrBody := `[{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}]`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
+	openai "github.com/openai/openai-go/v3"
 )
 
 func TestNewOpenAIClient_URLNormalization(t *testing.T) {
@@ -1920,5 +1921,138 @@ func TestAnthropicClient_RetryCodesTriggersRetry(t *testing.T) {
 	}
 	if got := resp.Content(); got != "success" {
 		t.Errorf("Content() = %q, want %q", got, "success")
+	}
+}
+
+func TestFormatOpenAIError_Gemini400BadRequest(t *testing.T) {
+	geminiErrBody := `{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(geminiErrBody))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		Provider: "gemini",
+		URL:      server.URL + "/v1/chat/completions",
+		APIKey:   "test-key",
+		Model:    "gemini-3.6-flash",
+	})
+
+	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Model:     "gemini-3.6-flash",
+		Messages:  []Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 64,
+	})
+	if err == nil {
+		t.Fatal("CompletionsWithCtx succeeded, want HTTP 400 error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "Google Gemini API error") {
+		t.Errorf("expected provider name in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
+		t.Errorf("expected HTTP 400 Bad Request in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "gemini-3.6-flash") {
+		t.Errorf("expected model in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "Invalid argument in tool call") {
+		t.Errorf("expected error message in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "FIELD_VIOLATION") {
+		t.Errorf("expected raw JSON response body details in error, got: %s", errMsg)
+	}
+
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected wrapped error to be unpackable as *openai.Error, got: %T", err)
+	}
+}
+
+func TestFormatOpenAIError_Streaming400BadRequest(t *testing.T) {
+	errBody := `{"error":{"message":"streaming rejected","type":"invalid_request_error","code":"param_invalid"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(errBody))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		Provider:  "openai",
+		URL:       server.URL + "/v1/chat/completions",
+		APIKey:    "test-key",
+		Model:     "gpt-4o",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Model:     "gpt-4o",
+		Messages:  []Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 64,
+	})
+	if err == nil {
+		t.Fatal("CompletionsWithCtx streaming succeeded, want HTTP 400 error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "OpenAI API error") {
+		t.Errorf("expected provider name in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "streaming rejected") {
+		t.Errorf("expected error message in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "param_invalid") {
+		t.Errorf("expected error code in error, got: %s", errMsg)
+	}
+}
+
+func TestFormatOpenAIError_PlainTextBody(t *testing.T) {
+	plainText := "Bad Request: upstream gateway rejected request syntax"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(plainText))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		URL:    server.URL + "/v1/chat/completions",
+		APIKey: "test-key",
+		Model:  "custom-model",
+	})
+
+	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Model:     "custom-model",
+		Messages:  []Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 64,
+	})
+	if err == nil {
+		t.Fatal("CompletionsWithCtx succeeded, want HTTP 400 error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
+		t.Errorf("expected HTTP 400 Bad Request, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, plainText) {
+		t.Errorf("expected plain text response body, got: %s", errMsg)
+	}
+}
+
+func TestFormatOpenAIError_NilAndNonAPIError(t *testing.T) {
+	if got := formatOpenAIError("openai", "m", nil); got != nil {
+		t.Errorf("formatOpenAIError(nil) = %v, want nil", got)
+	}
+
+	customErr := errors.New("context deadline exceeded")
+	if got := formatOpenAIError("openai", "m", customErr); got != customErr {
+		t.Errorf("formatOpenAIError(customErr) = %v, want %v", got, customErr)
 	}
 }

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1924,92 +1924,24 @@ func TestAnthropicClient_RetryCodesTriggersRetry(t *testing.T) {
 	}
 }
 
-func TestExtractOpenAIErrorDetails(t *testing.T) {
-	if details, ok := extractOpenAIErrorDetails(nil); ok || details != nil {
-		t.Errorf("extractOpenAIErrorDetails(nil) = (%v, %v), want (nil, false)", details, ok)
-	}
-
-	stdErr := errors.New("standard error")
-	if details, ok := extractOpenAIErrorDetails(stdErr); ok || details != nil {
-		t.Errorf("extractOpenAIErrorDetails(stdErr) = (%v, %v), want (nil, false)", details, ok)
-	}
-
-	apiErr := &openai.Error{
-		StatusCode: http.StatusBadRequest,
-		Message:    "Invalid tool choice",
-		Code:       "invalid_tool",
-		Type:       "invalid_request_error",
-		Request:    httptest.NewRequest(http.MethodPost, "https://example.com", nil),
-		Response: &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(strings.NewReader(`{"error":{"detail":"deep"}}`)),
-		},
-	}
-
-	details, ok := extractOpenAIErrorDetails(apiErr)
-	if !ok || details == nil {
-		t.Fatalf("extractOpenAIErrorDetails(apiErr) failed")
-	}
-	if details.Status != http.StatusBadRequest {
-		t.Errorf("Status = %d, want %d", details.Status, http.StatusBadRequest)
-	}
-	if details.Message != "Invalid tool choice" {
-		t.Errorf("Message = %q, want %q", details.Message, "Invalid tool choice")
-	}
-	if details.Code != "invalid_tool" {
-		t.Errorf("Code = %q, want %q", details.Code, "invalid_tool")
-	}
-	if details.Type != "invalid_request_error" {
-		t.Errorf("Type = %q, want %q", details.Type, "invalid_request_error")
-	}
-	if details.RawBody != `{"error":{"detail":"deep"}}` {
-		t.Errorf("RawBody = %q, want %q", details.RawBody, `{"error":{"detail":"deep"}}`)
-	}
-}
-
-func TestIsGemini(t *testing.T) {
-	tests := []struct {
-		provider string
-		url      string
-		want     bool
-	}{
-		{"gemini", "", true},
-		{"Gemini", "", true},
-		{"GEMINI", "", true},
-		{"", "https://generativelanguage.googleapis.com/v1beta/openai", true},
-		{"custom-gemini", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", true},
-		{"openai", "https://api.openai.com/v1", false},
-		{"deepseek", "https://api.deepseek.com/v1", false},
-		{"", "https://api.anthropic.com", false},
-	}
-
-	for _, tt := range tests {
-		got := isGemini(tt.provider, tt.url)
-		if got != tt.want {
-			t.Errorf("isGemini(%q, %q) = %v, want %v", tt.provider, tt.url, got, tt.want)
-		}
-	}
-}
-
-func TestFormatGeminiError_Gemini400BadRequest(t *testing.T) {
-	geminiErrBody := `[{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}]`
+func TestOpenAIClient_EnrichesRestoredErrorBody(t *testing.T) {
+	errBody := `[{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}]`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(geminiErrBody))
+		_, _ = w.Write([]byte(errBody))
 	}))
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		Provider: "gemini",
-		URL:      server.URL + "/v1/chat/completions",
-		APIKey:   "test-key",
-		Model:    "gemini-3.6-flash",
+		URL:    server.URL + "/v1/chat/completions",
+		APIKey: "test-key",
+		Model:  "custom-model",
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
-		Model:     "gemini-3.6-flash",
+		Model:     "custom-model",
 		Messages:  []Message{{Role: "user", Content: "hello"}},
 		MaxTokens: 64,
 	})
@@ -2018,17 +1950,8 @@ func TestFormatGeminiError_Gemini400BadRequest(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "Google Gemini API error") {
-		t.Errorf("expected provider name in error, got: %s", errMsg)
-	}
-	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
-		t.Errorf("expected HTTP 400 Bad Request in error, got: %s", errMsg)
-	}
-	if !strings.Contains(errMsg, "gemini-3.6-flash") {
-		t.Errorf("expected model in error, got: %s", errMsg)
-	}
-	if !strings.Contains(errMsg, "Invalid argument in tool call") {
-		t.Errorf("expected error message in error, got: %s", errMsg)
+	if !strings.Contains(errMsg, "OpenAI-compatible API error response body") {
+		t.Errorf("expected fallback prefix, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "FIELD_VIOLATION") {
 		t.Errorf("expected raw JSON response body details in error, got: %s", errMsg)
@@ -2036,11 +1959,21 @@ func TestFormatGeminiError_Gemini400BadRequest(t *testing.T) {
 
 	var apiErr *openai.Error
 	if !errors.As(err, &apiErr) {
-		t.Errorf("expected wrapped error to be unpackable as *openai.Error, got: %T", err)
+		t.Fatalf("expected wrapped error to be unpackable as *openai.Error, got: %T", err)
+	}
+	if apiErr.RawJSON() != "" {
+		t.Errorf("RawJSON() = %q, want empty for array-wrapped payload", apiErr.RawJSON())
+	}
+	restored, readErr := io.ReadAll(apiErr.Response.Body)
+	if readErr != nil {
+		t.Fatalf("read restored response body: %v", readErr)
+	}
+	if got := string(restored); got != errBody {
+		t.Errorf("restored response body = %q, want %q", got, errBody)
 	}
 }
 
-func TestFormatGeminiError_NonGeminiUntouched(t *testing.T) {
+func TestOpenAIClient_LeavesUsefulSDKErrorUnchanged(t *testing.T) {
 	errBody := `{"error":{"message":"streaming rejected","type":"invalid_request_error","code":"param_invalid"}}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2051,14 +1984,13 @@ func TestFormatGeminiError_NonGeminiUntouched(t *testing.T) {
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		Provider: "openai",
-		URL:      server.URL + "/v1/chat/completions",
-		APIKey:   "test-key",
-		Model:    "gpt-4o",
+		URL:    server.URL + "/v1/chat/completions",
+		APIKey: "test-key",
+		Model:  "custom-model",
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
-		Model:     "gpt-4o",
+		Model:     "custom-model",
 		Messages:  []Message{{Role: "user", Content: "hello"}},
 		MaxTokens: 64,
 	})
@@ -2066,23 +1998,21 @@ func TestFormatGeminiError_NonGeminiUntouched(t *testing.T) {
 		t.Fatal("CompletionsWithCtx succeeded, want error")
 	}
 
-	// For non-Gemini providers, the error must be returned unmodified without "Google Gemini API error" prefix
 	errMsg := err.Error()
-	if strings.Contains(errMsg, "Google Gemini API error") {
-		t.Errorf("did not expect Google Gemini prefix for openai provider, got: %s", errMsg)
+	if strings.Contains(errMsg, "OpenAI-compatible API error response body") {
+		t.Errorf("did not expect fallback prefix for standard error, got: %s", errMsg)
 	}
-
-	rawErr := &openai.Error{
-		StatusCode: http.StatusBadRequest,
-		Message:    "non-gemini error",
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *openai.Error, got %T", err)
 	}
-	if got := formatGeminiError("openai", "https://api.openai.com", "gpt-4o", rawErr); got != rawErr {
-		t.Errorf("formatGeminiError for openai = %v, want exact original error pointer %v", got, rawErr)
+	if apiErr.RawJSON() == "" {
+		t.Error("RawJSON() is empty, want SDK error payload")
 	}
 }
 
-func TestFormatGeminiError_Streaming400BadRequest(t *testing.T) {
-	errBody := `{"error":{"code":400,"message":"streaming rejected","status":"INVALID_ARGUMENT"}}`
+func TestOpenAIClient_StreamingEnrichesRestoredErrorBody(t *testing.T) {
+	errBody := `[{"error":{"code":400,"message":"streaming rejected","status":"INVALID_ARGUMENT"}}]`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2092,15 +2022,14 @@ func TestFormatGeminiError_Streaming400BadRequest(t *testing.T) {
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		Provider:  "gemini",
 		URL:       server.URL + "/v1/chat/completions",
 		APIKey:    "test-key",
-		Model:     "gemini-3.6-flash",
+		Model:     "custom-model",
 		ExtraBody: map[string]any{"stream": true},
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
-		Model:     "gemini-3.6-flash",
+		Model:     "custom-model",
 		Messages:  []Message{{Role: "user", Content: "hello"}},
 		MaxTokens: 64,
 	})
@@ -2109,15 +2038,15 @@ func TestFormatGeminiError_Streaming400BadRequest(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "Google Gemini API error") {
-		t.Errorf("expected provider name in error, got: %s", errMsg)
+	if !strings.Contains(errMsg, "OpenAI-compatible API error response body") {
+		t.Errorf("expected fallback prefix, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "streaming rejected") {
 		t.Errorf("expected error message in error, got: %s", errMsg)
 	}
 }
 
-func TestFormatGeminiError_PlainTextBody(t *testing.T) {
+func TestOpenAIClient_EnrichesPlainTextErrorBody(t *testing.T) {
 	plainText := "Bad Request: upstream gateway rejected request syntax"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2128,14 +2057,13 @@ func TestFormatGeminiError_PlainTextBody(t *testing.T) {
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		Provider: "gemini",
-		URL:      server.URL + "/v1/chat/completions",
-		APIKey:   "test-key",
-		Model:    "gemini-3.6-flash",
+		URL:    server.URL + "/v1/chat/completions",
+		APIKey: "test-key",
+		Model:  "custom-model",
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
-		Model:     "gemini-3.6-flash",
+		Model:     "custom-model",
 		Messages:  []Message{{Role: "user", Content: "hello"}},
 		MaxTokens: 64,
 	})
@@ -2144,58 +2072,55 @@ func TestFormatGeminiError_PlainTextBody(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
-		t.Errorf("expected HTTP 400 Bad Request, got: %s", errMsg)
+	if !strings.Contains(errMsg, "OpenAI-compatible API error response body") {
+		t.Errorf("expected fallback prefix, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, plainText) {
 		t.Errorf("expected plain text response body, got: %s", errMsg)
 	}
 }
 
-func TestFormatGeminiError_NilAndNonAPIError(t *testing.T) {
-	if got := formatGeminiError("gemini", "", "m", nil); got != nil {
-		t.Errorf("formatGeminiError(nil) = %v, want nil", got)
+func TestEnrichOpenAIError_NilAndNonAPIError(t *testing.T) {
+	if got := enrichOpenAIError(nil); got != nil {
+		t.Errorf("enrichOpenAIError(nil) = %v, want nil", got)
 	}
 
 	customErr := errors.New("context deadline exceeded")
-	if got := formatGeminiError("gemini", "", "m", customErr); got != customErr {
-		t.Errorf("formatGeminiError(customErr) = %v, want %v", got, customErr)
+	if got := enrichOpenAIError(customErr); got != customErr {
+		t.Errorf("enrichOpenAIError(customErr) = %v, want %v", got, customErr)
 	}
 }
 
-func TestFormatGeminiError_EmptyDetails(t *testing.T) {
+func TestEnrichOpenAIError_EmptyResponseBodyUntouched(t *testing.T) {
 	apiErr := &openai.Error{
 		StatusCode: http.StatusBadGateway,
-		Request:    httptest.NewRequest(http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", nil),
+		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
 		Response: &http.Response{
 			StatusCode: http.StatusBadGateway,
 			Body:       http.NoBody,
 		},
 	}
 
-	err := formatGeminiError("", "https://generativelanguage.googleapis.com/v1beta/openai", "gemini-test", apiErr)
-	if !strings.Contains(err.Error(), "Google Gemini API error (HTTP 502 Bad Gateway, model: gemini-test)") {
-		t.Errorf("expected formatted provider context, got: %s", err)
-	}
-
-	var got *openai.Error
-	if !errors.As(err, &got) || got != apiErr {
-		t.Errorf("expected wrapped original API error, got: %v", err)
+	if got := enrichOpenAIError(apiErr); got != apiErr {
+		t.Errorf("enrichOpenAIError(apiErr) = %v, want original error %v", got, apiErr)
 	}
 }
 
-func TestFormatGeminiError_ClosesReplacedResponseBody(t *testing.T) {
+func TestEnrichOpenAIError_ClosesAndRestoresResponseBody(t *testing.T) {
 	body := &trackingReadCloser{Reader: strings.NewReader("upstream error")}
 	apiErr := &openai.Error{
 		StatusCode: http.StatusBadRequest,
-		Request:    httptest.NewRequest(http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", nil),
+		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
 		Response: &http.Response{
 			StatusCode: http.StatusBadRequest,
 			Body:       body,
 		},
 	}
 
-	_ = formatGeminiError("gemini", "", "gemini-test", apiErr)
+	err := enrichOpenAIError(apiErr)
+	if !strings.Contains(err.Error(), "upstream error") {
+		t.Errorf("expected response body in error, got: %s", err)
+	}
 	if !body.closed {
 		t.Error("original response body was not closed")
 	}
@@ -2206,6 +2131,34 @@ func TestFormatGeminiError_ClosesReplacedResponseBody(t *testing.T) {
 	}
 	if got, want := string(restored), "upstream error"; got != want {
 		t.Errorf("restored response body = %q, want %q", got, want)
+	}
+}
+
+func TestEnrichOpenAIError_LimitsDiagnosticButRestoresFullBody(t *testing.T) {
+	bodyText := strings.Repeat("x", maxErrorBodyBytes) + "tail-marker"
+	apiErr := &openai.Error{
+		StatusCode: http.StatusBadRequest,
+		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
+		Response: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(bodyText)),
+		},
+	}
+
+	err := enrichOpenAIError(apiErr)
+	if !strings.Contains(err.Error(), "... (truncated)") {
+		t.Errorf("expected truncated diagnostic, got: %s", err)
+	}
+	if strings.Contains(err.Error(), "tail-marker") {
+		t.Errorf("diagnostic contains body content beyond the limit: %s", err)
+	}
+
+	restored, readErr := io.ReadAll(apiErr.Response.Body)
+	if readErr != nil {
+		t.Fatalf("read restored response body: %v", readErr)
+	}
+	if got := string(restored); got != bodyText {
+		t.Errorf("restored response body length = %d, want %d", len(got), len(bodyText))
 	}
 }
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -2209,27 +2209,16 @@ func TestFormatGeminiError_ClosesReplacedResponseBody(t *testing.T) {
 	}
 }
 
-func TestLimitErrorResponseBody(t *testing.T) {
-	body := &trackingReadCloser{Reader: strings.NewReader(strings.Repeat("x", maxErrorBodyBytes+1))}
-	resp, err := limitErrorResponseBody(httptest.NewRequest(http.MethodGet, "https://api.example.com", nil), func(*http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: http.StatusBadGateway, Body: body}, nil
-	})
-	if err != nil {
-		t.Fatalf("limitErrorResponseBody: %v", err)
+func TestLimitErrorBodyForLog(t *testing.T) {
+	withinLimit := strings.Repeat("x", maxErrorBodyBytes)
+	if got := limitErrorBodyForLog(withinLimit); got != withinLimit {
+		t.Errorf("limitErrorBodyForLog within limit = %q, want unmodified input", got)
 	}
 
-	contents, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read limited response body: %v", err)
-	}
-	if got, want := len(contents), maxErrorBodyBytes; got != want {
-		t.Errorf("limited response body length = %d, want %d", got, want)
-	}
-	if err := resp.Body.Close(); err != nil {
-		t.Fatalf("close limited response body: %v", err)
-	}
-	if !body.closed {
-		t.Error("limited response body did not close the transport body")
+	overLimit := strings.Repeat("x", maxErrorBodyBytes+1)
+	want := strings.Repeat("x", maxErrorBodyBytes) + "... (truncated)"
+	if got := limitErrorBodyForLog(overLimit); got != want {
+		t.Errorf("limitErrorBodyForLog over limit = %q, want %q", got, want)
 	}
 }
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1924,7 +1924,74 @@ func TestAnthropicClient_RetryCodesTriggersRetry(t *testing.T) {
 	}
 }
 
-func TestFormatOpenAIError_Gemini400BadRequest(t *testing.T) {
+func TestExtractOpenAIErrorDetails(t *testing.T) {
+	if details, ok := extractOpenAIErrorDetails(nil); ok || details != nil {
+		t.Errorf("extractOpenAIErrorDetails(nil) = (%v, %v), want (nil, false)", details, ok)
+	}
+
+	stdErr := errors.New("standard error")
+	if details, ok := extractOpenAIErrorDetails(stdErr); ok || details != nil {
+		t.Errorf("extractOpenAIErrorDetails(stdErr) = (%v, %v), want (nil, false)", details, ok)
+	}
+
+	apiErr := &openai.Error{
+		StatusCode: http.StatusBadRequest,
+		Message:    "Invalid tool choice",
+		Code:       "invalid_tool",
+		Type:       "invalid_request_error",
+		Request:    httptest.NewRequest(http.MethodPost, "https://example.com", nil),
+		Response: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"detail":"deep"}}`)),
+		},
+	}
+
+	details, ok := extractOpenAIErrorDetails(apiErr)
+	if !ok || details == nil {
+		t.Fatalf("extractOpenAIErrorDetails(apiErr) failed")
+	}
+	if details.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", details.Status, http.StatusBadRequest)
+	}
+	if details.Message != "Invalid tool choice" {
+		t.Errorf("Message = %q, want %q", details.Message, "Invalid tool choice")
+	}
+	if details.Code != "invalid_tool" {
+		t.Errorf("Code = %q, want %q", details.Code, "invalid_tool")
+	}
+	if details.Type != "invalid_request_error" {
+		t.Errorf("Type = %q, want %q", details.Type, "invalid_request_error")
+	}
+	if details.RawBody != `{"error":{"detail":"deep"}}` {
+		t.Errorf("RawBody = %q, want %q", details.RawBody, `{"error":{"detail":"deep"}}`)
+	}
+}
+
+func TestIsGemini(t *testing.T) {
+	tests := []struct {
+		provider string
+		url      string
+		want     bool
+	}{
+		{"gemini", "", true},
+		{"Gemini", "", true},
+		{"GEMINI", "", true},
+		{"", "https://generativelanguage.googleapis.com/v1beta/openai", true},
+		{"custom-gemini", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", true},
+		{"openai", "https://api.openai.com/v1", false},
+		{"deepseek", "https://api.deepseek.com/v1", false},
+		{"", "https://api.anthropic.com", false},
+	}
+
+	for _, tt := range tests {
+		got := isGemini(tt.provider, tt.url)
+		if got != tt.want {
+			t.Errorf("isGemini(%q, %q) = %v, want %v", tt.provider, tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestFormatGeminiError_Gemini400BadRequest(t *testing.T) {
 	geminiErrBody := `{"error":{"code":400,"message":"Invalid argument in tool call","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"FIELD_VIOLATION","metadata":{"field":"messages.tool_calls"}}]}}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1973,7 +2040,7 @@ func TestFormatOpenAIError_Gemini400BadRequest(t *testing.T) {
 	}
 }
 
-func TestFormatOpenAIError_Streaming400BadRequest(t *testing.T) {
+func TestFormatGeminiError_NonGeminiUntouched(t *testing.T) {
 	errBody := `{"error":{"message":"streaming rejected","type":"invalid_request_error","code":"param_invalid"}}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1984,11 +2051,10 @@ func TestFormatOpenAIError_Streaming400BadRequest(t *testing.T) {
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		Provider:  "openai",
-		URL:       server.URL + "/v1/chat/completions",
-		APIKey:    "test-key",
-		Model:     "gpt-4o",
-		ExtraBody: map[string]any{"stream": true},
+		Provider: "openai",
+		URL:      server.URL + "/v1/chat/completions",
+		APIKey:   "test-key",
+		Model:    "gpt-4o",
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
@@ -1997,22 +2063,61 @@ func TestFormatOpenAIError_Streaming400BadRequest(t *testing.T) {
 		MaxTokens: 64,
 	})
 	if err == nil {
+		t.Fatal("CompletionsWithCtx succeeded, want error")
+	}
+
+	// For non-Gemini providers, the error must be returned unmodified without "Google Gemini API error" prefix
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "Google Gemini API error") {
+		t.Errorf("did not expect Google Gemini prefix for openai provider, got: %s", errMsg)
+	}
+
+	rawErr := &openai.Error{
+		StatusCode: http.StatusBadRequest,
+		Message:    "non-gemini error",
+	}
+	if got := formatGeminiError("openai", "https://api.openai.com", "gpt-4o", rawErr); got != rawErr {
+		t.Errorf("formatGeminiError for openai = %v, want exact original error pointer %v", got, rawErr)
+	}
+}
+
+func TestFormatGeminiError_Streaming400BadRequest(t *testing.T) {
+	errBody := `{"error":{"code":400,"message":"streaming rejected","status":"INVALID_ARGUMENT"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(errBody))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		Provider:  "gemini",
+		URL:       server.URL + "/v1/chat/completions",
+		APIKey:    "test-key",
+		Model:     "gemini-3.6-flash",
+		ExtraBody: map[string]any{"stream": true},
+	})
+
+	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Model:     "gemini-3.6-flash",
+		Messages:  []Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 64,
+	})
+	if err == nil {
 		t.Fatal("CompletionsWithCtx streaming succeeded, want HTTP 400 error")
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "OpenAI API error") {
+	if !strings.Contains(errMsg, "Google Gemini API error") {
 		t.Errorf("expected provider name in error, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "streaming rejected") {
 		t.Errorf("expected error message in error, got: %s", errMsg)
 	}
-	if !strings.Contains(errMsg, "param_invalid") {
-		t.Errorf("expected error code in error, got: %s", errMsg)
-	}
 }
 
-func TestFormatOpenAIError_PlainTextBody(t *testing.T) {
+func TestFormatGeminiError_PlainTextBody(t *testing.T) {
 	plainText := "Bad Request: upstream gateway rejected request syntax"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2023,13 +2128,14 @@ func TestFormatOpenAIError_PlainTextBody(t *testing.T) {
 	defer server.Close()
 
 	client := NewOpenAIClient(ClientConfig{
-		URL:    server.URL + "/v1/chat/completions",
-		APIKey: "test-key",
-		Model:  "custom-model",
+		Provider: "gemini",
+		URL:      server.URL + "/v1/chat/completions",
+		APIKey:   "test-key",
+		Model:    "gemini-3.6-flash",
 	})
 
 	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
-		Model:     "custom-model",
+		Model:     "gemini-3.6-flash",
 		Messages:  []Message{{Role: "user", Content: "hello"}},
 		MaxTokens: 64,
 	})
@@ -2046,29 +2152,29 @@ func TestFormatOpenAIError_PlainTextBody(t *testing.T) {
 	}
 }
 
-func TestFormatOpenAIError_NilAndNonAPIError(t *testing.T) {
-	if got := formatOpenAIError("openai", "m", nil); got != nil {
-		t.Errorf("formatOpenAIError(nil) = %v, want nil", got)
+func TestFormatGeminiError_NilAndNonAPIError(t *testing.T) {
+	if got := formatGeminiError("gemini", "", "m", nil); got != nil {
+		t.Errorf("formatGeminiError(nil) = %v, want nil", got)
 	}
 
 	customErr := errors.New("context deadline exceeded")
-	if got := formatOpenAIError("openai", "m", customErr); got != customErr {
-		t.Errorf("formatOpenAIError(customErr) = %v, want %v", got, customErr)
+	if got := formatGeminiError("gemini", "", "m", customErr); got != customErr {
+		t.Errorf("formatGeminiError(customErr) = %v, want %v", got, customErr)
 	}
 }
 
-func TestFormatOpenAIError_EmptyDetails(t *testing.T) {
+func TestFormatGeminiError_EmptyDetails(t *testing.T) {
 	apiErr := &openai.Error{
 		StatusCode: http.StatusBadGateway,
-		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
+		Request:    httptest.NewRequest(http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", nil),
 		Response: &http.Response{
 			StatusCode: http.StatusBadGateway,
 			Body:       http.NoBody,
 		},
 	}
 
-	err := formatOpenAIError("openai", "gpt-test", apiErr)
-	if !strings.Contains(err.Error(), "OpenAI API error (HTTP 502 Bad Gateway, model: gpt-test)") {
+	err := formatGeminiError("", "https://generativelanguage.googleapis.com/v1beta/openai", "gemini-test", apiErr)
+	if !strings.Contains(err.Error(), "Google Gemini API error (HTTP 502 Bad Gateway, model: gemini-test)") {
 		t.Errorf("expected formatted provider context, got: %s", err)
 	}
 
@@ -2078,18 +2184,18 @@ func TestFormatOpenAIError_EmptyDetails(t *testing.T) {
 	}
 }
 
-func TestFormatOpenAIError_ClosesReplacedResponseBody(t *testing.T) {
+func TestFormatGeminiError_ClosesReplacedResponseBody(t *testing.T) {
 	body := &trackingReadCloser{Reader: strings.NewReader("upstream error")}
 	apiErr := &openai.Error{
 		StatusCode: http.StatusBadRequest,
-		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
+		Request:    httptest.NewRequest(http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", nil),
 		Response: &http.Response{
 			StatusCode: http.StatusBadRequest,
 			Body:       body,
 		},
 	}
 
-	_ = formatOpenAIError("openai", "gpt-test", apiErr)
+	_ = formatGeminiError("gemini", "", "gemini-test", apiErr)
 	if !body.closed {
 		t.Error("original response body was not closed")
 	}

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -2056,3 +2056,83 @@ func TestFormatOpenAIError_NilAndNonAPIError(t *testing.T) {
 		t.Errorf("formatOpenAIError(customErr) = %v, want %v", got, customErr)
 	}
 }
+
+func TestFormatOpenAIError_EmptyDetails(t *testing.T) {
+	apiErr := &openai.Error{
+		StatusCode: http.StatusBadGateway,
+		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
+		Response: &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Body:       http.NoBody,
+		},
+	}
+
+	err := formatOpenAIError("openai", "gpt-test", apiErr)
+	if !strings.Contains(err.Error(), "OpenAI API error (HTTP 502 Bad Gateway, model: gpt-test)") {
+		t.Errorf("expected formatted provider context, got: %s", err)
+	}
+
+	var got *openai.Error
+	if !errors.As(err, &got) || got != apiErr {
+		t.Errorf("expected wrapped original API error, got: %v", err)
+	}
+}
+
+func TestFormatOpenAIError_ClosesReplacedResponseBody(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("upstream error")}
+	apiErr := &openai.Error{
+		StatusCode: http.StatusBadRequest,
+		Request:    httptest.NewRequest(http.MethodPost, "https://api.example.com/v1/chat/completions", nil),
+		Response: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       body,
+		},
+	}
+
+	_ = formatOpenAIError("openai", "gpt-test", apiErr)
+	if !body.closed {
+		t.Error("original response body was not closed")
+	}
+
+	restored, err := io.ReadAll(apiErr.Response.Body)
+	if err != nil {
+		t.Fatalf("read restored response body: %v", err)
+	}
+	if got, want := string(restored), "upstream error"; got != want {
+		t.Errorf("restored response body = %q, want %q", got, want)
+	}
+}
+
+func TestLimitErrorResponseBody(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader(strings.Repeat("x", maxErrorBodyBytes+1))}
+	resp, err := limitErrorResponseBody(httptest.NewRequest(http.MethodGet, "https://api.example.com", nil), func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusBadGateway, Body: body}, nil
+	})
+	if err != nil {
+		t.Fatalf("limitErrorResponseBody: %v", err)
+	}
+
+	contents, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read limited response body: %v", err)
+	}
+	if got, want := len(contents), maxErrorBodyBytes; got != want {
+		t.Errorf("limited response body length = %d, want %d", got, want)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close limited response body: %v", err)
+	}
+	if !body.closed {
+		t.Error("limited response body did not close the transport body")
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -48,6 +48,7 @@ func NewOpenAIResponsesClient(cfg ClientConfig) *OpenAIResponsesClient {
 		openaiopt.WithMaxRetries(5),
 		openaiopt.WithHeader("User-Agent", userAgent("")),
 		openaiopt.WithRequestTimeout(cfg.Timeout),
+		openaiopt.WithMiddleware(limitErrorResponseBody),
 	}
 	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
 		opts = append(opts, openaiopt.WithMiddleware(mw))

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -126,7 +126,7 @@ func (c *OpenAIResponsesClient) CompletionsWithCtx(ctx context.Context, req Chat
 
 	sdkResp, err := c.sdk.Responses.New(ctx, params, opts...)
 	if err != nil {
-		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, model, err)
+		return nil, enrichOpenAIError(err)
 	}
 
 	// The Responses API returns HTTP 200 even when the response object is in a

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -126,7 +126,7 @@ func (c *OpenAIResponsesClient) CompletionsWithCtx(ctx context.Context, req Chat
 
 	sdkResp, err := c.sdk.Responses.New(ctx, params, opts...)
 	if err != nil {
-		return nil, err
+		return nil, formatOpenAIError(c.cfg.Provider, model, err)
 	}
 
 	// The Responses API returns HTTP 200 even when the response object is in a

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -127,7 +127,7 @@ func (c *OpenAIResponsesClient) CompletionsWithCtx(ctx context.Context, req Chat
 
 	sdkResp, err := c.sdk.Responses.New(ctx, params, opts...)
 	if err != nil {
-		return nil, formatOpenAIError(c.cfg.Provider, model, err)
+		return nil, formatGeminiError(c.cfg.Provider, c.cfg.URL, model, err)
 	}
 
 	// The Responses API returns HTTP 200 even when the response object is in a

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -48,7 +48,6 @@ func NewOpenAIResponsesClient(cfg ClientConfig) *OpenAIResponsesClient {
 		openaiopt.WithMaxRetries(5),
 		openaiopt.WithHeader("User-Agent", userAgent("")),
 		openaiopt.WithRequestTimeout(cfg.Timeout),
-		openaiopt.WithMiddleware(limitErrorResponseBody),
 	}
 	if mw := retryCodesMiddleware(cfg.RetryCodes); mw != nil {
 		opts = append(opts, openaiopt.WithMiddleware(mw))

--- a/internal/llm/responses_client_test.go
+++ b/internal/llm/responses_client_test.go
@@ -832,7 +832,7 @@ func TestOpenAIResponsesClient_ExtraBodyPromptCacheKeyOverridesSessionID(t *test
 	}
 }
 
-func TestOpenAIResponsesClient_FormatError400(t *testing.T) {
+func TestOpenAIResponsesClient_FormatGeminiError400(t *testing.T) {
 	errBody := `{"error":{"message":"responses parameter invalid","type":"invalid_request_error","code":"invalid_param"}}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -843,10 +843,10 @@ func TestOpenAIResponsesClient_FormatError400(t *testing.T) {
 	defer server.Close()
 
 	client := NewLLMClient(ResolvedEndpoint{
-		Provider: "openai",
+		Provider: "gemini",
 		URL:      server.URL + "/v1",
 		Token:    "test-key",
-		Model:    "gpt-5.4",
+		Model:    "gemini-3.6-flash",
 		Protocol: ProtocolOpenAIResponses,
 	}, nil)
 
@@ -858,7 +858,7 @@ func TestOpenAIResponsesClient_FormatError400(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "OpenAI API error") {
+	if !strings.Contains(errMsg, "Google Gemini API error") {
 		t.Errorf("expected provider name in error, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {

--- a/internal/llm/responses_client_test.go
+++ b/internal/llm/responses_client_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -828,5 +829,42 @@ func TestOpenAIResponsesClient_ExtraBodyPromptCacheKeyOverridesSessionID(t *test
 	}
 	if got := gotBody["prompt_cache_key"]; got != "file-session-uuid" {
 		t.Errorf("prompt_cache_key = %v, want typed SessionID %q", got, "file-session-uuid")
+	}
+}
+
+func TestOpenAIResponsesClient_FormatError400(t *testing.T) {
+	errBody := `{"error":{"message":"responses parameter invalid","type":"invalid_request_error","code":"invalid_param"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(errBody))
+	}))
+	defer server.Close()
+
+	client := NewLLMClient(ResolvedEndpoint{
+		Provider: "openai",
+		URL:      server.URL + "/v1",
+		Token:    "test-key",
+		Model:    "gpt-5.4",
+		Protocol: ProtocolOpenAIResponses,
+	}, nil)
+
+	_, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages: []Message{{Role: "user", Content: "ping"}},
+	})
+	if err == nil {
+		t.Fatal("CompletionsWithCtx succeeded, want HTTP 400 error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "OpenAI API error") {
+		t.Errorf("expected provider name in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
+		t.Errorf("expected HTTP 400 Bad Request in error, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "responses parameter invalid") {
+		t.Errorf("expected error message in error, got: %s", errMsg)
 	}
 }

--- a/internal/llm/responses_client_test.go
+++ b/internal/llm/responses_client_test.go
@@ -832,8 +832,8 @@ func TestOpenAIResponsesClient_ExtraBodyPromptCacheKeyOverridesSessionID(t *test
 	}
 }
 
-func TestOpenAIResponsesClient_FormatGeminiError400(t *testing.T) {
-	errBody := `{"error":{"message":"responses parameter invalid","type":"invalid_request_error","code":"invalid_param"}}`
+func TestOpenAIResponsesClient_EnrichesRestoredErrorBody(t *testing.T) {
+	errBody := `[{"error":{"message":"responses parameter invalid","type":"invalid_request_error","code":"invalid_param"}}]`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -843,10 +843,9 @@ func TestOpenAIResponsesClient_FormatGeminiError400(t *testing.T) {
 	defer server.Close()
 
 	client := NewLLMClient(ResolvedEndpoint{
-		Provider: "gemini",
 		URL:      server.URL + "/v1",
 		Token:    "test-key",
-		Model:    "gemini-3.6-flash",
+		Model:    "custom-model",
 		Protocol: ProtocolOpenAIResponses,
 	}, nil)
 
@@ -858,11 +857,8 @@ func TestOpenAIResponsesClient_FormatGeminiError400(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if !strings.Contains(errMsg, "Google Gemini API error") {
-		t.Errorf("expected provider name in error, got: %s", errMsg)
-	}
-	if !strings.Contains(errMsg, "HTTP 400 Bad Request") {
-		t.Errorf("expected HTTP 400 Bad Request in error, got: %s", errMsg)
+	if !strings.Contains(errMsg, "OpenAI-compatible API error response body") {
+		t.Errorf("expected fallback prefix, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "responses parameter invalid") {
 		t.Errorf("expected error message in error, got: %s", errMsg)


### PR DESCRIPTION
## Description

When Google Gemini (via OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`) returns an HTTP error (e.g. `400 Bad Request`), the default `*openai.Error` string only reports the HTTP status line without vendor payload details (such as Google RPC `details`, `fieldViolations`, and parameter error codes).

This PR introduces structured error extraction from the OpenAI SDK (`*openai.Error` / `*apierror.Error`), surfacing the raw JSON response payload and HTTP status specifically for Gemini endpoints, while leaving all other providers unmodified.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [x] Manual testing

For manual testing I ran the `make build` and `./dist/opencodereview review --from main --to HEAD --background "LLM error reporting improvements"` to see if the changes were successful.


## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [ ] I have performed a self-review of my code (will do before I switch from Draft to ready)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1042 .
<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
