### PR TITLE
fix(tool): support subpath and cross-platform queries in file_find

### DIFF
--- a/internal/tool/file_find.go
+++ b/internal/tool/file_find.go
@@ -31,11 +31,13 @@ func (p *FileFindProvider) Tool() Tool { return FileFind }
 
 func (p *FileFindProvider) Execute(ctx context.Context, args map[string]any) (string, error) {
 	queryName, _ := args["query_name"].(string)
-	if strings.TrimSpace(queryName) == "" {
+	queryName = strings.TrimSpace(queryName)
+	if queryName == "" {
 		return "// The file was not found", nil
 	}
 
 	caseSensitive, _ := args["case_sensitive"].(bool)
+	normalizedQuery := strings.ReplaceAll(queryName, "\\", "/")
 
 	files, err := p.listGitFiles(ctx)
 	if err != nil {
@@ -50,9 +52,10 @@ func (p *FileFindProvider) Execute(ctx context.Context, args map[string]any) (st
 		}
 		match := false
 		if caseSensitive {
-			match = strings.Contains(base, queryName)
+			match = strings.Contains(base, queryName) || strings.Contains(f, normalizedQuery)
 		} else {
-			match = strings.Contains(strings.ToLower(base), strings.ToLower(queryName))
+			match = strings.Contains(strings.ToLower(base), strings.ToLower(queryName)) ||
+				strings.Contains(strings.ToLower(f), strings.ToLower(normalizedQuery))
 		}
 		if match {
 			matched = append(matched, f)

--- a/internal/tool/file_find.go
+++ b/internal/tool/file_find.go
@@ -44,6 +44,12 @@ func (p *FileFindProvider) Execute(ctx context.Context, args map[string]any) (st
 		return "", err
 	}
 
+	var lowerQuery, lowerNormalizedQuery string
+	if !caseSensitive {
+		lowerQuery = strings.ToLower(queryName)
+		lowerNormalizedQuery = strings.ToLower(normalizedQuery)
+	}
+
 	var matched []string
 	for _, f := range files {
 		base := f
@@ -54,8 +60,8 @@ func (p *FileFindProvider) Execute(ctx context.Context, args map[string]any) (st
 		if caseSensitive {
 			match = strings.Contains(base, queryName) || strings.Contains(f, normalizedQuery)
 		} else {
-			match = strings.Contains(strings.ToLower(base), strings.ToLower(queryName)) ||
-				strings.Contains(strings.ToLower(f), strings.ToLower(normalizedQuery))
+			match = strings.Contains(strings.ToLower(base), lowerQuery) ||
+				strings.Contains(strings.ToLower(f), lowerNormalizedQuery)
 		}
 		if match {
 			matched = append(matched, f)

--- a/internal/tool/file_find_test.go
+++ b/internal/tool/file_find_test.go
@@ -225,3 +225,25 @@ func TestShouldSkipFile(t *testing.T) {
 		})
 	}
 }
+
+func TestFileFind_PathWithSubdirectory(t *testing.T) {
+	dir := setupFileFindRepo(t)
+	p := NewFileFind(&FileReader{RepoDir: dir, Mode: ModeWorkspace})
+
+	got, err := p.Execute(context.Background(), map[string]any{"query_name": "pkg/util"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "pkg/util.go") {
+		t.Fatalf("expected to find pkg/util.go when querying 'pkg/util', got: %s", got)
+	}
+
+	gotWin, errWin := p.Execute(context.Background(), map[string]any{"query_name": `pkg\util.go`})
+	if errWin != nil {
+		t.Fatal(errWin)
+	}
+	if !strings.Contains(gotWin, "pkg/util.go") {
+		t.Fatalf("expected to find pkg/util.go when querying 'pkg\\util.go', got: %s", gotWin)
+	}
+}
+


### PR DESCRIPTION
## Description

Fixes #1073

When LLM agents invoke the `file_find` tool to locate files across the project during review or planning (e.g. `query_name: "pkg/util"` or `query_name: "internal/diff"`), `file_find` previously failed to match any files because it stripped all directory paths (`base = f[idx+1:]`) and tested substring inclusion exclusively against the base filename (`base`).

Furthermore, Windows backslash path separators (`\`) in `query_name` (e.g. `pkg\util.go`) were not normalized to forward slashes.

### Key Changes
1. Normalized `query_name` path separators using `strings.ReplaceAll(queryName, "\\", "/")`.
2. Expanded matching in `file_find.Execute` to match against both the base filename and the relative project path `f`.
3. Added unit regression test `TestFileFind_PathWithSubdirectory` in `internal/tool/file_find_test.go` covering subpath queries and Windows-style paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` / targeted package tests pass locally:
  - `go test -v ./internal/tool` (all unit tests passed cleanly)
  - `go test -v ./internal/diff/... ./internal/tool/... ./internal/scan/...`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Fixes #1073
