### PR TITLE
ci(workflows): run the contract suite in a dedicated workflow

### DIFF
--- a/.github/workflows/action-contract.yml
+++ b/.github/workflows/action-contract.yml
@@ -1,0 +1,50 @@
+name: Action Contract
+
+# The composite action in action.yml is shell, not Go, so `make test` cannot
+# reach it. This workflow runs the executable contract suite that drives those
+# shell blocks with fake `ocr`/`npm` binaries. examples/github_actions/README.md
+# is a trigger path because action-contract.test.js asserts its documented
+# defaults, which makes it part of the contract rather than prose.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - 'package.json'
+      - 'scripts/github-actions/**'
+      - 'examples/github_actions/README.md'
+      - '.github/workflows/action-contract.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - 'package.json'
+      - 'scripts/github-actions/**'
+      - 'examples/github_actions/README.md'
+      - '.github/workflows/action-contract.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action-contract:
+    runs-on: self-hosted
+    timeout-minutes: 10
+    # node:24 fixes the Node major and is Debian-based, so /bin/bash and npm are
+    # both present: the contract harness spawns /bin/bash directly. No
+    # `npm install` step — these tests use only Node built-ins, and installing
+    # would trigger the postinstall binary download for no benefit.
+    container:
+      image: node:24
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Trust workspace
+        run: git config --global --replace-all safe.directory '*'
+
+      - name: Test GitHub Actions contracts
+        run: npm run test:github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - '**'
-      - '!**.md'
-      # GitHub evaluates paths in order; this later positive pattern re-includes the contract docs.
-      - 'examples/github_actions/README.md'
-      - '!**/LICENSE'
-      - '!**/.gitignore'
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - '**/.gitignore'
   pull_request:
     branches: [main]
-    paths:
-      - '**'
-      - '!**.md'
-      # GitHub evaluates paths in order; this later positive pattern re-includes the contract docs.
-      - 'examples/github_actions/README.md'
-      - '!**/LICENSE'
-      - '!**/.gitignore'
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - '**/.gitignore'
 
 permissions:
   contents: read
@@ -117,20 +111,6 @@ jobs:
           echo "$HELP" | grep -q "session"
           echo "$HELP" | grep -q "rules"
           rm -f ./opencodereview
-
-  github-actions:
-    runs-on: self-hosted
-    timeout-minutes: 10
-    container:
-      image: node:24
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Trust workspace
-        run: git config --global --replace-all safe.directory '*'
-
-      - name: Test GitHub Actions contracts
-        run: npm run test:github-actions
 
   # Runs the suite natively on Windows, which the cross-compile job below cannot
   # do: it only proves the windows arms of the build-tag splits compile. GitHub

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -22,8 +22,8 @@ const { spawnSync } = require("child_process");
 const ROOT = path.resolve(__dirname, "../..");
 const ACTION_PATH = path.join(ROOT, "action.yml");
 const ACTION_TEXT = fs.readFileSync(ACTION_PATH, "utf8");
-const CI_PATH = path.join(ROOT, ".github/workflows/ci.yml");
-const CI_TEXT = fs.readFileSync(CI_PATH, "utf8");
+const CONTRACT_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/action-contract.yml");
+const CONTRACT_WORKFLOW_TEXT = fs.readFileSync(CONTRACT_WORKFLOW_PATH, "utf8");
 const EXAMPLE_README_PATH = path.join(ROOT, "examples/github_actions/README.md");
 const EXAMPLE_README_TEXT = fs.readFileSync(EXAMPLE_README_PATH, "utf8");
 
@@ -1025,24 +1025,24 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
   }
 }
 
-function testGithubActionContractsRunInCi() {
+function testContractsRunInDedicatedWorkflow() {
   assert.match(
-    CI_TEXT,
+    CONTRACT_WORKFLOW_TEXT,
     /^\s+- name:\s*Test GitHub Actions contracts\s*$[\s\S]*?^\s+run:\s*npm run test:github-actions\s*$/m,
-    "ci.yml must execute the complete GitHub Actions contract suite"
+    "action-contract.yml must execute the complete GitHub Actions contract suite"
   );
   assert.match(
-    CI_TEXT,
+    CONTRACT_WORKFLOW_TEXT,
     /paths:\s*[\s\S]*?examples\/github_actions\/README\.md/,
-    "ci.yml must run the contract suite when the GitHub Actions README changes"
+    "action-contract.yml must run the contract suite when the GitHub Actions README changes"
   );
   assert.match(
-    CI_TEXT,
+    CONTRACT_WORKFLOW_TEXT,
     /uses:\s*actions\/checkout@[0-9a-f]{40}\s*#\s*v7/,
-    "the newly added GitHub-hosted contract job must pin checkout to an immutable commit"
+    "the dedicated contract workflow must pin checkout to an immutable commit"
   );
   assert.match(
-    CI_TEXT,
+    CONTRACT_WORKFLOW_TEXT,
     /container:\s*[\s\S]*?image:\s*node:[0-9]/,
     "the contract job must declare its Node runtime via a pinned container image"
   );
@@ -1098,7 +1098,7 @@ const TESTS = [
   ["Install OpenCodeReview enforces the auth_token_cmd version floor", testInstallEnforcesAuthTokenCommandVersionFloor],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
-  ["GitHub Actions contracts run in CI", testGithubActionContractsRunInCi],
+  ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],
   ["GitHub Actions README documents timeout and version contracts", testExampleReadmeDocumentsTimeoutAndVersionContracts],
 ];
 


### PR DESCRIPTION
## Description

Follow-up to #1051. That PR added the executable action-contract suite and wired it into CI, which required `ci.yml` to trigger on `examples/github_actions/README.md` — the suite asserts that file's documented defaults, so a README change has to be able to run it.

Because `paths` is a workflow-level filter rather than a job-level one, expressing that inside `ci.yml` meant inverting `paths-ignore` into a three-stage filter:

```yaml
paths:
  - '**'
  - '!**.md'
  - 'examples/github_actions/README.md'   # re-included; later match wins
  - '!**/LICENSE'
  - '!**/.gitignore'
```

The side effect is that a markdown-only change now pulls the entire matrix: the self-hosted Go race suite, native Windows, and all four cross-compile targets. Only the contract job actually needs that trigger.

## What changed

- **`.github/workflows/action-contract.yml`** (new) — the contract job in its own workflow with a narrow *positive* `paths` filter. No `!` negation and no dependence on "later match wins", so the intent reads directly. Keeps the `self-hosted` runner and `node:24` container the job was given in review, so queueing behaviour is unchanged.
- **`.github/workflows/ci.yml`** — restored to its pre-#1051 state (`paths-ignore` + no contract job). Verified byte-identical to `ci.yml` at `5679f44^`.
- **`scripts/github-actions/action-contract.test.js`** — the workflow assertions now read the new file. All four regexes are unchanged; only the constant/function names and the messages that named `ci.yml` were updated.

## Trigger-path completeness

Only `action-contract.test.js` reads real repository files (`action.yml`, its own workflow, `examples/github_actions/README.md`). The other two suites in `npm run test:github-actions` are pure unit tests with no `readFileSync`/`path.join(ROOT)` usage, so `scripts/github-actions/**` already covers them and the narrow filter does not lose coverage.

## Incidental fix

The SHA-pin and container-image assertions previously searched all of `ci.yml`, so they were only *incidentally* precise — a floating tag on the contract job could still have passed as long as some pinned action existed elsewhere in the file. Now that the file holds a single job, they are structurally precise.

## Testing

- `npm run test:github-actions` — 24/24 pass
- `git diff 5679f44^ HEAD -- .github/workflows/ci.yml` — empty (exact restoration)
- Workflow YAML parses with the expected shape
- Negative cases confirmed the guard still fails closed in its new location: removing the README trigger path, swapping the container to a non-Node image, and reverting the checkout pin to a floating tag each produce the corresponding assertion failure

## Action required on merge

The required status check name changes from **`github-actions`** to **`action-contract`**. Branch protection needs updating, otherwise the gate silently stops being enforced — nothing errors if this is missed.