### PR TITLE
fix(rules): route JavaScript module files to JS rules

### DIFF
--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -19,7 +19,7 @@
     "**/*.pug": "pug.md",
     "**/*.ets": "arkts.md",
     "**/*.astro": "astro.md",
-    "**/*.{ts,js,tsx,jsx}": "ts_js_tsx_jsx.md",
+    "**/*.{ts,js,tsx,jsx,mjs,cjs}": "ts_js_tsx_jsx.md",
     "**/*.{kt}": "kotlin.md",
     "**/*.rs": "rust.md",
     "**/*.{cpp,cc,hpp}": "cpp.md",

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -91,6 +91,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"src/pages/index.astro", "client:*"},
 		{"src/components/app.tsx", "React"},
 		{"lib/utils.ts", "TypeScript"},
+		{"scripts/config.mjs", "TypeScript"},
+		{"server/bootstrap.cjs", "TypeScript"},
 		{"app.kt", "Null Safety"},
 		{"src/main/handler.cpp", "Smart Pointer"},
 		{"driver.c", "malloc"},

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -163,7 +163,7 @@ matching order:
 | `**/*.{hbs,mustache}` | `handlebars_mustache.md` — Handlebars and Mustache templates. |
 | `**/*.ets` | `arkts.md` — ArkTS / HarmonyOS. |
 | `**/*.astro` | `astro.md` — Astro components and islands. |
-| `**/*.{ts,js,tsx,jsx}` | `ts_js_tsx_jsx.md` |
+| `**/*.{ts,js,tsx,jsx,mjs,cjs}` | `ts_js_tsx_jsx.md` |
 | `**/*.{kt}` | `kotlin.md` |
 | `**/*.rs` | `rust.md` |
 | `**/*.R` | `r.md` |

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -125,7 +125,7 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{hbs,mustache}` | `handlebars_mustache.md`: Handlebars / Mustache テンプレート。 |
 | `**/*.ets` | `arkts.md`: ArkTS / HarmonyOS。 |
 | `**/*.astro` | `astro.md`: Astro コンポーネントと islands。 |
-| `**/*.{ts,js,tsx,jsx}` | `ts_js_tsx_jsx.md` |
+| `**/*.{ts,js,tsx,jsx,mjs,cjs}` | `ts_js_tsx_jsx.md` |
 | `**/*.{kt}` | `kotlin.md` |
 | `**/*.rs` | `rust.md` |
 | `**/*.R` | `r.md` |

--- a/pages/src/content/docs/ko/review-rules.md
+++ b/pages/src/content/docs/ko/review-rules.md
@@ -154,7 +154,7 @@ diff 단계에서 일어납니다.
 | `**/*.{hbs,mustache}` | `handlebars_mustache.md` — Handlebars 및 Mustache 템플릿. |
 | `**/*.ets` | `arkts.md` — ArkTS / HarmonyOS. |
 | `**/*.astro` | `astro.md` — Astro 컴포넌트와 아일랜드. |
-| `**/*.{ts,js,tsx,jsx}` | `ts_js_tsx_jsx.md` |
+| `**/*.{ts,js,tsx,jsx,mjs,cjs}` | `ts_js_tsx_jsx.md` |
 | `**/*.{kt}` | `kotlin.md` |
 | `**/*.rs` | `rust.md` |
 | `**/*.R` | `r.md` |

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -165,7 +165,7 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.{hbs,mustache}` | `handlebars_mustache.md` — шаблоны Handlebars и Mustache. |
 | `**/*.ets` | `arkts.md` — ArkTS / HarmonyOS. |
 | `**/*.astro` | `astro.md` — компоненты и islands Astro. |
-| `**/*.{ts,js,tsx,jsx}` | `ts_js_tsx_jsx.md` |
+| `**/*.{ts,js,tsx,jsx,mjs,cjs}` | `ts_js_tsx_jsx.md` |
 | `**/*.{kt}` | `kotlin.md` |
 | `**/*.rs` | `rust.md` |
 | `**/*.R` | `r.md` |

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -146,7 +146,7 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{hbs,mustache}` | `handlebars_mustache.md`——Handlebars 与 Mustache 模板。 |
 | `**/*.ets` | `arkts.md`——ArkTS / HarmonyOS。 |
 | `**/*.astro` | `astro.md`——Astro 组件与 islands。 |
-| `**/*.{ts,js,tsx,jsx}` | `ts_js_tsx_jsx.md` |
+| `**/*.{ts,js,tsx,jsx,mjs,cjs}` | `ts_js_tsx_jsx.md` |
 | `**/*.{kt}` | `kotlin.md` |
 | `**/*.rs` | `rust.md` |
 | `**/*.R` | `r.md` |


### PR DESCRIPTION
## Description

OpenCodeReview already accepts `.mjs` and `.cjs` files through `supported_file_types.json`, but the built-in JavaScript/TypeScript rule mapping only covers `.ts`, `.js`, `.tsx`, and `.jsx`.

As a result, reviewable `.mjs` and `.cjs` files fall back to the generic `default.md` rule instead of receiving the existing JavaScript/TypeScript review guidance.

This PR fixes that routing gap by:

* extending the existing JavaScript/TypeScript rule pattern to include `.mjs` and `.cjs`;
* adding `.mjs` and `.cjs` coverage to the existing system rule resolver test matrix;
* synchronizing the documented built-in rule mapping across all supported locales.

`.mjs` and `.cjs` intentionally use the same existing JavaScript/TypeScript review rules as `.js` and `.ts`; no separate rule semantics are introduced.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature would cause existing functionality to change)
* [ ] Refactoring (no functional changes)
* [x] Documentation update
* [ ] CI / Build / Tooling

## How Has This Been Tested?

* [x] Added `.mjs` and `.cjs` cases to the existing system rule resolver tests.
* [x] Verified the updated `system_rules.json` is valid JSON.
* [ ] Full repository tests are pending upstream CI execution.

## Checklist

* [x] My code follows the project's existing style.
* [x] I have performed a self-review of the change.
* [x] I have added tests that prove the fix is effective.
* [ ] New and existing unit tests pass locally.
* [x] Documentation has been updated for the built-in rule mapping.
* [x] I have signed the CLA.

## Related Issues

No existing issue found for this routing gap.
