### PR TITLE
fix(diff): stop emitting comments whose quote matches no reviewed file

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -976,7 +976,10 @@ func TestDispatchSubtasks_WithFakeLLM(t *testing.T) {
 	})
 
 	a.diffs = []model.Diff{
-		{NewPath: "main.go", OldPath: "main.go", Diff: "+new line", Insertions: 1},
+		// The quoted code must exist in the diff: an unresolvable quote is
+		// dropped by the comment emission gate, which this plumbing test is
+		// not about.
+		{NewPath: "main.go", OldPath: "main.go", Diff: "@@ -0,0 +1,1 @@\n+    foo := bar.Baz()\n", Insertions: 1},
 	}
 	a.currentDate = "2025-06-26 10:00"
 

--- a/internal/diff/resolver.go
+++ b/internal/diff/resolver.go
@@ -72,6 +72,84 @@ func ResolveComment(cm *model.LlmComment, d *model.Diff) bool {
 	return resolveFromFileContent(d, cm)
 }
 
+// HasAnchorableQuote reports whether the comment carries a quote that could
+// ever anchor it: ExistingCode with at least one non-blank normalized line.
+// Degenerate quotes — a bare code fence, blank text — normalize to zero lines
+// and are treated as no evidence; a comment carrying one is general advice
+// rather than a located finding.
+func HasAnchorableQuote(cm *model.LlmComment) bool {
+	if cm == nil {
+		return false
+	}
+	return len(splitAndNormalize(cm.ExistingCode)) > 0
+}
+
+// plausibilityMinLineLen is the minimum normalized length a quote line must
+// reach before it can count as evidence that the quote belongs to a diff.
+// Boilerplate like "{", "}" or "return;" appears in every file and would make
+// any quote "plausible" anywhere.
+const plausibilityMinLineLen = 8
+
+// QuotePlausiblyInDiff reports whether the comment's quote shares at least one
+// non-trivial line with the diff — under exact normalized comparison or the
+// whitespace-eliding tier — across new-side hunks, old-side hunks, and the
+// full new-file content.
+//
+// It gates the LLM re-location step: that step is handed only the claimed
+// file's diff, so when the quote shares nothing with that file the model can
+// only answer with whatever looks closest (see RelocateAcrossFiles' doc for
+// the false-anchor that produces). A quote that genuinely belongs to the file
+// still shares lines with it even when drifted, so the rescue stays available
+// exactly where it can help. The predicate is deliberately weaker than full
+// resolution: one shared line is evidence of belonging, not a location.
+func QuotePlausiblyInDiff(cm *model.LlmComment, d *model.Diff) bool {
+	if cm == nil || d == nil {
+		return false
+	}
+	nonTrivial := make([]string, 0, 4)
+	for _, line := range splitAndNormalize(cm.ExistingCode) {
+		if len(line) >= plausibilityMinLineLen {
+			nonTrivial = append(nonTrivial, line)
+		}
+	}
+	if len(nonTrivial) == 0 {
+		return false
+	}
+
+	exact := make(map[string]struct{})
+	elided := make(map[string]struct{})
+	addLine := func(line string) {
+		if line == "" {
+			return
+		}
+		exact[line] = struct{}{}
+		elided[elideLine(line)] = struct{}{}
+	}
+	hunks := ParseHunks(d.Diff)
+	for i := range hunks {
+		for _, side := range []bool{true, false} {
+			for _, il := range extractSideLines(&hunks[i], side) {
+				addLine(il.content)
+			}
+		}
+	}
+	if d.NewFileContent != "" {
+		for _, line := range strings.Split(d.NewFileContent, "\n") {
+			addLine(normalizeLine(line))
+		}
+	}
+
+	for _, line := range nonTrivial {
+		if _, ok := exact[line]; ok {
+			return true
+		}
+		if _, ok := elided[elideLine(line)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // RelocateAcrossFiles handles the comment whose ExistingCode belongs to a
 // different file than the one it was filed against.
 //
@@ -147,7 +225,10 @@ type indexedLine struct {
 // resolveFromHunk tries to find startLine/endLine by matching ExistingCode
 // against hunk lines. It tries the new-side first (context + added lines →
 // new-file line numbers), then falls back to old-side (context + deleted →
-// old-file line numbers).
+// old-file line numbers). Each pass is then repeated with a whitespace-eliding
+// second-chance tier (see elideLine): all exact passes across both sides
+// outrank all loose passes, so any match the previous exact-only order
+// produced is still produced with the same anchor.
 func resolveFromHunk(d *model.Diff, cm *model.LlmComment) bool {
 	hunks := ParseHunks(d.Diff)
 	if len(hunks) == 0 {
@@ -159,21 +240,29 @@ func resolveFromHunk(d *model.Diff, cm *model.LlmComment) bool {
 		return false
 	}
 
-	for i := range hunks {
-		newSide := extractSideLines(&hunks[i], true)
-		if start, end, ok := matchConsecutive(newSide, targetLines); ok {
-			cm.StartLine = start
-			cm.EndLine = end
-			return true
+	for _, xform := range []func(string) string{identityLine, elideLine} {
+		// The target set is fixed for the whole tier; transform it once here
+		// instead of once per hunk per side.
+		targets := make([]string, len(targetLines))
+		for i, t := range targetLines {
+			targets[i] = xform(t)
 		}
-	}
+		for i := range hunks {
+			newSide := extractSideLines(&hunks[i], true)
+			if start, end, ok := matchConsecutivePrepared(newSide, targets, xform); ok {
+				cm.StartLine = start
+				cm.EndLine = end
+				return true
+			}
+		}
 
-	for i := range hunks {
-		oldSide := extractSideLines(&hunks[i], false)
-		if start, end, ok := matchConsecutive(oldSide, targetLines); ok {
-			cm.StartLine = start
-			cm.EndLine = end
-			return true
+		for i := range hunks {
+			oldSide := extractSideLines(&hunks[i], false)
+			if start, end, ok := matchConsecutivePrepared(oldSide, targets, xform); ok {
+				cm.StartLine = start
+				cm.EndLine = end
+				return true
+			}
 		}
 	}
 
@@ -213,21 +302,36 @@ func extractSideLines(hunk *Hunk, newSide bool) []indexedLine {
 	return result
 }
 
-// matchConsecutive scans sideLines for a consecutive run matching all targetLines.
+// matchConsecutive scans sideLines for a consecutive run matching all
+// targetLines, comparing normalized lines exactly. identityLine leaves lines
+// unchanged, so the targets need no up-front transformation.
 func matchConsecutive(sideLines []indexedLine, targetLines []string) (startLine, endLine int, found bool) {
-	if len(targetLines) == 0 || len(sideLines) < len(targetLines) {
+	return matchConsecutivePrepared(sideLines, targetLines, identityLine)
+}
+
+// matchConsecutivePrepared scans sideLines for a consecutive run matching all
+// preparedTargets, which the caller has already run through xform — one
+// target set is reused across every hunk and both sides in resolveFromHunk,
+// so it is transformed once per tier instead of once per call. Side lines are
+// transformed here, once per call.
+func matchConsecutivePrepared(sideLines []indexedLine, preparedTargets []string, xform func(string) string) (startLine, endLine int, found bool) {
+	if len(preparedTargets) == 0 || len(sideLines) < len(preparedTargets) {
 		return 0, 0, false
 	}
-	for i := 0; i <= len(sideLines)-len(targetLines); i++ {
+	sides := make([]string, len(sideLines))
+	for i, l := range sideLines {
+		sides[i] = xform(l.content)
+	}
+	for i := 0; i <= len(sides)-len(preparedTargets); i++ {
 		matched := true
-		for j, target := range targetLines {
-			if sideLines[i+j].content != target {
+		for j, target := range preparedTargets {
+			if sides[i+j] != target {
 				matched = false
 				break
 			}
 		}
 		if matched {
-			return sideLines[i].lineNum, sideLines[i+len(targetLines)-1].lineNum, true
+			return sideLines[i].lineNum, sideLines[i+len(preparedTargets)-1].lineNum, true
 		}
 	}
 	return 0, 0, false
@@ -264,10 +368,29 @@ func resolveFromFileContent(d *model.Diff, cm *model.LlmComment) bool {
 		return false
 	}
 
-	for i := 0; i <= len(normalizedFileLines)-len(targetLines); i++ {
+	for _, xform := range []func(string) string{identityLine, elideLine} {
+		if matchFileContentWindow(normalizedFileLines, fileLineNums, targetLines, xform, cm) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchFileContentWindow scans normalized file lines for a consecutive run
+// matching all target lines under xform, binding cm's lines on success.
+func matchFileContentWindow(normalizedFileLines []string, fileLineNums []int, targetLines []string, xform func(string) string, cm *model.LlmComment) bool {
+	if len(targetLines) == 0 || len(normalizedFileLines) < len(targetLines) {
+		return false
+	}
+	targets := make([]string, len(targetLines))
+	for i, t := range targetLines {
+		targets[i] = xform(t)
+	}
+	for i := 0; i <= len(normalizedFileLines)-len(targets); i++ {
 		matched := true
-		for j, target := range targetLines {
-			if normalizedFileLines[i+j] != target {
+		for j, target := range targets {
+			if xform(normalizedFileLines[i+j]) != target {
 				matched = false
 				break
 			}
@@ -278,7 +401,6 @@ func resolveFromFileContent(d *model.Diff, cm *model.LlmComment) bool {
 			return true
 		}
 	}
-
 	return false
 }
 
@@ -303,4 +425,14 @@ func normalizeLine(s string) string {
 	s = strings.TrimPrefix(s, "+")
 	s = strings.TrimPrefix(s, "-")
 	return strings.TrimSpace(s)
+}
+
+// identityLine is the exact-tier comparison: the normalized line as-is.
+func identityLine(s string) string { return s }
+
+// elideLine is the loose-tier comparison: the line with ALL whitespace
+// removed, so quotes that differ only in internal spacing (`id );` vs `id)`)
+// still match. Lines differing in any non-whitespace character never match.
+func elideLine(s string) string {
+	return strings.Join(strings.Fields(s), "")
 }

--- a/internal/diff/resolver_test.go
+++ b/internal/diff/resolver_test.go
@@ -878,3 +878,54 @@ func TestResolveLineNumbers_DiffMarkerInExistingCode(t *testing.T) {
 		t.Errorf("diff marker in existing_code: expected 2..2, got %d..%d", cm.StartLine, cm.EndLine)
 	}
 }
+
+func TestResolveLineNumbers_InternalWhitespaceElidingTier(t *testing.T) {
+	diffs := []model.Diff{
+		{NewPath: "pkg/example/handler.go", Diff: testDiff},
+	}
+	// The quote drifts from the file by one internal space (`"request: %s"`
+	// vs `"request:%s"`-class drift): `Printf("handling request: %s", ...)`).
+	// Only the whitespace-eliding tier can place it.
+	comments := []model.LlmComment{
+		{Path: "pkg/example/handler.go", ExistingCode: `    log.Printf("handling request: %s" , r.URL.Path)`},
+	}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	// The added Printf line is new-side line 11 in the hunk.
+	if cm.StartLine != 11 || cm.EndLine != 11 {
+		t.Errorf("eliding tier: expected 11..11, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveFromFileContent_InternalWhitespaceElidingTier(t *testing.T) {
+	content := "line one\nvalue := compute( a, b )\nline three\n"
+	diffs := []model.Diff{
+		{NewPath: "file.go", NewFileContent: content},
+	}
+	comments := []model.LlmComment{
+		{Path: "file.go", ExistingCode: "value := compute(a,b)"},
+	}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 2 || cm.EndLine != 2 {
+		t.Errorf("eliding tier over file content: expected 2..2, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}
+
+func TestResolveLineNumbers_NonWhitespaceDifferenceStillFails(t *testing.T) {
+	content := "int x = 1;\nint y = 2;\n"
+	diffs := []model.Diff{
+		{NewPath: "file.go", NewFileContent: content},
+	}
+	comments := []model.LlmComment{
+		{Path: "file.go", ExistingCode: "int x = 2;"},
+	}
+
+	result := ResolveLineNumbers(comments, diffs)
+	cm := result[0]
+	if cm.StartLine != 0 || cm.EndLine != 0 {
+		t.Errorf("materially different line must stay unresolved, got %d..%d", cm.StartLine, cm.EndLine)
+	}
+}

--- a/internal/llmloop/comment_anchor_integrity_test.go
+++ b/internal/llmloop/comment_anchor_integrity_test.go
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package llmloop
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/config/template"
+	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/model"
+	"github.com/alibaba/open-code-review/internal/session"
+	"github.com/alibaba/open-code-review/internal/tool"
+)
+
+// These tests characterize issue #746: a comment whose quoted code belongs to a
+// different file than the one it was filed against is emitted verbatim with the
+// wrong path at start_line 0 / end_line 0 once every resolution stage declines.
+
+const pomXMLPath = "pom.xml"
+const javaPath = "src/main/java/com/qz/onboard/pojo/DevOpsResource.java"
+
+const pomXMLContent = `<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.qz.onboard</groupId>
+</project>
+`
+
+const pomXMLDiff = `--- a/pom.xml
++++ b/pom.xml
+@@ -1,3 +1,4 @@
+ <project>
++  <modelVersion>4.0.0</modelVersion>
+   <groupId>com.qz.onboard</groupId>
+ </project>
+`
+
+const javaContent = `package com.qz.onboard.pojo;
+
+public class DevOpsResource {
+    private Long id;
+    private String resourceId;
+
+    public String toString() {
+        System.out.println("id=" + id);
+        System.out.println("resourceId=" + resourceId);
+        System.out.println("name=" + name);
+        return "DevOpsResource";
+    }
+}
+`
+
+// driftedJavaQuote quotes javaContent with one internal-whitespace drift
+// (`id );` instead of `id);`) — the shape reported in issue #746.
+const driftedJavaQuote = `    public String toString() {
+        System.out.println("id=" + id );
+        System.out.println("resourceId=" + resourceId);
+        System.out.println("name=" + name);
+`
+
+func anchorTestDiff(path, diffText, content string) model.Diff {
+	return model.Diff{OldPath: path, NewPath: path, Diff: diffText, NewFileContent: content}
+}
+
+func anchorTestRunner(collector *tool.CommentCollector, diffs []model.Diff, client llm.LLMClient, reLocation bool) *Runner {
+	byPath := make(map[string]*model.Diff, len(diffs))
+	for i := range diffs {
+		byPath[diffs[i].NewPath] = &diffs[i]
+	}
+	tpl := template.Template{MaxTokens: 100000, MaxToolRequestTimes: 10}
+	if reLocation {
+		tpl.ReLocationTask = &template.LlmConversation{
+			Messages: []template.ChatMessage{{Role: "user", Content: "locate {existing_code} in {diff}"}},
+		}
+	}
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+	return NewRunner(Deps{
+		LLMClient:        client,
+		Model:            "fake",
+		Template:         tpl,
+		Tools:            reg,
+		CommentCollector: collector,
+		Session:          session.New("/tmp/test-repo", "main", "fake", session.SessionOptions{}),
+		DiffLookup: func(path string) *model.Diff {
+			return byPath[path]
+		},
+		AllDiffs: func() []model.Diff {
+			return diffs
+		},
+	})
+}
+
+func submitCodeComment(t *testing.T, r *Runner, newPath string, comments []map[string]any) {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{"comments": comments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := r.executeToolCall(context.Background(), newPath, llm.ToolCall{
+		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(args)},
+	}, nil, "")
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("code_comment result = %q, want %q", cp.Data, tool.CommentSucceed)
+	}
+}
+
+// TestAnchorIntegrity_DriftedQuoteRefilesToRealFile is the grouped-review
+// reproducer from issue #746: the model files Java advice against pom.xml and
+// quotes the Java file with one internal-whitespace drift. The eliding tier
+// lets the cross-file search place it: the comment is re-filed onto the Java
+// file with real lines (the pre-fix behavior was emission under pom.xml at
+// 0/0).
+func TestAnchorIntegrity_DriftedQuoteRefilesToRealFile(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+		anchorTestDiff(javaPath, "", javaContent),
+	}, &fakeClient{}, false)
+
+	submitCodeComment(t, r, pomXMLPath+","+javaPath, []map[string]any{{
+		"path":          pomXMLPath,
+		"content":       "toString() should return, not print",
+		"existing_code": driftedJavaQuote,
+	}})
+
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("collected %d comments, want 1", len(comments))
+	}
+	if comments[0].Path != javaPath || comments[0].StartLine != 7 || comments[0].EndLine != 10 {
+		t.Fatalf("comment = %s:%d-%d; want re-filed onto the Java file at 7..10",
+			comments[0].Path, comments[0].StartLine, comments[0].EndLine)
+	}
+}
+
+// TestAnchorIntegrity_ZeroOverlapQuoteSkipsRelocation verifies the stage-3
+// plausibility gate: with the quoted code present nowhere in the run, the LLM
+// re-location step is NOT invoked (it would only be able to fabricate a
+// location from the wrong file's diff), and the comment stays unlocated with
+// its evidence quote intact.
+func TestAnchorIntegrity_ZeroOverlapQuoteSkipsRelocation(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	relocator := &fakeClient{responses: []*llm.ChatResponse{reLocationCodeBlockResponse(pomXMLSnippet)}}
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, relocator, true)
+
+	quote := strings.ReplaceAll(driftedJavaQuote, "id );", "id);")
+	submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+		"path":          pomXMLPath,
+		"content":       "toString() should return, not print",
+		"existing_code": quote,
+	}})
+
+	if relocator.calls != 0 {
+		t.Fatalf("re-location LLM invoked %d times, want 0 (zero-overlap quote)", relocator.calls)
+	}
+	if got := collector.Comments(); len(got) != 0 {
+		t.Fatalf("collected %d comments, want 0 (unresolvable quote dropped)", len(got))
+	}
+	warnings := r.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "comment_unresolved" || warnings[0].File != pomXMLPath {
+		t.Fatalf("warnings = %+v, want one comment_unresolved on %s", warnings, pomXMLPath)
+	}
+}
+
+// TestAnchorIntegrity_PlausibleQuoteStillRescued verifies the LLM rescue stays
+// available for its intended case: a quote that shares lines with the claimed
+// file but cannot be matched deterministically (a paraphrased line alongside a
+// real one) still gets the re-location attempt, which here locates it.
+func TestAnchorIntegrity_PlausibleQuoteStillRescued(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	relocator := &fakeClient{responses: []*llm.ChatResponse{reLocationCodeBlockResponse(pomXMLSnippet)}}
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, relocator, true)
+
+	submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+		"path":    pomXMLPath,
+		"content": "the project coordinates are wrong",
+		// First line exists in pom.xml (non-trivial, so the quote is
+		// plausible); the second does not, so deterministic matching fails.
+		"existing_code": "<project>\n  <artifactId>onboard-parent</artifactId>",
+	}})
+
+	if relocator.calls != 1 {
+		t.Fatalf("re-location LLM invoked %d times, want 1 (plausible quote)", relocator.calls)
+	}
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("collected %d comments, want 1", len(comments))
+	}
+	if comments[0].StartLine != 1 || comments[0].EndLine != 3 {
+		t.Fatalf("comment = %s:%d-%d; want rescued onto pom.xml lines 1..3",
+			comments[0].Path, comments[0].StartLine, comments[0].EndLine)
+	}
+}
+
+// TestAnchorIntegrity_ScanPathKeepsUnconditionalRelocation verifies scan-mode
+// wiring (AllDiffs nil) keeps the LLM rescue unconditional: even a
+// zero-overlap quote gets the attempt, exactly as before the gate existed.
+func TestAnchorIntegrity_ScanPathKeepsUnconditionalRelocation(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	relocator := &fakeClient{responses: []*llm.ChatResponse{reLocationCodeBlockResponse(pomXMLSnippet)}}
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, relocator, true)
+	r.deps.AllDiffs = nil
+
+	submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+		"path":          pomXMLPath,
+		"content":       "toString() should return, not print",
+		"existing_code": strings.ReplaceAll(driftedJavaQuote, "id );", "id);"),
+	}})
+
+	if relocator.calls != 1 {
+		t.Fatalf("re-location LLM invoked %d times, want 1 (scan keeps unconditional rescue)", relocator.calls)
+	}
+}
+
+// TestAnchorIntegrity_GroupKeyPathDropped verifies INV-2: a path-less comment
+// under a grouped review is bound to the comma-joined group key by the parser
+// fallback; the run holds no diff for that pseudo-path, so the emission gate
+// drops it with a warning instead of emitting it under a path that can never
+// resolve.
+func TestAnchorIntegrity_GroupKeyPathDropped(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, &fakeClient{}, false)
+
+	groupKey := pomXMLPath + "," + javaPath
+	submitCodeComment(t, r, groupKey, []map[string]any{{
+		"content": "general advice about the group",
+	}})
+
+	if got := collector.Comments(); len(got) != 0 {
+		t.Fatalf("collected %d comments, want 0 (group-key path dropped)", len(got))
+	}
+	warnings := r.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "comment_unresolved" || warnings[0].File != groupKey {
+		t.Fatalf("warnings = %+v, want one comment_unresolved on the group key", warnings)
+	}
+}
+
+// TestAnchorIntegrity_UnresolvableQuoteDroppedWhenRealFileAbsent is the issue
+// #746 end shape: Java advice filed against pom.xml with the Java file not
+// part of the run. No stage can place it, so it is dropped with a warning
+// rather than emitted under pom.xml at 0/0.
+func TestAnchorIntegrity_UnresolvableQuoteDroppedWhenRealFileAbsent(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, &fakeClient{}, false)
+
+	submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+		"path":          pomXMLPath,
+		"content":       "toString() should return, not print",
+		"existing_code": strings.ReplaceAll(driftedJavaQuote, "id );", "id);"),
+	}})
+
+	if got := collector.Comments(); len(got) != 0 {
+		t.Fatalf("collected %d comments, want 0 (wrong-file comment dropped)", len(got))
+	}
+	warnings := r.Warnings()
+	if len(warnings) != 1 || warnings[0].Type != "comment_unresolved" {
+		t.Fatalf("warnings = %+v, want one comment_unresolved", warnings)
+	}
+}
+
+// TestAnchorIntegrity_DegenerateQuoteKeptAsGeneralAdvice verifies INV-4's
+// degenerate edge: a quote that normalizes to zero lines (a bare code fence)
+// is no evidence at all, so on a reviewed file the comment is kept as general
+// advice exactly like an empty quote.
+func TestAnchorIntegrity_DegenerateQuoteKeptAsGeneralAdvice(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, &fakeClient{}, false)
+
+	submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+		"path":          pomXMLPath,
+		"content":       "keep the POM tidy",
+		"existing_code": "\n   \n",
+	}})
+
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("collected %d comments, want 1 (degenerate quote kept as general advice)", len(comments))
+	}
+	if comments[0].StartLine != 0 {
+		t.Fatalf("comment lines = %d..%d, want 0/0 general advice", comments[0].StartLine, comments[0].EndLine)
+	}
+	if len(r.Warnings()) != 0 {
+		t.Fatalf("warnings = %+v, want none", r.Warnings())
+	}
+}
+
+// TestAnchorIntegrity_ScanPathCollectsUnchanged verifies the emission gate is
+// review-only: with AllDiffs nil (scan wiring), even an unresolvable
+// quote-less group-key comment is collected exactly as before, with no
+// warnings.
+func TestAnchorIntegrity_ScanPathCollectsUnchanged(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	r := anchorTestRunner(collector, []model.Diff{
+		anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+	}, &fakeClient{}, false)
+	r.deps.AllDiffs = nil
+
+	groupKey := pomXMLPath + "," + javaPath
+	submitCodeComment(t, r, groupKey, []map[string]any{{
+		"content": "general advice about the group",
+	}})
+
+	comments := collector.Comments()
+	if len(comments) != 1 || comments[0].Path != groupKey {
+		t.Fatalf("comments = %+v, want 1 collected under the group key (scan unchanged)", comments)
+	}
+	if len(r.Warnings()) != 0 {
+		t.Fatalf("warnings = %+v, want none (scan unchanged)", r.Warnings())
+	}
+}
+
+// TestAnchorIntegrity_AmbiguousSnippetDroppedNotGuessed covers the ambiguous
+// cross-file edge: when the quoted snippet exists verbatim in TWO files of the
+// run, RelocateAcrossFiles declines rather than guessing, so the comment ends
+// resolution unlocated and the emission gate drops it with a warning. The
+// single-copy subtest is the contrast that keeps this test honest: the same
+// snippet with one copy removed must re-file, proving the two-copy drop is the
+// ambiguity decline and not an absence-of-match artifact.
+func TestAnchorIntegrity_AmbiguousSnippetDroppedNotGuessed(t *testing.T) {
+	const dupA = "src/main/java/com/qz/onboard/pojo/DupA.java"
+	const dupB = "src/main/java/com/qz/onboard/pojo/DupB.java"
+	contentA := "package pojo;\n\npublic class DupA {\n" + toStringBlock + "\treturn \"DupA\";\n}\n"
+	contentB := "package pojo;\n\npublic class DupB {\n" + toStringBlock + "\treturn \"DupB\";\n}\n"
+
+	// toStringBlock sits at lines 4..6 of both files.
+	run := func(t *testing.T, diffs []model.Diff) (*Runner, *tool.CommentCollector, *fakeClient) {
+		collector := tool.NewCommentCollector()
+		// The relocator is armed: if the ambiguity decline let the comment fall
+		// through to stage 3, the LLM would be invoked (and could fabricate a
+		// pom.xml anchor). Asserting zero calls pins the drop on the decline.
+		relocator := &fakeClient{responses: []*llm.ChatResponse{reLocationCodeBlockResponse(pomXMLSnippet)}}
+		return anchorTestRunner(collector, diffs, relocator, true), collector, relocator
+	}
+
+	t.Run("two copies decline and drop", func(t *testing.T) {
+		r, collector, relocator := run(t, []model.Diff{
+			anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+			anchorTestDiff(dupA, "", contentA),
+			anchorTestDiff(dupB, "", contentB),
+		})
+		submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+			"path":          pomXMLPath,
+			"content":       "toString() should return, not print",
+			"existing_code": toStringBlock,
+		}})
+
+		if relocator.calls != 0 {
+			t.Fatalf("re-location LLM invoked %d times, want 0 (quote implausible for pom.xml)", relocator.calls)
+		}
+		if got := collector.Comments(); len(got) != 0 {
+			t.Fatalf("collected %d comments, want 0 (ambiguous snippet must not be guessed onto either file)", len(got))
+		}
+		warnings := r.Warnings()
+		if len(warnings) != 1 || warnings[0].Type != "comment_unresolved" || warnings[0].File != pomXMLPath {
+			t.Fatalf("warnings = %+v, want one comment_unresolved on %s", warnings, pomXMLPath)
+		}
+	})
+
+	t.Run("single copy re-files", func(t *testing.T) {
+		r, collector, relocator := run(t, []model.Diff{
+			anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+			anchorTestDiff(dupA, "", contentA),
+		})
+		submitCodeComment(t, r, pomXMLPath, []map[string]any{{
+			"path":          pomXMLPath,
+			"content":       "toString() should return, not print",
+			"existing_code": toStringBlock,
+		}})
+
+		if relocator.calls != 0 {
+			t.Fatalf("re-location LLM invoked %d times, want 0 (unique cross-file hit needs no rescue)", relocator.calls)
+		}
+		comments := collector.Comments()
+		if len(comments) != 1 {
+			t.Fatalf("collected %d comments, want 1 re-filed", len(comments))
+		}
+		if comments[0].Path != dupA || comments[0].StartLine != 4 || comments[0].EndLine != 6 {
+			t.Fatalf("comment = %s:%d-%d; want re-filed onto %s at 4..6 (proves the snippet is findable)",
+				comments[0].Path, comments[0].StartLine, comments[0].EndLine, dupA)
+		}
+	})
+}
+
+// toStringBlock is the snippet shared by the ambiguity test's two candidate
+// files: non-trivial lines (so it is anchorable evidence) that exist verbatim
+// in both.
+const toStringBlock = `    public String toString() {
+        System.out.println("id=" + id);
+        System.out.println("resourceId=" + resourceId);
+`
+
+// submitCodeCommentViaPool drives code_comment through the CommentWorkerPool
+// branch and proves it: that branch records "(async)" on the task record
+// synchronously while the work runs on a worker under context.WithoutCancel.
+func submitCodeCommentViaPool(t *testing.T, r *Runner, newPath string, comments []map[string]any) {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{"comments": comments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := &session.TaskRecord{}
+	cp := r.executeToolCall(context.Background(), newPath, llm.ToolCall{
+		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(args)},
+	}, rec, "")
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("code_comment result = %q, want %q", cp.Data, tool.CommentSucceed)
+	}
+	if len(rec.ToolResults) != 1 || rec.ToolResults[0].Result != "(async)" {
+		t.Fatalf("recorded results = %+v, want one (async) entry — pool branch not taken", rec.ToolResults)
+	}
+}
+
+// TestAnchorIntegrity_AsyncPoolAppliesSameGate covers grouped reviews' real
+// wiring: comments arrive through the CommentWorkerPool, and the emission gate
+// must behave there exactly as on the synchronous path — a located comment is
+// collected with its lines, an unresolvable one is dropped with a
+// comment_unresolved warning. CollectPendingComments drains the pool before
+// any assertion, so the test is deterministic.
+func TestAnchorIntegrity_AsyncPoolAppliesSameGate(t *testing.T) {
+	t.Run("located comment collected with lines", func(t *testing.T) {
+		collector := tool.NewCommentCollector()
+		r := anchorTestRunner(collector, []model.Diff{
+			anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+		}, &fakeClient{}, false)
+		r.deps.CommentWorkerPool = NewCommentWorkerPool(2)
+
+		submitCodeCommentViaPool(t, r, pomXMLPath, []map[string]any{{
+			"path":          pomXMLPath,
+			"content":       "the coordinates are wrong",
+			"existing_code": pomXMLSnippet,
+		}})
+
+		comments := r.CollectPendingComments()
+		if len(comments) != 1 {
+			t.Fatalf("collected %d comments, want 1", len(comments))
+		}
+		if comments[0].Path != pomXMLPath || comments[0].StartLine != 1 || comments[0].EndLine != 3 {
+			t.Fatalf("comment = %s:%d-%d; want %s at 1..3 after pool drain",
+				comments[0].Path, comments[0].StartLine, comments[0].EndLine, pomXMLPath)
+		}
+		if len(r.Warnings()) != 0 {
+			t.Fatalf("warnings = %+v, want none", r.Warnings())
+		}
+	})
+
+	t.Run("unresolvable quote dropped with warning", func(t *testing.T) {
+		collector := tool.NewCommentCollector()
+		r := anchorTestRunner(collector, []model.Diff{
+			anchorTestDiff(pomXMLPath, pomXMLDiff, pomXMLContent),
+		}, &fakeClient{}, false)
+		r.deps.CommentWorkerPool = NewCommentWorkerPool(2)
+
+		submitCodeCommentViaPool(t, r, pomXMLPath, []map[string]any{{
+			"path":          pomXMLPath,
+			"content":       "toString() should return, not print",
+			"existing_code": strings.ReplaceAll(driftedJavaQuote, "id );", "id);"),
+		}})
+
+		if got := r.CollectPendingComments(); len(got) != 0 {
+			t.Fatalf("collected %d comments, want 0 (wrong-file quote dropped via pool)", len(got))
+		}
+		warnings := r.Warnings()
+		if len(warnings) != 1 || warnings[0].Type != "comment_unresolved" || warnings[0].File != pomXMLPath {
+			t.Fatalf("warnings = %+v, want one comment_unresolved on %s", warnings, pomXMLPath)
+		}
+	})
+}
+
+const pomXMLSnippet = `<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.qz.onboard</groupId>
+`
+
+func reLocationCodeBlockResponse(snippet string) *llm.ChatResponse {
+	content := "The code is:\n```xml\n" + snippet + "\n```\n"
+	return &llm.ChatResponse{
+		Choices: []llm.Choice{{Message: llm.ResponseMessage{Content: &content}}},
+		Model:   "fake",
+	}
+}

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -630,7 +630,15 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 					}
 				}
 				if d != nil {
-					if !located && r.deps.Template.ReLocationTask != nil {
+					// In review mode (AllDiffs wired) the LLM rescue runs only
+					// when the quote plausibly belongs to the claimed file: the
+					// step sees only that file's diff, and a quote that shares
+					// no line with it can at best be answered with a fabricated
+					// location (issue #746). Scan mode (AllDiffs nil) keeps the
+					// unconditional behavior — it has no cross-file stage and
+					// its synthetic diffs are the only evidence available.
+					plausible := r.deps.AllDiffs == nil || diff.QuotePlausiblyInDiff(cm, d)
+					if !located && plausible && r.deps.Template.ReLocationTask != nil {
 						// rlStart stays ahead of prompt construction, which is
 						// where it sat when ReLocateComment built the messages
 						// itself — moving it would silently change what
@@ -664,7 +672,23 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 						}
 					}
 				}
-				r.deps.CommentCollector.Add(*cm)
+				// Emission gate, review mode only (AllDiffs wired; scan keeps
+				// its legacy unconditional collection). A comment is emitted
+				// when it is located, or when it carries no anchorable quote
+				// AND the run holds a diff for its claimed path (general
+				// advice on a reviewed file). A quoted comment that ended
+				// resolution unlocated quotes code present in no reviewed
+				// file — emitting it would bind it to a file it does not
+				// belong to (issue #746), so it is dropped with a warning
+				// instead. Quote-less comments on paths with no diff (e.g. a
+				// grouped review's comma-joined key) are dropped the same
+				// way: that pseudo-path can never be resolved.
+				if r.deps.AllDiffs == nil || cm.StartLine > 0 || (d != nil && !diff.HasAnchorableQuote(cm)) {
+					r.deps.CommentCollector.Add(*cm)
+				} else {
+					r.RecordWarning("comment_unresolved", cm.Path, fmt.Sprintf(
+						"comment on %s quotes code not present in any reviewed file; dropped", cm.Path))
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

`ocr review` can emit a comment anchored to the wrong file: the reported cases are Java `toString()` advice rendered on `pom.xml` and a Java `@RequestMapping` security finding rendered on `.gitignore`, both with `start_line: 0, end_line: 0` (#746).

## Root cause

When the model files a comment against path P while quoting code from another file, the resolution chain declines at every stage:

1. in-file resolution — the quote is not in P's diff;
2. cross-file relocation — declines when the quote matches no other reviewed file exactly (or matches more than one);
3. LLM re-location — sees only P's diff, so for a quote that is not in P it can at best answer with the closest-looking block, fabricating a located-but-wrong anchor.

After all three, the comment was still collected and emitted **verbatim under the claimed path at 0/0** (`internal/llmloop/loop.go`, the unconditional `CommentCollector.Add`). Nothing ever flagged or dropped it. Quote matching is also exact per line after trimming, so a quote drifting only in internal spacing (`id )` vs `id)`) defeats even the stages that could have saved it.

## Fix

Three targeted changes in the comment resolution chain:

- **Whitespace-eliding second-chance tier** for deterministic matching (`internal/diff/resolver.go`): after the exact passes fail on both sides of a hunk (and in the full-content scan), lines are compared with all whitespace elided. Exact matches always outrank loose ones, so existing anchors are unchanged; only quotes that differ purely in internal spacing gain resolution.
- **Quote-plausibility gate on LLM re-location**: the rescue step now runs only when the comment's quote shares at least one non-trivial (≥ 8 normalized chars) line with the claimed file's diff — under exact or elided comparison, across hunks and full content. A quote from the right file still shares lines with it even when drifted; a Java quote against `pom.xml` shares none, and the step that could only fabricate a location is skipped.
- **Emission gate in review runs**: a comment that ends resolution unlocated while carrying an anchorable quote is dropped with a `comment_unresolved` run warning (same channel as the existing `comment_refiled`) instead of being emitted under a path it does not belong to. Path-less comments silently bound to a grouped review's comma-joined key are dropped the same way. Comments with no anchorable quote on a reviewed file keep today's behavior (general advice), and **scan keeps its collection behavior unchanged** (the gate is scoped to review wiring).

## Trade-off

A comment whose quote matches nothing in the run is now dropped rather than emitted mis-anchored. The dropped path/summary is visible in the run's warnings, so nothing disappears silently — but the finding itself no longer appears in the report. I took the view that a wrong-file comment is worse than a dropped one (it was reported as a bug twice); if you prefer emission with an explicit `unresolved` marker instead, the gate is one branch to change.

## Tests

- Loop-level reproducers for the issue scenario (wrong-file quote → drop + warn; drifted quote → re-filed onto the right file; LLM rescue preserved for plausible quotes, skipped for zero-overlap ones).
- Resolver tests for the eliding tier (hunk + full content) and for materially-different lines still failing.
- Ambiguous snippet (two files) still declines to guess; the async comment pool applies the same gate; scan wiring keeps unconditional re-location and unchanged collection.
- Full suite green under `-race`; touched packages at 89.3% / 95.1% coverage.

Fixes #746