### PR TITLE
docs(skill): correct timeout description to reflect effort-scaled group timeout

### DIFF
--- a/plugins/open-code-review/skills/open-code-review/SKILL.md
+++ b/plugins/open-code-review/skills/open-code-review/SKILL.md
@@ -48,7 +48,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
 - **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
 - **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
-- **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
+- **Timeout**: effective timeout per review group = `--timeout` × review rounds. Default `--timeout 15` with default effort `medium` (2 rounds) gives 30 minutes; `low`/`high` give 15/45 minutes.
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`

--- a/skills/open-code-review/SKILL.md
+++ b/skills/open-code-review/SKILL.md
@@ -43,7 +43,7 @@ ocr review --audience agent --background "business context here" [user-args]
 - **Default** (no user arguments): reviews staged, unstaged, and untracked changes (workspace mode)
 - **Specific commit**: use `--commit` or `-c` to review a single commit against its parent
 - **Branch comparison**: use `--from <ref>` and `--to <ref>` to review diff between two refs
-- **Timeout**: default timeout is 15 minutes per file; adjust with `--timeout <minutes>`
+- **Timeout**: effective timeout per review group = `--timeout` × review rounds. Default `--timeout 15` with default effort `medium` (2 rounds) gives 30 minutes; `low`/`high` give 15/45 minutes.
 - **Concurrency**: default concurrency is 8 file workers; reduce with `--concurrency <n>` if rate limits are hit
 - **Preview mode**: use `--preview` or `-p` to preview which files will be reviewed without running the LLM
 - **Installation**: if `ocr` command is not found, install it by running `npm i -g @alibaba-group/open-code-review`


### PR DESCRIPTION
## Description

The SKILL.md argument-handling section says "default timeout is 15 minutes per file". Since #1085 introduced effort-scaled review rounds, the actual formula is `ConcurrentTaskTimeout × ReviewRounds()` per review group — default effort `medium` (2 rounds) gives 30 minutes, not 15.

This updates both the canonical skill and the plugin mirror so host agents no longer kill healthy reviews by assuming a flat 15-minute per-file budget.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Manual verification against `internal/agent/agent.go:644` and `internal/config/template/effort.go` (low/medium/high = 1/2/3 rounds)
- [x] `make check` and `make test` pass

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

Follow-up to #1085.
