### PR TITLE
fix(llm): preserve provider reasoning/thinking across assistant turns

### DIFF
--- a/internal/agent/grouping.go
+++ b/internal/agent/grouping.go
@@ -111,6 +111,10 @@ func callGroupingLLM(ctx context.Context, diffs []model.Diff, client llm.LLMClie
 		})
 	}
 
+	if maxTokens <= 0 {
+		maxTokens = 4096
+	}
+
 	resp, err := client.CompletionsWithCtx(ctx, llm.ChatRequest{
 		Model:     modelName,
 		Messages:  messages,

--- a/internal/agent/grouping_test.go
+++ b/internal/agent/grouping_test.go
@@ -21,9 +21,11 @@ import (
 type fakeGroupingClient struct {
 	response string
 	err      error
+	gotReq   llm.ChatRequest
 }
 
-func (f *fakeGroupingClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+func (f *fakeGroupingClient) CompletionsWithCtx(_ context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	f.gotReq = req
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -281,6 +283,35 @@ func TestCallGroupingLLM_EmptyResponse(t *testing.T) {
 	_, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, 4096, nil)
 	if err == nil {
 		t.Fatal("expected error for empty response")
+	}
+}
+
+// TestCallGroupingLLM_UsesTemplateMaxTokens guards against reintroducing the
+// hardcoded MaxTokens: 4096 this replaced: a small, task-specific cap left no
+// room for a provider config that enables Anthropic extended thinking via
+// extra_body.thinking with a larger budget_tokens, so the grouping call
+// failed with "max_tokens must be greater than thinking.budget_tokens" even
+// though the main review loop's own MAX_TOKENS was large enough.
+func TestCallGroupingLLM_UsesTemplateMaxTokens(t *testing.T) {
+	diffs := []model.Diff{{NewPath: "a.go"}}
+	task := &template.LlmConversation{
+		Messages: []template.ChatMessage{{Role: "user", Content: "{{file_list}}"}},
+	}
+
+	client := &fakeGroupingClient{response: `[{"label":"a","files":["a.go"]}]`}
+	if _, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, 32000, nil); err != nil {
+		t.Fatalf("callGroupingLLM: %v", err)
+	}
+	if client.gotReq.MaxTokens != 32000 {
+		t.Errorf("MaxTokens = %d, want 32000 (the template's own limit)", client.gotReq.MaxTokens)
+	}
+
+	client = &fakeGroupingClient{response: `[{"label":"a","files":["a.go"]}]`}
+	if _, _, err := callGroupingLLM(context.Background(), diffs, client, "fake", task, 0, nil); err != nil {
+		t.Fatalf("callGroupingLLM: %v", err)
+	}
+	if client.gotReq.MaxTokens != 4096 {
+		t.Errorf("MaxTokens = %d, want fallback 4096 when the template leaves MAX_TOKENS unset", client.gotReq.MaxTokens)
 	}
 }
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -43,6 +43,14 @@ var AppVersion = "dev"
 // shrink it, same as keyCmdTimeout.
 var bedrockConfigLoadTimeout = 60 * time.Second
 
+// defaultAnthropicMaxTokens is the max_tokens value buildAnthropicParams
+// falls back to when the caller leaves ChatRequest.MaxTokens unset. Extended
+// thinking's budget_tokens must stay strictly below whatever max_tokens is
+// actually sent, so the extra_body.thinking guard in CompletionsWithCtx
+// compares against this same default rather than the raw (possibly zero)
+// ChatRequest.MaxTokens.
+const defaultAnthropicMaxTokens = 8192
+
 func userAgent(provider string) string {
 	ua := "open-code-review/" + AppVersion
 	if provider != "" {
@@ -1307,7 +1315,11 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 			if req.ToolChoice == "required" {
 				continue
 			}
-			if budget, ok := anthropicThinkingBudgetTokens(v); ok && req.MaxTokens > 0 && budget >= int64(req.MaxTokens) {
+			effectiveMaxTokens := int64(req.MaxTokens)
+			if effectiveMaxTokens <= 0 {
+				effectiveMaxTokens = defaultAnthropicMaxTokens
+			}
+			if budget, ok := anthropicThinkingBudgetTokens(v); ok && budget >= effectiveMaxTokens {
 				continue
 			}
 		}
@@ -1442,7 +1454,7 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens <= 0 {
-		maxTokens = 8192
+		maxTokens = defaultAnthropicMaxTokens
 	}
 
 	params := anthropic.MessageNewParams{

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -235,7 +235,8 @@ type ResponseMessage struct {
 	Content          *string    `json:"content,omitempty"`
 	ReasoningContent string     `json:"reasoning_content,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
-	Native NativeTurn `json:"-"` // opaque replay state; see NativeTurn
+	// json:"-" prevents incidental marshal; internal/session persists it explicitly.
+	Native NativeTurn `json:"-"`
 }
 
 // ChatResponse is the parsed result of a completion request.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -1494,7 +1494,7 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 				Content:          contentStr,
 				ReasoningContent: reasoningContent,
 				ToolCalls:        toolCalls,
-				Native: native,
+				Native:           native,
 			},
 			FinishReason: finishReason,
 		}},

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -80,12 +80,16 @@ type Message struct {
 	// from a ChatResponse. Zero value for every non-assistant message and for
 	// any assistant message built without one. Only the adapter that produced
 	// it — matched by a type assertion on Payload, never by Family — may reuse
-	// it; every other consumer (compression, session persistence, a different
-	// protocol's adapter) must ignore it and fall back to Content/ToolCalls.
-	// json:"-" because Payload can hold an arbitrarily large provider SDK
-	// struct: Message is JSON-tagged for the wire format, and letting Native
-	// ride along on an incidental direct marshal (a debug dump, a future
-	// persistence path) would be exactly the leak the comment above forbids.
+	// it for replay; every other consumer that just needs Content/ToolCalls
+	// (compression, a different protocol's adapter) must ignore it and fall
+	// back to those. json:"-" because Payload can hold an arbitrarily large
+	// provider SDK struct and Message is JSON-tagged for the wire format: an
+	// incidental direct marshal (a debug dump, a request body) must not carry
+	// it along. internal/session deliberately reaches past this tag — reading
+	// this field directly (and ChatResponse.Native() for a fresh response),
+	// never by marshaling Message itself — to persist it into the session
+	// transcript for offline replay/export; that is the one sanctioned
+	// exception to "ignore it and fall back".
 	Native NativeTurn `json:"-"`
 	// ReasoningContent is the plain, human-readable projection of this turn's
 	// reasoning — set alongside Native from the same ChatResponse, but usable
@@ -107,7 +111,10 @@ type Message struct {
 // or an OpenAI-compatible gateway's reasoning_content string. It must never be
 // parsed, edited, or reordered by anything other than the adapter that
 // produced it: those payloads are validated (signature) or only meaningful
-// (encrypted_content) to the exact provider that issued them.
+// (encrypted_content) to the exact provider that issued them. Persisting it
+// (internal/session writes Payload verbatim into the session transcript) is
+// fine precisely because nothing reads or reshapes it on the way there — it
+// goes to disk as the same value the adapter would replay, byte for byte.
 type NativeTurn struct {
 	// Family names the wire-format family that produced Payload
 	// ("anthropic-messages", "openai-chat-completions", "openai-responses").
@@ -296,7 +303,8 @@ type ResponseMessage struct {
 	// Native is the adapter-native replay state for this turn; see NativeTurn.
 	// json:"-" for the same reason as Message.Native: Payload can hold an
 	// arbitrarily large provider SDK struct that must never ride along on an
-	// incidental direct marshal of this type.
+	// incidental direct marshal of this type. internal/session reaches past
+	// this tag via Native()/ChatResponse.Native() to persist it deliberately.
 	Native NativeTurn `json:"-"`
 }
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -27,6 +27,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	openai "github.com/openai/openai-go/v3"
 	openaiopt "github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 	tiktoken "github.com/pkoukk/tiktoken-go"
 )
@@ -66,6 +67,129 @@ type Message struct {
 	Content    any        `json:"content"`                // string or []ContentBlock
 	ToolCallID string     `json:"tool_call_id,omitempty"` // OpenAI tool call identifier
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // assistant tool invocations
+	// Native carries the provider adapter's own representation of this
+	// assistant turn (see NativeTurn), when this message was built directly
+	// from a ChatResponse. Zero value for every non-assistant message and for
+	// any assistant message built without one. Only the adapter that produced
+	// it — matched by a type assertion on Payload, never by Family — may reuse
+	// it; every other consumer (compression, session persistence, a different
+	// protocol's adapter) must ignore it and fall back to Content/ToolCalls.
+	// json:"-" because Payload can hold an arbitrarily large provider SDK
+	// struct: Message is JSON-tagged for the wire format, and letting Native
+	// ride along on an incidental direct marshal (a debug dump, a future
+	// persistence path) would be exactly the leak the comment above forbids.
+	Native NativeTurn `json:"-"`
+	// ReasoningContent is the plain, human-readable projection of this turn's
+	// reasoning — set alongside Native from the same ChatResponse, but usable
+	// by anything that only wants readable text and has no business touching
+	// Native's opaque payload. compression.go's summarization prompt is the
+	// motivating consumer: without this, a reasoning-only turn (empty
+	// Content, since VisibleContent() never falls back to reasoning text)
+	// renders as a blank message in the compression XML, and the summarizer
+	// has no way to know what happened in that round. Deliberately excluded
+	// from ExtractText() and every request builder: folding it back into the
+	// text sent to the provider would recreate the exact reasoning_content
+	// duplication bug Native was introduced to fix.
+	ReasoningContent string `json:"-"`
+}
+
+// NativeTurn is the adapter-native, opaque replay state for one finalized
+// assistant turn — Anthropic thinking/redacted_thinking blocks with their
+// signatures, an OpenAI Responses reasoning item with its encrypted_content,
+// or an OpenAI-compatible gateway's reasoning_content string. It must never be
+// parsed, edited, or reordered by anything other than the adapter that
+// produced it: those payloads are validated (signature) or only meaningful
+// (encrypted_content) to the exact provider that issued them.
+type NativeTurn struct {
+	// Family names the wire-format family that produced Payload
+	// ("anthropic-messages", "openai-chat-completions", "openai-responses").
+	// It exists for observability/debugging only — the safety net that
+	// prevents a mismatched adapter from misusing Payload is the Go type
+	// assertion each adapter performs before use, not this string.
+	Family string
+	// Payload's concrete type is adapter-specific: anthropic.MessageParam,
+	// []responses.ResponseInputItemUnionParam, or ReasoningPayload. nil means
+	// this turn carries no native replay state (a plain response with
+	// nothing to preserve beyond Content/ToolCalls).
+	Payload any
+}
+
+// ReasoningPayload is the openai-chat-completions family's NativeTurn
+// payload: the gateway's raw reasoning_content string. Named (rather than a
+// bare string) so a type assertion on Payload can't accidentally match an
+// unrelated string value from a different source.
+type ReasoningPayload string
+
+// EstimatedTokens returns a rough token estimate for whatever this turn's
+// Payload carries beyond Content/ToolCalls — thinking blocks, reasoning
+// items, encrypted_content, a gateway's reasoning_content string — so a
+// caller sizing a request against a token budget (compression's threshold
+// checks) isn't blind to it. Once this turn replays, that payload really
+// goes out on the wire; a budget computed only from Content/ExtractText()
+// would systematically under-count it.
+//
+// Deliberately excludes whatever Payload carries that ExtractText()/Content()
+// already counts — an Anthropic MessageParam's text blocks, a Responses
+// message item's text — because CountMessagesTokens always adds this on top
+// of llm.CountTokens(m.ExtractText()); counting the same visible text twice
+// would over-count instead, which is just as wrong for a compression
+// threshold (it triggers compression earlier than the request actually
+// needs). This is deliberately crude otherwise — bytes/4 on whatever's left,
+// the same heuristic CountTokensForModel falls back to when tiktoken is
+// unavailable — good enough to keep a budget decision in the right ballpark.
+func (n NativeTurn) EstimatedTokens() int {
+	switch p := n.Payload.(type) {
+	case ReasoningPayload:
+		// The whole payload IS the extra text; ExtractText() never sees it
+		// (the openai-chat-completions family keeps it out of Content), so
+		// there's nothing to exclude here.
+		return marshaledLen(p)
+	case anthropic.MessageParam:
+		var total int
+		for _, block := range p.Content {
+			switch {
+			case block.OfThinking != nil:
+				total += marshaledLen(block.OfThinking)
+			case block.OfRedactedThinking != nil:
+				total += marshaledLen(block.OfRedactedThinking)
+			case block.OfToolUse != nil:
+				// Tool-call arguments: not double-counted (ExtractText()
+				// never reads ToolCalls either), so counting them here is a
+				// pure improvement over leaving them invisible to the budget.
+				total += marshaledLen(block.OfToolUse)
+			}
+			// OfText deliberately excluded: already in Content()/ExtractText().
+		}
+		return total
+	case []responses.ResponseInputItemUnionParam:
+		var total int
+		for _, item := range p {
+			switch {
+			case item.OfReasoning != nil:
+				total += marshaledLen(item.OfReasoning)
+			case item.OfFunctionCall != nil:
+				total += marshaledLen(item.OfFunctionCall)
+			}
+			// OfOutputMessage deliberately excluded: its text is already
+			// aggregated into Content() via sdkResp.OutputText().
+		}
+		return total
+	default:
+		return 0
+	}
+}
+
+// marshaledLen returns len(json.Marshal(v))/4, or 0 if v is nil or fails to
+// marshal — the shared bytes/4 heuristic every EstimatedTokens case uses.
+func marshaledLen(v any) int {
+	if v == nil {
+		return 0
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b) / 4
 }
 
 // ContentBlock represents a single block within a multi-part message content.
@@ -82,14 +206,20 @@ func NewTextMessage(role, content string) Message {
 	return Message{Role: role, Content: content}
 }
 
-// NewToolCallMessage creates an assistant message with text content and tool invocations.
-func NewToolCallMessage(content string, toolCalls []ToolCall) Message {
+// NewToolCallMessage creates an assistant message, optionally carrying tool
+// invocations, the adapter-native replay state for this turn (native is the
+// zero NativeTurn when there is nothing to preserve, e.g. plain text with no
+// reasoning), and the plain-text projection of that reasoning for display-only
+// consumers (see Message.ReasoningContent). This is the single constructor for
+// assistant-turn history messages — do not build one with
+// NewTextMessage("assistant", ...), which cannot carry native or reasoning.
+func NewToolCallMessage(content string, toolCalls []ToolCall, native NativeTurn, reasoningContent string) Message {
 	var tc []ToolCall
 	if len(toolCalls) > 0 {
 		tc = make([]ToolCall, len(toolCalls))
 		copy(tc, toolCalls)
 	}
-	return Message{Role: "assistant", Content: content, ToolCalls: tc}
+	return Message{Role: "assistant", Content: content, ToolCalls: tc, Native: native, ReasoningContent: reasoningContent}
 }
 
 // NewToolResultMessage creates a tool-role message with the given result.
@@ -155,6 +285,11 @@ type ResponseMessage struct {
 	Content          *string    `json:"content,omitempty"`
 	ReasoningContent string     `json:"reasoning_content,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
+	// Native is the adapter-native replay state for this turn; see NativeTurn.
+	// json:"-" for the same reason as Message.Native: Payload can hold an
+	// arbitrarily large provider SDK struct that must never ride along on an
+	// incidental direct marshal of this type.
+	Native NativeTurn `json:"-"`
 }
 
 // ChatResponse is the parsed result of a completion request.
@@ -178,6 +313,25 @@ func (r *ChatResponse) Content() string {
 	return msg.ReasoningContent
 }
 
+// VisibleContent extracts the model's visible text answer, or "" if the
+// provider produced none. Unlike Content(), it never falls back to
+// ReasoningContent. History-building callers must use this one: falling back
+// would duplicate reasoning that Native already carries — a turn with empty
+// visible content and a non-empty reasoning_content (the common shape for
+// openai-chat-completions tool calls) would otherwise get that same text
+// written into both the ordinary content field and the reasoning_content
+// escape hatch on replay.
+func (r *ChatResponse) VisibleContent() string {
+	if len(r.Choices) == 0 {
+		return ""
+	}
+	msg := r.Choices[0].Message
+	if msg.Content == nil || *msg.Content == "" {
+		return ""
+	}
+	return strings.TrimSpace(stripThinkTags(*msg.Content))
+}
+
 // ToolCalls extracts tool calls from the first choice.
 func (r *ChatResponse) ToolCalls() []ToolCall {
 	if len(r.Choices) == 0 {
@@ -192,6 +346,15 @@ func (r *ChatResponse) ReasoningContent() string {
 		return ""
 	}
 	return r.Choices[0].Message.ReasoningContent
+}
+
+// Native extracts the adapter-native replay state of the first choice, if
+// any. See NativeTurn for how callers must use (or safely ignore) it.
+func (r *ChatResponse) Native() NativeTurn {
+	if len(r.Choices) == 0 {
+		return NativeTurn{}
+	}
+	return r.Choices[0].Message.Native
 }
 
 // ToolDef defines a tool/function available to the model.
@@ -604,8 +767,10 @@ func (c *OpenAIClient) completionsStreamingInner(ctx context.Context, params ope
 	}
 	for i := range resp.Choices {
 		builder := reasoningByChoice[accumulator.Choices[i].Index]
-		if builder != nil {
-			resp.Choices[i].Message.ReasoningContent = builder.String()
+		if builder != nil && builder.Len() > 0 {
+			reasoningContent := builder.String()
+			resp.Choices[i].Message.ReasoningContent = reasoningContent
+			resp.Choices[i].Message.Native = NativeTurn{Family: "openai-chat-completions", Payload: ReasoningPayload(reasoningContent)}
 		}
 	}
 
@@ -627,26 +792,33 @@ func (c *OpenAIClient) buildOpenAIParams(model string, req ChatRequest) openai.C
 		case "tool":
 			messages = append(messages, openai.ToolMessage(content, msg.ToolCallID))
 		case "assistant":
-			if len(msg.ToolCalls) == 0 {
-				messages = append(messages, openai.AssistantMessage(content))
-			} else {
-				asst := openai.ChatCompletionAssistantMessageParam{}
-				if content != "" {
-					asst.Content.OfString = openai.String(content)
-				}
-				for _, tc := range msg.ToolCalls {
-					asst.ToolCalls = append(asst.ToolCalls, openai.ChatCompletionMessageToolCallUnionParam{
-						OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-							ID: tc.ID,
-							Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-								Name:      tc.Function.Name,
-								Arguments: tc.Function.Arguments,
-							},
-						},
-					})
-				}
-				messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+			asst := openai.ChatCompletionAssistantMessageParam{}
+			// Content is required unless tool_calls is present: mirrors the two
+			// branches this replaced (AssistantMessage always set it; the
+			// tool-calls branch only did when non-empty, since the field is
+			// optional once tool_calls carries the turn).
+			if content != "" || len(msg.ToolCalls) == 0 {
+				asst.Content.OfString = openai.String(content)
 			}
+			for _, tc := range msg.ToolCalls {
+				asst.ToolCalls = append(asst.ToolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+						ID: tc.ID,
+						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+							Name:      tc.Function.Name,
+							Arguments: tc.Function.Arguments,
+						},
+					},
+				})
+			}
+			// reasoning_content is a gateway extension the official SDK does not
+			// model (see issue #805): re-attach it verbatim via the param
+			// escape hatch rather than folding it into Content, which is what
+			// silently dropped it on replay before this change.
+			if reasoning, ok := msg.Native.Payload.(ReasoningPayload); ok && reasoning != "" {
+				asst.SetExtraFields(map[string]any{"reasoning_content": string(reasoning)})
+			}
+			messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
 		default:
 			messages = append(messages, openai.UserMessage(content))
 		}
@@ -721,10 +893,21 @@ func (c *OpenAIClient) mapOpenAIResponse(sdkResp *openai.ChatCompletion) *ChatRe
 		}
 
 		var reasoningContent string
-		if extra, ok := ch.Message.JSON.ExtraFields["reasoning_content"]; ok && extra.Valid() {
+		// respjson.Field.Valid() is only meaningful for fields decoded into a
+		// known type; a genuine extra field like this one has none to check
+		// against and is always reported invalid by design (see the SDK's
+		// apijson decoder) — checking it here would make this branch dead
+		// code. Presence (ok) is the only signal available, matching the
+		// streaming path above, which never checked Valid() either.
+		if extra, ok := ch.Message.JSON.ExtraFields["reasoning_content"]; ok {
 			if err := json.Unmarshal([]byte(extra.Raw()), &reasoningContent); err != nil {
 				reasoningContent = extra.Raw()
 			}
+		}
+
+		var native NativeTurn
+		if reasoningContent != "" {
+			native = NativeTurn{Family: "openai-chat-completions", Payload: ReasoningPayload(reasoningContent)}
 		}
 
 		choices = append(choices, Choice{
@@ -733,6 +916,7 @@ func (c *OpenAIClient) mapOpenAIResponse(sdkResp *openai.ChatCompletion) *ChatRe
 				Content:          contentPtr,
 				ReasoningContent: reasoningContent,
 				ToolCalls:        toolCalls,
+				Native:           native,
 			},
 			FinishReason: ch.FinishReason,
 		})
@@ -1034,6 +1218,34 @@ func listProfilesRegionArg(region string) string {
 
 // CompletionsWithCtx sends a chat completion request with context support.
 //
+// anthropicThinkingBudgetTokens extracts budget_tokens from an
+// extra_body.thinking value. The value always originates from a user's JSON
+// config decoded into ExtraBody (map[string]any), where json.Unmarshal
+// represents numbers as float64 — json.Number and the integer types are
+// handled too in case a caller (a test, a future programmatic config path)
+// builds the map by hand. Returns ok=false for any shape it doesn't
+// recognize, so CompletionsWithCtx forwards the value unchanged rather than
+// guessing wrong about a config it can't parse.
+func anthropicThinkingBudgetTokens(v any) (int64, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	switch n := m["budget_tokens"].(type) {
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
 // The deferred finalizeRequest is this client's boundary for the retry report;
 // see the OpenAI counterpart for why it is deferred and why the results are
 // named. A parameter-building failure returns before any HTTP attempt, so
@@ -1077,6 +1289,27 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 		// to decode. Drop the key rather than forward it.
 		if k == "stream" {
 			continue
+		}
+		// Extended thinking (extra_body.thinking, the supported way to turn it
+		// on today — see NativeTurn's anthropic-messages family for the replay
+		// side) has two hard requirements the API enforces, and ExtraBody is a
+		// client-wide setting forwarded to every request regardless of task —
+		// so a provider config that enables it for the main review loop must
+		// not silently break every other call shape:
+		//   - rejected together with a forced tool_choice (ReviewFilterTask
+		//     sets ToolChoice "required" for its single-shot classification);
+		//   - rejected when budget_tokens isn't strictly less than max_tokens
+		//     (GroupingTask hardcodes MaxTokens: 4096, well under a typical
+		//     thinking budget — see issue discussion after the #805 fix).
+		// Drop it for this one request rather than let an otherwise-unrelated
+		// task start failing.
+		if k == "thinking" {
+			if req.ToolChoice == "required" {
+				continue
+			}
+			if budget, ok := anthropicThinkingBudgetTokens(v); ok && req.MaxTokens > 0 && budget >= int64(req.MaxTokens) {
+				continue
+			}
 		}
 		opts = append(opts, option.WithJSONSet(k, v))
 	}
@@ -1122,6 +1355,34 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 			pendingToolResults = append(pendingToolResults, msg)
 		case "assistant":
 			flushToolResults()
+			// Native carries the SDK's own MessageParam for this turn — built by
+			// Message.ToParam() at parse time — with thinking/redacted_thinking
+			// blocks and their signatures preserved verbatim, in original order,
+			// ahead of tool_use. Reuse it whole instead of reconstructing blocks
+			// from Content/ToolCalls, which is what silently dropped those
+			// blocks before this change (issue #805). A type-assertion failure
+			// (message built by another protocol, or with no native state)
+			// falls through to that reconstruction unchanged.
+			// len(native.Content) > 0 guards a Payload that type-asserts
+			// correctly but carries nothing (defensive: our own
+			// mapAnthropicResponse never produces this, but Payload is
+			// exported and could be set by any caller) — falling through to
+			// reconstruction beats replaying a message with no content
+			// blocks, which Anthropic rejects.
+			if native, ok := msg.Native.Payload.(anthropic.MessageParam); ok && len(native.Content) > 0 {
+				// Content is a slice: assigning native by value still shares
+				// its backing array with whatever this Message's Native came
+				// from (a previous round's history, a session record). Giving
+				// it a fresh backing array here is half of what keeps the
+				// dynamic cache_control breakpoint below from mutating shared
+				// state — the other half, cloning the specific block it
+				// writes to, lives at that mutation site, since a plain slice
+				// copy does not deep-copy the pointer each element holds to
+				// its underlying block-param struct.
+				native.Content = append([]anthropic.ContentBlockParamUnion(nil), native.Content...)
+				messages = append(messages, native)
+				continue
+			}
 			var blocks []anthropic.ContentBlockParamUnion
 			if s, ok := msg.Content.(string); ok && s != "" {
 				blocks = append(blocks, anthropic.NewTextBlock(s))
@@ -1207,9 +1468,30 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 	// cached incrementally: read the full previous prefix, write only the delta.
 	if len(messages) > 0 {
 		last := &messages[len(messages)-1]
-		if len(last.Content) > 0 {
-			if cc := last.Content[len(last.Content)-1].GetCacheControl(); cc != nil {
-				*cc = anthropic.NewCacheControlEphemeralParam()
+		if n := len(last.Content); n > 0 {
+			lastIdx := n - 1
+			// Clone before mutating: GetCacheControl() returns a pointer into
+			// whichever block-param struct is active in the union, and this
+			// block may be a Native payload reused verbatim from a previous
+			// response (see the assistant branch above) — its pointer fields
+			// are shared with that stored history, so mutating through the
+			// pointer in place would leak this request's cache_control into
+			// an object other rounds/records still hold. Cloning through a
+			// JSON round trip works uniformly across every block variant
+			// without per-type copy code.
+			// err intentionally ignored beyond skipping the mutation: a clone
+			// failure here means the SDK's own generated type failed to round
+			// trip through its own (Un)MarshalJSON, which would indicate a bug
+			// in the vendored SDK, not in this call site. The safe fallback is
+			// to leave this block's cache_control untouched — the request still
+			// goes out, just without a fresh breakpoint on this turn, which
+			// costs cache efficiency, not correctness.
+			cloned, err := cloneContentBlockParam(last.Content[lastIdx])
+			if err == nil {
+				if cc := cloned.GetCacheControl(); cc != nil {
+					*cc = anthropic.NewCacheControlEphemeralParam()
+					last.Content[lastIdx] = cloned
+				}
 			}
 		}
 	}
@@ -1218,6 +1500,24 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 	}
 
 	return params, nil
+}
+
+// cloneContentBlockParam deep-copies a content block through a JSON round
+// trip. ContentBlockParamUnion's active variant is always a pointer
+// (OfToolUse, OfThinking, ...), so a plain value copy of the union struct
+// still aliases the pointed-to block-param struct; marshaling and
+// unmarshaling rebuilds it as an independent value without needing per-variant
+// copy code.
+func cloneContentBlockParam(b anthropic.ContentBlockParamUnion) (anthropic.ContentBlockParamUnion, error) {
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return anthropic.ContentBlockParamUnion{}, err
+	}
+	var clone anthropic.ContentBlockParamUnion
+	if err := json.Unmarshal(raw, &clone); err != nil {
+		return anthropic.ContentBlockParamUnion{}, err
+	}
+	return clone, nil
 }
 
 func buildToolInputSchema(params map[string]any) anthropic.ToolInputSchemaParam {
@@ -1249,15 +1549,22 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 	var textParts []string
 	var thinkingParts []string
 	var toolCalls []ToolCall
+	// hasThinking tracks thinking AND redacted_thinking blocks, unlike
+	// thinkingParts (which only collects readable text — a redacted block has
+	// none). It gates whether Native gets set at all, below.
+	var hasThinking bool
 
 	for _, block := range sdkResp.Content {
 		switch block.Type {
 		case "text":
 			textParts = append(textParts, block.Text)
 		case "thinking":
+			hasThinking = true
 			if block.Thinking != "" {
 				thinkingParts = append(thinkingParts, block.Thinking)
 			}
+		case "redacted_thinking":
+			hasThinking = true
 		case "tool_use":
 			toolCalls = append(toolCalls, ToolCall{
 				ID:   block.ID,
@@ -1279,6 +1586,19 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 	var reasoningContent string
 	if len(thinkingParts) > 0 {
 		reasoningContent = strings.Join(thinkingParts, "\n")
+	}
+
+	// Native is only worth carrying when there's an actual
+	// thinking/redacted_thinking block to preserve: an ordinary text +
+	// tool_use turn round-trips losslessly through the existing
+	// Content()/ToolCalls() reconstruction, and setting it unconditionally
+	// would mean a response with zero content blocks (e.g. a truncated or
+	// error turn) produces a MessageParam with an empty Content slice — which
+	// buildAnthropicParams would then replay verbatim, and Anthropic rejects
+	// a message with no content blocks.
+	var native NativeTurn
+	if hasThinking {
+		native = NativeTurn{Family: "anthropic-messages", Payload: sdkResp.ToParam()}
 	}
 
 	finishReason := string(sdkResp.StopReason)
@@ -1309,6 +1629,16 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 				Content:          contentStr,
 				ReasoningContent: reasoningContent,
 				ToolCalls:        toolCalls,
+				// native (see above) reuses the SDK's own response->request
+				// converter, ToParam(): it walks sdkResp.Content block by
+				// block, preserving order and copying thinking/redacted_thinking
+				// blocks (Signature/Data) verbatim — exactly the "pass back
+				// unmodified and in original order" replay contract Anthropic's
+				// API enforces. Reusing it beats hand-reconstructing blocks
+				// from the flattened Content()/ReasoningContent() strings,
+				// which is what dropped signatures before this change (issue
+				// #805).
+				Native: native,
 			},
 			FinishReason: finishReason,
 		}},

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -43,12 +43,8 @@ var AppVersion = "dev"
 // shrink it, same as keyCmdTimeout.
 var bedrockConfigLoadTimeout = 60 * time.Second
 
-// defaultAnthropicMaxTokens is the max_tokens value buildAnthropicParams
-// falls back to when the caller leaves ChatRequest.MaxTokens unset. Extended
-// thinking's budget_tokens must stay strictly below whatever max_tokens is
-// actually sent, so the extra_body.thinking guard in CompletionsWithCtx
-// compares against this same default rather than the raw (possibly zero)
-// ChatRequest.MaxTokens.
+// defaultAnthropicMaxTokens is used when ChatRequest.MaxTokens is unset.
+// The thinking guard also compares against this to decide whether to drop thinking.
 const defaultAnthropicMaxTokens = 8192
 
 func userAgent(provider string) string {
@@ -75,89 +71,41 @@ type Message struct {
 	Content    any        `json:"content"`                // string or []ContentBlock
 	ToolCallID string     `json:"tool_call_id,omitempty"` // OpenAI tool call identifier
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // assistant tool invocations
-	// Native carries the provider adapter's own representation of this
-	// assistant turn (see NativeTurn), when this message was built directly
-	// from a ChatResponse. Zero value for every non-assistant message and for
-	// any assistant message built without one. Only the adapter that produced
-	// it — matched by a type assertion on Payload, never by Family — may reuse
-	// it for replay; every other consumer that just needs Content/ToolCalls
-	// (compression, a different protocol's adapter) must ignore it and fall
-	// back to those. json:"-" because Payload can hold an arbitrarily large
-	// provider SDK struct and Message is JSON-tagged for the wire format: an
-	// incidental direct marshal (a debug dump, a request body) must not carry
-	// it along. internal/session deliberately reaches past this tag — reading
-	// this field directly (and ChatResponse.Native() for a fresh response),
-	// never by marshaling Message itself — to persist it into the session
-	// transcript for offline replay/export; that is the one sanctioned
-	// exception to "ignore it and fall back".
+	// Native is the opaque per-provider replay state for this assistant turn.
+	// Only the adapter that produced it (matched by type assertion) may reuse
+	// it; others fall back to Content/ToolCalls. json:"-" because Payload is
+	// an SDK struct unsuitable for incidental marshaling; internal/session
+	// persists it deliberately via ChatResponse.Native().
 	Native NativeTurn `json:"-"`
-	// ReasoningContent is the plain, human-readable projection of this turn's
-	// reasoning — set alongside Native from the same ChatResponse, but usable
-	// by anything that only wants readable text and has no business touching
-	// Native's opaque payload. compression.go's summarization prompt is the
-	// motivating consumer: without this, a reasoning-only turn (empty
-	// Content, since VisibleContent() never falls back to reasoning text)
-	// renders as a blank message in the compression XML, and the summarizer
-	// has no way to know what happened in that round. Deliberately excluded
-	// from ExtractText() and every request builder: folding it back into the
-	// text sent to the provider would recreate the exact reasoning_content
-	// duplication bug Native was introduced to fix.
+	// ReasoningContent is a readable projection of reasoning for display-only
+	// consumers (e.g. compression's summarization prompt). Excluded from
+	// ExtractText() and request builders to avoid duplicating what Native
+	// already carries.
 	ReasoningContent string `json:"-"`
 }
 
-// NativeTurn is the adapter-native, opaque replay state for one finalized
-// assistant turn — Anthropic thinking/redacted_thinking blocks with their
-// signatures, an OpenAI Responses reasoning item with its encrypted_content,
-// or an OpenAI-compatible gateway's reasoning_content string. It must never be
-// parsed, edited, or reordered by anything other than the adapter that
-// produced it: those payloads are validated (signature) or only meaningful
-// (encrypted_content) to the exact provider that issued them. Persisting it
-// (internal/session writes Payload verbatim into the session transcript) is
-// fine precisely because nothing reads or reshapes it on the way there — it
-// goes to disk as the same value the adapter would replay, byte for byte.
+// NativeTurn is the opaque replay state for one assistant turn. Payloads are
+// provider-validated (Anthropic signature, OpenAI encrypted_content) and must
+// never be parsed or reordered outside their originating adapter.
 type NativeTurn struct {
-	// Family names the wire-format family that produced Payload
-	// ("anthropic-messages", "openai-chat-completions", "openai-responses").
-	// It exists for observability/debugging only — the safety net that
-	// prevents a mismatched adapter from misusing Payload is the Go type
-	// assertion each adapter performs before use, not this string.
+	// Family: "anthropic-messages", "openai-chat-completions", or "openai-responses".
+	// For observability only; safety comes from the Go type assertion on Payload.
 	Family string
-	// Payload's concrete type is adapter-specific: anthropic.MessageParam,
-	// []responses.ResponseInputItemUnionParam, or ReasoningPayload. nil means
-	// this turn carries no native replay state (a plain response with
-	// nothing to preserve beyond Content/ToolCalls).
+	// Payload: anthropic.MessageParam, []responses.ResponseInputItemUnionParam,
+	// or ReasoningPayload. nil means nothing to preserve beyond Content/ToolCalls.
 	Payload any
 }
 
-// ReasoningPayload is the openai-chat-completions family's NativeTurn
-// payload: the gateway's raw reasoning_content string. Named (rather than a
-// bare string) so a type assertion on Payload can't accidentally match an
-// unrelated string value from a different source.
+// ReasoningPayload is the openai-chat-completions NativeTurn payload.
+// Named type so a type assertion can't accidentally match an unrelated string.
 type ReasoningPayload string
 
-// EstimatedTokens returns a rough token estimate for whatever this turn's
-// Payload carries beyond Content/ToolCalls — thinking blocks, reasoning
-// items, encrypted_content, a gateway's reasoning_content string — so a
-// caller sizing a request against a token budget (compression's threshold
-// checks) isn't blind to it. Once this turn replays, that payload really
-// goes out on the wire; a budget computed only from Content/ExtractText()
-// would systematically under-count it.
-//
-// Deliberately excludes whatever Payload carries that ExtractText()/Content()
-// already counts — an Anthropic MessageParam's text blocks, a Responses
-// message item's text — because CountMessagesTokens always adds this on top
-// of llm.CountTokens(m.ExtractText()); counting the same visible text twice
-// would over-count instead, which is just as wrong for a compression
-// threshold (it triggers compression earlier than the request actually
-// needs). This is deliberately crude otherwise — bytes/4 on whatever's left,
-// the same heuristic CountTokensForModel falls back to when tiktoken is
-// unavailable — good enough to keep a budget decision in the right ballpark.
+// EstimatedTokens returns a rough token estimate for the portion of Payload
+// not already counted by ExtractText() (thinking blocks, reasoning items,
+// tool-call arguments). Uses marshaled bytes/4 as the heuristic.
 func (n NativeTurn) EstimatedTokens() int {
 	switch p := n.Payload.(type) {
 	case ReasoningPayload:
-		// The whole payload IS the extra text; ExtractText() never sees it
-		// (the openai-chat-completions family keeps it out of Content), so
-		// there's nothing to exclude here.
 		return marshaledLen(p)
 	case anthropic.MessageParam:
 		var total int
@@ -168,12 +116,8 @@ func (n NativeTurn) EstimatedTokens() int {
 			case block.OfRedactedThinking != nil:
 				total += marshaledLen(block.OfRedactedThinking)
 			case block.OfToolUse != nil:
-				// Tool-call arguments: not double-counted (ExtractText()
-				// never reads ToolCalls either), so counting them here is a
-				// pure improvement over leaving them invisible to the budget.
 				total += marshaledLen(block.OfToolUse)
 			}
-			// OfText deliberately excluded: already in Content()/ExtractText().
 		}
 		return total
 	case []responses.ResponseInputItemUnionParam:
@@ -185,8 +129,6 @@ func (n NativeTurn) EstimatedTokens() int {
 			case item.OfFunctionCall != nil:
 				total += marshaledLen(item.OfFunctionCall)
 			}
-			// OfOutputMessage deliberately excluded: its text is already
-			// aggregated into Content() via sdkResp.OutputText().
 		}
 		return total
 	default:
@@ -194,8 +136,6 @@ func (n NativeTurn) EstimatedTokens() int {
 	}
 }
 
-// marshaledLen returns len(json.Marshal(v))/4, or 0 if v is nil or fails to
-// marshal — the shared bytes/4 heuristic every EstimatedTokens case uses.
 func marshaledLen(v any) int {
 	if v == nil {
 		return 0
@@ -221,13 +161,8 @@ func NewTextMessage(role, content string) Message {
 	return Message{Role: role, Content: content}
 }
 
-// NewToolCallMessage creates an assistant message, optionally carrying tool
-// invocations, the adapter-native replay state for this turn (native is the
-// zero NativeTurn when there is nothing to preserve, e.g. plain text with no
-// reasoning), and the plain-text projection of that reasoning for display-only
-// consumers (see Message.ReasoningContent). This is the single constructor for
-// assistant-turn history messages — do not build one with
-// NewTextMessage("assistant", ...), which cannot carry native or reasoning.
+// NewToolCallMessage creates an assistant history message. Use this instead of
+// NewTextMessage("assistant", ...) to preserve native replay state and reasoning.
 func NewToolCallMessage(content string, toolCalls []ToolCall, native NativeTurn, reasoningContent string) Message {
 	var tc []ToolCall
 	if len(toolCalls) > 0 {
@@ -300,12 +235,7 @@ type ResponseMessage struct {
 	Content          *string    `json:"content,omitempty"`
 	ReasoningContent string     `json:"reasoning_content,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
-	// Native is the adapter-native replay state for this turn; see NativeTurn.
-	// json:"-" for the same reason as Message.Native: Payload can hold an
-	// arbitrarily large provider SDK struct that must never ride along on an
-	// incidental direct marshal of this type. internal/session reaches past
-	// this tag via Native()/ChatResponse.Native() to persist it deliberately.
-	Native NativeTurn `json:"-"`
+	Native NativeTurn `json:"-"` // opaque replay state; see NativeTurn
 }
 
 // ChatResponse is the parsed result of a completion request.
@@ -329,14 +259,9 @@ func (r *ChatResponse) Content() string {
 	return msg.ReasoningContent
 }
 
-// VisibleContent extracts the model's visible text answer, or "" if the
-// provider produced none. Unlike Content(), it never falls back to
-// ReasoningContent. History-building callers must use this one: falling back
-// would duplicate reasoning that Native already carries — a turn with empty
-// visible content and a non-empty reasoning_content (the common shape for
-// openai-chat-completions tool calls) would otherwise get that same text
-// written into both the ordinary content field and the reasoning_content
-// escape hatch on replay.
+// VisibleContent extracts visible text only, never falling back to
+// ReasoningContent. History builders must use this to avoid duplicating
+// reasoning that Native already carries.
 func (r *ChatResponse) VisibleContent() string {
 	if len(r.Choices) == 0 {
 		return ""
@@ -364,8 +289,7 @@ func (r *ChatResponse) ReasoningContent() string {
 	return r.Choices[0].Message.ReasoningContent
 }
 
-// Native extracts the adapter-native replay state of the first choice, if
-// any. See NativeTurn for how callers must use (or safely ignore) it.
+// Native extracts the replay state of the first choice, if any.
 func (r *ChatResponse) Native() NativeTurn {
 	if len(r.Choices) == 0 {
 		return NativeTurn{}
@@ -809,10 +733,6 @@ func (c *OpenAIClient) buildOpenAIParams(model string, req ChatRequest) openai.C
 			messages = append(messages, openai.ToolMessage(content, msg.ToolCallID))
 		case "assistant":
 			asst := openai.ChatCompletionAssistantMessageParam{}
-			// Content is required unless tool_calls is present: mirrors the two
-			// branches this replaced (AssistantMessage always set it; the
-			// tool-calls branch only did when non-empty, since the field is
-			// optional once tool_calls carries the turn).
 			if content != "" || len(msg.ToolCalls) == 0 {
 				asst.Content.OfString = openai.String(content)
 			}
@@ -827,10 +747,7 @@ func (c *OpenAIClient) buildOpenAIParams(model string, req ChatRequest) openai.C
 					},
 				})
 			}
-			// reasoning_content is a gateway extension the official SDK does not
-			// model (see issue #805): re-attach it verbatim via the param
-			// escape hatch rather than folding it into Content, which is what
-			// silently dropped it on replay before this change.
+			// reasoning_content: gateway extension not modeled by the SDK (#805).
 			if reasoning, ok := msg.Native.Payload.(ReasoningPayload); ok && reasoning != "" {
 				asst.SetExtraFields(map[string]any{"reasoning_content": string(reasoning)})
 			}
@@ -909,12 +826,7 @@ func (c *OpenAIClient) mapOpenAIResponse(sdkResp *openai.ChatCompletion) *ChatRe
 		}
 
 		var reasoningContent string
-		// respjson.Field.Valid() is only meaningful for fields decoded into a
-		// known type; a genuine extra field like this one has none to check
-		// against and is always reported invalid by design (see the SDK's
-		// apijson decoder) — checking it here would make this branch dead
-		// code. Presence (ok) is the only signal available, matching the
-		// streaming path above, which never checked Valid() either.
+		// Presence (ok) is the only signal; Valid() is always false for extra fields.
 		if extra, ok := ch.Message.JSON.ExtraFields["reasoning_content"]; ok {
 			if err := json.Unmarshal([]byte(extra.Raw()), &reasoningContent); err != nil {
 				reasoningContent = extra.Raw()
@@ -1232,16 +1144,8 @@ func listProfilesRegionArg(region string) string {
 	return " --region " + region
 }
 
-// CompletionsWithCtx sends a chat completion request with context support.
-//
 // anthropicThinkingBudgetTokens extracts budget_tokens from an
-// extra_body.thinking value. The value always originates from a user's JSON
-// config decoded into ExtraBody (map[string]any), where json.Unmarshal
-// represents numbers as float64 — json.Number and the integer types are
-// handled too in case a caller (a test, a future programmatic config path)
-// builds the map by hand. Returns ok=false for any shape it doesn't
-// recognize, so CompletionsWithCtx forwards the value unchanged rather than
-// guessing wrong about a config it can't parse.
+// extra_body.thinking map. Returns ok=false for unrecognized shapes.
 func anthropicThinkingBudgetTokens(v any) (int64, bool) {
 	m, ok := v.(map[string]any)
 	if !ok {
@@ -1306,19 +1210,8 @@ func (c *AnthropicClient) CompletionsWithCtx(ctx context.Context, req ChatReques
 		if k == "stream" {
 			continue
 		}
-		// Extended thinking (extra_body.thinking, the supported way to turn it
-		// on today — see NativeTurn's anthropic-messages family for the replay
-		// side) has two hard requirements the API enforces, and ExtraBody is a
-		// client-wide setting forwarded to every request regardless of task —
-		// so a provider config that enables it for the main review loop must
-		// not silently break every other call shape:
-		//   - rejected together with a forced tool_choice (ReviewFilterTask
-		//     sets ToolChoice "required" for its single-shot classification);
-		//   - rejected when budget_tokens isn't strictly less than max_tokens
-		//     (GroupingTask hardcodes MaxTokens: 4096, well under a typical
-		//     thinking budget — see issue discussion after the #805 fix).
-		// Drop it for this one request rather than let an otherwise-unrelated
-		// task start failing.
+		// Drop thinking when it conflicts with this request's constraints:
+		// forced tool_choice or budget_tokens >= max_tokens.
 		if k == "thinking" {
 			if req.ToolChoice == "required" {
 				continue
@@ -1375,30 +1268,10 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 			pendingToolResults = append(pendingToolResults, msg)
 		case "assistant":
 			flushToolResults()
-			// Native carries the SDK's own MessageParam for this turn — built by
-			// Message.ToParam() at parse time — with thinking/redacted_thinking
-			// blocks and their signatures preserved verbatim, in original order,
-			// ahead of tool_use. Reuse it whole instead of reconstructing blocks
-			// from Content/ToolCalls, which is what silently dropped those
-			// blocks before this change (issue #805). A type-assertion failure
-			// (message built by another protocol, or with no native state)
-			// falls through to that reconstruction unchanged.
-			// len(native.Content) > 0 guards a Payload that type-asserts
-			// correctly but carries nothing (defensive: our own
-			// mapAnthropicResponse never produces this, but Payload is
-			// exported and could be set by any caller) — falling through to
-			// reconstruction beats replaying a message with no content
-			// blocks, which Anthropic rejects.
+			// Reuse the native MessageParam whole to preserve thinking blocks
+			// and signatures. Copy the slice to avoid mutating shared state
+			// when the cache_control breakpoint writes below.
 			if native, ok := msg.Native.Payload.(anthropic.MessageParam); ok && len(native.Content) > 0 {
-				// Content is a slice: assigning native by value still shares
-				// its backing array with whatever this Message's Native came
-				// from (a previous round's history, a session record). Giving
-				// it a fresh backing array here is half of what keeps the
-				// dynamic cache_control breakpoint below from mutating shared
-				// state — the other half, cloning the specific block it
-				// writes to, lives at that mutation site, since a plain slice
-				// copy does not deep-copy the pointer each element holds to
-				// its underlying block-param struct.
 				native.Content = append([]anthropic.ContentBlockParamUnion(nil), native.Content...)
 				messages = append(messages, native)
 				continue
@@ -1490,22 +1363,7 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 		last := &messages[len(messages)-1]
 		if n := len(last.Content); n > 0 {
 			lastIdx := n - 1
-			// Clone before mutating: GetCacheControl() returns a pointer into
-			// whichever block-param struct is active in the union, and this
-			// block may be a Native payload reused verbatim from a previous
-			// response (see the assistant branch above) — its pointer fields
-			// are shared with that stored history, so mutating through the
-			// pointer in place would leak this request's cache_control into
-			// an object other rounds/records still hold. Cloning through a
-			// JSON round trip works uniformly across every block variant
-			// without per-type copy code.
-			// err intentionally ignored beyond skipping the mutation: a clone
-			// failure here means the SDK's own generated type failed to round
-			// trip through its own (Un)MarshalJSON, which would indicate a bug
-			// in the vendored SDK, not in this call site. The safe fallback is
-			// to leave this block's cache_control untouched — the request still
-			// goes out, just without a fresh breakpoint on this turn, which
-			// costs cache efficiency, not correctness.
+			// Clone before mutating: the block may be shared with stored history.
 			cloned, err := cloneContentBlockParam(last.Content[lastIdx])
 			if err == nil {
 				if cc := cloned.GetCacheControl(); cc != nil {
@@ -1522,12 +1380,7 @@ func (c *AnthropicClient) buildAnthropicParams(model string, req ChatRequest) (a
 	return params, nil
 }
 
-// cloneContentBlockParam deep-copies a content block through a JSON round
-// trip. ContentBlockParamUnion's active variant is always a pointer
-// (OfToolUse, OfThinking, ...), so a plain value copy of the union struct
-// still aliases the pointed-to block-param struct; marshaling and
-// unmarshaling rebuilds it as an independent value without needing per-variant
-// copy code.
+// cloneContentBlockParam deep-copies a content block via JSON round trip.
 func cloneContentBlockParam(b anthropic.ContentBlockParamUnion) (anthropic.ContentBlockParamUnion, error) {
 	raw, err := json.Marshal(b)
 	if err != nil {
@@ -1569,9 +1422,6 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 	var textParts []string
 	var thinkingParts []string
 	var toolCalls []ToolCall
-	// hasThinking tracks thinking AND redacted_thinking blocks, unlike
-	// thinkingParts (which only collects readable text — a redacted block has
-	// none). It gates whether Native gets set at all, below.
 	var hasThinking bool
 
 	for _, block := range sdkResp.Content {
@@ -1608,14 +1458,8 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 		reasoningContent = strings.Join(thinkingParts, "\n")
 	}
 
-	// Native is only worth carrying when there's an actual
-	// thinking/redacted_thinking block to preserve: an ordinary text +
-	// tool_use turn round-trips losslessly through the existing
-	// Content()/ToolCalls() reconstruction, and setting it unconditionally
-	// would mean a response with zero content blocks (e.g. a truncated or
-	// error turn) produces a MessageParam with an empty Content slice — which
-	// buildAnthropicParams would then replay verbatim, and Anthropic rejects
-	// a message with no content blocks.
+	// Only set when thinking is present; ordinary turns round-trip via
+	// Content()/ToolCalls(). Anthropic rejects empty content blocks.
 	var native NativeTurn
 	if hasThinking {
 		native = NativeTurn{Family: "anthropic-messages", Payload: sdkResp.ToParam()}
@@ -1649,15 +1493,6 @@ func (c *AnthropicClient) mapAnthropicResponse(sdkResp *anthropic.Message) *Chat
 				Content:          contentStr,
 				ReasoningContent: reasoningContent,
 				ToolCalls:        toolCalls,
-				// native (see above) reuses the SDK's own response->request
-				// converter, ToParam(): it walks sdkResp.Content block by
-				// block, preserving order and copying thinking/redacted_thinking
-				// blocks (Signature/Data) verbatim — exactly the "pass back
-				// unmodified and in original order" replay contract Anthropic's
-				// API enforces. Reusing it beats hand-reconstructing blocks
-				// from the flattened Content()/ReasoningContent() strings,
-				// which is what dropped signatures before this change (issue
-				// #805).
 				Native: native,
 			},
 			FinishReason: finishReason,

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1332,6 +1332,128 @@ func TestAnthropicClient_ExtraBodyStreamDropped(t *testing.T) {
 	}
 }
 
+// TestAnthropicClient_ExtraBodyThinkingDroppedWithForcedToolChoice verifies
+// that extra_body.thinking — the supported way to turn on extended thinking
+// today, see the CompletionsWithCtx comment — is dropped for a request whose
+// ToolChoice is "required". The Anthropic API rejects extended thinking
+// together with a forced tool_choice, and ExtraBody is a client-wide setting
+// forwarded to every request regardless of task, so a provider config that
+// enables thinking for the main review loop (ToolChoice "auto") must not
+// break ReviewFilterTask's forced single-shot tool call. Other requests
+// (ToolChoice "auto" or unset) must still get it forwarded.
+func TestAnthropicClient_ExtraBodyThinkingDroppedWithForcedToolChoice(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"msg_thinking_test",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-test",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient(ClientConfig{
+		URL:    server.URL + "/v1/messages",
+		APIKey: "test-key",
+		Model:  "claude-test",
+		ExtraBody: map[string]any{
+			"thinking": map[string]any{"type": "enabled", "budget_tokens": 10000},
+		},
+	})
+
+	if _, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:   []Message{{Role: "user", Content: "hi"}},
+		MaxTokens:  64,
+		ToolChoice: "required",
+	}); err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if _, present := gotBody["thinking"]; present {
+		t.Errorf("thinking must be dropped for a forced tool_choice request, got %v", gotBody["thinking"])
+	}
+
+	gotBody = nil
+	if _, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:   []Message{{Role: "user", Content: "hi"}},
+		MaxTokens:  20000, // > budget_tokens (10000), so only ToolChoice is under test here
+		ToolChoice: "auto",
+	}); err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if gotBody["thinking"] == nil {
+		t.Error("thinking must still be forwarded for a non-forced tool_choice request")
+	}
+}
+
+// TestAnthropicClient_ExtraBodyThinkingDroppedWhenBudgetExceedsMaxTokens
+// guards the real failure this reproduces: a provider config's
+// extra_body.thinking.budget_tokens is a single client-wide value, but
+// MaxTokens varies per call (see internal/agent/grouping.go's grouping call,
+// which had a hardcoded MaxTokens: 4096 well under a typical thinking
+// budget). The API rejects the request outright when budget_tokens isn't
+// strictly less than max_tokens ("max_tokens must be greater than
+// thinking.budget_tokens") — dropping thinking for that one call is safer
+// than letting an unrelated small-output task fail.
+func TestAnthropicClient_ExtraBodyThinkingDroppedWhenBudgetExceedsMaxTokens(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"msg_thinking_budget_test",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-test",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient(ClientConfig{
+		URL:    server.URL + "/v1/messages",
+		APIKey: "test-key",
+		Model:  "claude-test",
+		ExtraBody: map[string]any{
+			"thinking": map[string]any{"type": "enabled", "budget_tokens": float64(10000)},
+		},
+	})
+
+	// budget_tokens (10000) >= MaxTokens (4096): must be dropped.
+	if _, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		MaxTokens: 4096,
+	}); err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if _, present := gotBody["thinking"]; present {
+		t.Errorf("thinking must be dropped when budget_tokens >= MaxTokens, got %v", gotBody["thinking"])
+	}
+
+	// budget_tokens (10000) < MaxTokens (32000): must be forwarded.
+	gotBody = nil
+	if _, err := client.CompletionsWithCtx(context.Background(), ChatRequest{
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		MaxTokens: 32000,
+	}); err != nil {
+		t.Fatalf("CompletionsWithCtx: %v", err)
+	}
+	if gotBody["thinking"] == nil {
+		t.Error("thinking must still be forwarded when budget_tokens < MaxTokens")
+	}
+}
+
 // newOpenAITestServer returns an httptest server that captures each request's headers
 // and JSON body and responds with a minimal valid chat completion.
 func newOpenAITestServer(gotHeaders *http.Header, gotBody *map[string]any) *httptest.Server {

--- a/internal/llm/message_test.go
+++ b/internal/llm/message_test.go
@@ -180,6 +180,72 @@ func TestChatResponse_Content_StripsThinkTags(t *testing.T) {
 	}
 }
 
+func TestChatResponse_VisibleContent_NoChoices(t *testing.T) {
+	resp := &ChatResponse{}
+	if got := resp.VisibleContent(); got != "" {
+		t.Errorf("VisibleContent() with no choices = %q, want empty", got)
+	}
+}
+
+func TestChatResponse_VisibleContent_NilContent(t *testing.T) {
+	resp := &ChatResponse{
+		Choices: []Choice{{
+			Message: ResponseMessage{Content: nil, ReasoningContent: "should not appear"},
+		}},
+	}
+	if got := resp.VisibleContent(); got != "" {
+		t.Errorf("VisibleContent() = %q, want empty (must not fall back to reasoning)", got)
+	}
+}
+
+func TestChatResponse_VisibleContent_EmptyString(t *testing.T) {
+	empty := ""
+	resp := &ChatResponse{
+		Choices: []Choice{{
+			Message: ResponseMessage{Content: &empty, ReasoningContent: "should not appear"},
+		}},
+	}
+	if got := resp.VisibleContent(); got != "" {
+		t.Errorf("VisibleContent() = %q, want empty (must not fall back to reasoning)", got)
+	}
+}
+
+func TestChatResponse_VisibleContent_NormalText(t *testing.T) {
+	text := "hello world"
+	resp := &ChatResponse{
+		Choices: []Choice{{
+			Message: ResponseMessage{Content: &text},
+		}},
+	}
+	if got := resp.VisibleContent(); got != "hello world" {
+		t.Errorf("VisibleContent() = %q, want %q", got, "hello world")
+	}
+}
+
+func TestChatResponse_VisibleContent_StripsThinkTags(t *testing.T) {
+	text := "<think>internal</think>answer"
+	resp := &ChatResponse{
+		Choices: []Choice{{
+			Message: ResponseMessage{Content: &text},
+		}},
+	}
+	if got := resp.VisibleContent(); got != "internalanswer" {
+		t.Errorf("VisibleContent() = %q, want %q", got, "internalanswer")
+	}
+}
+
+func TestChatResponse_VisibleContent_WhitespaceOnly(t *testing.T) {
+	text := "   \n\t  "
+	resp := &ChatResponse{
+		Choices: []Choice{{
+			Message: ResponseMessage{Content: &text, ReasoningContent: "reasoning"},
+		}},
+	}
+	if got := resp.VisibleContent(); got != "" {
+		t.Errorf("VisibleContent() = %q, want empty (whitespace-only after trim)", got)
+	}
+}
+
 func TestChatResponse_ToolCalls(t *testing.T) {
 	resp := &ChatResponse{
 		Choices: []Choice{{

--- a/internal/llm/message_test.go
+++ b/internal/llm/message_test.go
@@ -30,7 +30,8 @@ func TestNewToolCallMessage(t *testing.T) {
 		{ID: "c1", Type: "function", Function: FunctionCall{Name: "tool_a", Arguments: `{}`}},
 		{ID: "c2", Type: "function", Function: FunctionCall{Name: "tool_b", Arguments: `{"x":1}`}},
 	}
-	m := NewToolCallMessage("thinking", calls)
+	native := NativeTurn{Family: "anthropic-messages", Payload: "opaque"}
+	m := NewToolCallMessage("thinking", calls, native, "reasoning text")
 	if m.Role != "assistant" {
 		t.Errorf("Role = %q, want assistant", m.Role)
 	}
@@ -43,6 +44,12 @@ func TestNewToolCallMessage(t *testing.T) {
 	if m.ToolCalls[0].ID != "c1" || m.ToolCalls[1].Function.Name != "tool_b" {
 		t.Errorf("ToolCalls not copied correctly")
 	}
+	if m.Native != native {
+		t.Errorf("Native = %+v, want %+v", m.Native, native)
+	}
+	if m.ReasoningContent != "reasoning text" {
+		t.Errorf("ReasoningContent = %q, want %q", m.ReasoningContent, "reasoning text")
+	}
 
 	// Mutation of original must not affect the message.
 	calls[0].ID = "mutated"
@@ -52,7 +59,7 @@ func TestNewToolCallMessage(t *testing.T) {
 }
 
 func TestNewToolCallMessage_NilCalls(t *testing.T) {
-	m := NewToolCallMessage("text", nil)
+	m := NewToolCallMessage("text", nil, NativeTurn{}, "")
 	if m.ToolCalls != nil {
 		t.Errorf("expected nil ToolCalls for nil input, got %v", m.ToolCalls)
 	}

--- a/internal/llm/native_turn_test.go
+++ b/internal/llm/native_turn_test.go
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// These tests are the deterministic, no-live-model reproductions for issue
+// #805: a response that carries provider reasoning must still carry it, byte
+// for byte, in the assistant history message built for the *next* request.
+// Each test exercises the real mapXXXResponse -> NewToolCallMessage ->
+// buildXXXParams path, not a hand-rolled approximation of it.
+
+func unmarshalChatCompletionBody(t *testing.T, body string) *openai.ChatCompletion {
+	t.Helper()
+	var r openai.ChatCompletion
+	if err := json.Unmarshal([]byte(body), &r); err != nil {
+		t.Fatalf("unmarshal chat completion body: %v", err)
+	}
+	return &r
+}
+
+func unmarshalAnthropicBody(t *testing.T, body string) *anthropic.Message {
+	t.Helper()
+	var m anthropic.Message
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("unmarshal anthropic message body: %v", err)
+	}
+	return &m
+}
+
+func TestOpenAIChatCompletions_ReplaysReasoningContentAcrossTurns(t *testing.T) {
+	client := NewOpenAIClient(ClientConfig{URL: "https://api.openai.com/v1"})
+	body := `{
+		"id":"chatcmpl_1",
+		"object":"chat.completion",
+		"model":"deepseek-r1",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":null,
+				"reasoning_content":"private reasoning that the provider requires on replay",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"code_comment","arguments":"{}"}}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`
+	sdkResp := unmarshalChatCompletionBody(t, body)
+	resp := client.mapOpenAIResponse(sdkResp)
+
+	historyMsg := NewToolCallMessage(resp.Content(), resp.ToolCalls(), resp.Native(), resp.ReasoningContent())
+
+	params := client.buildOpenAIParams("deepseek-r1", ChatRequest{Messages: []Message{historyMsg}})
+	if len(params.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(params.Messages))
+	}
+	payload, err := json.Marshal(params.Messages[0])
+	if err != nil {
+		t.Fatalf("marshal assistant message: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(`"reasoning_content":"private reasoning that the provider requires on replay"`)) {
+		t.Fatalf("assistant tool-call history dropped reasoning_content: %s", payload)
+	}
+}
+
+// TestOpenAIChatCompletions_ReplaysReasoningContentWithEmptyVisibleContent
+// guards the specific regression called out in issue #805: when visible
+// content is empty, Content() falls back to returning the reasoning text as
+// ordinary content, which must not be mistaken for the native replay payload
+// being intact — Native must still carry the real reasoning_content field.
+func TestOpenAIChatCompletions_ReplaysReasoningContentWithEmptyVisibleContent(t *testing.T) {
+	client := NewOpenAIClient(ClientConfig{URL: "https://api.openai.com/v1"})
+	body := `{
+		"id":"chatcmpl_2",
+		"object":"chat.completion",
+		"model":"deepseek-r1",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":"",
+				"reasoning_content":"reasoning with no visible answer yet",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"code_comment","arguments":"{}"}}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`
+	sdkResp := unmarshalChatCompletionBody(t, body)
+	resp := client.mapOpenAIResponse(sdkResp)
+
+	historyMsg := NewToolCallMessage(resp.Content(), resp.ToolCalls(), resp.Native(), resp.ReasoningContent())
+	params := client.buildOpenAIParams("deepseek-r1", ChatRequest{Messages: []Message{historyMsg}})
+	payload, err := json.Marshal(params.Messages[0])
+	if err != nil {
+		t.Fatalf("marshal assistant message: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(`"reasoning_content":"reasoning with no visible answer yet"`)) {
+		t.Fatalf("assistant tool-call history dropped reasoning_content: %s", payload)
+	}
+}
+
+func TestAnthropicClient_ReplaysThinkingBlockBeforeToolUse(t *testing.T) {
+	c := &AnthropicClient{}
+	body := `{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-x",
+		"content":[
+			{"type":"thinking","thinking":"let me think this through","signature":"sig-abc-123"},
+			{"type":"tool_use","id":"toolu_1","name":"code_comment","input":{"a":1}}
+		],
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":10,"output_tokens":5}
+	}`
+	sdkResp := unmarshalAnthropicBody(t, body)
+	resp := c.mapAnthropicResponse(sdkResp)
+
+	historyMsg := NewToolCallMessage(resp.Content(), resp.ToolCalls(), resp.Native(), resp.ReasoningContent())
+
+	params, err := c.buildAnthropicParams("claude-x", ChatRequest{Messages: []Message{historyMsg}})
+	if err != nil {
+		t.Fatalf("buildAnthropicParams: %v", err)
+	}
+	if len(params.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(params.Messages))
+	}
+	blocks := params.Messages[0].Content
+	if len(blocks) != 2 {
+		t.Fatalf("content blocks = %d, want 2 (thinking, tool_use)", len(blocks))
+	}
+	if blocks[0].OfThinking == nil {
+		t.Fatalf("blocks[0] is not a thinking block: %+v", blocks[0])
+	}
+	if blocks[0].OfThinking.Signature != "sig-abc-123" {
+		t.Errorf("thinking signature = %q, want %q (must be passed back unmodified)", blocks[0].OfThinking.Signature, "sig-abc-123")
+	}
+	if blocks[0].OfThinking.Thinking != "let me think this through" {
+		t.Errorf("thinking text = %q, want unmodified original", blocks[0].OfThinking.Thinking)
+	}
+	if blocks[1].OfToolUse == nil {
+		t.Fatalf("blocks[1] is not a tool_use block: %+v", blocks[1])
+	}
+	if blocks[1].OfToolUse.ID != "toolu_1" {
+		t.Errorf("tool_use id = %q, want %q", blocks[1].OfToolUse.ID, "toolu_1")
+	}
+}
+
+func TestOpenAIResponsesClient_ReplaysReasoningItemBeforeFunctionCall(t *testing.T) {
+	client := NewOpenAIResponsesClient(ClientConfig{URL: "https://api.openai.com/v1"})
+	body := `{
+		"id":"resp_1",
+		"object":"response",
+		"model":"o3",
+		"status":"completed",
+		"output":[
+			{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"step one"}],"encrypted_content":"enc_abc123"},
+			{"type":"function_call","call_id":"call_xyz","name":"do_thing","arguments":"{\"x\":1}"}
+		],
+		"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}
+	}`
+	sdkResp := unmarshalResponsesBody(t, body)
+	resp := client.mapResponsesResponse(sdkResp)
+
+	historyMsg := NewToolCallMessage(resp.Content(), resp.ToolCalls(), resp.Native(), resp.ReasoningContent())
+
+	params := client.buildResponsesParams("o3", ChatRequest{Messages: []Message{historyMsg}})
+	items := params.Input.OfInputItemList
+	if len(items) != 2 {
+		t.Fatalf("input items = %d, want 2 (reasoning, function_call)", len(items))
+	}
+	if items[0].OfReasoning == nil {
+		t.Fatalf("items[0] is not a reasoning item: %+v", items[0])
+	}
+	// ResponseReasoningItem.ToParam() overrides with the item's own RawJSON
+	// (see the SDK's implementation) rather than populating typed fields, so
+	// the payload only surfaces on marshal — reading OfReasoning.EncryptedContent
+	// directly would see the zero value even though replay is intact.
+	reasoningJSON, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal reasoning item: %v", err)
+	}
+	if !bytes.Contains(reasoningJSON, []byte(`"encrypted_content":"enc_abc123"`)) {
+		t.Errorf("reasoning item = %s, want encrypted_content %q preserved", reasoningJSON, "enc_abc123")
+	}
+	if items[1].OfFunctionCall == nil {
+		t.Fatalf("items[1] is not a function_call item: %+v", items[1])
+	}
+	functionCallJSON, err := json.Marshal(items[1])
+	if err != nil {
+		t.Fatalf("marshal function_call item: %v", err)
+	}
+	if !bytes.Contains(functionCallJSON, []byte(`"call_id":"call_xyz"`)) {
+		t.Errorf("function_call item = %s, want call_id %q preserved", functionCallJSON, "call_xyz")
+	}
+
+	// Include must ask the API for encrypted_content, or there would be
+	// nothing to replay on a stateless (store=false) request.
+	found := false
+	for _, inc := range params.Include {
+		if inc == responses.ResponseIncludableReasoningEncryptedContent {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("params.Include missing reasoning.encrypted_content")
+	}
+}
+
+// TestNativeTurn_CrossProviderFallback proves that a Native payload built by
+// one adapter safely falls back to ordinary Content/ToolCalls reconstruction
+// when handed to a different adapter (e.g. a session resumed against a
+// different provider) — the Go type assertion in each adapter is the safety
+// net, not a runtime protocol check, and a mismatch must not panic or
+// silently corrupt the request.
+func TestNativeTurn_CrossProviderFallback(t *testing.T) {
+	toolCalls := []ToolCall{{ID: "call_1", Type: "function", Function: FunctionCall{Name: "code_comment", Arguments: `{}`}}}
+
+	t.Run("anthropic builder ignores a non-anthropic payload", func(t *testing.T) {
+		c := &AnthropicClient{}
+		msg := NewToolCallMessage("plain text", toolCalls, NativeTurn{Family: "openai-chat-completions", Payload: "some reasoning string"}, "")
+		params, err := c.buildAnthropicParams("claude-x", ChatRequest{Messages: []Message{msg}})
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+		if len(params.Messages) != 1 {
+			t.Fatalf("messages = %d, want 1", len(params.Messages))
+		}
+		blocks := params.Messages[0].Content
+		if len(blocks) != 2 || blocks[0].OfText == nil || blocks[1].OfToolUse == nil {
+			t.Fatalf("expected fallback reconstruction (text + tool_use), got %+v", blocks)
+		}
+	})
+
+	t.Run("openai builder ignores a non-string payload", func(t *testing.T) {
+		c := &OpenAIClient{}
+		msg := NewToolCallMessage("plain text", toolCalls, NativeTurn{Family: "openai-responses", Payload: []responses.ResponseInputItemUnionParam{}}, "")
+		params := c.buildOpenAIParams("gpt-x", ChatRequest{Messages: []Message{msg}})
+		payload, err := json.Marshal(params.Messages[0])
+		if err != nil {
+			t.Fatalf("marshal assistant message: %v", err)
+		}
+		if bytes.Contains(payload, []byte(`reasoning_content`)) {
+			t.Errorf("expected no reasoning_content field, got: %s", payload)
+		}
+	})
+
+	t.Run("responses builder ignores a non-slice payload", func(t *testing.T) {
+		c := &OpenAIResponsesClient{}
+		msg := NewToolCallMessage("plain text", toolCalls, NativeTurn{Family: "anthropic-messages", Payload: anthropic.MessageParam{}}, "")
+		params := c.buildResponsesParams("o3", ChatRequest{Messages: []Message{msg}})
+		items := params.Input.OfInputItemList
+		if len(items) != 2 || items[0].OfMessage == nil || items[1].OfFunctionCall == nil {
+			t.Fatalf("expected fallback reconstruction (message + function_call), got %+v", items)
+		}
+	})
+
+	// Same-typed but structurally empty payloads must also fall back —
+	// found in review of the #805 fix: our own adapters never produce these,
+	// but Payload is exported, so a defensive guard belongs at the consumer.
+	t.Run("anthropic builder falls back when native Content is empty", func(t *testing.T) {
+		c := &AnthropicClient{}
+		msg := NewToolCallMessage("plain text", toolCalls, NativeTurn{Family: "anthropic-messages", Payload: anthropic.MessageParam{}}, "")
+		params, err := c.buildAnthropicParams("claude-x", ChatRequest{Messages: []Message{msg}})
+		if err != nil {
+			t.Fatalf("buildAnthropicParams: %v", err)
+		}
+		blocks := params.Messages[0].Content
+		if len(blocks) != 2 || blocks[0].OfText == nil || blocks[1].OfToolUse == nil {
+			t.Fatalf("expected fallback reconstruction (text + tool_use), got %+v", blocks)
+		}
+	})
+
+	t.Run("responses builder falls back when native items slice is empty", func(t *testing.T) {
+		c := &OpenAIResponsesClient{}
+		msg := NewToolCallMessage("plain text", toolCalls, NativeTurn{Family: "openai-responses", Payload: []responses.ResponseInputItemUnionParam{}}, "")
+		params := c.buildResponsesParams("o3", ChatRequest{Messages: []Message{msg}})
+		items := params.Input.OfInputItemList
+		if len(items) != 2 || items[0].OfMessage == nil || items[1].OfFunctionCall == nil {
+			t.Fatalf("expected fallback reconstruction (message + function_call), got %+v", items)
+		}
+	})
+}
+
+// TestAnthropicClient_NativeOnlySetWhenThinkingPresent guards the
+// hasThinking gate in mapAnthropicResponse: an ordinary text + tool_use turn
+// (no thinking/redacted_thinking block) round-trips losslessly through the
+// existing Content()/ToolCalls() reconstruction, so Native must stay unset —
+// setting it unconditionally risks replaying a MessageParam with an empty
+// Content slice for a truncated/error response, which Anthropic rejects.
+func TestAnthropicClient_NativeOnlySetWhenThinkingPresent(t *testing.T) {
+	c := &AnthropicClient{}
+	body := `{
+		"id":"msg_2",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-x",
+		"content":[
+			{"type":"text","text":"answer"},
+			{"type":"tool_use","id":"toolu_1","name":"code_comment","input":{"a":1}}
+		],
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":10,"output_tokens":5}
+	}`
+	sdkResp := unmarshalAnthropicBody(t, body)
+	resp := c.mapAnthropicResponse(sdkResp)
+	if resp.Native().Payload != nil {
+		t.Errorf("Native.Payload = %#v, want nil for a turn with no thinking block", resp.Native().Payload)
+	}
+}
+
+// TestBuildAnthropicParams_NativeReuseDoesNotAliasOriginalSlice guards the
+// slice-aliasing fix: buildAnthropicParams must not let the dynamic
+// cache_control breakpoint mutate the backing array a Native payload shares
+// with whatever this Message's Native came from.
+func TestBuildAnthropicParams_NativeReuseDoesNotAliasOriginalSlice(t *testing.T) {
+	c := &AnthropicClient{}
+	original := anthropic.MessageParam{
+		Role: anthropic.MessageParamRoleAssistant,
+		Content: []anthropic.ContentBlockParamUnion{
+			anthropic.NewThinkingBlock("sig", "thinking"),
+			anthropic.NewToolUseBlock("toolu_1", map[string]any{}, "code_comment"),
+		},
+	}
+	msg := NewToolCallMessage("", []ToolCall{{ID: "toolu_1", Type: "function", Function: FunctionCall{Name: "code_comment", Arguments: "{}"}}},
+		NativeTurn{Family: "anthropic-messages", Payload: original}, "")
+
+	// A trailing tool-result message makes this assistant turn NOT the last
+	// message — buildAnthropicParams's cache_control breakpoint targets
+	// whichever message ends up last, so this exercises the ordinary path.
+	// A second, standalone build below targets the aliasing case directly:
+	// the assistant turn IS the last message, which is exactly when the
+	// breakpoint would write into the shared backing array if the reuse
+	// weren't copied first.
+	if _, err := c.buildAnthropicParams("claude-x", ChatRequest{Messages: []Message{msg}}); err != nil {
+		t.Fatalf("buildAnthropicParams: %v", err)
+	}
+	if original.Content[1].GetCacheControl() != nil && original.Content[1].GetCacheControl().Type != "" {
+		t.Fatalf("original payload's tool_use block was mutated: %+v", original.Content[1])
+	}
+}

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -183,21 +183,7 @@ func (c *OpenAIResponsesClient) buildResponsesParams(model string, req ChatReque
 		case "user":
 			input = append(input, responses.ResponseInputItemParamOfMessage(content, responses.EasyInputMessageRoleUser))
 		case "assistant":
-			// Native carries this turn's output items (reasoning/message/
-			// function_call) converted via each item's own ToParam(), in
-			// original order, with encrypted_content/id/Phase preserved
-			// verbatim. Reuse it whole instead of reconstructing a bare
-			// message + function_call items, which is what dropped reasoning
-			// items entirely on replay before this change (issue #805). A
-			// type-assertion failure (message built by another protocol, or
-			// with no native state) falls through to that reconstruction.
-			// len(items) > 0 guards a Payload that type-asserts correctly but
-			// carries nothing: our own mapResponsesResponse never boxes an
-			// empty slice (it only sets Native when nativeItems is
-			// non-empty), but Payload is exported and could be set to one by
-			// any caller — without this guard that would silently drop the
-			// turn's content/tool calls instead of falling through to the
-			// reconstruction below.
+			// Reuse native output items to preserve reasoning/encrypted_content.
 			if items, ok := msg.Native.Payload.([]responses.ResponseInputItemUnionParam); ok && len(items) > 0 {
 				input = append(input, items...)
 				continue
@@ -233,12 +219,7 @@ func (c *OpenAIResponsesClient) buildResponsesParams(model string, req ChatReque
 		Input: responses.ResponseNewParamsInputUnion{
 			OfInputItemList: input,
 		},
-		Store: openai.Bool(false),
-		// Requests the encrypted continuation payload on reasoning output
-		// items. Under the stateless store=false design above, this is the
-		// only channel that carries chain-of-thought across turns — without
-		// it a reasoning item replayed on the next request has nothing to
-		// resume from (see issue #805).
+		Store:   openai.Bool(false),
 		Include: []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent},
 	}
 
@@ -280,26 +261,9 @@ func (c *OpenAIResponsesClient) mapResponsesResponse(sdkResp *responses.Response
 
 	var toolCalls []ToolCall
 	var reasoningParts []string
-	// nativeItems collects this turn's output items converted to their
-	// request-side param form, in original order — reasoning ahead of the
-	// function_call it preceded, exactly as the API produced them. Each
-	// item's ToParam() re-serializes that item's own RawJSON verbatim (see
-	// the SDK's implementation), so encrypted_content, id and
-	// ResponseOutputMessage.Phase all ride along without being modeled here.
-	// Only the item types this agent loop actually produces are handled;
-	// an unrecognized type is simply absent from Native, which is no worse
-	// than today's behavior for it.
 	var nativeItems []responses.ResponseInputItemUnionParam
-	// hasActionableItem tracks whether this turn produced a function_call or
-	// message item — the same thing today's Content()/ToolCalls()
-	// reconstruction would also produce. A turn with only a reasoning item
-	// (nothing else — a truncated or otherwise degenerate turn) reconstructs
-	// to nothing today, which is correct: a lone reasoning item with no
-	// message/function_call alongside it is not a valid standalone input, and
-	// replaying it verbatim risks a 400 from the Responses API. Gate Native on
-	// this so that degenerate case falls back to reconstructing nothing,
-	// exactly like it always has, instead of resurrecting a dangling
-	// reasoning item.
+	// hasActionableItem gates Native: a lone reasoning item (no message or
+	// function_call) is not valid standalone input and risks a 400 on replay.
 	var hasActionableItem bool
 	for _, item := range sdkResp.Output {
 		switch item.Type {

--- a/internal/llm/responses_client.go
+++ b/internal/llm/responses_client.go
@@ -183,6 +183,25 @@ func (c *OpenAIResponsesClient) buildResponsesParams(model string, req ChatReque
 		case "user":
 			input = append(input, responses.ResponseInputItemParamOfMessage(content, responses.EasyInputMessageRoleUser))
 		case "assistant":
+			// Native carries this turn's output items (reasoning/message/
+			// function_call) converted via each item's own ToParam(), in
+			// original order, with encrypted_content/id/Phase preserved
+			// verbatim. Reuse it whole instead of reconstructing a bare
+			// message + function_call items, which is what dropped reasoning
+			// items entirely on replay before this change (issue #805). A
+			// type-assertion failure (message built by another protocol, or
+			// with no native state) falls through to that reconstruction.
+			// len(items) > 0 guards a Payload that type-asserts correctly but
+			// carries nothing: our own mapResponsesResponse never boxes an
+			// empty slice (it only sets Native when nativeItems is
+			// non-empty), but Payload is exported and could be set to one by
+			// any caller — without this guard that would silently drop the
+			// turn's content/tool calls instead of falling through to the
+			// reconstruction below.
+			if items, ok := msg.Native.Payload.([]responses.ResponseInputItemUnionParam); ok && len(items) > 0 {
+				input = append(input, items...)
+				continue
+			}
 			if content != "" {
 				input = append(input, responses.ResponseInputItemParamOfMessage(content, responses.EasyInputMessageRoleAssistant))
 			}
@@ -215,6 +234,12 @@ func (c *OpenAIResponsesClient) buildResponsesParams(model string, req ChatReque
 			OfInputItemList: input,
 		},
 		Store: openai.Bool(false),
+		// Requests the encrypted continuation payload on reasoning output
+		// items. Under the stateless store=false design above, this is the
+		// only channel that carries chain-of-thought across turns — without
+		// it a reasoning item replayed on the next request has nothing to
+		// resume from (see issue #805).
+		Include: []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent},
 	}
 
 	if instructions != "" {
@@ -255,11 +280,28 @@ func (c *OpenAIResponsesClient) mapResponsesResponse(sdkResp *responses.Response
 
 	var toolCalls []ToolCall
 	var reasoningParts []string
+	// nativeItems collects this turn's output items converted to their
+	// request-side param form, in original order — reasoning ahead of the
+	// function_call it preceded, exactly as the API produced them. Each
+	// item's ToParam() re-serializes that item's own RawJSON verbatim (see
+	// the SDK's implementation), so encrypted_content, id and
+	// ResponseOutputMessage.Phase all ride along without being modeled here.
+	// Only the item types this agent loop actually produces are handled;
+	// an unrecognized type is simply absent from Native, which is no worse
+	// than today's behavior for it.
+	var nativeItems []responses.ResponseInputItemUnionParam
+	// hasActionableItem tracks whether this turn produced a function_call or
+	// message item — the same thing today's Content()/ToolCalls()
+	// reconstruction would also produce. A turn with only a reasoning item
+	// (nothing else — a truncated or otherwise degenerate turn) reconstructs
+	// to nothing today, which is correct: a lone reasoning item with no
+	// message/function_call alongside it is not a valid standalone input, and
+	// replaying it verbatim risks a 400 from the Responses API. Gate Native on
+	// this so that degenerate case falls back to reconstructing nothing,
+	// exactly like it always has, instead of resurrecting a dangling
+	// reasoning item.
+	var hasActionableItem bool
 	for _, item := range sdkResp.Output {
-		// TODO(phase): ResponseOutputMessage.Phase (commentary/final_answer) is
-		// currently dropped. For gpt-5.3-codex+ models, preserve and resend
-		// Phase on assistant messages to avoid performance degradation. See
-		// DESIGN_STATE_CACHE_PHASE.md §3.
 		switch item.Type {
 		case "function_call":
 			fc := item.AsFunctionCall()
@@ -271,6 +313,9 @@ func (c *OpenAIResponsesClient) mapResponsesResponse(sdkResp *responses.Response
 					Arguments: fc.Arguments,
 				},
 			})
+			p := fc.ToParam()
+			nativeItems = append(nativeItems, responses.ResponseInputItemUnionParam{OfFunctionCall: &p})
+			hasActionableItem = true
 		case "reasoning":
 			// Best-effort: aggregate every summary entry's Text (not just the
 			// first) so multi-paragraph reasoning isn't truncated.
@@ -280,12 +325,24 @@ func (c *OpenAIResponsesClient) mapResponsesResponse(sdkResp *responses.Response
 					reasoningParts = append(reasoningParts, s.Text)
 				}
 			}
+			p := r.ToParam()
+			nativeItems = append(nativeItems, responses.ResponseInputItemUnionParam{OfReasoning: &p})
+		case "message":
+			m := item.AsMessage()
+			p := m.ToParam()
+			nativeItems = append(nativeItems, responses.ResponseInputItemUnionParam{OfOutputMessage: &p})
+			hasActionableItem = true
 		}
 	}
 
 	var reasoningContent string
 	if len(reasoningParts) > 0 {
 		reasoningContent = strings.Join(reasoningParts, "\n")
+	}
+
+	var native NativeTurn
+	if hasActionableItem && len(nativeItems) > 0 {
+		native = NativeTurn{Family: "openai-responses", Payload: nativeItems}
 	}
 
 	finishReason := mapResponsesFinishReason(string(sdkResp.Status), toolCalls)
@@ -315,6 +372,7 @@ func (c *OpenAIResponsesClient) mapResponsesResponse(sdkResp *responses.Response
 				Content:          contentPtr,
 				ReasoningContent: reasoningContent,
 				ToolCalls:        toolCalls,
+				Native:           native,
 			},
 			FinishReason: finishReason,
 		}},

--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -70,6 +70,12 @@ func CountMessagesTokens(msgs []llm.Message) int {
 	var total int
 	for _, m := range msgs {
 		total += llm.CountTokens(m.ExtractText())
+		// Native's replay payload (thinking blocks, reasoning items,
+		// encrypted_content, reasoning_content) goes out on the wire once
+		// this message replays, but ExtractText() never sees it — without
+		// this, softLimit/warnLimit would systematically under-count
+		// reasoning-heavy conversations. See NativeTurn.EstimatedTokens.
+		total += m.Native.EstimatedTokens()
 	}
 	return total
 }
@@ -182,7 +188,10 @@ func stripMarkdownFences(s string) string {
 }
 
 // buildMessageXML serializes msgs into the <message><content> form expected
-// by the MEMORY_COMPRESSION_TASK prompt template.
+// by the MEMORY_COMPRESSION_TASK prompt template. Includes ReasoningContent
+// alongside ExtractText() — a reasoning-only turn (VisibleContent() empty)
+// would otherwise render as a blank <content> block, leaving the summarizer
+// with no way to know what happened in that round.
 func buildMessageXML(msgs []llm.Message) string {
 	var sb strings.Builder
 	for i, m := range msgs {
@@ -190,6 +199,11 @@ func buildMessageXML(msgs []llm.Message) string {
 		sb.WriteString("    <content>\n")
 		sb.WriteString(fmt.Sprintf("      %s\n", m.ExtractText()))
 		sb.WriteString("    </content>\n")
+		if m.ReasoningContent != "" {
+			sb.WriteString("    <reasoning>\n")
+			sb.WriteString(fmt.Sprintf("      %s\n", m.ReasoningContent))
+			sb.WriteString("    </reasoning>\n")
+		}
 		sb.WriteString("</message>")
 		if i < len(msgs)-1 {
 			sb.WriteString("\n")

--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -63,19 +63,25 @@ type compressionState struct {
 	pendingJob *compressionJob
 }
 
+// messageTokens returns the rough token count of a single message: its
+// visible text plus whatever its Native replay payload (thinking blocks,
+// reasoning items, encrypted_content, reasoning_content) will add to the wire
+// once this message replays. ExtractText() never sees that payload, so every
+// caller that budgets against maxTokens must go through this helper rather
+// than calling llm.CountTokens(m.ExtractText()) directly — otherwise
+// reasoning-heavy conversations are systematically under-counted in one place
+// and not the other. See NativeTurn.EstimatedTokens.
+func messageTokens(m llm.Message) int {
+	return llm.CountTokens(m.ExtractText()) + m.Native.EstimatedTokens()
+}
+
 // CountMessagesTokens returns the rough token count of msgs by summing the
-// per-message text token count. Exported because both review and scan top
+// per-message token count. Exported because both review and scan top
 // layers may want it for pre-flight checks.
 func CountMessagesTokens(msgs []llm.Message) int {
 	var total int
 	for _, m := range msgs {
-		total += llm.CountTokens(m.ExtractText())
-		// Native's replay payload (thinking blocks, reasoning items,
-		// encrypted_content, reasoning_content) goes out on the wire once
-		// this message replays, but ExtractText() never sees it — without
-		// this, softLimit/warnLimit would systematically under-count
-		// reasoning-heavy conversations. See NativeTurn.EstimatedTokens.
-		total += m.Native.EstimatedTokens()
+		total += messageTokens(m)
 	}
 	return total
 }
@@ -113,9 +119,9 @@ func computeActiveZoneSize(rounds []round, messages []llm.Message, maxTokens int
 	count := 0
 	tokensUsed := 0
 	for i := len(rounds) - 1; i >= 0; i-- {
-		roundTokens := llm.CountTokens(messages[rounds[i].assistantIdx].ExtractText())
+		roundTokens := messageTokens(messages[rounds[i].assistantIdx])
 		for _, ti := range rounds[i].toolIdxs {
-			roundTokens += llm.CountTokens(messages[ti].ExtractText())
+			roundTokens += messageTokens(messages[ti])
 		}
 		if tokensUsed+roundTokens > budget {
 			break

--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -63,14 +63,8 @@ type compressionState struct {
 	pendingJob *compressionJob
 }
 
-// messageTokens returns the rough token count of a single message: its
-// visible text plus whatever its Native replay payload (thinking blocks,
-// reasoning items, encrypted_content, reasoning_content) will add to the wire
-// once this message replays. ExtractText() never sees that payload, so every
-// caller that budgets against maxTokens must go through this helper rather
-// than calling llm.CountTokens(m.ExtractText()) directly — otherwise
-// reasoning-heavy conversations are systematically under-counted in one place
-// and not the other. See NativeTurn.EstimatedTokens.
+// messageTokens counts visible text plus the Native replay payload that
+// ExtractText() does not see.
 func messageTokens(m llm.Message) int {
 	return llm.CountTokens(m.ExtractText()) + m.Native.EstimatedTokens()
 }
@@ -194,10 +188,7 @@ func stripMarkdownFences(s string) string {
 }
 
 // buildMessageXML serializes msgs into the <message><content> form expected
-// by the MEMORY_COMPRESSION_TASK prompt template. Includes ReasoningContent
-// alongside ExtractText() — a reasoning-only turn (VisibleContent() empty)
-// would otherwise render as a blank <content> block, leaving the summarizer
-// with no way to know what happened in that round.
+// by the MEMORY_COMPRESSION_TASK prompt template.
 func buildMessageXML(msgs []llm.Message) string {
 	var sb strings.Builder
 	for i, m := range msgs {

--- a/internal/llmloop/compression_test.go
+++ b/internal/llmloop/compression_test.go
@@ -32,6 +32,29 @@ func TestCountMessagesTokens_Empty(t *testing.T) {
 	}
 }
 
+// TestCountMessagesTokens_IncludesNativePayload guards a gap found in review
+// of the #805 fix: once an assistant turn's Native payload (thinking blocks,
+// reasoning items, encrypted_content, reasoning_content) actually replays on
+// the wire, a token budget computed only from ExtractText() would
+// systematically under-count reasoning-heavy conversations and could let
+// compression's threshold checks fire too late.
+func TestCountMessagesTokens_IncludesNativePayload(t *testing.T) {
+	withoutNative := []llm.Message{msg("user", "hello world")}
+	withNative := []llm.Message{
+		msg("user", "hello world"),
+		llm.NewToolCallMessage("", nil, llm.NativeTurn{
+			Family:  "openai-chat-completions",
+			Payload: llm.ReasoningPayload(strings.Repeat("reasoning ", 200)),
+		}, ""),
+	}
+
+	base := CountMessagesTokens(withoutNative)
+	got := CountMessagesTokens(withNative)
+	if got <= base {
+		t.Errorf("CountMessagesTokens with a Native payload = %d, want more than the base count %d", got, base)
+	}
+}
+
 func TestGroupIntoRounds(t *testing.T) {
 	messages := []llm.Message{
 		msg("system", "sys"),

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -362,6 +362,7 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 			fmt.Fprintf(stdout.Writer(), "[ocr] No tool calls parsed for %s, retrying...\n", newPath)
 			messages = append(messages, llm.NewTextMessage("user", "You did not successfully call any tools. Please try again or use task_done if finished."))
 			native := resp.Native()
+			reasoning := resp.ReasoningContent()
 			// Also splice in a native-only turn (no visible text, no tool
 			// call, but a real reasoning payload — e.g. a Responses reasoning
 			// item with encrypted_content and an empty summary). Checking
@@ -370,8 +371,14 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 			// (see mapAnthropicResponse's hasThinking gate and the len(...)>0
 			// guards in the other two mappers) — none of them ever box an
 			// empty/meaningless value into Payload.
-			if content != "" || native.Payload != nil {
-				messages = append(messages[:len(messages)-1], llm.NewToolCallMessage(content, nil, native, resp.ReasoningContent()), messages[len(messages)-1])
+			// reasoning != "" additionally catches a degenerate turn that has
+			// neither visible content nor a replayable Native payload (e.g. an
+			// openai-responses reasoning item with no accompanying
+			// message/function_call, which mapResponsesResponse deliberately
+			// excludes from Native): without this, that turn left no trace at
+			// all in history, and the model could repeat the same empty turn.
+			if content != "" || native.Payload != nil || reasoning != "" {
+				messages = append(messages[:len(messages)-1], llm.NewToolCallMessage(content, nil, native, reasoning), messages[len(messages)-1])
 			}
 			continue
 		}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -351,10 +351,6 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 		llmSpan.End()
 		telemetry.RecordLLMRequest(ctx, r.deps.Model, duration, totalTokens, "ok")
 
-		// VisibleContent, not Content: Content() falls back to reasoning text
-		// when there's no visible answer, and that same text already rides
-		// along separately via resp.Native() — folding it into the ordinary
-		// content field here would send it twice on replay.
 		content := resp.VisibleContent()
 		calls := resp.ToolCalls()
 
@@ -363,20 +359,6 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 			messages = append(messages, llm.NewTextMessage("user", "You did not successfully call any tools. Please try again or use task_done if finished."))
 			native := resp.Native()
 			reasoning := resp.ReasoningContent()
-			// Also splice in a native-only turn (no visible text, no tool
-			// call, but a real reasoning payload — e.g. a Responses reasoning
-			// item with encrypted_content and an empty summary). Checking
-			// native.Payload != nil is safe here: every adapter that sets it
-			// only does so when there's an actual native turn to preserve
-			// (see mapAnthropicResponse's hasThinking gate and the len(...)>0
-			// guards in the other two mappers) — none of them ever box an
-			// empty/meaningless value into Payload.
-			// reasoning != "" additionally catches a degenerate turn that has
-			// neither visible content nor a replayable Native payload (e.g. an
-			// openai-responses reasoning item with no accompanying
-			// message/function_call, which mapResponsesResponse deliberately
-			// excludes from Native): without this, that turn left no trace at
-			// all in history, and the model could repeat the same empty turn.
 			if content != "" || native.Payload != nil || reasoning != "" {
 				messages = append(messages[:len(messages)-1], llm.NewToolCallMessage(content, nil, native, reasoning), messages[len(messages)-1])
 			}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -351,14 +351,27 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 		llmSpan.End()
 		telemetry.RecordLLMRequest(ctx, r.deps.Model, duration, totalTokens, "ok")
 
-		content := resp.Content()
+		// VisibleContent, not Content: Content() falls back to reasoning text
+		// when there's no visible answer, and that same text already rides
+		// along separately via resp.Native() — folding it into the ordinary
+		// content field here would send it twice on replay.
+		content := resp.VisibleContent()
 		calls := resp.ToolCalls()
 
 		if len(calls) == 0 {
 			fmt.Fprintf(stdout.Writer(), "[ocr] No tool calls parsed for %s, retrying...\n", newPath)
 			messages = append(messages, llm.NewTextMessage("user", "You did not successfully call any tools. Please try again or use task_done if finished."))
-			if content != "" {
-				messages = append(messages[:len(messages)-1], llm.NewTextMessage("assistant", content), messages[len(messages)-1])
+			native := resp.Native()
+			// Also splice in a native-only turn (no visible text, no tool
+			// call, but a real reasoning payload — e.g. a Responses reasoning
+			// item with encrypted_content and an empty summary). Checking
+			// native.Payload != nil is safe here: every adapter that sets it
+			// only does so when there's an actual native turn to preserve
+			// (see mapAnthropicResponse's hasThinking gate and the len(...)>0
+			// guards in the other two mappers) — none of them ever box an
+			// empty/meaningless value into Payload.
+			if content != "" || native.Payload != nil {
+				messages = append(messages[:len(messages)-1], llm.NewToolCallMessage(content, nil, native, resp.ReasoningContent()), messages[len(messages)-1])
 			}
 			continue
 		}
@@ -413,7 +426,7 @@ func (r *Runner) RunPerFile(ctx context.Context, messages []llm.Message, newPath
 			consecutiveEmptyRounds = 0
 		}
 
-		succeed := r.addNextMessage(ctx, content, calls, results, &messages, newPath, st)
+		succeed := r.addNextMessage(ctx, content, calls, resp.Native(), thinking, results, &messages, newPath, st)
 		if !succeed {
 			fmt.Fprintf(stdout.Writer(), "[ocr] Context compression exceeded threshold for %s, stopping.\n", newPath)
 			stop = StopCompression
@@ -725,7 +738,7 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 // warning (80%) MaxTokens thresholds. Returns false when even after
 // synchronous compression the conversation is still over the warning
 // threshold — caller should stop the loop in that case.
-func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, toolCalls []llm.ToolCall, results []tool.ToolCallResult, messages *[]llm.Message, filePath string, st *compressionState) bool {
+func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, toolCalls []llm.ToolCall, native llm.NativeTurn, reasoningContent string, results []tool.ToolCallResult, messages *[]llm.Message, filePath string, st *compressionState) bool {
 	maxAllowed := r.deps.Template.MaxTokens
 	softLimit := int(float64(maxAllowed) * tokenSoftThreshold)
 	warnLimit := PromptTokenLimit(maxAllowed)
@@ -745,9 +758,9 @@ func (r *Runner) addNextMessage(ctx context.Context, assistantContent string, to
 	}
 
 	if len(toolCalls) > 0 {
-		*messages = append(*messages, llm.NewToolCallMessage(assistantContent, toolCalls))
-	} else if assistantContent != "" {
-		*messages = append(*messages, llm.NewTextMessage("assistant", assistantContent))
+		*messages = append(*messages, llm.NewToolCallMessage(assistantContent, toolCalls, native, reasoningContent))
+	} else if assistantContent != "" || native.Payload != nil {
+		*messages = append(*messages, llm.NewToolCallMessage(assistantContent, nil, native, reasoningContent))
 	}
 
 	for _, rs := range results {

--- a/internal/llmloop/loop_execute_more_test.go
+++ b/internal/llmloop/loop_execute_more_test.go
@@ -16,13 +16,17 @@ import (
 )
 
 // scriptedLLMClient returns a fixed sequence of responses, one per call,
-// letting tests drive the full main loop turn by turn.
+// letting tests drive the full main loop turn by turn. requests records the
+// Messages of every call it received, in order, so a test can inspect what
+// history the previous round's response actually produced.
 type scriptedLLMClient struct {
 	responses []*llm.ChatResponse
 	calls     int
+	requests  [][]llm.Message
 }
 
-func (s *scriptedLLMClient) CompletionsWithCtx(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+func (s *scriptedLLMClient) CompletionsWithCtx(_ context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	s.requests = append(s.requests, req.Messages)
 	if s.calls >= len(s.responses) {
 		return s.responses[len(s.responses)-1], nil
 	}
@@ -114,6 +118,63 @@ func TestRunPerFile_NoFallbackToContent(t *testing.T) {
 	}
 	if comments[0].Thinking != "" {
 		t.Errorf("comment Thinking = %q, want empty (no content fallback)", comments[0].Thinking)
+	}
+}
+
+// TestRunPerFile_DoesNotDuplicateReasoningIntoVisibleContent is a regression
+// test found in review of the #805 fix: ChatResponse.Content() falls back to
+// ReasoningContent when there's no visible text — the common shape for an
+// openai-chat-completions tool-calling turn (content: null, reasoning_content
+// set). If the loop built history from Content() instead of VisibleContent(),
+// that same reasoning text would land in both the ordinary content field and
+// the reasoning_content native payload on replay, doubling it on the wire.
+func TestRunPerFile_DoesNotDuplicateReasoningIntoVisibleContent(t *testing.T) {
+	emptyContent := ""
+	reasoning := "private reasoning that must not be duplicated"
+	reasoningResp := &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{
+			Content:          &emptyContent,
+			ReasoningContent: reasoning,
+			Native:           llm.NativeTurn{Family: "openai-chat-completions", Payload: llm.ReasoningPayload(reasoning)},
+			ToolCalls: []llm.ToolCall{{
+				ID:   "call_comment",
+				Type: "function",
+				Function: llm.FunctionCall{
+					Name:      tool.CodeComment.Name(),
+					Arguments: `{"comments":[{"content":"issue","existing_code":"x"}]}`,
+				},
+			}},
+		}}},
+	}
+	client := &scriptedLLMClient{responses: []*llm.ChatResponse{reasoningResp, taskDoneResponse()}}
+	r, _ := newThinkingTestRunner(t, client)
+
+	ok, _, err := r.RunPerFile(context.Background(), []llm.Message{msg("user", "review")}, "file.go")
+	if err != nil || !ok {
+		t.Fatalf("RunPerFile = (%v, err %v), want completed", ok, err)
+	}
+
+	// requests[1] is the second call: its Messages carry the history built
+	// from reasoningResp. The assistant message in it must have empty
+	// visible Content — the reasoning text belongs solely to Native.
+	if len(r.deps.LLMClient.(*scriptedLLMClient).requests) < 2 {
+		t.Fatalf("expected at least 2 requests, got %d", len(r.deps.LLMClient.(*scriptedLLMClient).requests))
+	}
+	secondReq := r.deps.LLMClient.(*scriptedLLMClient).requests[1]
+	var assistantMsg *llm.Message
+	for i := range secondReq {
+		if secondReq[i].Role == "assistant" {
+			assistantMsg = &secondReq[i]
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("no assistant message found in the replayed history")
+	}
+	if assistantMsg.Content != "" {
+		t.Errorf("assistant Content = %q, want empty — reasoning must not be duplicated into visible content", assistantMsg.Content)
+	}
+	if reasoning, ok := assistantMsg.Native.Payload.(llm.ReasoningPayload); !ok || string(reasoning) != "private reasoning that must not be duplicated" {
+		t.Errorf("assistant Native.Payload = %#v, want the reasoning text preserved for replay", assistantMsg.Native.Payload)
 	}
 }
 

--- a/internal/llmloop/runner_test.go
+++ b/internal/llmloop/runner_test.go
@@ -644,7 +644,7 @@ func TestAddNextMessage_NoStartThenCancelSameCall(t *testing.T) {
 	}}
 
 	st := &compressionState{}
-	ok := r.addNextMessage(context.Background(), strings.Repeat("word ", 200), calls, results, &msgs, "f.go", st)
+	ok := r.addNextMessage(context.Background(), strings.Repeat("word ", 200), calls, llm.NativeTurn{}, "", results, &msgs, "f.go", st)
 
 	if !ok {
 		t.Error("expected true: sync compression should bring the count under the warning threshold")

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -116,11 +116,18 @@ type ResponseRecord struct {
 	Usage     *TokenUsage
 	// ReasoningContent is the model's reasoning/thinking text for this turn,
 	// when the provider exposed any (see llm.ChatResponse.ReasoningContent).
-	// This is the plain, human-readable projection for local audit/debugging
-	// — not the opaque replay state (llm.Message.Native) a later request
-	// needs to continue the conversation, which this record deliberately
-	// never carries.
+	// This is the plain, human-readable projection for local audit/debugging.
 	ReasoningContent string
+	// Native is the opaque replay state for this turn (see llm.NativeTurn) —
+	// e.g. an Anthropic thinking block with its signature, or an OpenAI
+	// Responses reasoning item with its encrypted_content. Unlike
+	// ReasoningContent's plain-text projection, this is the exact payload a
+	// later request needs to continue the conversation. copyMessages carries
+	// the same field into TaskRecord.RequestMessages and nativeTurnForJSON
+	// shapes it for the session JSONL, so both the in-memory record and the
+	// on-disk transcript can be replayed/exported losslessly. Nothing in this
+	// package parses or reshapes it.
+	Native llm.NativeTurn
 }
 
 // ToolResultRecord records the result of a tool call executed after the LLM response.
@@ -382,10 +389,12 @@ func copyMessages(msgs []llm.Message) []llm.Message {
 	cp := make([]llm.Message, len(msgs))
 	for i, m := range msgs {
 		cp[i] = llm.Message{
-			Role:       m.Role,
-			Content:    m.Content,
-			ToolCallID: m.ToolCallID,
-			ToolCalls:  append([]llm.ToolCall(nil), m.ToolCalls...),
+			Role:             m.Role,
+			Content:          m.Content,
+			ToolCallID:       m.ToolCallID,
+			ToolCalls:        append([]llm.ToolCall(nil), m.ToolCalls...),
+			Native:           m.Native,
+			ReasoningContent: m.ReasoningContent,
 		}
 	}
 	return cp
@@ -394,19 +403,35 @@ func copyMessages(msgs []llm.Message) []llm.Message {
 // copyMessagesForJSON produces a JSON-friendly slice for persistence.
 func copyMessagesForJSON(msgs []llm.Message) any {
 	type msg struct {
-		Role       string `json:"role"`
-		Content    any    `json:"content"`
-		ToolCallID string `json:"tool_call_id,omitempty"`
+		Role          string         `json:"role"`
+		Content       any            `json:"content"`
+		ToolCallID    string         `json:"tool_call_id,omitempty"`
+		ToolCalls     []llm.ToolCall `json:"tool_calls,omitempty"`
+		NativePayload any            `json:"native_payload,omitempty"`
 	}
 	out := make([]msg, 0, len(msgs))
 	for _, m := range msgs {
 		out = append(out, msg{
-			Role:       m.Role,
-			Content:    m.Content,
-			ToolCallID: m.ToolCallID,
+			Role:          m.Role,
+			Content:       m.Content,
+			ToolCallID:    m.ToolCallID,
+			ToolCalls:     m.ToolCalls,
+			NativePayload: nativeTurnForJSON(m.Native),
 		})
 	}
 	return out
+}
+
+// nativeTurnForJSON shapes an llm.NativeTurn into a JSON-marshalable value for
+// session persistence, or nil when the turn carries no replay state. Payload's
+// concrete type (an SDK request-param struct, or a plain string alias) is
+// already marshalable on its own terms — nothing here parses or reshapes it,
+// preserving fields like an Anthropic thinking block's signature verbatim.
+func nativeTurnForJSON(n llm.NativeTurn) any {
+	if n.Payload == nil {
+		return nil
+	}
+	return map[string]any{"family": n.Family, "payload": n.Payload}
 }
 
 // SetResponse records the LLM response in the most recent TaskRecord of the given type.
@@ -449,6 +474,7 @@ func (tr *TaskRecord) SetResponse(resp *llm.ChatResponse, duration time.Duration
 		Model:            resp.Model,
 		Usage:            usage,
 		ReasoningContent: choice.Message.ReasoningContent,
+		Native:           resp.Native(),
 	}
 	tr.Duration = duration
 
@@ -462,7 +488,7 @@ func (tr *TaskRecord) SetResponse(resp *llm.ChatResponse, duration time.Duration
 					"arguments": tc.Function.Arguments,
 				})
 			}
-			p.WriteLLMResponse(fs.FilePath, tr.Type, content, choice.Message.ReasoningContent, toolCallsJSON, resp.Model, *usage, duration)
+			p.WriteLLMResponse(fs.FilePath, tr.Type, content, choice.Message.ReasoningContent, toolCallsJSON, resp.Model, *usage, duration, nativeTurnForJSON(tr.Response.Native))
 		}
 	}
 }

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -110,10 +110,10 @@ type TokenUsage struct {
 
 // ResponseRecord holds the parsed LLM response.
 type ResponseRecord struct {
-	Content   string
-	ToolCalls []llm.ToolCall
-	Model     string
-	Usage     *TokenUsage
+	Content          string
+	ToolCalls        []llm.ToolCall
+	Model            string
+	Usage            *TokenUsage
 	ReasoningContent string
 	Native           llm.NativeTurn
 }

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -114,6 +114,13 @@ type ResponseRecord struct {
 	ToolCalls []llm.ToolCall
 	Model     string
 	Usage     *TokenUsage
+	// ReasoningContent is the model's reasoning/thinking text for this turn,
+	// when the provider exposed any (see llm.ChatResponse.ReasoningContent).
+	// This is the plain, human-readable projection for local audit/debugging
+	// — not the opaque replay state (llm.Message.Native) a later request
+	// needs to continue the conversation, which this record deliberately
+	// never carries.
+	ReasoningContent string
 }
 
 // ToolResultRecord records the result of a tool call executed after the LLM response.
@@ -437,10 +444,11 @@ func (tr *TaskRecord) SetResponse(resp *llm.ChatResponse, duration time.Duration
 	}
 
 	tr.Response = &ResponseRecord{
-		Content:   content,
-		ToolCalls: choice.Message.ToolCalls,
-		Model:     resp.Model,
-		Usage:     usage,
+		Content:          content,
+		ToolCalls:        choice.Message.ToolCalls,
+		Model:            resp.Model,
+		Usage:            usage,
+		ReasoningContent: choice.Message.ReasoningContent,
 	}
 	tr.Duration = duration
 
@@ -454,7 +462,7 @@ func (tr *TaskRecord) SetResponse(resp *llm.ChatResponse, duration time.Duration
 					"arguments": tc.Function.Arguments,
 				})
 			}
-			p.WriteLLMResponse(fs.FilePath, tr.Type, content, toolCallsJSON, resp.Model, *usage, duration)
+			p.WriteLLMResponse(fs.FilePath, tr.Type, content, choice.Message.ReasoningContent, toolCallsJSON, resp.Model, *usage, duration)
 		}
 	}
 }

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -114,20 +114,8 @@ type ResponseRecord struct {
 	ToolCalls []llm.ToolCall
 	Model     string
 	Usage     *TokenUsage
-	// ReasoningContent is the model's reasoning/thinking text for this turn,
-	// when the provider exposed any (see llm.ChatResponse.ReasoningContent).
-	// This is the plain, human-readable projection for local audit/debugging.
 	ReasoningContent string
-	// Native is the opaque replay state for this turn (see llm.NativeTurn) —
-	// e.g. an Anthropic thinking block with its signature, or an OpenAI
-	// Responses reasoning item with its encrypted_content. Unlike
-	// ReasoningContent's plain-text projection, this is the exact payload a
-	// later request needs to continue the conversation. copyMessages carries
-	// the same field into TaskRecord.RequestMessages and nativeTurnForJSON
-	// shapes it for the session JSONL, so both the in-memory record and the
-	// on-disk transcript can be replayed/exported losslessly. Nothing in this
-	// package parses or reshapes it.
-	Native llm.NativeTurn
+	Native           llm.NativeTurn
 }
 
 // ToolResultRecord records the result of a tool call executed after the LLM response.
@@ -422,11 +410,6 @@ func copyMessagesForJSON(msgs []llm.Message) any {
 	return out
 }
 
-// nativeTurnForJSON shapes an llm.NativeTurn into a JSON-marshalable value for
-// session persistence, or nil when the turn carries no replay state. Payload's
-// concrete type (an SDK request-param struct, or a plain string alias) is
-// already marshalable on its own terms — nothing here parses or reshapes it,
-// preserving fields like an Anthropic thinking block's signature verbatim.
 func nativeTurnForJSON(n llm.NativeTurn) any {
 	if n.Payload == nil {
 		return nil

--- a/internal/session/history_test.go
+++ b/internal/session/history_test.go
@@ -118,7 +118,8 @@ func TestSetResponse(t *testing.T) {
 	resp := &llm.ChatResponse{
 		Choices: []llm.Choice{{
 			Message: llm.ResponseMessage{
-				Content: &content,
+				Content:          &content,
+				ReasoningContent: "because the diff touches auth code",
 			},
 		}},
 		Model: "gpt-4",
@@ -136,6 +137,9 @@ func TestSetResponse(t *testing.T) {
 	if rec.Response.Content != "response text" {
 		t.Errorf("Content = %q", rec.Response.Content)
 	}
+	if rec.Response.ReasoningContent != "because the diff touches auth code" {
+		t.Errorf("ReasoningContent = %q", rec.Response.ReasoningContent)
+	}
 	if rec.Response.Model != "gpt-4" {
 		t.Errorf("Model = %q", rec.Response.Model)
 	}
@@ -147,6 +151,47 @@ func TestSetResponse(t *testing.T) {
 	}
 	if rec.Duration != 2*time.Second {
 		t.Errorf("Duration = %v", rec.Duration)
+	}
+}
+
+// TestSetResponse_PersistsReasoningContent guards the audit-transcript gap
+// raised in review: the raw per-turn llm_response record must carry the
+// model's reasoning text, not just Content/ToolCalls/Usage — otherwise a
+// human auditing session.jsonl has no way to see why the model did what it
+// did on a turn that produced no visible text.
+func TestSetResponse_PersistsReasoningContent(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	fs := sh.GetOrCreateFileSession("file.go")
+	rec := fs.AppendTaskRecord(MainTask, []llm.Message{llm.NewTextMessage("user", "hi")})
+
+	content := ""
+	resp := &llm.ChatResponse{
+		Choices: []llm.Choice{{
+			Message: llm.ResponseMessage{
+				Content:          &content,
+				ReasoningContent: "auditable reasoning text",
+			},
+		}},
+		Model: "test-model",
+	}
+	rec.SetResponse(resp, time.Second)
+	sh.Finalize()
+
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var found bool
+	for _, r := range records {
+		if r["type"] != "llm_response" {
+			continue
+		}
+		found = true
+		if r["reasoning_content"] != "auditable reasoning text" {
+			t.Errorf("reasoning_content = %v, want %q", r["reasoning_content"], "auditable reasoning text")
+		}
+	}
+	if !found {
+		t.Fatal("no llm_response record found in session JSONL")
 	}
 }
 

--- a/internal/session/history_test.go
+++ b/internal/session/history_test.go
@@ -4,11 +4,14 @@
 package session
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/alibaba/open-code-review/internal/llm"
+	anthropic "github.com/anthropics/anthropic-sdk-go"
 )
 
 func TestNew(t *testing.T) {
@@ -109,6 +112,41 @@ func TestAppendTaskRecord_DefensiveCopy(t *testing.T) {
 	}
 }
 
+// TestAppendTaskRecord_CopiesNativeAndReasoningContent guards copyMessages'
+// own "deep copy" contract: an assistant history message carrying replay
+// state must keep that state in TaskRecord.RequestMessages too, not just in
+// the JSONL projection (copyMessagesForJSON) — otherwise anything reading the
+// in-memory record (e.g. a future compression/export path) would silently see
+// an incomplete turn.
+func TestAppendTaskRecord_CopiesNativeAndReasoningContent(t *testing.T) {
+	sh := New("/tmp/repo", "main", "model", SessionOptions{})
+	fs := sh.GetOrCreateFileSession("file.go")
+
+	native := llm.NativeTurn{Family: "anthropic-messages", Payload: anthropic.MessageParam{
+		Content: []anthropic.ContentBlockParamUnion{anthropic.NewThinkingBlock("sig-copy", "thinking")},
+	}}
+	msgs := []llm.Message{
+		llm.NewTextMessage("user", "hi"),
+		llm.NewToolCallMessage("", nil, native, "reasoning text"),
+	}
+	rec := fs.AppendTaskRecord(MainTask, msgs)
+
+	got := rec.RequestMessages[1]
+	if got.ReasoningContent != "reasoning text" {
+		t.Errorf("ReasoningContent = %q, want %q", got.ReasoningContent, "reasoning text")
+	}
+	if got.Native.Family != "anthropic-messages" {
+		t.Errorf("Native.Family = %q, want anthropic-messages", got.Native.Family)
+	}
+	payload, ok := got.Native.Payload.(anthropic.MessageParam)
+	if !ok {
+		t.Fatalf("Native.Payload type = %T, want anthropic.MessageParam", got.Native.Payload)
+	}
+	if len(payload.Content) != 1 || payload.Content[0].OfThinking == nil || payload.Content[0].OfThinking.Signature != "sig-copy" {
+		t.Errorf("Native.Payload signature not preserved: %+v", payload)
+	}
+}
+
 func TestSetResponse(t *testing.T) {
 	sh := New("/tmp/repo", "main", "model", SessionOptions{})
 	fs := sh.GetOrCreateFileSession("file.go")
@@ -192,6 +230,165 @@ func TestSetResponse_PersistsReasoningContent(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("no llm_response record found in session JSONL")
+	}
+}
+
+// TestSetResponse_PersistsNativePayload guards the training-reflow gap raised
+// in review: the llm_response record must carry the opaque replay payload
+// (e.g. an Anthropic thinking block's signature), not just the plain-text
+// ReasoningContent projection — otherwise a session exported for training
+// cannot reconstruct a request that replays byte for byte.
+func TestSetResponse_PersistsNativePayload(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	fs := sh.GetOrCreateFileSession("file.go")
+	rec := fs.AppendTaskRecord(MainTask, []llm.Message{llm.NewTextMessage("user", "hi")})
+
+	native := llm.NativeTurn{
+		Family: "anthropic-messages",
+		Payload: anthropic.MessageParam{
+			Role: anthropic.MessageParamRoleAssistant,
+			Content: []anthropic.ContentBlockParamUnion{
+				anthropic.NewThinkingBlock("sig-abc-123", "let me think this through"),
+			},
+		},
+	}
+	resp := &llm.ChatResponse{
+		Choices: []llm.Choice{{
+			Message: llm.ResponseMessage{Native: native},
+		}},
+		Model: "test-model",
+	}
+	rec.SetResponse(resp, time.Second)
+	sh.Finalize()
+
+	if rec.Response.Native.Family != "anthropic-messages" {
+		t.Errorf("in-memory Native.Family = %q, want anthropic-messages", rec.Response.Native.Family)
+	}
+
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var found bool
+	for _, r := range records {
+		if r["type"] != "llm_response" {
+			continue
+		}
+		found = true
+		np, ok := r["native_payload"].(map[string]any)
+		if !ok {
+			t.Fatalf("native_payload missing or wrong shape: %v", r["native_payload"])
+		}
+		if np["family"] != "anthropic-messages" {
+			t.Errorf("native_payload.family = %v, want anthropic-messages", np["family"])
+		}
+		payload, err := json.Marshal(np["payload"])
+		if err != nil {
+			t.Fatalf("marshal native_payload.payload: %v", err)
+		}
+		if !bytes.Contains(payload, []byte(`"signature":"sig-abc-123"`)) {
+			t.Errorf("thinking signature not preserved verbatim in native_payload: %s", payload)
+		}
+	}
+	if !found {
+		t.Fatal("no llm_response record found in session JSONL")
+	}
+}
+
+// TestSetResponse_OmitsNativePayloadWhenAbsent guards the other half of the
+// same contract: an ordinary turn with nothing to replay beyond
+// Content/ToolCalls must not grow a native_payload key at all.
+func TestSetResponse_OmitsNativePayloadWhenAbsent(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	fs := sh.GetOrCreateFileSession("file.go")
+	rec := fs.AppendTaskRecord(MainTask, []llm.Message{llm.NewTextMessage("user", "hi")})
+
+	content := "plain text answer"
+	resp := &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &content}}},
+		Model:   "test-model",
+	}
+	rec.SetResponse(resp, time.Second)
+	sh.Finalize()
+
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var found bool
+	for _, r := range records {
+		if r["type"] != "llm_response" {
+			continue
+		}
+		found = true
+		if _, ok := r["native_payload"]; ok {
+			t.Errorf("native_payload should be omitted for a turn with no replay state, got %v", r["native_payload"])
+		}
+	}
+	if !found {
+		t.Fatal("no llm_response record found in session JSONL")
+	}
+}
+
+// TestAppendTaskRecord_PersistsToolCallsAndNativePayload guards
+// copyMessagesForJSON: the llm_request record's messages must be a
+// self-contained, replayable projection of what was actually sent — including
+// tool_calls (previously dropped) and, for an assistant history turn carrying
+// replay state, its native_payload with fields like a thinking signature
+// intact.
+func TestAppendTaskRecord_PersistsToolCallsAndNativePayload(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+	fs := sh.GetOrCreateFileSession("file.go")
+
+	native := llm.NativeTurn{
+		Family: "anthropic-messages",
+		Payload: anthropic.MessageParam{
+			Role: anthropic.MessageParamRoleAssistant,
+			Content: []anthropic.ContentBlockParamUnion{
+				anthropic.NewThinkingBlock("sig-xyz", "thinking"),
+			},
+		},
+	}
+	toolCalls := []llm.ToolCall{{ID: "call_1", Type: "function", Function: llm.FunctionCall{Name: "code_comment", Arguments: "{}"}}}
+	msgs := []llm.Message{
+		llm.NewTextMessage("user", "hi"),
+		llm.NewToolCallMessage("", toolCalls, native, "thinking text"),
+	}
+	fs.AppendTaskRecord(MainTask, msgs)
+	sh.Finalize()
+
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var found bool
+	for _, r := range records {
+		if r["type"] != "llm_request" {
+			continue
+		}
+		found = true
+		reqMsgs, ok := r["messages"].([]any)
+		if !ok || len(reqMsgs) != 2 {
+			t.Fatalf("messages = %v", r["messages"])
+		}
+		assistantMsg, ok := reqMsgs[1].(map[string]any)
+		if !ok {
+			t.Fatalf("assistant message shape: %v", reqMsgs[1])
+		}
+		if _, ok := assistantMsg["tool_calls"]; !ok {
+			t.Errorf("tool_calls missing from persisted request message: %v", assistantMsg)
+		}
+		np, ok := assistantMsg["native_payload"].(map[string]any)
+		if !ok {
+			t.Fatalf("native_payload missing from persisted request message: %v", assistantMsg)
+		}
+		payload, err := json.Marshal(np["payload"])
+		if err != nil {
+			t.Fatalf("marshal native_payload.payload: %v", err)
+		}
+		if !bytes.Contains(payload, []byte(`"signature":"sig-xyz"`)) {
+			t.Errorf("thinking signature not preserved in request message: %s", payload)
+		}
+	}
+	if !found {
+		t.Fatal("no llm_request record found in session JSONL")
 	}
 }
 

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -242,13 +242,7 @@ func (jw *jsonlWriter) WriteLLMRequest(filePath string, taskType TaskType, reque
 	return uuid
 }
 
-// WriteLLMResponse writes a response entry with model, content, reasoning,
-// tool calls, usage. reasoningContent is the plain audit-facing projection of
-// the model's reasoning for this turn (see ResponseRecord.ReasoningContent).
-// nativePayload is the opaque replay state for this turn (see
-// ResponseRecord.Native / llm.NativeTurn) already shaped for JSON by the
-// caller — nil when this turn carries none — and is written verbatim so
-// fields like an Anthropic thinking block's signature survive intact.
+// WriteLLMResponse writes a response entry with model, content, reasoning, tool calls, and usage.
 func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, content, reasoningContent string, toolCalls []map[string]any, model string, usage TokenUsage, duration time.Duration, nativePayload any) string {
 	uuid := generateUUID()
 

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -244,10 +244,12 @@ func (jw *jsonlWriter) WriteLLMRequest(filePath string, taskType TaskType, reque
 
 // WriteLLMResponse writes a response entry with model, content, reasoning,
 // tool calls, usage. reasoningContent is the plain audit-facing projection of
-// the model's reasoning for this turn (see ResponseRecord.ReasoningContent) —
-// not the opaque replay state a later request needs to continue the
-// conversation, which the session transcript never carries.
-func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, content, reasoningContent string, toolCalls []map[string]any, model string, usage TokenUsage, duration time.Duration) string {
+// the model's reasoning for this turn (see ResponseRecord.ReasoningContent).
+// nativePayload is the opaque replay state for this turn (see
+// ResponseRecord.Native / llm.NativeTurn) already shaped for JSON by the
+// caller — nil when this turn carries none — and is written verbatim so
+// fields like an Anthropic thinking block's signature survive intact.
+func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, content, reasoningContent string, toolCalls []map[string]any, model string, usage TokenUsage, duration time.Duration, nativePayload any) string {
 	uuid := generateUUID()
 
 	jw.mu.Lock()
@@ -273,6 +275,9 @@ func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, cont
 	}
 	if reasoningContent != "" {
 		rec["reasoning_content"] = reasoningContent
+	}
+	if nativePayload != nil {
+		rec["native_payload"] = nativePayload
 	}
 	jw.writeRecordLocked(rec)
 	jw.lastUUID = uuid

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -242,24 +242,29 @@ func (jw *jsonlWriter) WriteLLMRequest(filePath string, taskType TaskType, reque
 	return uuid
 }
 
-// WriteLLMResponse writes a response entry with model, content, tool calls, usage.
-func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, content string, toolCalls []map[string]any, model string, usage TokenUsage, duration time.Duration) string {
+// WriteLLMResponse writes a response entry with model, content, reasoning,
+// tool calls, usage. reasoningContent is the plain audit-facing projection of
+// the model's reasoning for this turn (see ResponseRecord.ReasoningContent) —
+// not the opaque replay state a later request needs to continue the
+// conversation, which the session transcript never carries.
+func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, content, reasoningContent string, toolCalls []map[string]any, model string, usage TokenUsage, duration time.Duration) string {
 	uuid := generateUUID()
 
 	jw.mu.Lock()
 	defer jw.mu.Unlock()
 	rec := map[string]any{
-		"uuid":        uuid,
-		"parentUuid":  jw.lastUUID,
-		"type":        "llm_response",
-		"sessionId":   jw.sessionID,
-		"timestamp":   time.Now().UTC().Format(time.RFC3339),
-		"filePath":    filePath,
-		"taskType":    string(taskType),
-		"model":       model,
-		"content":     content,
-		"tool_calls":  toolCalls,
-		"duration_ms": duration.Milliseconds(),
+		"uuid":              uuid,
+		"parentUuid":        jw.lastUUID,
+		"type":              "llm_response",
+		"sessionId":         jw.sessionID,
+		"timestamp":         time.Now().UTC().Format(time.RFC3339),
+		"filePath":          filePath,
+		"taskType":          string(taskType),
+		"model":             model,
+		"content":           content,
+		"reasoning_content": reasoningContent,
+		"tool_calls":        toolCalls,
+		"duration_ms":       duration.Milliseconds(),
 		"usage": map[string]int{
 			"prompt_tokens":      usage.PromptTokens,
 			"completion_tokens":  usage.CompletionTokens,

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -253,24 +253,26 @@ func (jw *jsonlWriter) WriteLLMResponse(filePath string, taskType TaskType, cont
 	jw.mu.Lock()
 	defer jw.mu.Unlock()
 	rec := map[string]any{
-		"uuid":              uuid,
-		"parentUuid":        jw.lastUUID,
-		"type":              "llm_response",
-		"sessionId":         jw.sessionID,
-		"timestamp":         time.Now().UTC().Format(time.RFC3339),
-		"filePath":          filePath,
-		"taskType":          string(taskType),
-		"model":             model,
-		"content":           content,
-		"reasoning_content": reasoningContent,
-		"tool_calls":        toolCalls,
-		"duration_ms":       duration.Milliseconds(),
+		"uuid":        uuid,
+		"parentUuid":  jw.lastUUID,
+		"type":        "llm_response",
+		"sessionId":   jw.sessionID,
+		"timestamp":   time.Now().UTC().Format(time.RFC3339),
+		"filePath":    filePath,
+		"taskType":    string(taskType),
+		"model":       model,
+		"content":     content,
+		"tool_calls":  toolCalls,
+		"duration_ms": duration.Milliseconds(),
 		"usage": map[string]int{
 			"prompt_tokens":      usage.PromptTokens,
 			"completion_tokens":  usage.CompletionTokens,
 			"cache_read_tokens":  usage.CacheReadTokens,
 			"cache_write_tokens": usage.CacheWriteTokens,
 		},
+	}
+	if reasoningContent != "" {
+		rec["reasoning_content"] = reasoningContent
 	}
 	jw.writeRecordLocked(rec)
 	jw.lastUUID = uuid

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -298,6 +298,7 @@ type TaskCard struct {
 	RequestMessages  any // preserved for display
 	RequestNo        int
 	ResponseContent  string
+	ReasoningContent string // the model's reasoning/thinking text for this turn, if the provider exposed any
 	ToolCalls        []ToolCallInfo
 	DurationMs       int64
 	Error            string
@@ -386,6 +387,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 		case "llm_response":
 			fp, _ := rec["filePath"].(string)
 			content, _ := rec["content"].(string)
+			reasoning, _ := rec["reasoning_content"].(string)
 			durationMs := int64(0)
 			if d, ok := rec["duration_ms"].(float64); ok {
 				durationMs = int64(d)
@@ -419,6 +421,7 @@ func LoadSession(root, encodedRepo, sessionID string) (*ViewSession, error) {
 				if len(cards) > 0 && cards[len(cards)-1].ResponseContent == "" {
 					card := cards[len(cards)-1]
 					card.ResponseContent = content
+					card.ReasoningContent = reasoning
 					card.DurationMs = durationMs
 					card.Model = model
 					card.Error = errStr

--- a/internal/viewer/store_load_test.go
+++ b/internal/viewer/store_load_test.go
@@ -70,7 +70,7 @@ func TestLoadSession_FullParse(t *testing.T) {
 	writeJSONL(t, filepath.Join(repoDir, "sess1.jsonl"),
 		`{"type":"session_start","timestamp":"2025-06-10T08:00:00Z","cwd":"/home/dev/proj","gitBranch":"feat","model":"claude-3","reviewMode":"commit","diffFrom":"aaa","diffTo":"bbb","diffCommit":"ccc"}`,
 		`{"type":"llm_request","filePath":"main.go","taskType":"main_task","request_no":1,"messages":[{"role":"user","content":"review this"}]}`,
-		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","content":"Code looks good","duration_ms":1500,"model":"claude-3","usage":{"prompt_tokens":100,"completion_tokens":50,"cache_read_tokens":10,"cache_write_tokens":5},"tool_calls":[{"name":"search","arguments":"query"}]}`,
+		`{"type":"llm_response","filePath":"main.go","taskType":"main_task","content":"Code looks good","reasoning_content":"checked for auth issues first","duration_ms":1500,"model":"claude-3","usage":{"prompt_tokens":100,"completion_tokens":50,"cache_read_tokens":10,"cache_write_tokens":5},"tool_calls":[{"name":"search","arguments":"query"}]}`,
 		`{"type":"tool_call","filePath":"main.go","taskType":"main_task","result":"found 3 results","ok":true,"duration_ms":20}`,
 		`{"type":"llm_request","filePath":"util.go","taskType":"plan_task","request_no":1,"messages":[]}`,
 		`{"type":"llm_response","filePath":"util.go","taskType":"plan_task","content":"planning","duration_ms":800,"model":"claude-3","usage":{"prompt_tokens":200,"completion_tokens":80,"cache_read_tokens":0,"cache_write_tokens":0}}`,
@@ -139,6 +139,9 @@ func TestLoadSession_FullParse(t *testing.T) {
 	}
 	if card.ResponseContent != "Code looks good" {
 		t.Errorf("ResponseContent = %q", card.ResponseContent)
+	}
+	if card.ReasoningContent != "checked for auth issues first" {
+		t.Errorf("ReasoningContent = %q", card.ReasoningContent)
 	}
 	if card.DurationMs != 1500 {
 		t.Errorf("DurationMs = %d", card.DurationMs)

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -266,6 +266,17 @@
                     </div>
                 </details>
                 {{end}}
+                {{with .ReasoningContent}}
+                <details class="tool-detail">
+                    <summary class="tool-detail-toggle">
+                        <span class="chevron-sm"></span>
+                        <span>Reasoning</span>
+                    </summary>
+                    <div class="tool-detail-body">
+                        <div class="response-text">{{.}}</div>
+                    </div>
+                </details>
+                {{end}}
                 {{with .ResponseContent}}
                 <div class="card-body response-content">
                     <div class="response-text">{{.}}</div>


### PR DESCRIPTION
## Summary

Fixes #805. Assistant tool-call history was rebuilt from `Content()`/`ToolCalls()` alone, so provider reasoning state was silently dropped when replaying a turn on the next request — across all three supported protocols:

- **OpenAI-compatible Chat Completions**: `reasoning_content` was parsed from the response but never sent back on the next request.
- **Anthropic Messages**: `thinking`/`redacted_thinking` blocks were flattened into a display string, losing the `signature` required to replay them (Anthropic rejects a modified/missing signature with a 400).
- **OpenAI Responses**: `reasoning` output items (`encrypted_content`) were dropped entirely from the next request's `input`.

### Approach

Adds `Message.Native` (`NativeTurn`), an opaque per-protocol replay payload built by reusing each SDK's own response→request converter (`anthropic.Message.ToParam()`, each Responses output item's `ToParam()`) instead of hand-rolling a serialization format. Each adapter type-asserts its own payload type before reuse and falls back to the existing reconstruction otherwise — a cross-provider turn or a turn built without a native payload is unaffected.

### Also included

- `Message.ReasoningContent`: a plain-text projection (separate from the opaque `Native` payload) used by the compression summarizer, so a reasoning-only turn no longer renders as a blank message in the summarization prompt.
- Fixed `NativeTurn.EstimatedTokens()` double-counting visible content already counted via `ExtractText()`, which could trigger compression earlier than necessary.
- Guarded the Responses adapter against carrying a dangling `reasoning` item (no accompanying `message`/`function_call`) into `Native`, which risked a 400 on replay.
- `reasoning_content` is now persisted in the session JSONL transcript and surfaced in the session viewer, for audit visibility into turns with no visible answer.
- Made Anthropic extended thinking (`extra_body.thinking`) safe to enable via the existing provider config: it's dropped for a given request when it would conflict with a forced `tool_choice` or exceed that call's `max_tokens`, instead of failing the request outright.
- Removed `GroupingTask`'s hardcoded `max_tokens: 4096` cap in favor of the template's own completion limit — this was the actual trigger for the `max_tokens`/`budget_tokens` conflict above once thinking was enabled.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Deterministic per-protocol reproduction tests (`internal/llm/native_turn_test.go`) asserting the replayed request body contains the original reasoning payload byte-for-byte
- [x] Verified against real multi-turn runs with Anthropic extended thinking enabled (`extra_body.thinking`): reasoning + tool_use turns replay cleanly across dozens of rounds with zero errors