### PR TITLE
docs(zh-CN): improve branch range wording

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,7 +137,7 @@ cd your-project
 # 工作区模式 —— 审查所有暂存、未暂存和未跟踪的变更
 ocr review
 
-# 分支范围 —— 评审 feature-branch 自与 main 分叉以来的变更（合并基准模式）
+# 分支范围 —— 评审 feature-branch 与 main 分叉后的变更（合并基准模式）
 ocr review --from main --to feature-branch
 
 # 单个提交

--- a/pages/src/content/docs/zh/quickstart.md
+++ b/pages/src/content/docs/zh/quickstart.md
@@ -66,7 +66,7 @@ cd path/to/your-repo
 # 工作区模式 —— 评审 staged + unstaged + untracked 变更（默认）
 ocr review
 
-# 分支区间 —— 评审 feature-branch 自与 main 分叉以来的变更（合并基准模式）
+# 分支区间 —— 评审 feature-branch 与 main 分叉后的变更（合并基准模式）
 ocr review --from main --to feature-branch
 
 # 单个 commit —— 评审该 commit 引入的 diff


### PR DESCRIPTION
## Description

Improve the Chinese wording for branch-range reviews in `README.zh-CN.md` and the Chinese quickstart guide.

The previous phrase “自与 main 分叉以来” was awkward. The revised wording “与 main 分叉后的变更” preserves the documented merge-base behavior while reading more naturally.

This is a documentation-only change. No commands or application behavior are changed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [ ] `make test` passes locally
- [x] Manual testing (describe below)

Validation performed:

- `node scripts/github-actions/check-translation-sync.test.js`
- `git diff --check`
- Manual review of both Chinese documentation locations

## Checklist

- [ ] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

None.