### PR TITLE
feat(allowlist): add Pug template support

### DIFF
--- a/internal/config/allowlist/allowed_ext_test.go
+++ b/internal/config/allowlist/allowed_ext_test.go
@@ -41,6 +41,8 @@ func TestIsAllowedExt(t *testing.T) {
 		{".HBS", true},
 		{".mustache", true},
 		{".MUSTACHE", true},
+		{".pug", true},
+		{".PUG", true},
 		{".graphql", true},
 		{".GRAPHQL", true},
 		{".gql", true},
@@ -171,6 +173,12 @@ func TestIsExcludedPath(t *testing.T) {
 		{"mustache fixture", "spec/fixtures/email.mustache", true},
 		{"handlebars template in tests directory", "tests/templates/card.hbs", false},
 		{"mustache template in test directory", "test/templates/email.mustache", false},
+
+		// Pug has no extension-specific test-path convention;
+		// generic fixture directories remain excluded.
+		{"pug fixture", "test/fixtures/page.pug", true},
+		{"pug template in tests directory", "tests/templates/page.pug", false},
+		{"pug template in test directory", "test/templates/page.pug", false},
 
 		// HarmonyOS oh_modules and test files
 		{"oh_modules root", "oh_modules/some_lib/index.ets", true},

--- a/internal/config/allowlist/supported_file_types.json
+++ b/internal/config/allowlist/supported_file_types.json
@@ -49,6 +49,7 @@
   ".ftlx",
   ".hbs",
   ".mustache",
+  ".pug",
   ".astro",
   ".vue",
   ".ipynb",

--- a/internal/config/rules/rule_docs/pug.md
+++ b/internal/config/rules/rule_docs/pug.md
@@ -1,0 +1,56 @@
+> Favor precision over recall: only raise an issue when the rendered consequence or trust boundary is clear. Pug evaluates JavaScript and compiles to HTML, so distinguish Pug's built-in HTML escaping from the additional validation or serialization required by the actual output context.
+
+#### Pug Escaping and Output Contexts
+- Unescaped string interpolation (`!{value}`) or unescaped buffered code (`!= value`) that can receive untrusted HTML without prior, context-appropriate sanitization
+- Escaped interpolation (`#{value}`) or buffered code (`= value`) used inside JavaScript, CSS, JSON, URL, or event-handler syntax as though HTML escaping protected those grammars
+- Do not report ordinary `#{value}` or `= value` in an HTML text node solely for lacking an explicit escape helper; Pug HTML-escapes those forms by default
+- Sanitized HTML rendered through `!{}` or `!=` after transformations that invalidate the sanitizer's guarantee, such as concatenating new untrusted markup afterward
+
+#### Attributes, URLs, and Dynamic Markup
+- Attribute values from untrusted data that are HTML-escaped but not validated for the sink, especially `href`, `src`, `action`, `formaction`, `srcdoc`, `style`, and event-handler attributes
+- Direct `&attributes(object)` spreads of untrusted objects: Pug does not automatically escape values in a general attribute spread, and attacker-controlled keys can introduce event handlers or override security-sensitive attributes
+- Do not flag conventional mixin forwarding solely because it uses `&attributes(attributes)` or `!= attributes.name`; values in the implicit mixin `attributes` object are already escaped by Pug. Inspect the original caller, attribute names, and non-HTML sink semantics instead
+- Boolean attributes whose values use strings such as `"false"` when presence still enables the HTML behavior, or conditional attributes that leave a control enabled, selected, or focusable on the wrong branch
+- IDs, `name` values, fragment links, or ARIA references generated in loops without a stable uniqueness guarantee
+
+#### Embedded JavaScript and Server-to-Client Data
+- Values interpolated into `script.` blocks or inline handlers without JavaScript-string or JSON-safe serialization; HTML escaping is not a substitute for JavaScript encoding
+- `!{JSON.stringify(data)}` embedded in an inline script without neutralizing HTML parser terminators such as `</script>` (and relevant line-separator characters for the supported JavaScript target), allowing data to end the script element or break parsing
+- Secrets, session data, authorization material, internal-only fields, or unnecessarily large objects serialized into client-visible markup or scripts
+- Client-compiled templates (`compileClient` / `compileFileClient`) that can render attacker-controlled raw output before the caller inserts the result with `innerHTML` or an equivalent HTML sink
+- Server-only assumptions embedded in client-compiled Pug, including access to unavailable globals, modules, filesystem state, or locals the browser never receives
+
+#### Template Trust, JavaScript, Missing Data, and Side Effects
+- Attacker-controlled template source passed to `compile` / `render`, or attacker-writable files passed to `compileFile` / `renderFile`; Pug templates can execute embedded JavaScript, so treating untrusted templates as presentation data creates a server-side template injection and code-execution boundary
+- Request-controlled template file selection without a strict name allowlist and template-root boundary, allowing unintended templates or paths to be rendered even though `include` and `extends` directives inside a trusted template are static
+- Request, query, or body objects spread wholesale into Pug render/compiler options, allowing untrusted keys to alter options such as `filename`, `basedir`, `filters`, `globals`, `cache`, or `pretty` as well as locals; keep compiler options fixed, expose an explicit locals shape, and verify the project's Pug version before claiming exploitability
+- Unbuffered code (`-` or an unbuffered code block) that performs database, network, filesystem, shared-state mutation, or other externally observable side effects during rendering
+- Required locals that can become empty output, omitted attributes, invalid identifiers, or broken URLs without an explicit default or branch; do not require defaults for optional display-only values
+- Exceptions from property access or function calls on absent locals that can abort the whole render, especially inside shared layouts or error pages
+- Business logic, authorization decisions, or non-trivial data shaping implemented in the template instead of the controller/view-model layer
+
+#### Includes, Inheritance, Mixins, and Filters
+- Relative `include` or `extends` paths used without the `filename` context needed for correct resolution, or absolute paths that unintentionally depend on a different `basedir`
+- Non-Pug includes that insert raw HTML, JavaScript, CSS, or secrets when the author appears to expect Pug parsing or escaping
+- Child templates that replace, append, or prepend the wrong named block and thereby drop required metadata, scripts, security controls, fallback content, or accessibility structure
+- Content or unbuffered code placed at the top level of an extending template even though child templates may only define named blocks and mixins there
+- Mixins invoked with arguments in the wrong order, implicit caller context, or an overly broad attribute object, producing missing data or leaking fields across component boundaries
+- Filters treated as runtime sanitizers or as processors for dynamic locals even though Pug filters run at compile time and cannot support dynamic content or options
+
+#### Indentation, Control Flow, and Whitespace
+- Indentation changes that move an element into the wrong parent, loop, conditional, or block, changing form ownership, DOM structure, visibility, or execution scope
+- `while` loops with a reachable non-terminating path, or expensive expressions and function calls repeated inside large `each` loops
+- `each ... else` or conditional branches that omit required empty/error states, duplicate IDs, or render controls without the data needed by their handlers
+- Inline tags and text whose Pug whitespace rules concatenate words or tokens, or reliance on trailing spaces that formatters and editors can remove
+- Literal HTML or plain-text blocks whose indentation looks like Pug nesting but is emitted mostly unprocessed, producing a different structure than intended
+
+#### Accessibility
+- Interactive non-button elements without equivalent keyboard activation, focusability, and semantics when a native element would provide them
+- Inputs generated without an associated label, repeated form-control IDs, or labels/ARIA references that point to a different loop item
+- Images with missing or misleading alternatives, and conditional content that changes visible state without updating accessible name, role, or `aria-*` state
+- Inheritance or mixin overrides that silently remove landmarks, heading structure, fallback text, focus management, or required attributes supplied by the parent
+
+#### Performance and Review Scope
+- Templates compiled on every request or repeatedly inside a hot loop when they are static and the host can precompile or cache them with a stable `filename` key
+- Expensive helpers, mixins, serialization, or data reshaping repeated per item when the result can be prepared once by the host application
+- Report performance findings only when request frequency, collection size, or repeated compilation is evident; do not turn indentation preferences or equivalent shorthand forms into blocking findings

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -16,6 +16,7 @@
     "**/*.go": "go.md",
     "**/*.{ftl,ftlh,ftlx}": "freemarker.md",
     "**/*.{hbs,mustache}": "handlebars_mustache.md",
+    "**/*.pug": "pug.md",
     "**/*.ets": "arkts.md",
     "**/*.astro": "astro.md",
     "**/*.{ts,js,tsx,jsx}": "ts_js_tsx_jsx.md",

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -76,6 +76,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"templates/account.HBS", "Handlebars/Mustache Escaping Boundaries"},
 		{"templates/email.mustache", "Handlebars/Mustache Escaping Boundaries"},
 		{"templates/email.MUSTACHE", "Handlebars/Mustache Escaping Boundaries"},
+		{"templates/account.pug", "Pug Escaping and Output Contexts"},
+		{"templates/account.PUG", "Pug Escaping and Output Contexts"},
 		{"src/main/resources/mapper/usermapper.xml", "SQL Logic Error Detection"},
 		{"src/main/resources/dao/userdao.xml", "SQL Logic Error Detection"},
 		{"pom.xml", "snapshot"},
@@ -902,6 +904,38 @@ func TestResolveDetail_SystemPrismaPatternMatch(t *testing.T) {
 			}
 			if !strings.Contains(detail.Rule, "Prisma Schema Review Principles") {
 				t.Errorf("expected Prisma rule, got %q", truncate(detail.Rule, 80))
+			}
+		})
+	}
+}
+
+func TestResolveDetail_SystemPugPatternMatch(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	resolver, _, err := NewResolver(t.TempDir(), "", ResolverOptions{})
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	dr := resolver.(DetailResolver)
+
+	for _, path := range []string{"index.pug", "views/account/profile.pug", "VIEWS/INDEX.PUG"} {
+		t.Run(path, func(t *testing.T) {
+			detail := dr.ResolveDetail(path)
+			if detail.Source != "system" {
+				t.Errorf("expected source 'system', got %q", detail.Source)
+			}
+			if detail.Pattern != "**/*.pug" {
+				t.Errorf("expected pattern '**/*.pug', got %q", detail.Pattern)
+			}
+			for _, required := range []string{
+				"Pug Escaping and Output Contexts",
+				"server-side template injection",
+				"&attributes",
+				"compileClient",
+				"Accessibility",
+			} {
+				if !strings.Contains(detail.Rule, required) {
+					t.Errorf("expected Pug rule to contain %q", required)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add `.pug` to the case-insensitive supported-extension allowlist;
- route Pug templates to a dedicated review rule covering escaping contexts, attribute spreads and URL sinks, server-side template trust, embedded client data, includes/inheritance/mixins/filters, indentation and whitespace, accessibility, and hot-path compilation;
- preserve the existing generic fixture exclusions without adding a broad Pug-only test-directory exclusion;
- add lower- and upper-case allowlist and resolver coverage, including `ResolveDetail` metadata and rule-content assertions.

## Why a dedicated rule

Pug compiles JavaScript-backed, indentation-sensitive templates to HTML. Its safe defaults are context-specific: `#{}` / `=` and ordinary attributes are HTML-escaped, while `!{}` / `!=` and general `&attributes(object)` spreads cross explicit raw-output boundaries. HTML escaping also does not make values safe inside JavaScript, CSS, URLs, or event handlers.

The rule therefore aims for high-signal findings while explicitly suppressing common false positives, including ordinary escaped text interpolation and the already-escaped implicit mixin `attributes` object.

## Validation

- `make test`
- `make check`
- `make build`
- built CLI: `ocr rules check views/account.pug`
- built CLI: `ocr rules check VIEWS/ACCOUNT.PUG`

All commands passed with Go 1.25.5. The runtime checks matched `Source: System built-in`, `Pattern: **/*.pug`, and the dedicated Pug rule for both path casings.

## Self-review

`ocr review --preview` initially exposed the repository's default exclusion of test files and unsupported rule-doc extensions. A temporary, repository-external include rule then confirmed all 5 changed files were selected with 0 exclusions. LLM-backed `ocr review` could not dispatch because this environment has no OCR LLM endpoint configured, so I used `ocr delegate` to produce the complete 5-file rules/background bundle and performed separate Standards and Spec passes; both produced 0 findings.

Closes #1113
Part of #470

## AI assistance disclosure

Codex was used to inspect repository conventions, cross-check the rule against Pug's official language/API documentation and security guidance, draft the implementation and tests, run validation, and review the final diff. I verified the final file set, behavior, test logs, commit, and remote branch before submission.