### PR TITLE
fix: preserve live context during memory compression

### DIFF
--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -136,10 +136,11 @@ func partitionMessages(messages []llm.Message, maxTokens int, prevSummaryTokenEs
 		return result
 	}
 
-	result.activeCount = computeActiveZoneSize(result.rounds, messages, maxTokens, prevSummaryTokenEstimate)
+	frozenTokens := CountMessagesTokens(messages[:result.frozenEnd])
+	result.activeCount = computeActiveZoneSize(result.rounds, messages, maxTokens, frozenTokens+prevSummaryTokenEstimate)
 	if result.activeCount >= len(result.rounds) {
 		// Everything fits — no compression needed.
-		result.compressEnd = len(messages)
+		result.compressEnd = result.frozenEnd
 		result.activeCount = 0
 		return result
 	}
@@ -211,7 +212,7 @@ func copyMessages(msgs []llm.Message) []llm.Message {
 // the user prompt] + [active].
 func (r *Runner) runCompression(ctx context.Context, msgs []llm.Message, filePath string) ([]llm.Message, error) {
 	if len(r.deps.Template.MemoryCompressionTask.Messages) == 0 || len(msgs) <= 2 {
-		return msgs[:min(len(msgs), 2)], nil
+		return msgs, nil
 	}
 
 	part := partitionMessages(msgs, r.deps.Template.MaxTokens, 0)

--- a/internal/llmloop/compression_zone_repro_test.go
+++ b/internal/llmloop/compression_zone_repro_test.go
@@ -1,0 +1,73 @@
+package llmloop
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/config/template"
+)
+
+func msg(role, content string) llm.Message {
+	return llm.NewTextMessage(role, content)
+}
+
+func TestRepro_EverythingFitsSummarizesLiveTail(t *testing.T) {
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "resp1"),
+		msg("tool", "result1"),
+		msg("assistant", "resp2"),
+		msg("tool", "result2"),
+	}
+	result := partitionMessages(messages, 1_000_000, 0)
+	if result.compressEnd != result.frozenEnd {
+		t.Errorf("compressEnd = %d, want %d", result.compressEnd, result.frozenEnd)
+	}
+}
+
+func TestRepro_FrozenZoneNotReservedFromBudget(t *testing.T) {
+	roundText := strings.Repeat("round content ", 100)
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", strings.Repeat("frozen prompt content ", 200)),
+		msg("assistant", roundText),
+		msg("tool", roundText),
+		msg("assistant", roundText),
+		msg("tool", roundText),
+	}
+
+	frozenTokens := CountMessagesTokens(messages[:2])
+	oneRound := CountMessagesTokens(messages[2:4])
+	budget := frozenTokens + oneRound + oneRound/2
+	maxTokens := budget * 5 / 4 
+
+	actualBudget := PromptTokenLimit(maxTokens)
+	if actualBudget-frozenTokens < oneRound || actualBudget-frozenTokens >= 2*oneRound || actualBudget < 2*oneRound {
+		t.Fatalf("test setup out of range: budget=%d frozen=%d round=%d", actualBudget, frozenTokens, oneRound)
+	}
+
+	result := partitionMessages(messages, maxTokens, 0)
+	if result.activeCount != 1 {
+		t.Errorf("activeCount = %d, want 1", result.activeCount)
+	}
+}
+
+func TestRepro_MissingTemplateTruncatesConversation(t *testing.T) {
+	r := newTestRunner(&fakeLLMClient{}, template.Template{MaxTokens: 1000})
+
+	msgs := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "resp"),
+	}
+	got, err := r.runCompression(context.Background(), msgs, "test.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(msgs) {
+		t.Errorf("runCompression returned %d messages, want %d", len(got), len(msgs))
+	}
+}


### PR DESCRIPTION
### Problem
Three-zone compression (`internal/llmloop/compression.go`) discards live context it is designed to preserve, in three related ways:
1. When every round fits the token budget, the "everything fits" branch marks the whole tail as the compress zone, causing every round to be summarized.
2. The frozen zone's tokens are never reserved from the budget, allowing the active zone to overfill past the warning threshold.
3. A missing compression template truncates the conversation to 2 messages instead of leaving it alone.

This leads to unintended truncation and summarization of recent context.

### Solution
This PR applies the following fixes:
- Represents the empty compress zone as `compressEnd == frozenEnd`, rather than `compressEnd == len(messages)`.
- Reserves the token count of `messages[:frozenEnd]` in addition to `prevSummaryTokenEstimate` when computing the active zone size.
- Makes `runCompression` return the conversation unchanged when no template is configured instead of slicing it down to the first 2 messages.

### Changes Made
- **`internal/llmloop/compression.go`**: 
  - Modified `partitionMessages` to compute and pass the frozen zone token count to `computeActiveZoneSize`.
  - Modified `partitionMessages` to set `compressEnd = result.frozenEnd` instead of `len(messages)` when everything fits in the active zone.
  - Modified `runCompression` to return `msgs` instead of `msgs[:min(len(msgs), 2)]` when the compression template is empty.
- **`internal/llmloop/compression_zone_repro_test.go`**: Added reproduction tests to ensure these edge cases are covered.

### Testing
- Added automated unit tests to verify each edge case: `TestRepro_EverythingFitsSummarizesLiveTail`, `TestRepro_FrozenZoneNotReservedFromBudget`, and `TestRepro_MissingTemplateTruncatesConversation`.

Fixes #838
