### PR TITLE
fix(cli): exit 128+signo when the native binary is killed by a signal

### DIFF
--- a/bin/ocr.js
+++ b/bin/ocr.js
@@ -14,6 +14,24 @@ const { resolveNativeBinary } = require("../scripts/platform");
 const { version: packageVersion } = require("../package.json");
 const { shouldShowUpdateHint } = require("../scripts/version");
 
+// Maps a child process result to the launcher exit code.
+// A child killed by a signal has status = null, which must not fall through
+// to a clean 0 — pipelines gating on the exit code would read an OOM kill
+// (or any signal death) as success. Conventional 128+signo is used instead.
+function launcherExitCode(result) {
+  if (result.signal) {
+    return 128 + (os.constants.signals[result.signal] ?? 1);
+  }
+  return result.status ?? (result.error ? 1 : 0);
+}
+
+module.exports = { launcherExitCode };
+
+if (require.main !== module) {
+  // Required as a module (tests); the launcher body below must not run.
+  return;
+}
+
 const resolved = resolveNativeBinary();
 if (!resolved) {
   console.error(
@@ -64,4 +82,4 @@ const result = spawnSync(binaryPath, process.argv.slice(2), {
   env: process.env,
 });
 
-process.exit(result.status ?? (result.error ? 1 : 0));
+process.exit(launcherExitCode(result));

--- a/bin/ocr.test.js
+++ b/bin/ocr.test.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+"use strict";
+
+const assert = require("assert");
+const os = require("os");
+
+const { launcherExitCode } = require("./ocr");
+
+// Normal exits pass the child's status through unchanged.
+assert.strictEqual(launcherExitCode({ status: 0 }), 0);
+assert.strictEqual(launcherExitCode({ status: 1 }), 1);
+assert.strictEqual(launcherExitCode({ status: 2 }), 2);
+
+// Spawn failures (binary missing, etc.) keep the historical fallback of 1.
+assert.strictEqual(launcherExitCode({ status: null, error: new Error("enoent") }), 1);
+
+// A child killed by a signal has status = null; it must exit non-zero,
+// conventionally 128 + signo, so pipelines cannot read a signal death
+// as a clean run.
+assert.strictEqual(launcherExitCode({ status: null, signal: "SIGTERM" }), 128 + os.constants.signals.SIGTERM);
+assert.strictEqual(launcherExitCode({ status: null, signal: "SIGKILL" }), 128 + os.constants.signals.SIGKILL);
+assert.strictEqual(launcherExitCode({ status: null, signal: "SIGINT" }), 128 + os.constants.signals.SIGINT);
+
+// An unrecognized signal name still exits non-zero rather than 0.
+assert.strictEqual(launcherExitCode({ status: null, signal: "SIGFAKE" }) > 0, true);
+
+// A signal result never lets a null status fall through to the error branch's 0.
+assert.strictEqual(
+  launcherExitCode({ status: null, signal: "SIGTERM", error: undefined }),
+  128 + os.constants.signals.SIGTERM
+);
+
+console.log("ocr launcher exit-code tests passed");

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "postinstall": "node scripts/install.js",
     "test:github-actions": "node scripts/github-actions/post-review-comments.test.js && node scripts/github-actions/check-translation-sync.test.js",
-    "test:update": "node scripts/version.test.js"
+    "test:update": "node scripts/version.test.js",
+    "test:launcher": "node bin/ocr.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

`bin/ocr.js` forwarded the child's exit status as

```js
process.exit(result.status ?? (result.error ? 1 : 0));
```

When the native binary is terminated by a signal, `spawnSync` returns `status = null` and `error = undefined`, so the launcher exits **0**. Downstream automation gating on the exit code then reads an OOM kill (or any signal death) as a clean success with empty stdout.

This adds the conventional `128 + signo` mapping for signal deaths, keeping the existing `status`/`error` behavior for every other case.

## Changes

- `bin/ocr.js`: new `launcherExitCode(result)` — returns `128 + os.constants.signals[result.signal]` when the child died by signal (falling back to a non-zero `129` for an unrecognized name), otherwise the previous `status ?? (error ? 1 : 0)`. The launcher body is wrapped in a `require.main` guard so the module can be imported by tests without side effects.
- `bin/ocr.test.js`: asserts status passthrough, the spawn-error fallback, the SIGTERM/SIGKILL/SIGINT mappings, and that an unknown signal name still exits non-zero.
- `package.json`: `test:launcher` script alongside the existing `test:update` pattern.

## Test plan

- [x] `node bin/ocr.test.js` — all mappings pass
- [x] `require('./bin/ocr.js')` imports cleanly without running the launcher
- [x] `node bin/ocr.js` with no binary installed still prints the install hint and exits 1 (behavior unchanged)

Fixes #931