### PR TITLE
fix(viewer): report selected files from run manifest

### DIFF
--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -328,8 +328,17 @@ func (sh *SessionHistory) Finalize() error {
 		manifest := sh.finalManifest
 		duration := sh.EndTime.Sub(sh.StartTime)
 		filesReviewed := make([]string, 0, len(sh.FileSessions))
-		for fp := range sh.FileSessions {
-			filesReviewed = append(filesReviewed, fp)
+		if manifest != nil && manifest.SchemaVersion == ManifestSchemaVersion {
+			filesReviewed = make([]string, 0, len(manifest.Coverage.Selected))
+			for _, item := range manifest.Coverage.Selected {
+				filesReviewed = append(filesReviewed, item.Path)
+			}
+		} else {
+			// Legacy and scan sessions have no manifest, so retain the historical
+			// all-FileSessions behavior for their summary record.
+			for fp := range sh.FileSessions {
+				filesReviewed = append(filesReviewed, fp)
+			}
 		}
 		failures := atomic.LoadInt64(&sh.llmFailures)
 		sh.mu.Unlock()

--- a/internal/session/history_test.go
+++ b/internal/session/history_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
@@ -69,6 +70,50 @@ func TestGetOrCreateFileSession(t *testing.T) {
 	fs3 := sh.GetOrCreateFileSession("other.go")
 	if fs3 == fs1 {
 		t.Error("different paths should yield different sessions")
+	}
+}
+
+func TestFinalizeFilesReviewedUsesManifestSelectedPaths(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "model", SessionOptions{Operation: "review"})
+	sh.SetFinalManifest(&RunManifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Coverage: Coverage{Selected: []CoverageItem{
+			{ItemID: "a", Path: "a.go"},
+			{ItemID: "b", Path: "b.go"},
+			{ItemID: "c", Path: "c.go"},
+		}},
+	})
+
+	// c.go deliberately has no FileSession: the manifest, not the conversation
+	// scope registry, is authoritative for the selected file list.
+	for _, key := range []string{"__grouping__", "a.go,b.go", "a.go", "b.go"} {
+		sh.GetOrCreateFileSession(key)
+	}
+	if err := sh.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var got []string
+	for _, rec := range records {
+		if rec["type"] != "session_end" {
+			continue
+		}
+		for _, raw := range rec["files_reviewed"].([]any) {
+			got = append(got, raw.(string))
+		}
+	}
+	sort.Strings(got)
+	want := []string{"a.go", "b.go", "c.go"}
+	if len(got) != len(want) {
+		t.Fatalf("files_reviewed = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("files_reviewed = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/internal/viewer/store.go
+++ b/internal/viewer/store.go
@@ -618,6 +618,7 @@ func applySessionEnd(summary *SessionSummary, rec map[string]any) {
 			if err := json.Unmarshal(data, &manifest); err == nil && manifest.SchemaVersion == session.ManifestSchemaVersion {
 				summary.RunManifest = &manifest
 				summary.TerminalState = string(manifest.TerminalState)
+				summary.FilesReviewed = filesReviewedFromSelected(manifest.Coverage.Selected)
 				summary.SelectedCount = len(manifest.Coverage.Selected)
 				summary.CompletedCount = len(manifest.Coverage.Completed)
 				summary.ReusedCount = len(manifest.Coverage.Reused)
@@ -631,6 +632,14 @@ func applySessionEnd(summary *SessionSummary, rec map[string]any) {
 		summary.Legacy = true
 		summary.FileCount = len(summary.FilesReviewed)
 	}
+}
+
+func filesReviewedFromSelected(selected []session.CoverageItem) []string {
+	files := make([]string, 0, len(selected))
+	for _, item := range selected {
+		files = append(files, item.Path)
+	}
+	return files
 }
 
 func taskDoneSucceeded(arguments string) bool {

--- a/internal/viewer/store_load_test.go
+++ b/internal/viewer/store_load_test.go
@@ -280,7 +280,7 @@ func TestLoadSessionReadsV1Manifest(t *testing.T) {
 	}
 	writeJSONL(t, filepath.Join(repoDir, "manifest.jsonl"),
 		`{"type":"session_start","timestamp":"2025-01-01T00:00:00Z","cwd":"/x","model":"m"}`,
-		`{"type":"session_end","duration_seconds":1,"run_manifest":{"schema_version":"ocr.run-manifest/v1","run_id":"run-1","operation":"review","terminal_state":"complete","repository":{},"input":{"mode":"workspace"},"execution":{},"coverage":{"selected":[{"item_id":"a","path":"a.go"},{"item_id":"b","path":"b.go"}],"completed":[{"item_id":"a","path":"a.go"}],"reused":[{"item_id":"b","path":"b.go"}],"failed":[],"waived":[]},"elapsed_ms":1000}}`)
+		`{"type":"session_end","duration_seconds":1,"files_reviewed":["__grouping__","a.go,b.go","a.go"],"run_manifest":{"schema_version":"ocr.run-manifest/v1","run_id":"run-1","operation":"review","terminal_state":"complete","repository":{},"input":{"mode":"workspace"},"execution":{},"coverage":{"selected":[{"item_id":"a","path":"a.go"},{"item_id":"b","path":"b.go"}],"completed":[{"item_id":"a","path":"a.go"}],"reused":[{"item_id":"b","path":"b.go"}],"failed":[],"waived":[]},"elapsed_ms":1000}}`)
 
 	vs, err := LoadSession(root, "repo", "manifest")
 	if err != nil {
@@ -291,6 +291,9 @@ func TestLoadSessionReadsV1Manifest(t *testing.T) {
 	}
 	if vs.Summary.CompletedCount != 1 || vs.Summary.ReusedCount != 1 || vs.Summary.FailedCount != 0 || vs.Summary.WaivedCount != 0 {
 		t.Fatalf("coverage counts = %+v", vs.Summary)
+	}
+	if got := vs.Summary.FilesReviewed; len(got) != 2 || got[0] != "a.go" || got[1] != "b.go" {
+		t.Fatalf("files reviewed = %v, want [a.go b.go]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- use the v1 run manifest as the authoritative source for files_reviewed
- prevent grouping and composite conversation keys from appearing as reviewed files
- correct existing session displays in Viewer without rewriting JSONL files
- preserve existing behavior for legacy and scan sessions without a manifest

## Testing

- make check
- make test
- OCR review: 0 findings