### PR TITLE
chore(skill): remove Prerequisites section from delegate SKILL.md

### DIFF
--- a/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review-delegate/SKILL.md
@@ -27,20 +27,6 @@ installs may only materialize the plugin subtree.
 
 A skill for performing AI code review where OCR provides deterministic engineering (file filtering, rule resolution) and the host agent performs the actual review using its own intelligence and tools.
 
-## Prerequisites
-
-```bash
-which ocr || echo "NOT INSTALLED"
-```
-
-If `ocr` is not installed:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
-No LLM configuration is needed for delegation mode.
-
 ## Workflow
 
 ### Step 1: Preview — Determine What to Review

--- a/skills/open-code-review-delegate/SKILL.md
+++ b/skills/open-code-review-delegate/SKILL.md
@@ -22,20 +22,6 @@ metadata:
 
 A skill for performing AI code review where OCR provides deterministic engineering (file filtering, rule resolution) and the host agent performs the actual review using its own intelligence and tools.
 
-## Prerequisites
-
-```bash
-which ocr || echo "NOT INSTALLED"
-```
-
-If `ocr` is not installed:
-
-```bash
-npm install -g @alibaba-group/open-code-review
-```
-
-No LLM configuration is needed for delegation mode.
-
 ## Workflow
 
 ### Step 1: Preview — Determine What to Review


### PR DESCRIPTION
## Summary

- Removes the `## Prerequisites` section from `open-code-review-delegate` SKILL.md in both `skills/` and `plugins/` directories.
- The prerequisite check (`which ocr`) and install instructions are unnecessary in the skill body — installation guidance already exists in the frontmatter `compatibility` field and the project README.

## Test plan

- [ ] Verify the skill still loads correctly without the Prerequisites section
- [ ] Confirm `ocr delegate preview` workflow instructions remain intact