### PR TITLE
docs(cli): align --max-tools help text with min 50 clamp

### DIFF
--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -52,7 +52,7 @@ func addExcludeFlag(cmd *cobra.Command, target *string) {
 func addConcurrencyFlags(cmd *cobra.Command, concurrency, timeout, maxTools, maxGitProcs, maxTokens, maxTokensBudget *int) {
 	cmd.Flags().IntVar(concurrency, "concurrency", 8, "max concurrent file reviews")
 	cmd.Flags().IntVar(timeout, "timeout", 10, "concurrent task timeout in minutes")
-	cmd.Flags().IntVar(maxTools, "max-tools", 0, "max tool call rounds per file (0 = template default; min 10)")
+	cmd.Flags().IntVar(maxTools, "max-tools", 0, "max tool call rounds per file (0 = template default; min 50)")
 	cmd.Flags().IntVar(maxGitProcs, "max-git-procs", 16, "max concurrent git subprocesses")
 	cmd.Flags().IntVar(maxTokens, "max-tokens", 0, "per-file prompt token ceiling (0 = configured or template default)")
 	cmd.Flags().IntVar(maxTokensBudget, "max-tokens-budget", 0, "cap total token usage (input+output) for this review; dispatch stops once exceeded and skipped files are reported as failed(budget). Partial results are published and review exits 0; it exits non-zero only if every selected item failed (0 = unlimited)")

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -52,7 +52,7 @@ func addExcludeFlag(cmd *cobra.Command, target *string) {
 func addConcurrencyFlags(cmd *cobra.Command, concurrency, timeout, maxTools, maxGitProcs, maxTokens, maxTokensBudget *int) {
 	cmd.Flags().IntVar(concurrency, "concurrency", 8, "max concurrent file reviews")
 	cmd.Flags().IntVar(timeout, "timeout", 10, "concurrent task timeout in minutes")
-	cmd.Flags().IntVar(maxTools, "max-tools", 0, "max tool call rounds per file (0 = template default; min 50)")
+	cmd.Flags().IntVar(maxTools, "max-tools", 0, "max tool call rounds per subtask (0 = template default; min 50)")
 	cmd.Flags().IntVar(maxGitProcs, "max-git-procs", 16, "max concurrent git subprocesses")
 	cmd.Flags().IntVar(maxTokens, "max-tokens", 0, "per-file prompt token ceiling (0 = configured or template default)")
 	cmd.Flags().IntVar(maxTokensBudget, "max-tokens-budget", 0, "cap total token usage (input+output) for this review; dispatch stops once exceeded and skipped files are reported as failed(budget). Partial results are published and review exits 0; it exits non-zero only if every selected item failed (0 = unlimited)")

--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -290,7 +290,7 @@ const reviewArgs = {
   overallTimeoutMinutes: optionalPositiveInt(
     "Optional wall-clock timeout for the complete OCR process in minutes.",
   ),
-  maxTools: optionalPositiveInt("Maximum tool-call rounds per file; OCR enforces a minimum of 10."),
+  maxTools: optionalPositiveInt("Maximum tool-call rounds per file; OCR enforces a minimum of 50."),
   maxGitProcesses: optionalPositiveInt("Maximum concurrent Git subprocesses."),
   preview: tool.schema.boolean().optional().describe(
     "List the files that would be reviewed without calling an LLM.",

--- a/plugins/open-code-review/opencode/open-code-review.ts
+++ b/plugins/open-code-review/opencode/open-code-review.ts
@@ -290,7 +290,7 @@ const reviewArgs = {
   overallTimeoutMinutes: optionalPositiveInt(
     "Optional wall-clock timeout for the complete OCR process in minutes.",
   ),
-  maxTools: optionalPositiveInt("Maximum tool-call rounds per file; OCR enforces a minimum of 50."),
+  maxTools: optionalPositiveInt("Maximum tool-call rounds per subtask; OCR enforces a minimum of 50."),
   maxGitProcesses: optionalPositiveInt("Maximum concurrent Git subprocesses."),
   preview: tool.schema.boolean().optional().describe(
     "List the files that would be reviewed without calling an LLM.",


### PR DESCRIPTION
## Description

`ocr review --help` and the OpenCode plugin still describe `--max-tools` as `min 10`, but `validateReviewOptions` clamps positive values below **50** (raised in #808). Website CLI docs already document the 1–49 clamp.

This only updates those leftover user-facing strings so they match the existing implementation. No behavior change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Inspected `validateReviewOptions` (`minMaxTools = 50`) and `TestParseReviewFlags_MaxToolsBelowMin` (`--max-tools 30` is clamped to 50). Full `go test ./cmd/opencodereview/` was not used as a gate: unrelated tests fail locally because `git commit` in temp repos hits GPG signing (`No secret key`).

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Not a duplicate of #935 / #936 (those cover raise-only vs lower-override semantics). This is leftover help text after #808 raised the floor from 10 to 50.


Made with [Cursor](https://cursor.com)