### PR TITLE
feat(session): register GroupingTask as a tracked TaskType

### DIFF
--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -403,6 +403,7 @@ var retryStages = []struct {
 	{session.MemoryCompressionTask, "Context compaction"},
 	{session.ReLocationTask, "Comment re-location"},
 	{session.ReviewFilterTask, "Comment filtering"},
+	{session.GroupingTask, "File grouping"},
 }
 
 // Keep the terminal concise; JSON retains every request.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -625,7 +625,8 @@ func (a *Agent) dispatchSubtasks(ctx context.Context) ([]model.LlmComment, error
 
 	// Group files semantically via LLM.
 	groupResult := groupDiffs(ctx, nonDeleted, a.args.LLMClient, a.args.Model,
-		a.args.Template, llmloop.PromptTokenLimit(a.args.Template.MaxTokens))
+		a.args.Template, llmloop.PromptTokenLimit(a.args.Template.MaxTokens),
+		&groupingSessionOpts{session: a.session, provider: a.args.Provider, model: a.args.Model})
 	groups := groupResult.groups
 	a.fileGroups = groups
 	if groupResult.usage != nil {

--- a/internal/agent/grouping.go
+++ b/internal/agent/grouping.go
@@ -63,7 +63,7 @@ func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, m
 		return groupDiffsResult{groups: toSingleFileGroups(diffs)}
 	}
 
-	groups, usage, err := callGroupingLLM(ctx, diffs, client, modelName, tpl.GroupingTask, sessOpts)
+	groups, usage, err := callGroupingLLM(ctx, diffs, client, modelName, tpl.GroupingTask, tpl.CompletionTokenLimit(), sessOpts)
 	if err != nil {
 		fmt.Fprintf(stdout.Writer(), "[ocr] LLM grouping failed (%v), falling back to per-file dispatch\n", err)
 		return groupDiffsResult{groups: toSingleFileGroups(diffs), usage: usage}
@@ -73,7 +73,7 @@ func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, m
 	return groupDiffsResult{groups: groups, usage: usage}
 }
 
-func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, task *template.LlmConversation, sessOpts *groupingSessionOpts) (groups []FileGroup, usage *llm.UsageInfo, err error) {
+func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, task *template.LlmConversation, maxTokens int, sessOpts *groupingSessionOpts) (groups []FileGroup, usage *llm.UsageInfo, err error) {
 	var rec *session.TaskRecord
 	startTime := time.Now()
 	defer func() {
@@ -81,6 +81,7 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 			groups = nil
 			err = fmt.Errorf("grouping LLM panicked: %v", r)
 			if rec != nil {
+				rec.Response = nil
 				rec.SetError(err, time.Since(startTime))
 			}
 		}
@@ -113,7 +114,7 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 	resp, err := client.CompletionsWithCtx(ctx, llm.ChatRequest{
 		Model:     modelName,
 		Messages:  messages,
-		MaxTokens: 4096,
+		MaxTokens: maxTokens,
 	})
 	duration := time.Since(startTime)
 
@@ -126,13 +127,16 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 
 	usage = resp.Usage
 
-	if rec != nil {
-		rec.SetResponse(resp, duration)
-	}
-
 	content := resp.Content()
 	if content == "" {
+		if rec != nil {
+			rec.SetError(fmt.Errorf("grouping LLM returned empty response"), duration)
+		}
 		return nil, usage, fmt.Errorf("grouping LLM returned empty response")
+	}
+
+	if rec != nil {
+		rec.SetResponse(resp, duration)
 	}
 
 	groups, err = parseGroupingResponse(content, diffs)

--- a/internal/agent/grouping.go
+++ b/internal/agent/grouping.go
@@ -74,10 +74,15 @@ func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, m
 }
 
 func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, task *template.LlmConversation, sessOpts *groupingSessionOpts) (groups []FileGroup, usage *llm.UsageInfo, err error) {
+	var rec *session.TaskRecord
+	startTime := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
 			groups = nil
 			err = fmt.Errorf("grouping LLM panicked: %v", r)
+			if rec != nil {
+				rec.SetError(err, time.Since(startTime))
+			}
 		}
 	}()
 
@@ -91,7 +96,6 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 
 	const groupingFileKey = "__grouping__"
 
-	var rec *session.TaskRecord
 	if sessOpts != nil && sessOpts.session != nil {
 		fs := sessOpts.session.GetOrCreateFileSession(groupingFileKey)
 		rec = fs.AppendTaskRecord(session.GroupingTask, messages)
@@ -106,7 +110,6 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 		})
 	}
 
-	startTime := time.Now()
 	resp, err := client.CompletionsWithCtx(ctx, llm.ChatRequest{
 		Model:     modelName,
 		Messages:  messages,

--- a/internal/agent/grouping.go
+++ b/internal/agent/grouping.go
@@ -135,11 +135,14 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 		return nil, usage, fmt.Errorf("grouping LLM returned empty response")
 	}
 
-	if rec != nil {
-		rec.SetResponse(resp, duration)
-	}
-
 	groups, err = parseGroupingResponse(content, diffs)
+	if rec != nil {
+		if err != nil {
+			rec.SetError(fmt.Errorf("grouping response parse failed: %w", err), duration)
+		} else {
+			rec.SetResponse(resp, duration)
+		}
+	}
 	return groups, usage, err
 }
 

--- a/internal/agent/grouping.go
+++ b/internal/agent/grouping.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/alibaba/open-code-review/internal/config/template"
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/model"
+	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/alibaba/open-code-review/internal/stdout"
 )
 
@@ -41,9 +43,18 @@ type groupDiffsResult struct {
 	usage  *llm.UsageInfo
 }
 
+// groupingSessionOpts carries optional session-recording context.
+// When non-nil, callGroupingLLM writes an LLM request/response record into the
+// session history so the grouping call is visible in retry reports and viewers.
+type groupingSessionOpts struct {
+	session  *session.SessionHistory
+	provider string
+	model    string
+}
+
 // groupDiffs calls the LLM with file metadata (no diff content) to produce
 // semantic groups. Falls back to one-file-per-group on any error.
-func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, tpl template.Template, tokenLimit int) groupDiffsResult {
+func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, tpl template.Template, tokenLimit int, sessOpts *groupingSessionOpts) groupDiffsResult {
 	if len(diffs) <= 1 {
 		return groupDiffsResult{groups: toSingleFileGroups(diffs)}
 	}
@@ -52,7 +63,7 @@ func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, m
 		return groupDiffsResult{groups: toSingleFileGroups(diffs)}
 	}
 
-	groups, usage, err := callGroupingLLM(ctx, diffs, client, modelName, tpl.GroupingTask)
+	groups, usage, err := callGroupingLLM(ctx, diffs, client, modelName, tpl.GroupingTask, sessOpts)
 	if err != nil {
 		fmt.Fprintf(stdout.Writer(), "[ocr] LLM grouping failed (%v), falling back to per-file dispatch\n", err)
 		return groupDiffsResult{groups: toSingleFileGroups(diffs), usage: usage}
@@ -62,7 +73,7 @@ func groupDiffs(ctx context.Context, diffs []model.Diff, client llm.LLMClient, m
 	return groupDiffsResult{groups: groups, usage: usage}
 }
 
-func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, task *template.LlmConversation) (groups []FileGroup, usage *llm.UsageInfo, err error) {
+func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClient, modelName string, task *template.LlmConversation, sessOpts *groupingSessionOpts) (groups []FileGroup, usage *llm.UsageInfo, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			groups = nil
@@ -78,16 +89,43 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 		messages = append(messages, llm.NewTextMessage(m.Role, content))
 	}
 
+	const groupingFileKey = "__grouping__"
+
+	var rec *session.TaskRecord
+	if sessOpts != nil && sessOpts.session != nil {
+		fs := sessOpts.session.GetOrCreateFileSession(groupingFileKey)
+		rec = fs.AppendTaskRecord(session.GroupingTask, messages)
+		ctx = llm.ContextWithSessionKey(ctx,
+			llm.SessionTaskKey(sessOpts.session.SessionID, string(session.GroupingTask), groupingFileKey))
+		ctx = llm.WithRequestMeta(ctx, llm.RequestMeta{
+			Provider:  sessOpts.provider,
+			Model:     sessOpts.model,
+			FilePath:  groupingFileKey,
+			TaskType:  string(session.GroupingTask),
+			RequestNo: rec.RequestNo,
+		})
+	}
+
+	startTime := time.Now()
 	resp, err := client.CompletionsWithCtx(ctx, llm.ChatRequest{
 		Model:     modelName,
 		Messages:  messages,
 		MaxTokens: 4096,
 	})
+	duration := time.Since(startTime)
+
 	if err != nil {
+		if rec != nil {
+			rec.SetError(err, duration)
+		}
 		return nil, nil, fmt.Errorf("grouping LLM call: %w", err)
 	}
 
 	usage = resp.Usage
+
+	if rec != nil {
+		rec.SetResponse(resp, duration)
+	}
 
 	content := resp.Content()
 	if content == "" {

--- a/internal/agent/grouping_test.go
+++ b/internal/agent/grouping_test.go
@@ -278,7 +278,7 @@ func TestCallGroupingLLM_EmptyResponse(t *testing.T) {
 	task := &template.LlmConversation{
 		Messages: []template.ChatMessage{{Role: "user", Content: "{{file_list}}"}},
 	}
-	_, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, nil)
+	_, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, 4096, nil)
 	if err == nil {
 		t.Fatal("expected error for empty response")
 	}

--- a/internal/agent/grouping_test.go
+++ b/internal/agent/grouping_test.go
@@ -222,7 +222,7 @@ func TestFileGroupKey_Multiple(t *testing.T) {
 
 func TestGroupDiffs_SingleFile(t *testing.T) {
 	diffs := []model.Diff{{NewPath: "a.go"}}
-	result := groupDiffs(nil, diffs, nil, "", template.Template{}, 0)
+	result := groupDiffs(nil, diffs, nil, "", template.Template{}, 0, nil)
 	if len(result.groups) != 1 {
 		t.Fatalf("got %d groups, want 1", len(result.groups))
 	}
@@ -230,7 +230,7 @@ func TestGroupDiffs_SingleFile(t *testing.T) {
 
 func TestGroupDiffs_NoGroupingTask(t *testing.T) {
 	diffs := []model.Diff{{NewPath: "a.go"}, {NewPath: "b.go"}}
-	result := groupDiffs(nil, diffs, nil, "", template.Template{}, 0)
+	result := groupDiffs(nil, diffs, nil, "", template.Template{}, 0, nil)
 	if len(result.groups) != 2 {
 		t.Fatalf("got %d groups, want 2 (fallback to per-file)", len(result.groups))
 	}
@@ -244,7 +244,7 @@ func TestGroupDiffs_LLMError_Fallback(t *testing.T) {
 			Messages: []template.ChatMessage{{Role: "user", Content: "{{file_list}}"}},
 		},
 	}
-	result := groupDiffs(context.Background(), diffs, client, "fake", tpl, 0)
+	result := groupDiffs(context.Background(), diffs, client, "fake", tpl, 0, nil)
 	if len(result.groups) != 2 {
 		t.Fatalf("got %d groups, want 2 (fallback on error)", len(result.groups))
 	}
@@ -260,7 +260,7 @@ func TestGroupDiffs_LLMSuccess(t *testing.T) {
 			Messages: []template.ChatMessage{{Role: "user", Content: "{{file_list}}"}},
 		},
 	}
-	result := groupDiffs(context.Background(), diffs, client, "fake", tpl, 0)
+	result := groupDiffs(context.Background(), diffs, client, "fake", tpl, 0, nil)
 	if len(result.groups) != 2 {
 		t.Fatalf("got %d groups, want 2", len(result.groups))
 	}
@@ -278,7 +278,7 @@ func TestCallGroupingLLM_EmptyResponse(t *testing.T) {
 	task := &template.LlmConversation{
 		Messages: []template.ChatMessage{{Role: "user", Content: "{{file_list}}"}},
 	}
-	_, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task)
+	_, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, nil)
 	if err == nil {
 		t.Fatal("expected error for empty response")
 	}

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -25,6 +25,7 @@ const (
 	MemoryCompressionTask TaskType = "memory_compression_task"
 	ReLocationTask        TaskType = "re_location_task"
 	ReviewFilterTask      TaskType = "review_filter_task"
+	GroupingTask          TaskType = "grouping_task"
 )
 
 const (

--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -196,15 +196,25 @@ func parseTemplate(name string) (*template.Template, error) {
 				return "task-memory"
 			case ReLocationTask:
 				return "task-relocation"
+			case GroupingTask:
+				return "task-grouping"
 			default:
 				return "task-default"
+			}
+		},
+		"sessionTaskLabel": func(fp string) string {
+			switch fp {
+			case "__grouping__":
+				return "File Grouping"
+			default:
+				return fp
 			}
 		},
 		"orderedTasks": func(tasks map[TaskType][]*TaskCard) []struct {
 			Type  TaskType
 			Cards []*TaskCard
 		} {
-			order := []TaskType{PlanTask, MainTask, ReLocationTask, MemoryCompressionTask}
+			order := []TaskType{PlanTask, MainTask, ReLocationTask, MemoryCompressionTask, GroupingTask}
 			var result []struct {
 				Type  TaskType
 				Cards []*TaskCard
@@ -218,7 +228,7 @@ func parseTemplate(name string) (*template.Template, error) {
 				}
 			}
 			for tt, cards := range tasks {
-				if tt != PlanTask && tt != MainTask && tt != ReLocationTask && tt != MemoryCompressionTask {
+				if tt != PlanTask && tt != MainTask && tt != ReLocationTask && tt != MemoryCompressionTask && tt != GroupingTask {
 					result = append(result, struct {
 						Type  TaskType
 						Cards []*TaskCard

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -40,6 +40,7 @@
     --task-plan: #7c3aed;
     --task-memory: #8b949e;
     --task-relocation: #ea580c;
+    --task-grouping: #0891b2;
     --task-default: #57606a;
     --tool-name: #7c3aed;
     --danger: #dc2626;
@@ -90,6 +91,7 @@
 
         --task-main: #818cf8;
         --task-plan: #a78bfa;
+        --task-grouping: #22d3ee;
         --task-default: #6b7394;
         --tool-name: #a78bfa;
         --danger: #f87171;
@@ -608,6 +610,7 @@ h3 {
 .task-plan .task-type-dot { background: var(--task-plan); color: var(--task-plan); }
 .task-memory .task-type-dot { background: var(--task-memory); color: var(--task-memory); }
 .task-relocation .task-type-dot { background: var(--task-relocation); color: var(--task-relocation); }
+.task-grouping .task-type-dot { background: var(--task-grouping); color: var(--task-grouping); }
 .task-default .task-type-dot { background: var(--task-default); color: var(--task-default); }
 
 /* Card */
@@ -627,6 +630,7 @@ h3 {
 .task-plan .card { border-left: 3px solid var(--task-plan); }
 .task-memory .card { border-left: 3px solid var(--task-memory); }
 .task-relocation .card { border-left: 3px solid var(--task-relocation); }
+.task-grouping .card { border-left: 3px solid var(--task-grouping); }
 
 .card-header {
     background: var(--surface-alt);
@@ -816,6 +820,50 @@ h3 {
 @keyframes slideDown {
     from { opacity: 0; transform: translateY(-4px); }
     to { opacity: 1; transform: translateY(0); }
+}
+
+/* Error detail (expandable) */
+.error-detail {
+    border-top: 1px solid var(--danger);
+    background: color-mix(in srgb, var(--danger) 5%, transparent);
+}
+.error-detail summary { list-style: none; }
+.error-detail summary::-webkit-details-marker { display: none; }
+.error-detail summary::marker { display: none; content: ""; }
+.error-detail-toggle {
+    cursor: pointer;
+    padding: 0.45rem 0.85rem;
+    font-size: 0.76rem;
+    color: var(--danger);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    user-select: none;
+    transition: background var(--transition);
+    font-weight: 500;
+}
+.error-detail-toggle:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); }
+.error-detail[open] > .error-detail-toggle .chevron-sm {
+    transform: rotate(45deg);
+}
+.error-detail-toggle .chevron-sm {
+    border-right-color: var(--danger);
+    border-bottom-color: var(--danger);
+}
+.error-detail-body {
+    padding: 0 0.85rem 0.75rem;
+    animation: slideDown 0.2s ease;
+}
+.error-content {
+    font-size: 0.78rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    color: var(--danger);
+    margin: 0;
+    padding: 0.5rem;
+    background: color-mix(in srgb, var(--danger) 4%, var(--surface));
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in srgb, var(--danger) 20%, transparent);
 }
 
 .tool-section { margin-top: 0.5rem; }

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -285,8 +285,12 @@ const (
 	GroupingTask          TaskType = "grouping_task"
 )
 
+var sessionLevelPaths = map[string]bool{
+	"__grouping__": true,
+}
+
 func isSessionLevelPath(fp string) bool {
-	return len(fp) > 4 && fp[:2] == "__" && fp[len(fp)-2:] == "__"
+	return sessionLevelPaths[fp]
 }
 
 // TaskCard links an LLM request with its response and tool calls.

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -242,10 +242,11 @@ type ReviewComment struct {
 
 // ViewSession holds fully parsed records for one session.
 type ViewSession struct {
-	Summary    SessionSummary
-	TokenUsage TokenUsageSummary
-	Files      []*FileGroup     // ordered by file path
-	Comments   []*ReviewComment // review findings from review_item_done/reused records
+	Summary      SessionSummary
+	TokenUsage   TokenUsageSummary
+	Files        []*FileGroup     // ordered by file path
+	SessionTasks []*FileGroup     // session-level tasks (grouping, etc.) separated from file-level
+	Comments     []*ReviewComment // review findings from review_item_done/reused records
 }
 
 // TokenUsageSummary aggregates token counts across the session.
@@ -283,6 +284,10 @@ const (
 	ReLocationTask        TaskType = "re_location_task"
 	GroupingTask          TaskType = "grouping_task"
 )
+
+func isSessionLevelPath(fp string) bool {
+	return len(fp) > 4 && fp[:2] == "__" && fp[len(fp)-2:] == "__"
+}
 
 // TaskCard links an LLM request with its response and tool calls.
 type TaskCard struct {
@@ -561,6 +566,17 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 		return fileBreakdown[i].PromptTokens+fileBreakdown[i].CompletionTokens > fileBreakdown[j].PromptTokens+fileBreakdown[j].CompletionTokens
 	})
 	vs.TokenUsage.FileTokenBreakdown = fileBreakdown
+
+	// Separate session-level virtual paths from real file paths.
+	realFiles := make([]*FileGroup, 0, len(vs.Files))
+	for _, fg := range vs.Files {
+		if isSessionLevelPath(fg.FilePath) {
+			vs.SessionTasks = append(vs.SessionTasks, fg)
+		} else {
+			realFiles = append(realFiles, fg)
+		}
+	}
+	vs.Files = realFiles
 
 	sort.Slice(vs.Files, func(i, j int) bool {
 		return vs.Files[i].FilePath < vs.Files[j].FilePath

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -281,6 +281,7 @@ const (
 	MainTask              TaskType = "main_task"
 	MemoryCompressionTask TaskType = "memory_compression_task"
 	ReLocationTask        TaskType = "re_location_task"
+	GroupingTask          TaskType = "grouping_task"
 )
 
 // TaskCard links an LLM request with its response and tool calls.

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -92,7 +92,7 @@
                 <tbody>
                 {{range .}}
                     <tr>
-                        <td title="{{.FilePath}}">{{sessionTaskLabel .FilePath | truncate 60}}</td>
+                        <td title="{{sessionTaskLabel .FilePath}}">{{sessionTaskLabel .FilePath | truncate 60}}</td>
                         <td title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</td>
                         <td title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</td>
                         {{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<td title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</td><td title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</td>{{end}}
@@ -228,6 +228,39 @@
                 {{with .ResponseContent}}
                 <div class="card-body response-content">
                     <div class="response-text">{{.}}</div>
+                </div>
+                {{end}}
+                {{if .ToolCalls}}
+                <div class="tool-calls-section">
+                    <div class="tool-calls-label">Tool Calls ({{len .ToolCalls}})</div>
+                    {{range .ToolCalls}}
+                    <div class="tool-call-item {{if not .Ok}}tool-call-error{{end}}">
+                        <div class="tool-call-header">
+                            <span class="tool-icon">&#9881;</span>
+                            <strong class="tool-name">{{.Name}}</strong>
+                            {{if .DurationMs}}<span class="badge badge-duration">{{.DurationMs}}ms</span>{{end}}
+                            {{if not .Ok}}<span class="badge badge-error">Failed</span>{{end}}
+                        </div>
+                        <details class="tool-detail">
+                            <summary class="tool-detail-toggle">
+                                <span class="chevron-sm"></span>
+                                <span>Show Details</span>
+                            </summary>
+                            <div class="tool-detail-body">
+                                <div class="tool-section">
+                                    <div class="tool-section-label">Arguments</div>
+                                    <pre>{{.Arguments}}</pre>
+                                </div>
+                                {{if .Result}}
+                                <div class="tool-section">
+                                    <div class="tool-section-label">Result</div>
+                                    <pre>{{.Result}}</pre>
+                                </div>
+                                {{end}}
+                            </div>
+                        </details>
+                    </div>
+                    {{end}}
                 </div>
                 {{end}}
             </div>

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -92,7 +92,7 @@
                 <tbody>
                 {{range .}}
                     <tr>
-                        <td title="{{.FilePath}}">{{.FilePath | truncate 60}}</td>
+                        <td title="{{.FilePath}}">{{sessionTaskLabel .FilePath | truncate 60}}</td>
                         <td title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</td>
                         <td title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</td>
                         {{if or $.Session.TokenUsage.TotalCacheReadTokens $.Session.TokenUsage.TotalCacheWriteTokens}}<td title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</td><td title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</td>{{end}}
@@ -189,6 +189,55 @@
             <li>{{.}}</li>
         {{end}}
         </ul>
+    </div>
+</details>
+{{end}}
+
+{{if .Session.SessionTasks}}
+<details class="file-accordion section-accordion" open>
+    <summary class="file-accordion-header">
+        <span class="chevron"></span>
+        <span class="section-title">Session Tasks</span>
+        <span class="file-count-badge">{{len .Session.SessionTasks}} tasks</span>
+    </summary>
+    <div class="file-accordion-body">
+        <div class="conversations">
+{{range .Session.SessionTasks}}
+<details class="file-accordion">
+    <summary class="file-accordion-header">
+        <span class="chevron"></span>
+        <span class="file-path">{{sessionTaskLabel .FilePath}}</span>
+        <span class="file-count-badge">{{cardCount .Tasks}} requests</span>
+    </summary>
+    <div class="file-accordion-body">
+        {{range $tg := orderedTasks .Tasks}}
+        <div class="task-group {{taskTypeClass $tg.Type}}">
+            <h4 class="task-type-label">
+                <span class="task-type-dot"></span>
+                {{$tg.Type}}
+            </h4>
+            {{range $tg.Cards}}
+            <div class="card">
+                <div class="card-header">
+                    <span class="request-label">Request #{{.RequestNo}}</span>
+                    {{if .Model}}<span class="badge badge-model">{{.Model}}</span>{{end}}
+                    {{if or .PromptTokens .CompletionTokens}}<span class="badge badge-tokens">P:<span title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</span> C:<span title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</span>{{if or .CacheReadTokens .CacheWriteTokens}} CR:<span title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</span> CW:<span title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</span>{{end}}</span>{{end}}
+                    {{if .DurationMs}}<span class="badge badge-duration">{{.DurationMs}}ms</span>{{end}}
+                    {{if .Error}}<span class="badge badge-error">{{.Error}}</span>{{end}}
+                </div>
+                {{with .ResponseContent}}
+                <div class="card-body response-content">
+                    <div class="response-text">{{.}}</div>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+</details>
+{{end}}
+        </div>
     </div>
 </details>
 {{end}}

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -203,6 +203,36 @@
     <div class="file-accordion-body">
         <div class="conversations">
 {{range .Session.SessionTasks}}
+{{template "task-cards" .}}
+{{end}}
+        </div>
+    </div>
+</details>
+{{end}}
+
+{{if .Session.Files}}
+<details class="file-accordion section-accordion">
+    <summary class="file-accordion-header">
+        <span class="chevron"></span>
+        <span class="section-title">Conversations</span>
+        <span class="file-count-badge">{{len .Session.Files}} files</span>
+    </summary>
+    <div class="file-accordion-body">
+        <div class="conversations">
+{{range .Session.Files}}
+{{template "task-cards" .}}
+{{end}}
+        </div>
+    </div>
+</details>
+{{end}}
+
+<script src="/static/session.js"></script>
+</main>
+</body>
+</html>
+
+{{define "task-cards"}}
 <details class="file-accordion">
     <summary class="file-accordion-header">
         <span class="chevron"></span>
@@ -223,8 +253,19 @@
                     {{if .Model}}<span class="badge badge-model">{{.Model}}</span>{{end}}
                     {{if or .PromptTokens .CompletionTokens}}<span class="badge badge-tokens">P:<span title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</span> C:<span title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</span>{{if or .CacheReadTokens .CacheWriteTokens}} CR:<span title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</span> CW:<span title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</span>{{end}}</span>{{end}}
                     {{if .DurationMs}}<span class="badge badge-duration">{{.DurationMs}}ms</span>{{end}}
-                    {{if .Error}}<span class="badge badge-error">{{.Error}}</span>{{end}}
+                    {{if .Error}}<span class="badge badge-error">Error</span>{{end}}
                 </div>
+                {{if .Error}}
+                <details class="error-detail">
+                    <summary class="error-detail-toggle">
+                        <span class="chevron-sm"></span>
+                        <span>Error Detail</span>
+                    </summary>
+                    <div class="error-detail-body">
+                        <pre class="error-content">{{.Error}}</pre>
+                    </div>
+                </details>
+                {{end}}
                 {{with .ResponseContent}}
                 <div class="card-body response-content">
                     <div class="response-text">{{.}}</div>
@@ -270,94 +311,3 @@
     </div>
 </details>
 {{end}}
-        </div>
-    </div>
-</details>
-{{end}}
-
-{{if .Session.Files}}
-<details class="file-accordion section-accordion">
-    <summary class="file-accordion-header">
-        <span class="chevron"></span>
-        <span class="section-title">Conversations</span>
-        <span class="file-count-badge">{{len .Session.Files}} files</span>
-    </summary>
-    <div class="file-accordion-body">
-        <div class="conversations">
-{{range .Session.Files}}
-<details class="file-accordion">
-    <summary class="file-accordion-header">
-        <span class="chevron"></span>
-        <span class="file-path">{{.FilePath}}</span>
-        <span class="file-count-badge">{{cardCount .Tasks}} requests</span>
-    </summary>
-    <div class="file-accordion-body">
-        {{range $tg := orderedTasks .Tasks}}
-        <div class="task-group {{taskTypeClass $tg.Type}}">
-            <h4 class="task-type-label">
-                <span class="task-type-dot"></span>
-                {{$tg.Type}}
-            </h4>
-            {{range $tg.Cards}}
-            <div class="card">
-                <div class="card-header">
-                    <span class="request-label">Request #{{.RequestNo}}</span>
-                    {{if .Model}}<span class="badge badge-model">{{.Model}}</span>{{end}}
-                    {{if or .PromptTokens .CompletionTokens}}<span class="badge badge-tokens">P:<span title="{{.PromptTokens}}">{{formatNumber .PromptTokens}}</span> C:<span title="{{.CompletionTokens}}">{{formatNumber .CompletionTokens}}</span>{{if or .CacheReadTokens .CacheWriteTokens}} CR:<span title="{{.CacheReadTokens}}">{{formatNumber .CacheReadTokens}}</span> CW:<span title="{{.CacheWriteTokens}}">{{formatNumber .CacheWriteTokens}}</span>{{end}}</span>{{end}}
-                    {{if .DurationMs}}<span class="badge badge-duration">{{.DurationMs}}ms</span>{{end}}
-                    {{if .Error}}<span class="badge badge-error">{{.Error}}</span>{{end}}
-                </div>
-                {{with .ResponseContent}}
-                <div class="card-body response-content">
-                    <div class="response-text">{{.}}</div>
-                </div>
-                {{end}}
-                {{if .ToolCalls}}
-                <div class="tool-calls-section">
-                    <div class="tool-calls-label">Tool Calls ({{len .ToolCalls}})</div>
-                    {{range .ToolCalls}}
-                    <div class="tool-call-item {{if not .Ok}}tool-call-error{{end}}">
-                        <div class="tool-call-header">
-                            <span class="tool-icon">&#9881;</span>
-                            <strong class="tool-name">{{.Name}}</strong>
-                            {{if .DurationMs}}<span class="badge badge-duration">{{.DurationMs}}ms</span>{{end}}
-                            {{if not .Ok}}<span class="badge badge-error">Failed</span>{{end}}
-                        </div>
-                        <details class="tool-detail">
-                            <summary class="tool-detail-toggle">
-                                <span class="chevron-sm"></span>
-                                <span>Show Details</span>
-                            </summary>
-                            <div class="tool-detail-body">
-                                <div class="tool-section">
-                                    <div class="tool-section-label">Arguments</div>
-                                    <pre>{{.Arguments}}</pre>
-                                </div>
-                                {{if .Result}}
-                                <div class="tool-section">
-                                    <div class="tool-section-label">Result</div>
-                                    <pre>{{.Result}}</pre>
-                                </div>
-                                {{end}}
-                            </div>
-                        </details>
-                    </div>
-                    {{end}}
-                </div>
-                {{end}}
-            </div>
-            {{end}}
-        </div>
-        {{end}}
-    </div>
-</details>
-{{end}}
-        </div>
-    </div>
-</details>
-{{end}}
-
-<script src="/static/session.js"></script>
-</main>
-</body>
-</html>


### PR DESCRIPTION
## Summary

- Add `session.GroupingTask` (`"grouping_task"`) to the `TaskType` constants so the grouping LLM call is recorded in session history.
- Wire `callGroupingLLM` through the standard session recording path (`AppendTaskRecord` + `WithRequestMeta` + `SetResponse`/`SetError`) via an optional `groupingSessionOpts` parameter.
- Add the new task type to the viewer constants and the CLI retry-stage display table.

## Motivation

The grouping LLM call previously bypassed session recording entirely — it called `CompletionsWithCtx` directly without writing a `TaskRecord` or attaching `RequestMeta`. This meant no entry in session JSONL (invisible to retry reports), no visibility in the viewer or terminal retry summary, and no request-level telemetry attribution.

## Test plan

- [x] All existing `TestGroupDiffs_*` and `TestCallGroupingLLM_*` tests pass (nil sessOpts → graceful no-op)
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/agent/ ./internal/viewer/ ./cmd/opencodereview/` all pass
- [ ] Manual: run a multi-file review, verify `grouping_task` appears in session JSONL and in `ocr session show` output