### PR TITLE
fix(diff): preserve staged ignored files in workspace

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -385,15 +385,17 @@ func matchGitignoreDirectory(relPath, pattern string) bool {
 }
 
 // filterDiffs removes diffs whose file paths are excluded.
+//
+// .gitignore governs untracked files only; untrackedFilesList
+// already screens those before they become diffs.
 func (p *Provider) filterDiffs(diffs []model.Diff) []model.Diff {
-	patterns := p.loadGitignorePatterns()
 	var result []model.Diff
 	for _, d := range diffs {
 		path := d.NewPath
 		if path == "/dev/null" {
 			path = d.OldPath
 		}
-		if !p.isPathExcluded(path, patterns) {
+		if !p.isPathExcluded(path, nil) {
 			result = append(result, d)
 		}
 	}

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -538,3 +538,55 @@ func TestCommitDiffMergeCommitReviewsFirstParentDiff(t *testing.T) {
 		t.Error("NewFileContent is empty: content was not read at the merge commit")
 	}
 }
+
+// Issue #1121: staged additions matching .gitignore vanished from
+// workspace review; only untracked ignored files stay excluded.
+func TestWorkspaceDiffKeepsStagedFileMatchingGitignore(t *testing.T) {
+	repo := t.TempDir()
+	runGitTest(t, repo, "init", "-q")
+	runGitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitTest(t, repo, "config", "user.name", "Test User")
+	runGitTest(t, repo, "config", "commit.gpgsign", "false")
+
+	writeFile := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	writeFile(".gitignore", "vendor/\n")
+	writeFile("src/app.go", "package app\n\nconst Version = 1\n")
+	runGitTest(t, repo, "add", ".gitignore", "src/app.go")
+	runGitTest(t, repo, "commit", "-q", "-m", "initial commit")
+
+	// Tracked modification, force-added new file, and an untracked ignored file.
+	writeFile("src/app.go", "package app\n\nconst Version = 2\n")
+	writeFile("src/ui/vendor/lib/helper.go", "package lib\n\nfunc Helper() {}\n")
+	writeFile("src/ui/vendor/lib/generated.go", "package lib\n\nfunc Generated() {}\n")
+	runGitTest(t, repo, "add", "-f", "src/ui/vendor/lib/helper.go")
+
+	provider := NewWorkspaceProvider(repo, gitcmd.New(0))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff (workspace) returned error: %v", err)
+	}
+
+	paths := make(map[string]bool, len(diffs))
+	for _, d := range diffs {
+		paths[d.NewPath] = true
+	}
+	if !paths["src/app.go"] {
+		t.Errorf("modified tracked file missing from workspace diff; got %v", paths)
+	}
+	if !paths["src/ui/vendor/lib/helper.go"] {
+		t.Errorf("staged new file matching .gitignore was dropped; got %v", paths)
+	}
+	if paths["src/ui/vendor/lib/generated.go"] {
+		t.Errorf("untracked ignored file must stay excluded; got %v", paths)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes workspace reviews dropping staged files that match `.gitignore` patterns.

## Changes

- Stop reapplying `.gitignore` rules to diffs already collected by Git.
- Continue excluding ignored untracked files.
- Preserve existing internal directory exclusions.
- Add a regression test covering tracked, staged, and ignored untracked files together.

Related #1121 