### PR TITLE
fix(ci): bump artifact actions to node24 runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           go build -ldflags "${LD_FLAGS}" -o "${BIN_NAME}" ./cmd/opencodereview
           echo "bin_name=${BIN_NAME}" >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ${{ env.bin_name }}
@@ -136,7 +136,7 @@ jobs:
             echo "RELEASE_NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: binary-*
           merge-multiple: true
@@ -176,7 +176,7 @@ jobs:
       - name: Install jq
         run: apt-get update && apt-get install -y jq
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: binary-*
           merge-multiple: true

--- a/action.yml
+++ b/action.yml
@@ -372,7 +372,7 @@ runs:
 
     - name: Upload review artifacts
       if: ${{ always() && inputs.upload_artifacts == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ocr-review-result-${{ github.run_id }}-${{ github.run_attempt }}
         path: |


### PR DESCRIPTION
## Description

GitHub Actions runners are deprecating Node.js 20: steps that still target `node20` get force-run on Node 24 with a deprecation warning (see [the changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Consumers of this action currently see:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

This bumps every `actions/upload-artifact` / `actions/download-artifact` usage in the repo to the Node 24 runtimes:

| File | Before | After |
|---|---|---|
| `action.yml` | `upload-artifact@v4.6.2` (SHA-pinned, node20) | `upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (SHA-pinned, `v7.0.1`, node24) |
| `.github/workflows/release.yml` | `upload-artifact@v4` | `upload-artifact@v7` |
| `.github/workflows/release.yml` (×2) | `download-artifact@v4` | `download-artifact@v7` |

Compatibility notes:

- All inputs in use (`name`, `path`, `if-no-files-found`; `pattern`, `merge-multiple`) exist unchanged in v7.
- upload-artifact v7 adds an `archive` input that defaults to `true`, so the existing multi-file zipped upload behavior is preserved.
- v6/v7 of both actions require Actions Runner ≥ 2.327.1. GitHub-hosted runners already satisfy this; only consumers on older self-hosted runners need to update their runner before picking this up.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Verified against `actions/upload-artifact` and `actions/download-artifact` release notes / `action.yml` that the pinned v7.0.1 runs on `node24` and that every input used here is present with the same semantics. Pure workflow/action version bumps — no source code touched.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

None — preemptive cleanup driven by the runner-side Node 20 deprecation warning.
