### PR TITLE
fix(review): handle SIGTERM for graceful shutdown

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/alibaba/open-code-review/internal/agent"
@@ -99,7 +100,7 @@ var reviewCmd = &cobra.Command{
 		if err := validateReviewOptions(&reviewOpts); err != nil {
 			return err
 		}
-		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		return executeReviewContext(ctx, reviewOpts)
 	},


### PR DESCRIPTION
## Description

`ocr review` registers `signal.NotifyContext` with only `os.Interrupt`, so SIGTERM kills the process with zero cleanup. Real-world SIGTERM producers:

- **docker stop** — sends SIGTERM to PID 1 (10s grace, then SIGKILL)
- **GitLab CI** — job cancellation and timeout send SIGTERM
- **The project's own VS Code extension** — sends SIGTERM on review cancel (merged PR #489), with a 3s SIGKILL escalation

Impact when SIGTERM hits mid-review:
- `--output` report is never created (the lazy writer opens the file only at emit time — not truncated, simply absent)
- `session_end` and `run_manifest` are never persisted
- `--resume` is rejected even when completed per-file checkpoints are on disk — the user pays for a full re-review

With this change, SIGTERM follows the same graceful path as Ctrl+C: context cancellation runs the existing defer chain (closeOut, MCP client close, manifest freeze, session_end persist). Measured graceful-shutdown latency on the SIGINT path is ~25ms — two orders of magnitude inside docker's 10s grace and the extension's 3s escalation window.

Ecosystem precedent: long-running container/CI CLIs (docker compose, hugo, terraform, controller-runtime) all register SIGINT+SIGTERM; SIGINT-only tools (gh CLI, kubectl port-forward) are short-lived commands where the distinction rarely matters.

Scope: only `review_cmd.go`. The scan path has a separate open PR (#996).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] `make check` passes (gofmt, go vet, license, english-check)
- [x] `go test ./cmd/opencodereview/ -run TestReview` passes
- [x] Cross-platform compile verified (linux/amd64, windows/amd64, darwin/arm64) — `syscall.SIGTERM` is a cross-platform constant
- [x] End-to-end: built a local binary with mock LLM, sent SIGTERM mid-review → exit 1, partial `--output` written, session_end persisted, `--resume` accepted (identical to SIGINT behavior); unpatched control → exit 143, output absent, resume rejected

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed the CLA

## Related Issues

Follow-up to #902 (which introduced the SIGINT-only NotifyContext and scoped out non-graceful termination) and #1054 (which fixed the launcher's exit code on signal death but not the graceful-shutdown half).
