### PR TITLE
fix(skill): handle delegate CLI version skew and background limits

### DIFF
--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -167,6 +167,8 @@ If the user requested "review and fix":
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
 
+- **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
+
 ### Recovering Oversized Background Context
 
 `--background-file` has two independent limits. The raw file must not exceed
@@ -185,8 +187,6 @@ condition aborts the command. When the command reports either limit:
    oversized file and fail again.
 4. If a faithful summary is not possible, omit the OCR background entirely and
    read the original material directly during the review.
-
-- **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
 
 ### Troubleshooting CLI Version Compatibility
 

--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -166,7 +166,6 @@ If the user requested "review and fix":
 - **Working directory matters** — `ocr delegate` operates on the Git repo at the current directory. Use `--repo /path` to override.
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
-
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
 
 ### Recovering Oversized Background Context

--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -63,6 +63,29 @@ This outputs:
 | Branch comparison | `ocr delegate preview --from main --to feature` |
 | Single commit | `ocr delegate preview -c abc123` |
 
+### CLI Output Compatibility
+
+The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and
+the installed CLI can be updated independently, so try the JSON form first
+and make the fallback decision from the actual error:
+
+1. Run the requested `preview` or `rule` command with `--format json`.
+2. If it fails specifically with `unknown flag: --format`, rerun the same
+   command without `--format json` and use text output for the rest of the
+   delegation run. Preserve the explicit mode, ref, file, and rule information
+   from that output; do not parse text output as JSON or invent missing schema
+   fields.
+3. Do not retry without the flag for any other error. Report that error and
+   stop the affected workflow.
+
+For integrations that require `schema_version` or other JSON fields, do not
+silently fall back to text. Require `ocr` v1.9.0 or newer, verify with
+`ocr --version`, and upgrade the CLI when necessary:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
 ### Step 2: Get Rules for Files
 
 ```bash
@@ -166,4 +189,20 @@ If the user requested "review and fix":
 - **Working directory matters** — `ocr delegate` operates on the Git repo at the current directory. Use `--repo /path` to override.
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
+
+### Recovering Oversized Background Context
+
+`--background-file` has two independent limits. The raw file must not exceed
+1 MiB, and the sanitized content must not exceed 8000 characters. Either
+condition aborts the command. When the command reports either limit:
+
+1. Do not silently truncate the source file.
+2. Summarize the original material while preserving its requirements,
+   constraints, acceptance criteria, and other review-critical details.
+3. Retry the affected command with `--background "<summary>"`; omit
+   `--background-file` because the file option takes precedence when both are
+   provided.
+4. If a faithful summary is not possible, omit the OCR background entirely and
+   read the original material directly during the review.
+
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.

--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -63,29 +63,6 @@ This outputs:
 | Branch comparison | `ocr delegate preview --from main --to feature` |
 | Single commit | `ocr delegate preview -c abc123` |
 
-### CLI Output Compatibility
-
-The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and
-the installed CLI can be updated independently, so try the JSON form first
-and make the fallback decision from the actual error:
-
-1. Run the requested `preview` or `rule` command with `--format json`.
-2. If it fails specifically with `unknown flag: --format`, rerun the same
-   command without `--format json` and use text output for the rest of the
-   delegation run. Preserve the explicit mode, ref, file, and rule information
-   from that output; do not parse text output as JSON or invent missing schema
-   fields.
-3. Do not retry without the flag for any other error. Report that error and
-   stop the affected workflow.
-
-For integrations that require `schema_version` or other JSON fields, do not
-silently fall back to text. Require `ocr` v1.9.0 or newer, verify with
-`ocr --version`, and upgrade the CLI when necessary:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
 ### Step 2: Get Rules for Files
 
 ```bash
@@ -199,10 +176,34 @@ condition aborts the command. When the command reports either limit:
 1. Do not silently truncate the source file.
 2. Summarize the original material while preserving its requirements,
    constraints, acceptance criteria, and other review-critical details.
-3. Retry the affected command with `--background "<summary>"`; omit
-   `--background-file` because the file option takes precedence when both are
-   provided.
+3. Retry the affected command by passing the summary as one shell-safe
+   argument (for example, use a quoted/escaped argument produced by the host
+   shell, or write it to a new size-bounded file and pass that file). Do not
+   place untrusted summary text directly in a double-quoted shell template;
+   `$()`, backticks, quotes, and variable references can still be evaluated.
+   Omit the original `--background-file` so the CLI does not reload the same
+   oversized file and fail again.
 4. If a faithful summary is not possible, omit the OCR background entirely and
    read the original material directly during the review.
 
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
+
+### Troubleshooting CLI Version Compatibility
+
+The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and the
+installed CLI can be updated independently. If a requested `preview` or `rule`
+command with `--format json` fails specifically with `unknown flag: --format`,
+rerun it without the flag and use text output for the rest of the delegation
+run. Preserve the explicit mode, ref, file, and rule information from that
+output; do not parse text output as JSON or invent missing schema fields. Do
+not retry without the flag for any other error; report it and stop the affected
+workflow.
+
+The host-agent Skill may consume the equivalent text output to complete its
+review checklist. Programmatic integrations that require `schema_version` or
+other JSON fields must require a JSON-capable CLI instead: verify with
+`ocr --version` and upgrade when necessary:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -58,29 +58,6 @@ This outputs:
 | Branch comparison | `ocr delegate preview --from main --to feature` |
 | Single commit | `ocr delegate preview -c abc123` |
 
-### CLI Output Compatibility
-
-The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and
-the installed CLI can be updated independently, so try the JSON form first
-and make the fallback decision from the actual error:
-
-1. Run the requested `preview` or `rule` command with `--format json`.
-2. If it fails specifically with `unknown flag: --format`, rerun the same
-   command without `--format json` and use text output for the rest of the
-   delegation run. Preserve the explicit mode, ref, file, and rule information
-   from that output; do not parse text output as JSON or invent missing schema
-   fields.
-3. Do not retry without the flag for any other error. Report that error and
-   stop the affected workflow.
-
-For integrations that require `schema_version` or other JSON fields, do not
-silently fall back to text. Require `ocr` v1.9.0 or newer, verify with
-`ocr --version`, and upgrade the CLI when necessary:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
 ### Step 2: Get Rules for Files
 
 ```bash
@@ -194,10 +171,34 @@ condition aborts the command. When the command reports either limit:
 1. Do not silently truncate the source file.
 2. Summarize the original material while preserving its requirements,
    constraints, acceptance criteria, and other review-critical details.
-3. Retry the affected command with `--background "<summary>"`; omit
-   `--background-file` because the file option takes precedence when both are
-   provided.
+3. Retry the affected command by passing the summary as one shell-safe
+   argument (for example, use a quoted/escaped argument produced by the host
+   shell, or write it to a new size-bounded file and pass that file). Do not
+   place untrusted summary text directly in a double-quoted shell template;
+   `$()`, backticks, quotes, and variable references can still be evaluated.
+   Omit the original `--background-file` so the CLI does not reload the same
+   oversized file and fail again.
 4. If a faithful summary is not possible, omit the OCR background entirely and
    read the original material directly during the review.
 
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
+
+### Troubleshooting CLI Version Compatibility
+
+The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and the
+installed CLI can be updated independently. If a requested `preview` or `rule`
+command with `--format json` fails specifically with `unknown flag: --format`,
+rerun it without the flag and use text output for the rest of the delegation
+run. Preserve the explicit mode, ref, file, and rule information from that
+output; do not parse text output as JSON or invent missing schema fields. Do
+not retry without the flag for any other error; report it and stop the affected
+workflow.
+
+The host-agent Skill may consume the equivalent text output to complete its
+review checklist. Programmatic integrations that require `schema_version` or
+other JSON fields must require a JSON-capable CLI instead: verify with
+`ocr --version` and upgrade when necessary:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -162,6 +162,8 @@ If the user requested "review and fix":
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
 
+- **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
+
 ### Recovering Oversized Background Context
 
 `--background-file` has two independent limits. The raw file must not exceed
@@ -180,8 +182,6 @@ condition aborts the command. When the command reports either limit:
    oversized file and fail again.
 4. If a faithful summary is not possible, omit the OCR background entirely and
    read the original material directly during the review.
-
-- **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
 
 ### Troubleshooting CLI Version Compatibility
 

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -58,6 +58,29 @@ This outputs:
 | Branch comparison | `ocr delegate preview --from main --to feature` |
 | Single commit | `ocr delegate preview -c abc123` |
 
+### CLI Output Compatibility
+
+The `--format` flag is available in `ocr` v1.9.0 and later. The Skill and
+the installed CLI can be updated independently, so try the JSON form first
+and make the fallback decision from the actual error:
+
+1. Run the requested `preview` or `rule` command with `--format json`.
+2. If it fails specifically with `unknown flag: --format`, rerun the same
+   command without `--format json` and use text output for the rest of the
+   delegation run. Preserve the explicit mode, ref, file, and rule information
+   from that output; do not parse text output as JSON or invent missing schema
+   fields.
+3. Do not retry without the flag for any other error. Report that error and
+   stop the affected workflow.
+
+For integrations that require `schema_version` or other JSON fields, do not
+silently fall back to text. Require `ocr` v1.9.0 or newer, verify with
+`ocr --version`, and upgrade the CLI when necessary:
+
+```bash
+npm install -g @alibaba-group/open-code-review
+```
+
 ### Step 2: Get Rules for Files
 
 ```bash
@@ -161,4 +184,20 @@ If the user requested "review and fix":
 - **Working directory matters** — `ocr delegate` operates on the Git repo at the current directory. Use `--repo /path` to override.
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
+
+### Recovering Oversized Background Context
+
+`--background-file` has two independent limits. The raw file must not exceed
+1 MiB, and the sanitized content must not exceed 8000 characters. Either
+condition aborts the command. When the command reports either limit:
+
+1. Do not silently truncate the source file.
+2. Summarize the original material while preserving its requirements,
+   constraints, acceptance criteria, and other review-critical details.
+3. Retry the affected command with `--background "<summary>"`; omit
+   `--background-file` because the file option takes precedence when both are
+   provided.
+4. If a faithful summary is not possible, omit the OCR background entirely and
+   read the original material directly during the review.
+
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -161,7 +161,6 @@ If the user requested "review and fix":
 - **Working directory matters** — `ocr delegate` operates on the Git repo at the current directory. Use `--repo /path` to override.
 - **Untracked files in workspace mode** — `preview` includes untracked files. For these, read the file directly instead of using `git diff`.
 - **Background context** — pass `--background` to `preview` when you have requirement context; it appears in the output for your reference during review.
-
 - **Coverage is mandatory** — every `reviewable_files` entry must end as reviewed or explicitly skipped; do not silently omit files.
 
 ### Recovering Oversized Background Context


### PR DESCRIPTION
## Description

Improve the `open-code-review-delegate` Skill so delegation runs can recover
safely from CLI version skew and oversized background input.

The Skill and the locally installed `ocr` CLI may be updated independently.
When a newer Skill invokes `ocr delegate preview` or `ocr delegate rule` with
`--format json` against an older CLI, the command exits with:

```text
Error: unknown flag: --format
```

This PR updates both the canonical and plugin copies of the delegation Skill to:

- try the JSON command first instead of running both `--help` commands as
  routine capability probes
- fall back to text output only when the command specifically reports
  `unknown flag: --format`
- keep unrelated command failures visible instead of retrying them as
  compatibility failures
- require `ocr` v1.9.0 or newer when an integration depends on
  `schema_version` or other JSON fields
- document recovery for both `--background-file` limits: raw file size
  exceeding 1 MiB and sanitized content exceeding 8000 characters
- require a faithful summary that preserves requirements, constraints, and
  acceptance criteria instead of silently truncating the source
- omit the OCR background and let the host agent read the original material
  directly when a faithful summary is not possible
- keep the canonical and plugin Skill instructions synchronized

This changes the delegation Skill's host-agent behavior without modifying the
OCR CLI runtime.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Validation performed:

- `git diff --check`
- verified both modified Skill files use LF line endings
- verified the compatibility and background-recovery instructions remain
  synchronized between the canonical and plugin Skill copies
- cross-checked the documented limits and precedence behavior against
  `cmd/opencodereview/background_file.go`
- cross-checked the JSON output contract and `schema_version` behavior against
  `cmd/opencodereview/delegate_cmd.go`

`make test`, `make build`, and `make check` were not run because the current WSL
environment does not have Go or Make installed. No Go source or OCR CLI runtime
behavior is changed by this PR; the Skill workflow changes were validated
manually as described above.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`) - N/A, Markdown only
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works - not applicable, Skill workflow changes were validated manually
- [ ] New and existing unit tests pass locally with my changes - not run, no runtime changes
- [x] I have updated the documentation accordingly
- [ ] I have signed the CLA

## Related Issues

Closes #1044
## Revision after maintainer feedback

The follow-up changes address the review feedback as follows:

- Oversized background recovery now requires passing the generated summary as one shell-safe argument or using a new bounded summary file; untrusted summary text must not be interpolated directly into a double-quoted shell template.
- The original `--background-file` is omitted on retry for a version-neutral reason: the CLI must not reload the same oversized file and fail again, including on older CLI versions.
- CLI `--format` compatibility handling is documented under Troubleshooting rather than the main Step 1 workflow. The host-agent Skill may consume equivalent text output, while programmatic integrations that require `schema_version` or other JSON fields must use a JSON-capable CLI.
- The canonical Skill and mirrored plugin Skill remain synchronized.

Validation for this follow-up included `git diff --check` and synchronization checks for both Skill copies. Runtime checks requiring `make` or the `ocr` binary were not available in the local environment.