### PR TITLE
fix(tests): Windows path got embedded into json string

### DIFF
--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -1674,8 +1674,13 @@ func TestLoadProjectRule_ConfinesUntrustedReferences(t *testing.T) {
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := `{"rules":[{"path":"**/*.go","rule":"` + outside + `"}]}`
-	if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"), []byte(cfg), 0o644); err != nil {
+	cfgData, err := json.Marshal(ProjectRule{
+		Rules: []ProjectRuleEntry{{Path: "**/*.go", Rule: outside}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"), cfgData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Description
`TestLoadProjectRule_ConfinesUntrustedReferences` embeds a Windows path directly into a JSON string, so \U becomes an invalid JSON escape.
<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [ ] Manual testing (describe below)
> [!CAUTION]
> Tested only on `macOS`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
This is a part of a security advisory.