### PR TITLE
docs(ko): add Korean translation for integration guides

### DIFF
--- a/pages/src/content/docs/index.ts
+++ b/pages/src/content/docs/index.ts
@@ -63,6 +63,10 @@ import jaFaq from './ja/faq.md';
 import koQuickstart from './ko/quickstart.md';
 import koInstallation from './ko/installation.md';
 import koConfiguration from './ko/configuration.md';
+import koAgentSkill from './ko/integrations/agent-skill.md';
+import koClaudeCode from './ko/integrations/claude-code.md';
+import koCicd from './ko/integrations/ci.md';
+import koDelegate from './ko/integrations/delegate.md';
 
 // Russian docs (incremental — partial LocalizedDocs)
 import ruQuickstart from './ru/quickstart.md';
@@ -163,6 +167,10 @@ const koDocs: LocalizedDocs = {
   'quickstart': koQuickstart,
   'installation': koInstallation,
   'configuration': koConfiguration,
+  'agent-skill': koAgentSkill,
+  'claude-code': koClaudeCode,
+  'cicd': koCicd,
+  'delegate': koDelegate,
 };
 
 const ruDocs: LocalizedDocs = {

--- a/pages/src/content/docs/ko/integrations/agent-skill.md
+++ b/pages/src/content/docs/ko/integrations/agent-skill.md
@@ -58,7 +58,7 @@ SKILL.md는 프롬프트입니다. 호출한 Agent가 이 파일을 읽고 각 �
    LLM에 연결되는지 확인합니다.
 2. **CLI가 없으면 자동 설치.** `which ocr`이 "NOT INSTALLED"를 반환하면 Agent가
    `npm install -g @alibaba-group/open-code-review`를 실행하고 작업을 이어 갑니다.
-   일상적인 설치 단계로 보고 사용자에게 묻지 않습니다.
+   일상적인 설치 단계로 여겨 사용자에게 묻지 않습니다.
 3. **LLM 설정이 없으면 멈추고 질문.** `ocr llm test`가 실패하면 Agent는 자격 증명을
    임의로 지어내지 *않습니다*. 지원하는 두 가지 방법(환경 변수 또는
    `ocr config set …`)을 안내하고 사용자가 API 키를 줄 때까지 기다립니다.
@@ -77,8 +77,8 @@ SKILL.md는 프롬프트입니다. 호출한 Agent가 이 파일을 읽고 각 �
 
 정확한 분류 기준과 출력 템플릿, 주의할 점을 포함한 전체 프롬프트는
 [`skills/open-code-review/SKILL.md`](https://github.com/alibaba/open-code-review/blob/main/skills/open-code-review/SKILL.md)에
-있습니다. 위 동작을 더 조이고 싶다면(예: 수정 전에 항상 묻도록 기본값을 바꾸는 등)
-로컬 사본을 편집하세요.
+있습니다. 위 동작을 더 엄격하게 바꾸고 싶다면(예: 수정 전에 항상 묻도록 기본값을
+바꾸는 등) 로컬 사본을 편집하세요.
 
 ## Anthropic Agent SDK {#anthropic-agent-sdk}
 
@@ -96,7 +96,7 @@ agent.run("Review my staged changes — focus on race conditions.")
 
 SDK가 SKILL.md 프롬프트를 읽으면 Agent가
 [스킬이 하는 일](#what-the-skill-does)에 적힌 워크플로를 실행합니다.
-`npm install` 대체 설치와, LLM이 설정되어 있지 않을 때 자격 증명을 묻는 단계도
+`npm install` 대체 설치도, LLM이 설정되어 있지 않을 때 자격 증명을 묻는 단계도
 여기에 포함됩니다.
 
 ## 다른 Agent 프레임워크 {#other-agent-frameworks}

--- a/pages/src/content/docs/ko/integrations/agent-skill.md
+++ b/pages/src/content/docs/ko/integrations/agent-skill.md
@@ -1,0 +1,111 @@
+---
+title: Agent Skill
+sidebar:
+  order: 1
+---
+
+OCR을 호출 가능한 스킬로 등록하면, Agent 프레임워크가 알맞은 플래그와 사전 점검,
+분류 기준을 갖춘 채로 OCR을 실행합니다. 호출하는 쪽에서 그 내용을 다시 만들 필요가
+없습니다.
+
+## 저장소에 포함된 것 {#what-ships-in-the-repo}
+
+저장소에는 SKILL 매니페스트가
+[`skills/open-code-review/SKILL.md`](https://github.com/alibaba/open-code-review/blob/main/skills/open-code-review/SKILL.md)에
+들어 있습니다. OCR을 호출 가능한 스킬로 선언하며, 사전 점검과 호출 워크플로,
+코멘트 분류 기준(High/Medium/Low)을 함께 담고 있습니다.
+
+## 설치 {#install}
+
+### 방법 1: `npx skills add` (권장) {#option-1-npx-skills-add-recommended}
+
+스킬을 사용할 프로젝트 안에서 실행하세요:
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review
+```
+
+이 명령은
+[스킬 레지스트리](https://github.com/alibaba/open-code-review/blob/main/skills/open-code-review/SKILL.md)에서
+매니페스트를 가져와 프로젝트에 넣습니다. 스킬 규약을 따르는 코딩 Agent라면 다음
+호출부터 이를 인식합니다. 같은 명령을 다시 실행하면 스킬이 최신 버전으로 갱신됩니다.
+
+> **사전 요구 사항:** `ocr` 바이너리가 `PATH`에 없으면 스킬이 처음 실행될 때 CLI를
+> 직접 설치합니다(`npm install -g @alibaba-group/open-code-review`). 아래
+> [스킬이 하는 일](#what-the-skill-does)을 참고하세요. 다만 LLM은 **미리 설정해
+> 두어야 합니다**. 스킬이 대신 설정할 수 없으므로, 설정이 없으면 실행을 멈추고
+> 사용자에게 묻습니다. [설정](../../configuration/)을 참고하세요.
+
+### 방법 2: 수동 복사 (시스템 전역) {#option-2-manual-copy-system-wide}
+
+프로젝트마다 설치하는 대신 전역에 두고 싶다면 스킬 폴더를 스킬 디렉터리로
+복사하세요:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R /path/to/open-code-review/skills/open-code-review ~/.claude/skills/
+```
+
+이렇게 하면 그 머신의 모든 프로젝트에서 스킬을 쓸 수 있습니다.
+
+## 스킬이 하는 일 {#what-the-skill-does}
+
+SKILL.md는 프롬프트입니다. 호출한 Agent가 이 파일을 읽고 각 단계를 직접 실행합니다.
+`/open-code-review`(또는 이에 준하는) 요청 하나가 처음부터 끝까지 다음 순서로
+진행됩니다.
+
+1. **사전 점검.** `which ocr`로 CLI가 `PATH`에 있는지 확인한 뒤, `ocr llm test`로
+   LLM에 연결되는지 확인합니다.
+2. **CLI가 없으면 자동 설치.** `which ocr`이 "NOT INSTALLED"를 반환하면 Agent가
+   `npm install -g @alibaba-group/open-code-review`를 실행하고 작업을 이어 갑니다.
+   일상적인 설치 단계로 보고 사용자에게 묻지 않습니다.
+3. **LLM 설정이 없으면 멈추고 질문.** `ocr llm test`가 실패하면 Agent는 자격 증명을
+   임의로 지어내지 *않습니다*. 지원하는 두 가지 방법(환경 변수 또는
+   `ocr config set …`)을 안내하고 사용자가 API 키를 줄 때까지 기다립니다.
+4. **비즈니스 맥락 추출.** 리뷰 대상(커밋, 브랜치, 작업 복사본)을 살펴 짧은
+   `--background` 문자열을 만듭니다.
+5. **리뷰 실행.**
+   `ocr review --audience agent --background "…" [--commit | --from/--to]`를
+   호출합니다. 사용자가 작업 복사본, 특정 커밋, 브랜치 범위 중 무엇을 리뷰해
+   달라고 했는지에 따라 플래그를 고릅니다.
+6. **분류와 보고.** SKILL.md의 기준에 따라 JSON 코멘트를 **High** / **Medium** /
+   **Low**로 묶습니다(버그와 보안 이슈는 High, 사소한 지적과 오탐으로 보이는 항목은
+   조용히 버립니다). 그런 다음 Markdown 요약을 렌더링합니다.
+7. **요청이 있으면 수정.** 사용자가 "리뷰하고 **고쳐 줘**"처럼 요청했다면
+   High/Medium 항목을 안전한 범위에서 바로 수정합니다. 그렇지 않으면 코드를 건드리기
+   전에 먼저 묻습니다.
+
+정확한 분류 기준과 출력 템플릿, 주의할 점을 포함한 전체 프롬프트는
+[`skills/open-code-review/SKILL.md`](https://github.com/alibaba/open-code-review/blob/main/skills/open-code-review/SKILL.md)에
+있습니다. 위 동작을 더 조이고 싶다면(예: 수정 전에 항상 묻도록 기본값을 바꾸는 등)
+로컬 사본을 편집하세요.
+
+## Anthropic Agent SDK {#anthropic-agent-sdk}
+
+SDK를 초기화할 때 설치된 스킬 경로를 지정하세요:
+
+```python
+from anthropic_agent_sdk import Agent
+
+agent = Agent(
+    skill_paths=["/path/to/open-code-review/skills/open-code-review"],
+)
+
+agent.run("Review my staged changes — focus on race conditions.")
+```
+
+SDK가 SKILL.md 프롬프트를 읽으면 Agent가
+[스킬이 하는 일](#what-the-skill-does)에 적힌 워크플로를 실행합니다.
+`npm install` 대체 설치와, LLM이 설정되어 있지 않을 때 자격 증명을 묻는 단계도
+여기에 포함됩니다.
+
+## 다른 Agent 프레임워크 {#other-agent-frameworks}
+
+"외부 스킬 등록" 기능이 있는 프레임워크라면 SKILL.md를 그대로 읽어 들일 수 있습니다.
+frontmatter가 붙은 마크다운 파일일 뿐이기 때문입니다. 프레임워크가 다른 스키마를
+요구하더라도 마크다운 본문은 프롬프트 템플릿으로 쓸 수 있습니다.
+
+## 관련 문서 {#see-also}
+
+- [Command (Claude Code 플러그인)](../claude-code/) — 같은 스킬을 슬래시 명령
+  형태로 제공합니다.

--- a/pages/src/content/docs/ko/integrations/ci.md
+++ b/pages/src/content/docs/ko/integrations/ci.md
@@ -7,7 +7,7 @@ sidebar:
 Pull Request나 Merge Request마다 OCR을 실행합니다. 업스트림 저장소는 그대로 복사해
 설정만 하면 되는 파이프라인 두 벌을 제공합니다. 하나는 GitHub Actions용, 하나는
 GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 설명하는 핵심
-명령을 얇게 감싼 것입니다.
+명령을 감싸기만 한 얇은 래퍼입니다.
 
 ## CI/CD 연동은 어떻게 동작하나 {#how-ci-cd-integration-works}
 
@@ -15,14 +15,14 @@ GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 
 절은 그 흐름을 각각 구현한 것일 뿐입니다.
 
 1. **PR / MR 이벤트에서 트리거.** 새 pull request, 갱신된 merge request, 또는 수동으로
-   남긴 `/open-code-review` 코멘트가 작업을 시작시킵니다.
+   남긴 `/open-code-review` 코멘트가 작업을 시작합니다.
 2. **러너에 `ocr` 설치.** 보통
    `npm install -g @alibaba-group/open-code-review`를 씁니다. 러너는 일회성이므로
    실행할 때마다 설치합니다.
 3. **CI 시크릿으로 LLM 설정.** `ocr config set`으로 엔드포인트·토큰·모델을
    지정합니다. 러너에는 기댈 만한 `~/.opencodereview`가 남아 있지 않습니다.
 4. **range 모드로 리뷰 실행.** 기계가 읽을 수 있는 형식으로 출력해 stdout이 깔끔한
-   JSON 봉투가 되게 합니다.
+   JSON 응답만 담게 합니다.
 
    ```bash
    ocr review \
@@ -33,19 +33,19 @@ GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 
    ```
 
    `--format json`은 파싱 가능한 페이로드를 만들고, `--audience agent`는 진행 상황
-   출력을 억제합니다. 모든 레시피가 소비하는 봉투 구조는
+   출력을 억제합니다. 모든 레시피가 소비하는 응답 구조는
    [JSON 출력](../cli-reference/#json)을 참고하세요.
 5. **JSON 파싱** 후 `comments[]`를 순회합니다.
 6. **코멘트를 PR / MR에 게시.** 각 플랫폼의 리뷰 API를 씁니다. 유효한 라인 정보가
    없는 항목(파일 단위 지적)은 인라인으로 달지 않고 요약 노트에 모읍니다. 인라인
    일괄 등록 API가 요청을 거부하면 게시 단계가 일반 요약 코멘트로 대체합니다.
 
-여기에는 항상 두 종류의 자격 증명이 등장합니다. OCR이 지적을 생성할 때 쓰는 **LLM
-자격 증명**과, 게시 단계가 코멘트를 남길 때 쓰는 **PR/MR 쓰기 토큰**입니다. GitHub
-레시피는 후자를 `GITHUB_TOKEN`으로 별도 설정 없이 얻습니다. GitLab은
-`GITLAB_API_TOKEN`을 명시적으로 두기를 권장하지만, fork MR에서는 내장
-`CI_JOB_TOKEN`이 대체로 쓰입니다(`/discussions`로 디스커션을 남길 수 있습니다).
-안정적으로 쓰려면 전용 토큰을 권장합니다.
+여기에는 항상 두 종류의 자격 증명이 등장합니다. 하나는 OCR이 지적을 생성할 때 쓰는
+**LLM 자격 증명**이고, 다른 하나는 게시 단계가 코멘트를 남길 때 쓰는 **PR/MR 쓰기
+토큰**입니다. GitHub 레시피는 후자를 `GITHUB_TOKEN`으로 별도 설정 없이 얻습니다.
+GitLab은 `GITLAB_API_TOKEN`을 명시적으로 두기를 권장하지만, fork MR에서는 내장
+`CI_JOB_TOKEN`이 대체 수단으로 쓰입니다(`/discussions`로 디스커션을 남길 수
+있습니다). 안정적으로 쓰려면 전용 토큰을 권장합니다.
 
 ## GitHub Actions {#github-actions}
 
@@ -55,7 +55,7 @@ GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 
 
 ### 무엇을 하나 {#what-it-does}
 
-- `pull_request_target`(`opened`) 이벤트와, 본문이 `/open-code-review` 또는
+- `pull_request_target`(`opened`) 이벤트와 본문이 `/open-code-review` 또는
   `@open-code-review`로 시작하는 `issue_comment` 이벤트에서 트리거합니다. 후자
   덕분에 리뷰어가 PR에 코멘트를 남겨 OCR을 다시 돌릴 수 있습니다.
   (`pull_request` 대신 `pull_request_target`을 쓰는 이유는 fork에서 올라온 PR에서도
@@ -63,7 +63,7 @@ GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 
   실행하지 않습니다.)
 - `npm install -g @alibaba-group/open-code-review`로 OCR을 설치하고,
   `ocr config set`으로 설정을 기록한 뒤, 브랜치 range 모드로 핵심 명령을 실행합니다.
-- JSON 봉투를 파싱해 각 지적을 GitHub Pull Request Review API로 인라인 리뷰 코멘트로
+- JSON 응답을 파싱해 각 지적을 GitHub Pull Request Review API로 인라인 리뷰 코멘트로
   게시합니다. 라인 정보가 없는 코멘트는 요약 본문에 모읍니다. 일괄 등록이 실패하면
   코멘트를 하나씩 게시하는 방식으로 대체하고, 통계를 요약 코멘트로 남깁니다.
 
@@ -104,7 +104,7 @@ curl -o .github/workflows/ocr-review.yml \
 
 #### 배경 맥락 {#background-context}
 
-`--background`는 효과가 가장 큰 플래그 하나입니다.
+`--background`는 효과가 가장 큰 플래그입니다.
 [모든 패턴에 적용되는 팁](../#tips-that-apply-to-every-pattern)을 참고하세요. PR
 제목을 넘기면 됩니다(`feat(auth): add OAuth2 support`처럼 제목이 시맨틱 규약을 따를
 때 특히 잘 맞습니다).
@@ -146,7 +146,7 @@ PR에서 제어할 수 있는 값은 `run:` 안에 `${{ }}`로 직접 넣지 말
 
 #### 동시 실행 수 {#concurrency}
 
-기본값은 파일 그룹당 하나씩, 서브 Agent 8개를 병렬로 돌립니다. 큰 PR에서 LLM
+기본적으로 파일 그룹당 하나씩, 서브 Agent 8개를 병렬로 돌립니다. 큰 PR에서 LLM
 프로바이더의 요청 한도를 넘지 않으려면 값을 낮추세요:
 
 ```yaml
@@ -162,7 +162,7 @@ PR에서 제어할 수 있는 값은 `run:` 안에 `${{ }}`로 직접 넣지 말
 
 #### 트리거 조건 {#trigger-pattern}
 
-기본 워크플로는 PR **opened**와, `/open-code-review` 또는 `@open-code-review`로
+기본 워크플로는 PR **opened**와 `/open-code-review` 또는 `@open-code-review`로
 시작하는 PR 코멘트에서 트리거합니다. 흔히 다음 두 가지를 조정합니다.
 
 더 많은 PR 생명주기 이벤트에서 실행하기(예: 새 커밋이 푸시되면 다시 리뷰):
@@ -295,7 +295,7 @@ SARIF는 기계가 읽는 형식이므로 OCR은 stdout에 진행 상황을 출�
 - `merge_requests` 이벤트에서 트리거합니다(생성·수정·재오픈 등 모든 MR 이벤트).
 - `node:20` 이미지에서 실행하며, OCR을 설치하고 `ocr config set`으로 설정한 뒤 MR
   diff 모드로 핵심 명령을 실행합니다.
-- 인라인 Python 스크립트로 JSON 봉투를 파싱해 각 지적을 GitLab 디스커션(diff 위
+- 인라인 Python 스크립트로 JSON 응답을 파싱해 각 지적을 GitLab 디스커션(diff 위
   인라인)으로 게시합니다. 위치를 정확히 잡기 위해 MR의 `versions` 엔드포인트로
   올바른 `base_sha` / `start_sha` / `head_sha`를 계산합니다. 인라인으로 달 수 없는
   코멘트는 일반 MR 노트로 대체하고, 마지막에 요약 노트를 남깁니다.
@@ -340,7 +340,7 @@ include:
 
 > **봇 이름을 빠르게 붙이는 팁.** 프로젝트 액세스 토큰과 그룹 액세스 토큰은 토큰의
 > **이름**이 MR 디스커션 옆에 표시됩니다. 토큰 이름을 `OpenCodeReview Bot`으로
-> 지으면 다른 설정 없이 리뷰어에 브랜드를 붙일 수 있습니다.
+> 지으면 다른 설정 없이 리뷰어 이름에 브랜드를 입힐 수 있습니다.
 > [서비스 계정 명의로 게시하기](#post-under-a-service-account-identity)에 적힌 더
 > 견고한 서비스 계정 설정까지는 필요 없을 때 쓸 만합니다.
 

--- a/pages/src/content/docs/ko/integrations/ci.md
+++ b/pages/src/content/docs/ko/integrations/ci.md
@@ -1,0 +1,474 @@
+---
+title: CI/CD
+sidebar:
+  order: 4
+---
+
+Pull Request나 Merge Request마다 OCR을 실행합니다. 업스트림 저장소는 그대로 복사해
+설정만 하면 되는 파이프라인 두 벌을 제공합니다. 하나는 GitHub Actions용, 하나는
+GitLab CI용입니다. 둘 다 [CLI 레퍼런스](../cli-reference/#json)에서 설명하는 핵심
+명령을 얇게 감싼 것입니다.
+
+## CI/CD 연동은 어떻게 동작하나 {#how-ci-cd-integration-works}
+
+이 페이지의 모든 레시피는 같은 흐름을 따릅니다. 아래 GitHub Actions와 GitLab CI
+절은 그 흐름을 각각 구현한 것일 뿐입니다.
+
+1. **PR / MR 이벤트에서 트리거.** 새 pull request, 갱신된 merge request, 또는 수동으로
+   남긴 `/open-code-review` 코멘트가 작업을 시작시킵니다.
+2. **러너에 `ocr` 설치.** 보통
+   `npm install -g @alibaba-group/open-code-review`를 씁니다. 러너는 일회성이므로
+   실행할 때마다 설치합니다.
+3. **CI 시크릿으로 LLM 설정.** `ocr config set`으로 엔드포인트·토큰·모델을
+   지정합니다. 러너에는 기댈 만한 `~/.opencodereview`가 남아 있지 않습니다.
+4. **range 모드로 리뷰 실행.** 기계가 읽을 수 있는 형식으로 출력해 stdout이 깔끔한
+   JSON 봉투가 되게 합니다.
+
+   ```bash
+   ocr review \
+     --from "origin/<base-branch>" \
+     --to "origin/<head-branch>" \
+     --format json \
+     --audience agent
+   ```
+
+   `--format json`은 파싱 가능한 페이로드를 만들고, `--audience agent`는 진행 상황
+   출력을 억제합니다. 모든 레시피가 소비하는 봉투 구조는
+   [JSON 출력](../cli-reference/#json)을 참고하세요.
+5. **JSON 파싱** 후 `comments[]`를 순회합니다.
+6. **코멘트를 PR / MR에 게시.** 각 플랫폼의 리뷰 API를 씁니다. 유효한 라인 정보가
+   없는 항목(파일 단위 지적)은 인라인으로 달지 않고 요약 노트에 모읍니다. 인라인
+   일괄 등록 API가 요청을 거부하면 게시 단계가 일반 요약 코멘트로 대체합니다.
+
+여기에는 항상 두 종류의 자격 증명이 등장합니다. OCR이 지적을 생성할 때 쓰는 **LLM
+자격 증명**과, 게시 단계가 코멘트를 남길 때 쓰는 **PR/MR 쓰기 토큰**입니다. GitHub
+레시피는 후자를 `GITHUB_TOKEN`으로 별도 설정 없이 얻습니다. GitLab은
+`GITLAB_API_TOKEN`을 명시적으로 두기를 권장하지만, fork MR에서는 내장
+`CI_JOB_TOKEN`이 대체로 쓰입니다(`/discussions`로 디스커션을 남길 수 있습니다).
+안정적으로 쓰려면 전용 토큰을 권장합니다.
+
+## GitHub Actions {#github-actions}
+
+업스트림 워크플로는
+[`examples/github_actions/ocr-review.yml`](https://github.com/alibaba/open-code-review/blob/main/examples/github_actions/ocr-review.yml)에
+있습니다.
+
+### 무엇을 하나 {#what-it-does}
+
+- `pull_request_target`(`opened`) 이벤트와, 본문이 `/open-code-review` 또는
+  `@open-code-review`로 시작하는 `issue_comment` 이벤트에서 트리거합니다. 후자
+  덕분에 리뷰어가 PR에 코멘트를 남겨 OCR을 다시 돌릴 수 있습니다.
+  (`pull_request` 대신 `pull_request_target`을 쓰는 이유는 fork에서 올라온 PR에서도
+  시크릿을 쓸 수 있게 하기 위해서입니다. OCR은 diff를 읽기만 하고 PR의 코드를
+  실행하지 않습니다.)
+- `npm install -g @alibaba-group/open-code-review`로 OCR을 설치하고,
+  `ocr config set`으로 설정을 기록한 뒤, 브랜치 range 모드로 핵심 명령을 실행합니다.
+- JSON 봉투를 파싱해 각 지적을 GitHub Pull Request Review API로 인라인 리뷰 코멘트로
+  게시합니다. 라인 정보가 없는 코멘트는 요약 본문에 모읍니다. 일괄 등록이 실패하면
+  코멘트를 하나씩 게시하는 방식으로 대체하고, 통계를 요약 코멘트로 남깁니다.
+
+### 설치 {#install}
+
+워크플로 파일을 저장소에 넣으세요:
+
+```bash
+mkdir -p .github/workflows
+curl -o .github/workflows/ocr-review.yml \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/examples/github_actions/ocr-review.yml
+```
+
+### 필요한 시크릿 {#required-secrets}
+
+**Settings → Secrets and variables → Actions**에서 설정합니다.
+
+| 시크릿 | 필수 | 설명 |
+|---|---|---|
+| `OCR_LLM_URL` | 예 | LLM API 엔드포인트(예: `https://api.openai.com/v1/chat/completions`). |
+| `OCR_LLM_AUTH_TOKEN` | 예 | LLM API 인증 토큰. 이 CI 시크릿은 `ocr config set llm.auth_token`으로 전달됩니다. (OCR이 직접 읽는 환경 변수는 `OCR_LLM_AUTH_TOKEN`이 아니라 `OCR_LLM_TOKEN`입니다.) |
+| `OCR_LLM_MODEL` | 아니요 | 모델 이름. 기본값이 없으므로 반드시 지정해야 합니다. |
+| `OCR_LLM_USE_ANTHROPIC` | 아니요 | Anthropic Claude 모델을 쓸 때 `true`로 설정합니다. |
+
+`GITHUB_TOKEN`은 자동으로 제공됩니다. 워크플로가 리뷰 코멘트를 남길 수 있도록
+`pull-requests: write`를 선언해 두었습니다.
+
+> 워크플로는 시작할 때
+> `ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'`도
+> 실행합니다. 이 필드를 지원하지 않는 LLM 프로바이더와의 호환을 위해 thinking 모드
+> 요청을 끄는 설정입니다. 쓰는 프로바이더가 thinking 모드를 켠 채로 두어야 한다면
+> 이 줄을 지우세요.
+
+### 커스터마이즈 {#customization}
+
+아래 내용은 모두 방금 복사한 워크플로 파일
+(`.github/workflows/ocr-review.yml`)을 고치는 방법입니다.
+
+#### 배경 맥락 {#background-context}
+
+`--background`는 효과가 가장 큰 플래그 하나입니다.
+[모든 패턴에 적용되는 팁](../#tips-that-apply-to-every-pattern)을 참고하세요. PR
+제목을 넘기면 됩니다(`feat(auth): add OAuth2 support`처럼 제목이 시맨틱 규약을 따를
+때 특히 잘 맞습니다).
+
+```yaml
+- name: Run OCR review
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
+  run: |
+    ocr review \
+      --background "$PR_TITLE" \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF" \
+      --format json --audience agent
+```
+
+PR에서 제어할 수 있는 값은 `run:` 안에 `${{ }}`로 직접 넣지 말고 `env:`로
+넘기세요. GitHub는 셸이 줄을 파싱하기 *전에* `${{ }}`를 텍스트로 치환하므로, 셸
+메타문자가 들어간 PR 제목이나 브랜치 이름이 러너에서 그대로 실행될 수 있습니다.
+
+#### 커스텀 규칙 {#custom-rules}
+
+`--rule`로 프로젝트 전용 규칙 파일을 넘깁니다:
+
+```yaml
+- name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
+  run: |
+    ocr review --rule ./my-rules.json \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
+```
+
+스키마는 [리뷰 규칙](../../review-rules/)을 참고하세요.
+
+#### 동시 실행 수 {#concurrency}
+
+기본값은 파일 그룹당 하나씩, 서브 Agent 8개를 병렬로 돌립니다. 큰 PR에서 LLM
+프로바이더의 요청 한도를 넘지 않으려면 값을 낮추세요:
+
+```yaml
+- name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
+  run: |
+    ocr review --concurrency 5 \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF"
+```
+
+#### 트리거 조건 {#trigger-pattern}
+
+기본 워크플로는 PR **opened**와, `/open-code-review` 또는 `@open-code-review`로
+시작하는 PR 코멘트에서 트리거합니다. 흔히 다음 두 가지를 조정합니다.
+
+더 많은 PR 생명주기 이벤트에서 실행하기(예: 새 커밋이 푸시되면 다시 리뷰):
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+```
+
+다른 코멘트 키워드 쓰기:
+
+```yaml
+if: |
+  github.event_name == 'pull_request' ||
+  (github.event_name == 'issue_comment'
+    && github.event.issue.pull_request
+    && startsWith(github.event.comment.body, '/review'))
+```
+
+`github.event.issue.pull_request` 검사는 그 코멘트가 일반 이슈가 아니라 PR에 달린
+것임을 보장합니다.
+
+#### OCR 버전 고정 {#pin-the-ocr-version}
+
+기본 워크플로는 가장 최근에 배포된 버전을 설치합니다. 고정하려면:
+
+```yaml
+- name: Install OpenCodeReview
+  run: npm install -g @alibaba-group/open-code-review@1.0.0
+```
+
+#### GitHub App 명의로 게시하기 {#post-under-a-github-app-identity}
+
+기본적으로 리뷰 코멘트는 `github-actions[bot]` 이름으로 달립니다.
+`OpenCodeReview Bot` 같은 브랜드 봇 명의로 남기려면 `GITHUB_TOKEN` 대신 GitHub App
+설치 토큰을 쓰세요.
+
+1. *Settings → Developer settings → GitHub Apps → New GitHub App*에서 **앱을
+   만듭니다.** 웹훅은 이 용도에 필요 없으므로 끕니다. *Repository permissions*에서
+   다음을 부여합니다.
+   - **Pull requests**: Read and write
+   - **Contents**: Read-only (diff를 가져오는 데 필요)
+   - **Metadata**: Read-only (필수)
+
+2. 앱 설정 페이지에서 **개인 키를 생성해** `.pem` 파일을 내려받습니다. 같은
+   페이지에서 **App ID**도 확인해 둡니다.
+
+3. OCR로 리뷰할 저장소에 **앱을 설치합니다.** 설치 후 URL에 Installation ID가
+   나옵니다. 예를 들어 `https://github.com/settings/installations/12345`라면 ID는
+   `12345`입니다.
+
+4. *Settings → Secrets and variables → Actions*에서 **시크릿 세 개를 추가합니다.**
+
+   | 시크릿 | 값 |
+   |---|---|
+   | `GITHUB_APP_ID` | App ID. |
+   | `GITHUB_APP_PRIVATE_KEY` | `.pem` 파일의 전체 내용. `-----BEGIN RSA PRIVATE KEY-----`와 `-----END RSA PRIVATE KEY-----` 줄도 포함합니다. |
+   | `GITHUB_APP_INSTALLATION_ID` | Installation ID. |
+
+5. 코멘트 게시 단계에서 **토큰을 발급받아 사용합니다.**
+
+   ```yaml
+   - name: Get GitHub App Token
+     id: app-token
+     uses: actions/create-github-app-token@v1
+     with:
+       app-id: ${{ secrets.GITHUB_APP_ID }}
+       private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+
+   - name: Post review comments to PR
+     uses: actions/github-script@v7
+     with:
+       github-token: ${{ steps.app-token.outputs.token }}
+       script: |
+         # ...기존 게시 스크립트...
+   ```
+
+이제 리뷰가 `github-actions[bot]`이 아니라 앱 이름으로 올라갑니다.
+
+#### GitHub Code Scanning으로 결과 업로드 (SARIF) {#upload-findings-to-github-code-scanning-sarif}
+
+`--format sarif`는
+[SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+리포트를 stdout으로 출력합니다. 파일로 저장한 뒤 CodeQL `upload-sarif` 액션으로
+업로드하면 결과가 **Security → Code scanning**에 나타납니다:
+
+```yaml
+- name: Run OCR review
+  env:
+    BASE_REF: ${{ github.base_ref }}
+    HEAD_REF: ${{ github.head_ref }}
+  run: |
+    ocr review \
+      --from "origin/$BASE_REF" \
+      --to "origin/$HEAD_REF" \
+      --format sarif --audience agent > results.sarif
+
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+SARIF는 기계가 읽는 형식이므로 OCR은 stdout에 진행 상황을 출력하지 않고,
+`results.sarif`에는 리포트만 담깁니다. `--preview`는 `--format sarif`를 지원하지
+않습니다. 리포트를 만들려면 전체 리뷰를 실행하거나 `ocr scan`을 쓰세요.
+
+### 문제 해결 {#troubleshooting}
+
+| 증상 | 원인 / 해결 |
+|---|---|
+| `Cannot find merge-base` | 체크아웃 단계가 shallow clone을 썼는데, range 모드 리뷰에는 전체 히스토리가 필요합니다. 업스트림 워크플로는 `actions/checkout`에 `fetch-depth: 0`을 설정해 둡니다. 파일을 고치더라도 이 설정은 남겨 두세요. |
+| `Failed to parse OCR output` | `OCR_LLM_URL`이나 `OCR_LLM_AUTH_TOKEN`이 없거나 잘못됐습니다. *Settings → Secrets and variables → Actions*에서 값을 다시 확인하세요. |
+| 리뷰 코멘트가 엉뚱한 줄에 달림 | 대개 리뷰를 시작한 시점과 코멘트를 게시한 시점 사이에 diff가 밀린 경우입니다. 게시 스크립트가 일반 이슈 코멘트로 대체하므로 따로 할 일은 없습니다. |
+
+> **참고.** `OCR_DEBUG` 환경 변수는 **아직 구현되어 있지 않습니다.**
+> `OCR_DEBUG: "1"`을 설정해도 아무 효과가 없습니다. 나중에 연결될 경우를 대비해
+> 여기 적어 둡니다. 지금 자세한 출력을 보려면 워크플로가
+> `/tmp/ocr-result.json`과 `/tmp/ocr-stderr.log`에 남기는 원본 리뷰 JSON과 stderr를
+> 확인하거나(아래 문제 해결 참고), `ocr review`를 로컬에서 실행하세요.
+
+## GitLab CI {#gitlab-ci}
+
+업스트림 파이프라인은
+[`examples/gitlab_ci/.gitlab-ci.yml`](https://github.com/alibaba/open-code-review/blob/main/examples/gitlab_ci/.gitlab-ci.yml)에
+있습니다.
+
+### 무엇을 하나 {#what-it-does}
+
+- `merge_requests` 이벤트에서 트리거합니다(생성·수정·재오픈 등 모든 MR 이벤트).
+- `node:20` 이미지에서 실행하며, OCR을 설치하고 `ocr config set`으로 설정한 뒤 MR
+  diff 모드로 핵심 명령을 실행합니다.
+- 인라인 Python 스크립트로 JSON 봉투를 파싱해 각 지적을 GitLab 디스커션(diff 위
+  인라인)으로 게시합니다. 위치를 정확히 잡기 위해 MR의 `versions` 엔드포인트로
+  올바른 `base_sha` / `start_sha` / `head_sha`를 계산합니다. 인라인으로 달 수 없는
+  코멘트는 일반 MR 노트로 대체하고, 마지막에 요약 노트를 남깁니다.
+
+### 설치 {#install}
+
+파이프라인 파일을 저장소 루트에 넣으세요:
+
+```bash
+curl -o .gitlab-ci.yml \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/examples/gitlab_ci/.gitlab-ci.yml
+```
+
+이미 `.gitlab-ci.yml`이 있고 그대로 두고 싶다면, 레시피를 다른 경로에 넣고
+`include:`로 불러오세요:
+
+```yaml
+include:
+  - local: 'ci/ocr-review.gitlab-ci.yml'
+```
+
+### 필요한 CI/CD 변수 {#required-ci-cd-variables}
+
+**Settings → CI/CD → Variables**에서 설정합니다.
+
+| 변수 | 필수 | 마스킹 | 설명 |
+|---|---|---|---|
+| `OCR_LLM_URL` | 예 | 아니요 | LLM API 엔드포인트 URL. |
+| `OCR_LLM_AUTH_TOKEN` | 예 | 예 | API 인증 토큰. 이 CI 변수는 `ocr config set llm.auth_token`으로 전달됩니다. (OCR이 직접 읽는 환경 변수는 `OCR_LLM_AUTH_TOKEN`이 아니라 `OCR_LLM_TOKEN`입니다.) |
+| `OCR_LLM_MODEL` | 아니요 | 아니요 | 모델 이름. 기본값이 없으므로 반드시 지정해야 합니다. |
+| `GITLAB_API_TOKEN` | 아니요 | 예 | `api` 스코프를 가진 프로젝트 / 개인 / 그룹 액세스 토큰. 없으면 내장 `CI_JOB_TOKEN`이 대신 쓰입니다(예: fork MR). 안정적으로 쓰려면 전용 `GITLAB_API_TOKEN`을 권장합니다. |
+
+> GitLab은 8자보다 짧은 변수를 거부하므로 파이프라인에서 `llm.use_anthropic`을
+> `false`로 하드코딩해 두었습니다. Anthropic Claude 모델을 쓰려면 스크립트를 직접
+> 고치세요.
+
+> 파이프라인도 시작할 때
+> `ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'`를
+> 실행합니다. 이 필드를 지원하지 않는 LLM 프로바이더와의 호환을 위해 thinking 모드
+> 요청을 끄는 설정입니다. 쓰는 프로바이더가 thinking 모드를 켠 채로 두어야 한다면
+> 이 줄을 지우세요.
+
+> **봇 이름을 빠르게 붙이는 팁.** 프로젝트 액세스 토큰과 그룹 액세스 토큰은 토큰의
+> **이름**이 MR 디스커션 옆에 표시됩니다. 토큰 이름을 `OpenCodeReview Bot`으로
+> 지으면 다른 설정 없이 리뷰어에 브랜드를 붙일 수 있습니다.
+> [서비스 계정 명의로 게시하기](#post-under-a-service-account-identity)에 적힌 더
+> 견고한 서비스 계정 설정까지는 필요 없을 때 쓸 만합니다.
+
+### 커스터마이즈 {#customization}
+
+아래 내용은 모두 방금 복사한 `.gitlab-ci.yml`을 고치는 방법입니다.
+
+#### 배경 맥락 {#background-context}
+
+MR 제목을 `--background`로 넘기세요. `feat(auth): add OAuth2 support`처럼 제목이
+시맨틱 규약을 따를 때 특히 유용합니다:
+
+```yaml
+script:
+  - |
+    ocr review \
+      --background "$CI_MERGE_REQUEST_TITLE" \
+      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" \
+      --to "${CI_COMMIT_SHA}" \
+      --format json --audience agent
+```
+
+#### 커스텀 규칙과 동시 실행 수 {#custom-rules-and-concurrency}
+
+GitHub Actions 레시피와 같은 플래그를 씁니다. 프로젝트 전용 규칙 파일은 `--rule`로,
+병렬 서브 Agent 수(기본값 8) 조절은 `--concurrency`로 합니다:
+
+```yaml
+script:
+  - |
+    ocr review --rule ./my-rules.json --concurrency 5 \
+      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" \
+      --to "${CI_COMMIT_SHA}"
+```
+
+규칙 스키마는 [리뷰 규칙](../../review-rules/)을 참고하세요.
+
+#### OCR 버전 고정 {#pin-the-ocr-version}
+
+```yaml
+script:
+  - npm install -g @alibaba-group/open-code-review@1.0.0
+```
+
+#### 푸시할 때마다 다시 리뷰하지 않기 {#avoid-re-reviewing-on-every-push}
+
+`only: [merge_requests]`는 **모든** MR 갱신에서 트리거하므로, 오래 열려 있는 MR에서는
+LLM 토큰을 많이 쓰게 됩니다. GitLab에는 "생성 시에만" 같은 이벤트가 없으므로, 리뷰를
+실행하기 전에 기존 OCR 노트가 있는지 확인하고 있으면 빠져나오는 방식을 권장합니다.
+`ocr review` 호출을 다음 Python 래퍼로 바꾸세요:
+
+```python
+import json, os, sys, urllib.request
+
+GITLAB_URL = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+PROJECT_ID = os.environ["CI_PROJECT_ID"]
+MR_IID     = os.environ["CI_MERGE_REQUEST_IID"]
+API_TOKEN  = os.environ["GITLAB_API_TOKEN"]
+
+url = (
+    f"{GITLAB_URL}/api/v4/projects/{PROJECT_ID}"
+    f"/merge_requests/{MR_IID}/notes?per_page=100"
+)
+req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": API_TOKEN})
+with urllib.request.urlopen(req) as resp:
+    notes = json.loads(resp.read().decode())
+
+if any("OpenCodeReview" in n.get("body", "") for n in notes):
+    print("OCR already reviewed this MR. Skipping to save tokens.")
+    sys.exit(0)
+
+# ...노트가 없으면 평소처럼 `ocr review ...`를 호출하고, 게시 단계가 기대하는
+# 파일에 JSON을 씁니다.
+```
+
+이 상태에서 다시 리뷰하고 싶다면 MR에서 기존 OCR 노트를 지우세요. 다음 파이프라인
+실행에서 OCR 노트가 보이지 않으면 리뷰가 진행됩니다.
+
+#### 자체 호스팅 GitLab {#self-hosted-gitlab}
+
+코드를 고칠 필요가 없습니다. 게시 스크립트가 `CI_SERVER_URL`(GitLab이 모든 러너에
+자동으로 설정합니다)을 읽으므로 자체 인스턴스와 그대로 통신합니다. `GITLAB_API_TOKEN`을
+`gitlab.com`이 아니라 자체 호스팅 인스턴스에서 발급했는지만 확인하세요.
+
+#### 서비스 계정 명의로 게시하기 {#post-under-a-service-account-identity}
+
+기본적으로 리뷰 디스커션은 `GITLAB_API_TOKEN`을 소유한 사용자 이름으로 올라갑니다.
+`OpenCodeReview Bot` 같은 브랜드 봇 명의로 남기려면 프로젝트 범위의 서비스 계정으로
+바꾸세요.
+
+1. *Project → Settings → Service Accounts → New service account*에서 **서비스 계정을
+   만듭니다.** 여기서 정한 이름(예: `OpenCodeReview Bot`)이 MR 디스커션 옆에
+   표시됩니다.
+
+2. *Settings → Members → Invite member*에서 **프로젝트에 초대합니다.** 서비스 계정
+   이름으로 검색해 `Developer`나 `Maintainer`를 부여하세요. 둘 다 디스커션을 남길
+   권한이 있습니다.
+
+3. *Settings → Service Accounts → (해당 계정) → Add new token*에서 **액세스 토큰을
+   발급합니다.** 필요한 스코프는 `api`입니다. GitLab은 토큰을 한 번만 보여 주므로
+   즉시 복사해 두세요.
+
+4. *Settings → CI/CD → Variables*에서 **토큰 값을 교체합니다.** 기존
+   `GITLAB_API_TOKEN` 값을 서비스 계정 토큰으로 바꾸되 변수 이름은 그대로 둡니다.
+
+이제 디스커션이 원래 토큰을 만든 사용자가 아니라 서비스 계정 이름으로 올라갑니다.
+
+### 문제 해결 {#troubleshooting}
+
+| 증상 | 원인 / 해결 |
+|---|---|
+| `Cannot find merge-base` | 러너가 shallow clone을 썼습니다. 업스트림 파이프라인은 전체 클론을 강제하도록 `GIT_DEPTH: 0`을 설정해 둡니다. 파일을 고치더라도 이 설정은 남겨 두세요. |
+| 게시할 때 `API error 403` | `GITLAB_API_TOKEN`에 `api` 스코프가 없거나, 프로젝트 멤버가 아니거나, 자체 호스팅 환경에서 다른 인스턴스가 발급한 토큰입니다. `api` 스코프로 다시 발급해 *Settings → CI/CD → Variables*에 등록하세요. |
+| `Failed to parse OCR output` | `OCR_LLM_URL`이나 `OCR_LLM_AUTH_TOKEN`이 잘못됐습니다. *Settings → CI/CD → Variables*에서 값을 다시 확인하세요. |
+| 인라인 코멘트가 엉뚱한 줄에 달림 | GitLab은 인라인 디스커션에 정확한 SHA 일치를 요구하므로, 게시 스크립트가 `versions` 메타데이터를 가져와 올바른 `base_sha` / `start_sha` / `head_sha`를 씁니다. 그래도 위치를 잡지 못한 지적은 일반 MR 노트로 대체됩니다. |
+
+파이프라인은 원본 리뷰 JSON을 `/tmp/ocr-result.json`에, stderr를
+`/tmp/ocr-stderr.log`에 남깁니다. OCR이 무엇을 반환했는지 보려면 디버그 단계에서
+두 파일을 출력하세요:
+
+```yaml
+script:
+  - cat /tmp/ocr-result.json
+  - cat /tmp/ocr-stderr.log
+```
+
+## 관련 문서 {#see-also}
+
+- [CLI 레퍼런스](../cli-reference/#json) — 두 파이프라인이 소비하는 JSON 출력
+  구조입니다. CI 스크립트를 처음부터 직접 작성할 때 유용합니다.
+- [설정](../../configuration/) — OCR이 인식하는 모든 환경 변수와 설정 키입니다.

--- a/pages/src/content/docs/ko/integrations/claude-code.md
+++ b/pages/src/content/docs/ko/integrations/claude-code.md
@@ -1,0 +1,105 @@
+---
+title: Command (Claude Code 플러그인)
+sidebar:
+  order: 2
+---
+
+함께 제공되는 명령을 설치하면
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 안에서 OCR이 처음부터
+끝까지 실행됩니다. diff를 리뷰하고, 발견한 문제를 분류하고, 반영할 만한 항목은
+자동으로 수정까지 합니다.
+
+## 저장소에 포함된 것 {#what-ships-in-the-repo}
+
+저장소에는 Claude Code 플러그인이
+[`plugins/open-code-review/claude-code/`](https://github.com/alibaba/open-code-review/tree/main/plugins/open-code-review/claude-code)
+아래에 들어 있습니다. 명령 프롬프트 자체는
+[`plugins/open-code-review/claude-code/commands/review.md`](https://github.com/alibaba/open-code-review/blob/main/plugins/open-code-review/claude-code/commands/review.md)에
+있으며, 아래에서 설명하는 워크플로의 기준이 되는 파일입니다.
+
+## 설치 {#install}
+
+### 방법 1: 플러그인 마켓플레이스 (권장) {#option-1-plugin-marketplace-recommended}
+
+**Claude Code 안에서** 다음 두 명령을 실행하세요:
+
+```bash
+/plugin marketplace add alibaba/open-code-review
+/plugin install open-code-review@open-code-review
+```
+
+`/open-code-review:review` 슬래시 명령이 등록되며, 이후 `/plugin`으로 계속 업데이트할
+수 있습니다.
+
+### 방법 2: 명령 파일 직접 복사 {#option-2-copy-the-command-file-directly}
+
+플러그인 마켓플레이스를 거치지 않으려면 명령 파일을 `.claude/commands/`에 바로
+넣으면 됩니다. 이때는 `:review` 접미사 없이 `/open-code-review`로 등록됩니다.
+
+**프로젝트 수준**(저장소에 함께 커밋해 팀이 공유):
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/review.md
+```
+
+**사용자 수준**(머신의 모든 프로젝트에서 사용):
+
+```bash
+mkdir -p ~/.claude/commands
+curl -o ~/.claude/commands/open-code-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/review.md
+```
+
+### 명령을 지원하는 다른 Agent {#other-agents-with-command-support}
+
+명령 파일은 frontmatter 필드가 하나뿐인 평범한 마크다운이며, Claude Code에만 해당하는
+내용은 없습니다. 사용하는 Agent가 비슷한 **명령** 규약(디렉터리에서 마크다운 프롬프트를
+읽어 호출 가능한 명령으로 등록하는 방식)을 지원한다면, 위의 파일 복사 방법을 그대로
+쓰면 됩니다. `open-code-review.md`를 그 Agent가 명령을 읽는 디렉터리에 넣고, 평소
+명령을 부르던 방식으로 호출하세요. 프롬프트 본문은 특정 Agent에 매이지 않습니다.
+어떤 `ocr` 플래그를 고르고 결과를 어떻게 분류할지만 모델에 알려 줍니다.
+
+> **팁:** LLM을 직접 설정하고 싶지 않다면 [위임 모드](../delegate/)를 써 보세요.
+> 호스트 Agent(Claude Code)가 모델을 제공하므로 별도의 LLM 설정이 필요 없습니다.
+
+## 사용 {#use}
+
+Claude Code에서 명령을 이름으로 호출합니다. 플러그인 마켓플레이스로 설치했다면
+`/open-code-review:review`를, 파일을 직접 복사했다면 `/open-code-review`를 쓰세요:
+
+```
+/open-code-review:review
+/open-code-review:review review this PR against main
+/open-code-review:review focus on race conditions in commit abc123
+```
+
+프롬프트가 요청을 해석해 알맞은 `ocr review` 플래그를 고릅니다. 인자가 없으면
+워크스페이스 모드(스테이징된 변경 + 스테이징되지 않은 변경 + 추적되지 않은 파일),
+커밋을 언급하면 `--commit`, 브랜치 범위를 언급하면 `--from` / `--to`를 씁니다. OCR
+플래그를 직접 넘겨도 됩니다(예: `/open-code-review:review --commit abc123`,
+`--from main --to feature`).
+
+## 명령이 하는 일 {#what-the-command-does}
+
+명령 프롬프트는 짧습니다. 세 단계로 끝납니다.
+
+1. **리뷰 실행.** 요청에서 유추한 플래그로 `ocr review --audience agent`를
+   호출합니다(요구사항 맥락을 설명했다면 `--background`도 함께 붙습니다). 출력은
+   5분 타임아웃으로 수집합니다.
+2. **필터링과 평가.** 각 코멘트를 **High** / **Medium** / **Low**로 분류합니다.
+   확신이 낮은 코멘트(오탐으로 보이거나, 사소한 지적이거나, 맥락이 부족한 항목)는
+   조용히 버리고 나머지만 보여 줍니다.
+3. **수정.** 반영할 만한 High/Medium 항목을 자동으로 고칩니다.
+   [Agent Skill](../agent-skill/)과 달리 이 명령은 **기본적으로 자동 수정**합니다.
+   "diff만 보여 줘"가 아니라 "리뷰하고 정리까지 해 줘" 흐름에 맞춘 선택입니다.
+
+코드를 건드리기 전에 묻게 하거나 분류 기준을 더 엄격하게 바꾸고 싶다면 프롬프트의
+로컬 사본을 편집하세요. Claude Code는 호출할 때마다 명령을 다시 읽으므로 재시작할
+필요가 없습니다.
+
+## 관련 문서 {#see-also}
+
+- [Agent Skill](../agent-skill/) — SDK 수준의 대응 기능입니다. 같은 CLI를 쓰지만
+  기본값이 다릅니다(수정 전에 먼저 묻습니다).

--- a/pages/src/content/docs/ko/integrations/delegate.md
+++ b/pages/src/content/docs/ko/integrations/delegate.md
@@ -4,7 +4,7 @@ sidebar:
   order: 5
 ---
 
-위임 모드(Delegation Mode)에서는 OCR이 결정적인 엔지니어링(파일 선택, 규칙 해석)을
+위임 모드(Delegation Mode)에서는 OCR이 결정적 엔지니어링(파일 선택, 규칙 해석)을
 맡고, 실제 코드 리뷰는 호스트 Agent가 자신의 LLM으로 수행합니다. OCR 쪽에는 LLM
 엔드포인트가 필요 없습니다.
 

--- a/pages/src/content/docs/ko/integrations/delegate.md
+++ b/pages/src/content/docs/ko/integrations/delegate.md
@@ -1,0 +1,160 @@
+---
+title: 위임 모드
+sidebar:
+  order: 5
+---
+
+위임 모드(Delegation Mode)에서는 OCR이 결정적인 엔지니어링(파일 선택, 규칙 해석)을
+맡고, 실제 코드 리뷰는 호스트 Agent가 자신의 LLM으로 수행합니다. OCR 쪽에는 LLM
+엔드포인트가 필요 없습니다.
+
+## 언제 쓰나 {#when-to-use-delegation-mode}
+
+위임 모드는 구독형 AI 코딩 Agent를 염두에 두고 만들었습니다. Claude Code, Codex,
+Cursor, Open Code, Qoder처럼 이미 호스트 Agent에 LLM 구독이 묶여 있는 환경입니다.
+OCR용으로 모델 엔드포인트를 따로 설정하는 대신, 호스트 Agent가 쓰던 구독 할당량을
+그대로 리뷰에 씁니다.
+
+다음과 같을 때 위임 모드를 쓰세요.
+
+1. AI 코딩 Agent를 구독 요금제로 쓰고 있고, 그 할당량을 코드 리뷰에도 쓰고 싶을 때.
+   API 키나 모델 설정을 따로 하지 않아도 됩니다.
+2. OCR의 엔지니어링 뼈대(파일 필터링, 규칙 해석, 제외 처리)만 쓰고 LLM 추론은 전부
+   호스트 Agent에 맡기고 싶을 때.
+3. 자체 Agent 파이프라인을 만들면서 리뷰 단계에 구조화된 입력(파일 목록 + 규칙)이
+   필요할 때.
+
+## 사전 요구 사항 {#prerequisites}
+
+`ocr` CLI가 설치되어 있어야 합니다:
+
+```bash
+which ocr || npm install -g @alibaba-group/open-code-review
+```
+
+LLM 설정(`ocr config set …`이나 환경 변수)은 필요 없습니다. 위임 모드에서는 OCR이
+LLM을 호출하지 않습니다.
+
+## 스킬 / 명령 설치 {#install-the-skill-command}
+
+### Claude Code — 명령 {#claude-code-command}
+
+```bash
+mkdir -p .claude/commands
+curl -o .claude/commands/delegate-review.md \
+  https://raw.githubusercontent.com/alibaba/open-code-review/main/plugins/open-code-review/claude-code/commands/delegate-review.md
+```
+
+### 모든 Agent — 스킬 {#any-agent-skill}
+
+```bash
+npx skills add alibaba/open-code-review --skill open-code-review-delegate
+```
+
+매니페스트를 직접 복사해도 됩니다:
+
+```bash
+cp -R /path/to/open-code-review/skills/open-code-review-delegate ~/.claude/skills/
+```
+
+## 워크플로 {#workflow}
+
+### 1단계: 미리 보기 — 리뷰 대상 확인 {#step-1-preview-determine-what-to-review}
+
+```bash
+ocr delegate preview [--from <ref> --to <ref>] [--commit <hash>] [--exclude <patterns>]
+```
+
+출력 내용:
+
+- **mode** — workspace / range / commit
+- **ref 메타데이터** — from, to, commit, merge\_base
+- **리뷰 대상 파일 목록** — 경로, 상태, 추가/삭제 라인 수
+- **제외된 파일** — 제외 사유 포함
+
+자주 쓰는 호출:
+
+| 상황 | 명령 |
+|----------|---------|
+| 워크스페이스 변경 | `ocr delegate preview` |
+| 브랜치 비교 | `ocr delegate preview --from main --to feature` |
+| 단일 커밋 | `ocr delegate preview -c abc123` |
+
+### 2단계: 파일별 규칙 가져오기 {#step-2-get-rules-for-files}
+
+```bash
+ocr delegate rule <path1> <path2> ...
+```
+
+1단계에서 얻은 리뷰 대상 경로를 넘깁니다. 출력은 규칙 내용별로 묶여 나오므로, 같은
+규칙을 쓰는 파일은 한 그룹에 모여 중복이 없습니다.
+
+### 3단계: diff 가져오기 {#step-3-get-diffs}
+
+1단계에서 얻은 모드와 ref 정보를 바탕으로 git을 직접 씁니다.
+
+**range 모드**(merge\_base가 제공됨):
+```bash
+git diff <merge_base>..<to> -- <path>
+```
+
+**commit 모드**:
+```bash
+git show <commit> -- <path>
+```
+
+**workspace 모드**:
+```bash
+git diff HEAD -- <path>        # 추적 중인 파일
+cat <path>                     # 새로 추가된 추적되지 않은 파일
+```
+
+### 4단계: 파일별 리뷰 {#step-4-review-each-file}
+
+리뷰 대상 파일마다 다음을 수행합니다.
+
+1. 해당 파일의 diff를 가져옵니다(3단계).
+2. 대응하는 Rule Group(2단계)을 리뷰 체크리스트로 삼습니다.
+3. 필요한 만큼 맥락을 탐색하며 꼼꼼히 리뷰합니다.
+
+### 5단계: 보고 {#step-5-report}
+
+발견한 문제를 심각도로 분류합니다.
+
+- **Critical/High** — 버그, 보안 이슈, 데이터 유실 위험. 항상 보고합니다.
+- **Medium** — 성능 문제, 오류 처리 누락. 맥락과 함께 보고합니다.
+- **Low** — 스타일 지적, 사소한 제안. 분명히 가치 있는 경우가 아니면 조용히 버립니다.
+
+## 하위 명령 레퍼런스 {#sub-commands-reference}
+
+| 명령 | 용도 |
+|---------|---------|
+| `ocr delegate preview` | 리뷰 대상 파일과 모드/ref 메타데이터를 나열 |
+| `ocr delegate rule <path...>` | 리뷰 규칙을 내용별로 묶어 해석 |
+
+## 공통 플래그 {#shared-flags}
+
+| 플래그 | 설명 |
+|------|-------------|
+| `--from <ref>` | range 모드의 원본 ref |
+| `--to <ref>` | range 모드의 대상 ref |
+| `-c, --commit <hash>` | 단일 커밋 모드 |
+| `--repo <path>` | 저장소 루트(기본값: 현재 디렉터리) |
+| `--rule <path>` | 커스텀 rule.json 경로 |
+| `--exclude <patterns>` | 쉼표로 구분한 제외 패턴 |
+| `-b, --background <text>` | 비즈니스 맥락 |
+| `-B, --background-file <path>` | Markdown 파일에서 읽는 비즈니스 맥락(`-b`보다 우선) |
+
+## 다른 연동 방식과 비교 {#comparison-with-other-integration-modes}
+
+| 방식 | LLM을 호출하는 주체 | 용도 |
+|------|-------------------|----------|
+| [Agent Skill](../agent-skill/) | OCR | Agent가 `ocr review`를 호출하고, OCR이 리뷰 전체를 주도 |
+| [Command (Claude Code)](../claude-code/) | OCR | Claude Code의 슬래시 명령. OCR이 리뷰를 주도 |
+| **위임 모드** | 호스트 Agent | OCR은 뼈대만 제공하고, Agent가 리뷰를 주도 |
+
+## 관련 문서 {#see-also}
+
+- [Agent Skill](../agent-skill/) — Agent를 대신해 OCR이 리뷰 전체를 수행합니다.
+- [Command (Claude Code)](../claude-code/) — 자동 수정이 기본인 슬래시 명령
+  형태입니다.


### PR DESCRIPTION
## Description

Korean translations for the four integration guides — `agent-skill`, `claude-code`, `ci`, `delegate` (897 lines of English source) — the second batch of the ko docs rollout started in #993.

- Terminology follows what `ko.ts` already ships (프로바이더, 내장, 워크스페이스 모드, 위임 모드), so docs and UI never disagree. `docs.sidebar.delegate` is `위임 모드`, so the page title matches; the first paragraph glosses it as `위임 모드(Delegation Mode)` to keep the link from the already-merged ko quickstart readable.
- Code blocks, flags, config keys, URLs, and table values are verbatim; only prose and code comments are translated.
- **Every heading carries an explicit `{#id}`.** `generateHeadingId` keeps only `[a-z0-9]` and CJK ideographs, so a Korean heading collapses to an empty or colliding id — `## 설치` → `""`, `## 사전 요구 사항` → `""`, and `### 1단계…` / `### 2단계…` → `"1"` / `"2"`. The TOC then resolves several entries to the same target. The repo already supports the `{#id}` marker (`parseExplicitHeadingId`, used by `ru/review-rules.md` and `ru/integrations/ci.md`), so each heading reuses its English slug. A verification pass confirms the ko anchor sequence is identical to en for all four files, which also keeps deep links stable across a language switch.
- `DOCS_LOCALES` in `check-translation-sync.js` still excludes `ko` — sync warnings would be unactionable until the full set exists. It flips in the final batch.

The remaining pages (cli-reference, review-rules, architecture, tools, mcp, viewer, telemetry, contributing, faq) plus the `DOCS_LOCALES` flip will follow in the final batch.

<img width="800" alt="Korean delegation-mode page rendered with Korean sidebar and TOC" src="https://github.com/user-attachments/assets/5d2bc11e-0ad2-4113-861d-c8a7dae1607a" />

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

`typecheck` / `lint` / `test` (32/32) / `build` / `size` (94.7 kB / 150 kB), `go run scripts/verify-english-only.go`, and `scripts/verify-license.sh` all pass. Rendering verified with headless Chrome under `--accept-lang=ko-KR`: the four pages serve Korean content, the heading ids match the English slugs exactly, the `{#id}` markers do not leak into the rendered text, and untranslated pages still fall back to English.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Follow-up to #471 / #857 / #993.

