### PR TITLE
docs(skill): prefer --output flag over shell redirection

### DIFF
--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -51,7 +51,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
-- **Output file**: use `--output <path>` or `-o <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
+- **Output file**: use `--output <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
 
 **Common invocation patterns:**

--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -51,6 +51,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
+- **Output file**: use `--output <path>` or `-o <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
 
 **Common invocation patterns:**
@@ -65,7 +66,7 @@ ocr review --audience agent --background "business context here" [user-args]
 **Output mode:**
 
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
-- **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
+- **Prevent output truncation**: For large reviews or restricted tool environments, pass `--output /tmp/ocr_out.txt` and inspect the file in full via a file reading tool instead of piping stdout through `tail` or `head`, which drops earlier review comments.
 
 **On failure:** If `ocr review` exits non-zero (e.g. an LLM connection error), do not retry blindly — consult the Troubleshooting section below for the matching fix before re-running.
 
@@ -179,7 +180,7 @@ ocr rules check src/main/java/com/example/Foo.java
 - **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
 - **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
 - **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
-- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Redirect output to a file and read it in full.
+- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Use `--output <path>` and read it in full; on older CLIs, follow the **Output file** guidance above.
 
 ## Validation
 
@@ -200,6 +201,10 @@ Install the CLI:
 ```bash
 npm install -g @alibaba-group/open-code-review
 ```
+
+**`unknown flag: --output`**
+
+The CLI is older than v1.10.0. Do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 
 **`ocr review` fails with LLM connection error**
 

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -46,6 +46,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
+- **Output file**: use `--output <path>` or `-o <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
 
 **Common invocation patterns:**
@@ -60,7 +61,7 @@ ocr review --audience agent --background "business context here" [user-args]
 **Output mode:**
 
 - Always use `--audience agent` to suppress progress UI and emit only the final summary
-- **Prevent output truncation**: For large reviews or restricted tool environments, redirect output to a temporary file (`ocr review --audience agent ... > /tmp/ocr_out.txt 2>&1`) and inspect it in full via a file reading tool instead of piping through `tail` or `head`, which drops earlier review comments.
+- **Prevent output truncation**: For large reviews or restricted tool environments, pass `--output /tmp/ocr_out.txt` and inspect the file in full via a file reading tool instead of piping stdout through `tail` or `head`, which drops earlier review comments.
 
 **On failure:** If `ocr review` exits non-zero (e.g. an LLM connection error), do not retry blindly — consult the Troubleshooting section below for the matching fix before re-running.
 
@@ -174,7 +175,7 @@ ocr rules check src/main/java/com/example/Foo.java
 - **Plan phase triggers at 50 lines** — diffs exceeding 50 changed lines run an extra risk-analysis phase before main review. This adds latency but improves quality.
 - **Don't pass `--audience human`** — it streams progress UI that pollutes output. Always use `--audience agent`.
 - **Comment language follows config** — set `language` config to `English` or `Chinese` (default: Chinese) to control review comment language.
-- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Redirect output to a file and read it in full.
+- **Avoid output truncation** — Large review runs produce verbose output. Never pipe command output to `tail` or `head` as it drops review comments from earlier sections. Use `--output <path>` and read it in full; on older CLIs, follow the **Output file** guidance above.
 
 ## Validation
 
@@ -195,6 +196,10 @@ Install the CLI:
 ```bash
 npm install -g @alibaba-group/open-code-review
 ```
+
+**`unknown flag: --output`**
+
+The CLI is older than v1.10.0. Do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 
 **`ocr review` fails with LLM connection error**
 

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -46,7 +46,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
-- **Output file**: use `--output <path>` or `-o <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
+- **Output file**: use `--output <path>` to write the full result to a file instead of stdout. If the command fails with `unknown flag: --output`, do not continue the review with plain stdout. Ask the user whether to upgrade (`npm i -g @alibaba-group/open-code-review@latest`) and wait for the answer before proceeding. After the user confirms and the upgrade succeeds, rerun with `--output`.
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`
 
 **Common invocation patterns:**


### PR DESCRIPTION
## Description

The agent skill taught shell redirection (`> /tmp/ocr_out.txt 2>&1`) as the way to avoid losing review comments to tool-output truncation. Since #852 (v1.10.0), `ocr review` natively supports `--output <path>` / `-o`, which writes results directly to a UTF-8 file and fits agents better than shell redirection.

This PR updates the skill in four places, in both the canonical and the plugin mirror copy.

- Register `--output` / `-o` in the Argument handling catalog, with an upgrade gate for older CLIs (on `unknown flag: --output`, stop the review and ask the user before upgrading with `@latest`; never fall back to redirection or plain stdout silently)
- Switch the Output mode guidance to `--output`, and align the Gotchas reminder with it
- Add an `unknown flag: --output` Troubleshooting entry that mirrors the gate

Documentation only, no code changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Verified both SKILL.md copies stay identical except the intentional mirror note, the flag descriptions match the CLI help and the cli-reference docs, and line endings are LF. Also tested end-to-end with Claude Opus 4.6, which followed the updated skill and used `--output` for the review run. On an older CLI (pre-v1.10.0), the agent stopped the review and asked whether to upgrade instead of silently falling back to stdout.

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Follow-up to #852 (the `--output` flag).