### PR TITLE
feat(session): persist retry reports in session end

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -216,6 +216,7 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 		SystemRule:            cc.Resolver,
 		FileFilter:            cc.FileFilter,
 		LLMClient:             rt.Client,
+		RetryCollector:        rt.RetryCollector,
 		Tools:                 tools,
 		PlanToolDefs:          rt.PlanToolDefs,
 		MainToolDefs:          rt.MainToolDefs,
@@ -257,12 +258,10 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 	comments, runErr := ag.Run(runCtx)
 	manifest := ag.RunManifest()
 
-	// Freeze the retry report at the same boundary as the manifest: ag.Run has
-	// returned and joined its background work, so every request this run made is
-	// finalized and the report can no longer change. run_id is the session's
-	// in-memory UUID (ag.Session().SessionID) rather than ag.SessionID(), which
-	// returns "" when persistence failed — the report's logical_request_id must
-	// stay stable and unique per run even for an unpersisted session.
+	// The agent already froze an equal snapshot before session_end was written.
+	// Freeze is a deterministic read over the collector, so taking the CLI's own
+	// snapshot here preserves the existing output path without exposing agent
+	// state solely for reuse.
 	retryReport, freezeErr := rt.RetryCollector.Freeze(ag.Session().SessionID)
 	if freezeErr != nil {
 		// A construction error means the collector's invariants were violated, so

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -188,7 +188,8 @@ type llmRuntime struct {
 	// built before either exists, and it is per-run rather than package-level so
 	// two runs in one process cannot share data. scan gets one too; its requests
 	// carry no RequestMeta, so every attempt is dropped and the frozen report is
-	// nil.
+	// nil. The review path hands it to the agent for the pre-session_end snapshot;
+	// the command takes the equal output snapshot after Run. scan never freezes.
 	RetryCollector *llm.RetryCollector
 	AppCfg         *Config
 	// RuntimeConfig holds the allowlisted, non-secret runtime settings (protocol,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -81,6 +81,11 @@ type Args struct {
 	// LLM client for model inference.
 	LLMClient llm.LLMClient
 
+	// RetryCollector is the collector the LLMClient reports attempts to. The
+	// agent holds it only to freeze the report at the run boundary. Nil means
+	// this run persists none.
+	RetryCollector *llm.RetryCollector
+
 	// Tool registry mapping tool aliases to implementations.
 	Tools *tool.Registry
 
@@ -292,6 +297,9 @@ func (a *Agent) Run(ctx context.Context) ([]model.LlmComment, error) {
 		if b := a.session.Manifest(); b != nil {
 			_ = b.SetRunFailure(session.RunFailureInput, "failed to resolve review input")
 		}
+		// Collector is empty here (no request issued yet); frozen anyway so a future
+		// path issuing requests before this exit cannot silently lose them.
+		a.freezeRetryReport()
 		manifestErr := a.finalizeManifest()
 		// Keep the load failure as the primary cause, but never drop a persistence
 		// failure: a run that could not even write its failed session_end must
@@ -328,6 +336,8 @@ func (a *Agent) Run(ctx context.Context) ([]model.LlmComment, error) {
 		// run_failure), which is the correct terminal state for "nothing to do".
 		// A persistence failure here is still a delivery error — a clean skip
 		// cannot be claimed if its session_end never reached disk.
+		// Empty here too: grouping and every task run after this point.
+		a.freezeRetryReport()
 		manifestErr := a.finalizeManifest()
 		if ferr := a.session.Finalize(); ferr != nil {
 			manifestErr = errors.Join(manifestErr, fmt.Errorf("finalize session: %w", ferr))
@@ -385,6 +395,8 @@ func (a *Agent) Run(ctx context.Context) ([]model.LlmComment, error) {
 	// and be discarded wholesale. Cheap in the normal case — every job has
 	// already been cancelled by now.
 	a.runner.WaitBackground()
+	// Every request is finalized now, so the report can be frozen.
+	a.freezeRetryReport()
 	// Freeze coverage into the immutable manifest before session_end embeds it,
 	// so the CLI and the persisted session serialize the identical object. A
 	// persistence failure is a delivery error in its own right: when the review
@@ -1254,6 +1266,28 @@ func (a *Agent) finalizeManifest() error {
 	}
 	a.session.SetFinalManifest(&m)
 	return nil
+}
+
+// freezeRetryReport freezes this run's retry report into the session. Every
+// terminal path calls it just before finalizeManifest, and the normal path only
+// after WaitBackground: a request still in flight is un-finalized, and Freeze
+// discards the whole report over one such entry.
+//
+// A nil report is the ordinary outcome — Freeze withholds one unless something
+// retried, failed or was cancelled. An error means the collector's invariants
+// were violated, so the report contradicts itself and is published nowhere.
+func (a *Agent) freezeRetryReport() {
+	if a.args.RetryCollector == nil {
+		return
+	}
+	// The in-memory UUID, not a.SessionID(), which is "" when persistence failed:
+	// logical_request_id must stay unique per run, and Freeze rejects an empty
+	// run_id.
+	rep, err := a.args.RetryCollector.Freeze(a.session.SessionID)
+	if err != nil {
+		return
+	}
+	a.session.SetFinalRetryReport(rep)
 }
 
 func resumedFromSession(resume *session.ResumeState) string {

--- a/internal/agent/retry_report_freeze_test.go
+++ b/internal/agent/retry_report_freeze_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/open-code-review/internal/gitcmd"
+	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/session"
+)
+
+// retryMeta is a minimal valid RequestMeta; RecordAttempt drops anything whose
+// Model, FilePath or TaskType is empty, or whose RequestNo is not positive.
+func retryMeta(requestNo int) llm.RequestMeta {
+	return llm.RequestMeta{
+		Provider:  "test-provider",
+		Model:     "fake",
+		FilePath:  "main.go",
+		TaskType:  string(session.MainTask),
+		RequestNo: requestNo,
+	}
+}
+
+// runInputFailureAgent drives the load-diffs exit of Run, the cheapest terminal
+// path that still goes through freezeRetryReport and session_end.
+func runInputFailureAgent(t *testing.T, collector *llm.RetryCollector) (*Agent, string, error) {
+	t.Helper()
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := session.New(repoDir, "feature", "fake", session.SessionOptions{
+		ReviewMode: session.ReviewModeRange,
+		DiffFrom:   "missing-base",
+		DiffTo:     "missing-head",
+		Operation:  session.OperationReview,
+	})
+	a := New(Args{
+		RepoDir:        repoDir,
+		From:           "missing-base",
+		To:             "missing-head",
+		ReviewMode:     session.ReviewModeRange,
+		GitRunner:      gitcmd.New(1),
+		LLMClient:      manifestFlowClient{},
+		RetryCollector: collector,
+		Model:          "fake",
+		Session:        sh,
+	})
+	_, err := a.Run(context.Background())
+	if err == nil {
+		t.Fatal("invalid review input must fail")
+	}
+	return a, repoDir, err
+}
+
+// TestRunPersistsRetryReport pins that the report is frozen inside Run and
+// embedded into session_end. The command takes its own deterministic snapshot
+// after Run, so the two serialized values must be equal.
+func TestRunPersistsRetryReport(t *testing.T) {
+	collector := llm.NewRetryCollector()
+	meta := retryMeta(1)
+	now := time.Now()
+	collector.RecordAttempt(meta, llm.AttemptRecord{
+		Number:       1,
+		ErrorClass:   llm.ErrorClassOverloaded,
+		FailurePhase: llm.FailurePhaseHTTP,
+		StatusCode:   529,
+	}, now, now.Add(time.Second))
+	collector.RecordAttempt(meta, llm.AttemptRecord{Number: 2, StatusCode: 200}, now.Add(2*time.Second), now.Add(3*time.Second))
+	collector.Finalize(meta, nil, false)
+
+	a, repoDir, _ := runInputFailureAgent(t, collector)
+
+	rep, err := collector.Freeze(a.Session().SessionID)
+	if err != nil {
+		t.Fatalf("Freeze() after Run = %v", err)
+	}
+	if rep == nil {
+		t.Fatal("Freeze() after Run = nil, want the output snapshot")
+	}
+	if rep.RetriedRequests != 1 || rep.TotalRetries != 1 {
+		t.Errorf("report = %+v, want RetriedRequests=1 TotalRetries=1", rep)
+	}
+
+	persisted := persistedRetryReport(t, repoDir, a.Session().SessionID)
+	if persisted == nil {
+		t.Fatal("session_end carries no llm_retry_report")
+	}
+	wantJSON, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal output snapshot: %v", err)
+	}
+	var want map[string]any
+	if err := json.Unmarshal(wantJSON, &want); err != nil {
+		t.Fatalf("unmarshal output snapshot: %v", err)
+	}
+	if !reflect.DeepEqual(persisted, want) {
+		t.Errorf("persisted report differs from output snapshot:\n persisted: %v\n output:    %v", persisted, want)
+	}
+}
+
+// TestRunSuppressesInvalidRetryReport pins that a collector invariant failure
+// does not enter Run's error or agent warnings and is persisted nowhere. The
+// command's own Freeze call remains the single diagnostic outlet.
+func TestRunSuppressesInvalidRetryReport(t *testing.T) {
+	// An attempt that is never finalized is exactly what Freeze rejects — it means
+	// the client boundary let a request escape without recording its outcome.
+	collector := llm.NewRetryCollector()
+	now := time.Now()
+	collector.RecordAttempt(retryMeta(1), llm.AttemptRecord{Number: 1, StatusCode: 200}, now, now.Add(time.Second))
+
+	a, repoDir, runErr := runInputFailureAgent(t, collector)
+
+	_, freezeErr := collector.Freeze(a.Session().SessionID)
+	if freezeErr == nil {
+		t.Fatal("Freeze() after Run = nil, want the un-finalized-request error")
+	}
+	if !strings.Contains(runErr.Error(), "load diffs") {
+		t.Errorf("Run error = %v, want the input failure", runErr)
+	}
+	if strings.Contains(runErr.Error(), freezeErr.Error()) {
+		t.Errorf("Run error absorbed the freeze error: %v", runErr)
+	}
+
+	// A report that contradicts itself is published nowhere, not even partially.
+	if persisted := persistedRetryReport(t, repoDir, a.Session().SessionID); persisted != nil {
+		t.Errorf("session_end carries a report after a failed freeze: %v", persisted)
+	}
+
+	// Agent warnings feed text and JSON result output. The freeze diagnostic stays
+	// solely in the command layer, so Run must not add a second output path.
+	for _, w := range a.Warnings() {
+		if w.Type == "retry_report_error" {
+			t.Errorf("agent warnings unexpectedly include retry_report_error: %+v", a.Warnings())
+		}
+	}
+
+	// The manifest terminal state stays the one the input failure produced.
+	manifest := a.RunManifest()
+	if manifest == nil || manifest.RunFailure == nil || manifest.RunFailure.Classification != session.RunFailureInput {
+		t.Errorf("manifest = %+v, want an input run failure", manifest)
+	}
+}
+
+// TestRunWithoutCollectorPersistsNoReport covers the nil-collector wiring, which
+// is what scan and every test that does not opt in look like.
+func TestRunWithoutCollectorPersistsNoReport(t *testing.T) {
+	a, repoDir, _ := runInputFailureAgent(t, nil)
+
+	if persisted := persistedRetryReport(t, repoDir, a.Session().SessionID); persisted != nil {
+		t.Errorf("session_end carries a report without a collector: %v", persisted)
+	}
+}
+
+func persistedRetryReport(t *testing.T, repoDir, sessionID string) map[string]any {
+	t.Helper()
+	dir, err := session.SessionsDir(repoDir)
+	if err != nil {
+		t.Fatalf("sessions dir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, sessionID+".jsonl"))
+	if err != nil {
+		t.Fatalf("read session jsonl: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal jsonl line: %v", err)
+		}
+		if rec["type"] != "session_end" {
+			continue
+		}
+		rep, _ := rec["llm_retry_report"].(map[string]any)
+		return rep
+	}
+	t.Fatal("no session_end record found")
+	return nil
+}

--- a/internal/llm/retry_report.go
+++ b/internal/llm/retry_report.go
@@ -461,8 +461,9 @@ func (c *RetryCollector) Finalize(m RequestMeta, reqErr error, parentCancelled b
 	}
 }
 
-// Freeze builds the immutable report. It must be called once, after the run is
-// done, and runID is the review session ID.
+// Freeze builds an immutable report after the run is done. It is a deterministic
+// read and may be called again with the same runID to give independent consumers
+// equal snapshots. runID is the review session ID.
 //
 // The three return shapes are distinct and callers must handle all of them:
 //

--- a/internal/session/final_retry_report_test.go
+++ b/internal/session/final_retry_report_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package session
+
+import (
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/llm"
+)
+
+// TestSessionEndEmbedsRetryReport pins that a frozen report reaches session_end
+// under llm_retry_report, so a session can be diagnosed on its own without the
+// command output that was printed at the time.
+func TestSessionEndEmbedsRetryReport(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+
+	sh.SetFinalRetryReport(&llm.RetryReport{
+		SchemaVersion:   llm.RetryReportSchemaVersion,
+		TotalRequests:   3,
+		RetriedRequests: 1,
+		TotalRetries:    2,
+	})
+	if err := sh.Finalize(); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	endRec := sessionEndRecord(t, repoDir, sh.SessionID)
+	rep, ok := endRec["llm_retry_report"].(map[string]any)
+	if !ok {
+		t.Fatalf("llm_retry_report missing or wrong type: %v", endRec["llm_retry_report"])
+	}
+	if rep["schema_version"] != llm.RetryReportSchemaVersion {
+		t.Errorf("schema_version = %v, want %v", rep["schema_version"], llm.RetryReportSchemaVersion)
+	}
+	if got, _ := rep["total_retries"].(float64); int(got) != 2 {
+		t.Errorf("total_retries = %v, want 2", rep["total_retries"])
+	}
+}
+
+// TestSessionEndOmitsAbsentRetryReport pins the other half: a run with nothing to
+// report must leave the field out entirely rather than write an empty object,
+// which a reader would otherwise have to distinguish from a real report.
+func TestSessionEndOmitsAbsentRetryReport(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "test-model", SessionOptions{ReviewMode: ReviewModeWorkspace})
+
+	if err := sh.Finalize(); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	endRec := sessionEndRecord(t, repoDir, sh.SessionID)
+	if _, present := endRec["llm_retry_report"]; present {
+		t.Errorf("llm_retry_report present without a frozen report: %v", endRec["llm_retry_report"])
+	}
+}
+
+func sessionEndRecord(t *testing.T, repoDir, sessionID string) map[string]any {
+	t.Helper()
+	for _, r := range readJSONLRecords(t, sessionJSONLPath(t, repoDir, sessionID)) {
+		if r["type"] == "session_end" {
+			return r
+		}
+	}
+	t.Fatal("no session_end record found")
+	return nil
+}

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -64,6 +64,10 @@ type SessionHistory struct {
 	// Finalize, embedded into session_end and exposed to the CLI. Nil for
 	// legacy/scan runs.
 	finalManifest *RunManifest
+	// finalRetryReport is the frozen retry report handed back by the agent before
+	// Finalize and embedded into session_end. Nil is the common case: Freeze
+	// withholds a report unless something retried, failed or was cancelled.
+	finalRetryReport *llm.RetryReport
 	// persistInitErr records a failure to create the JSONL writer. The run may
 	// still produce a manifest for CLI output, but Finalize must report that the
 	// persisted-session outlet was never available.
@@ -219,6 +223,19 @@ func (sh *SessionHistory) FinalManifest() *RunManifest {
 	return &m
 }
 
+// SetFinalRetryReport stores the frozen retry report the agent produced, which
+// Finalize embeds into session_end. Passing nil leaves the field out, which is
+// what a run with nothing to report looks like. The report is frozen before it
+// gets here and never mutated, so it is stored by pointer rather than cloned.
+func (sh *SessionHistory) SetFinalRetryReport(r *llm.RetryReport) {
+	if sh == nil {
+		return
+	}
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.finalRetryReport = r
+}
+
 // HasPersistence reports whether this session has a JSONL writer. A false value
 // means no resumable session file exists, even though the run still has its own
 // in-memory ID and may produce a CLI manifest.
@@ -324,6 +341,7 @@ func (sh *SessionHistory) Finalize() error {
 		p := sh.persist
 		persistInitErr := sh.persistInitErr
 		manifest := sh.finalManifest
+		retryReport := sh.finalRetryReport
 		duration := sh.EndTime.Sub(sh.StartTime)
 		filesReviewed := make([]string, 0, len(sh.FileSessions))
 		for fp := range sh.FileSessions {
@@ -341,7 +359,7 @@ func (sh *SessionHistory) Finalize() error {
 		// result is cached in finalizeErr. sync.Once guarantees every other
 		// caller blocks until this completes, then reads the same finalizeErr.
 		if p != nil {
-			sh.finalizeErr = p.WriteSessionEnd(duration, filesReviewed, failures, manifest)
+			sh.finalizeErr = p.WriteSessionEnd(duration, filesReviewed, failures, manifest, retryReport)
 		}
 	})
 	return sh.finalizeErr

--- a/internal/session/persist.go
+++ b/internal/session/persist.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/model"
 )
 
@@ -355,12 +356,13 @@ func (jw *jsonlWriter) WriteResumeLineage(l *ResumeLineage) string {
 }
 
 // WriteSessionEnd writes the final session_end summary record and closes the
-// file. When manifest is non-nil it is embedded under "run_manifest"; session_end
-// is the last physical record of the stream and no separate run_manifest record
-// is appended. The record is flushed before the file is closed. Any marshal,
-// flush or close error is returned so the caller can surface it as a delivery
-// error rather than silently losing the manifest.
-func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []string, llmFailures int64, manifest *RunManifest) error {
+// file. When manifest is non-nil it is embedded under "run_manifest", and when
+// retryReport is non-nil under "llm_retry_report"; session_end is the last
+// physical record of the stream and neither gets a record of its own. A nil
+// retryReport is the normal case, not a loss. The record is flushed before the
+// file is closed. Any marshal, flush or close error is returned so the caller can
+// surface it as a delivery error rather than silently losing the manifest.
+func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []string, llmFailures int64, manifest *RunManifest, retryReport *llm.RetryReport) error {
 	uuid := generateUUID()
 
 	jw.mu.Lock()
@@ -377,6 +379,9 @@ func (jw *jsonlWriter) WriteSessionEnd(duration time.Duration, filesReviewed []s
 	}
 	if manifest != nil {
 		rec["run_manifest"] = manifest
+	}
+	if retryReport != nil {
+		rec["llm_retry_report"] = retryReport
 	}
 	jw.lastUUID = uuid
 


### PR DESCRIPTION
## Description

Retry reports are currently available only in the CLI output. They are frozen after `Agent.Run` returns, but `session_end` is written inside `Agent.Run`, so the report is unavailable when the session is finalized.

This PR persists the existing retry report in `session_end.llm_retry_report`:

- passes the per-run `RetryCollector` to the review agent;
- freezes the report before session finalization on every terminal path;
- waits for background requests before freezing on the normal path;
- stores the optional report in `SessionHistory` and embeds it in `session_end`;
- keeps the CLI's existing post-run `Freeze` and output path unchanged;
- omits `llm_retry_report` for clean runs with nothing to report;
- suppresses invalid reports without changing warnings, terminal state, or exit code.

`RetryCollector.Freeze` remains a deterministic read. The agent and CLI take independent snapshots with the same run ID, and tests verify that their serialized values are equal.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

Additional verification:

- `make check`
- full test suite with race detection
- retry report is embedded in `session_end`
- absent reports are omitted rather than serialized as empty objects
- persisted and CLI-equivalent snapshots are fully equal
- invalid reports are suppressed without entering `Run` errors or agent warnings
- nil collector paths remain unchanged

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation is not required because this reuses the existing retry report schema
