### PR TITLE
fix(tool): prevent path traversal bypass and normalize paths in code_search and code_comment

### DIFF
--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/alibaba/open-code-review/internal/model"
@@ -123,11 +124,11 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 		if severity, ok := obj["severity"].(string); ok {
 			cm.Severity = normalizeCodeCommentSeverity(severity)
 		}
-		if path, ok := obj["path"].(string); ok && path != "" {
-			cm.Path = path
+		if pathVal, ok := obj["path"].(string); ok && pathVal != "" {
+			cm.Path = normalizeCommentPath(pathVal)
 		}
 		if cm.Path == "" {
-			cm.Path = defaultPath
+			cm.Path = normalizeCommentPath(defaultPath)
 		}
 
 		if cm.Path == "" || cm.Content == "" {
@@ -137,6 +138,18 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 		comments = append(comments, cm)
 	}
 	return comments, ""
+}
+
+func normalizeCommentPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = path.Clean(p)
+	if p == "." {
+		return ""
+	}
+	return strings.TrimPrefix(p, "/")
 }
 
 func normalizeCodeCommentCategory(category string) string {

--- a/internal/tool/code_comment_test.go
+++ b/internal/tool/code_comment_test.go
@@ -342,3 +342,22 @@ func TestCodeCommentProvider_Execute(t *testing.T) {
 		}
 	})
 }
+
+func TestParseComments_NormalizePath(t *testing.T) {
+	args := map[string]any{
+		"comments": []any{
+			map[string]any{"path": `pkg\util.go`, "content": "fix 1"},
+			map[string]any{"path": `./pkg/util.go`, "content": "fix 2"},
+			map[string]any{"path": `pkg/sub//util.go`, "content": "fix 3"},
+		},
+	}
+	comments, errMsg := ParseComments(args)
+	if errMsg != "" || len(comments) != 3 {
+		t.Fatalf("ParseComments failed: err=%q len=%d", errMsg, len(comments))
+	}
+	for i, want := range []string{"pkg/util.go", "pkg/util.go", "pkg/sub/util.go"} {
+		if comments[i].Path != want {
+			t.Errorf("comment[%d].Path = %q, want %q", i, comments[i].Path, want)
+		}
+	}
+}

--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -40,7 +40,7 @@ func (p *CodeSearchProvider) Execute(ctx context.Context, args map[string]any) (
 			if hasTraversalPathComponent(s) {
 				return "Error: file_patterns must not contain ..", nil
 			}
-			patterns = append(patterns, s)
+			patterns = append(patterns, strings.ReplaceAll(s, "\\", "/"))
 		}
 	}
 
@@ -99,7 +99,8 @@ func (p *CodeSearchProvider) buildGrepArgs(searchText string, caseSensitive bool
 }
 
 func hasTraversalPathComponent(pathspec string) bool {
-	for _, part := range strings.Split(pathspec, "/") {
+	norm := strings.ReplaceAll(pathspec, "\\", "/")
+	for _, part := range strings.Split(norm, "/") {
 		if part == ".." {
 			return true
 		}

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -437,15 +437,27 @@ func TestCodeSearchProvider_Execute_WithFilePatterns(t *testing.T) {
 	dir := setupTestRepo(t)
 	p := NewCodeSearch(&FileReader{RepoDir: dir, Mode: ModeWorkspace})
 
-	got, err := p.Execute(context.Background(), map[string]any{
-		"search_text":   "Util",
-		"file_patterns": []any{"pkg/"},
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "forward slash", pattern: "pkg/"},
+		{name: "backslash", pattern: "pkg\\"},
 	}
-	if !strings.Contains(got, "util.go") {
-		t.Errorf("expected util.go in result, got: %s", got)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := p.Execute(context.Background(), map[string]any{
+				"search_text":   "Util",
+				"file_patterns": []any{test.pattern},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, "util.go") {
+				t.Errorf("expected util.go for pattern %q, got: %s", test.pattern, got)
+			}
+		})
 	}
 }
 

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -460,6 +460,9 @@ func TestCodeSearchProvider_Execute_RejectsTraversalPattern(t *testing.T) {
 		{name: "leading parent", pattern: "../pkg", want: "Error: file_patterns must not contain .."},
 		{name: "middle parent", pattern: "pkg/../internal", want: "Error: file_patterns must not contain .."},
 		{name: "trailing parent", pattern: "pkg/..", want: "Error: file_patterns must not contain .."},
+		{name: "leading parent backslash", pattern: `..\pkg`, want: "Error: file_patterns must not contain .."},
+		{name: "middle parent backslash", pattern: `pkg\..\internal`, want: "Error: file_patterns must not contain .."},
+		{name: "trailing parent backslash", pattern: `pkg\..`, want: "Error: file_patterns must not contain .."},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

This PR fixes two cross-platform path handling issues in `internal/tool`:

1. **Fix path traversal bypass & normalize pathspecs in `code_search`**:
   - `hasTraversalPathComponent` now normalizes backslashes `\` to `/` before splitting on `/`, preventing traversal sequences like `..\pkg` or `pkg\..\internal` from bypassing the `..` safety check.
   - Normalizes `file_patterns` items from `\` to `/` before passing them to `git grep` so pathspec matching works consistently on all platforms.

2. **Normalize comment paths in `code_comment`**:
   - `parseCommentsInner` now canonicalizes comment paths (`\` to `/`, stripping leading `./`, resolving `.`, and trimming redundant slashes via `normalizeCommentPath`).
   - Ensures that review comments produced with Windows backslashes or leading `./` correctly match `CommentCollector.CommentsForPath(d.NewPath)` during review compilation instead of being silently dropped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- Added `TestParseComments_NormalizePath` in `internal/tool/code_comment_test.go` to verify normalization of `\`, `./`, and redundant slashes.
- Added backslash test cases to `TestCodeSearchProvider_Execute_RejectsTraversalPattern` in `internal/tool/code_search_test.go`.
- Verified targeted unit tests and full package tests pass cleanly (`go test -v ./internal/tool/...`).

- [x] `make test` passes locally
- [x] Unit tests pass locally

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1088
