### PR TITLE
fix(action): support explicit llm_protocol and preserve protocol env override (#1134)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,20 @@ inputs:
   llm_model:
     description: Model name (mapped to env OCR_LLM_MODEL).
     required: true
+  llm_protocol:
+    description: >-
+      LLM protocol: openai, openai-responses, anthropic, or a custom protocol name
+      (mapped to env OCR_LLM_PROTOCOL). If omitted, falls back to the protocol
+      selected by llm_use_anthropic.
+    required: false
   llm_use_anthropic:
     description: >-
       Selects the LLM protocol (mapped to env OCR_USE_ANTHROPIC). An explicitly supplied empty
       string, true, 1, or yes selects Anthropic
       case-insensitively; every other value selects the OpenAI-compatible
-      protocol, preserving the CLI environment contract.
-    required: true
+      protocol, preserving the CLI environment contract. Ignored when llm_protocol is set.
+    required: false
+    default: 'false'
   llm_auth_header:
     description: Custom auth header name (mapped to env OCR_LLM_AUTH_HEADER).
     required: false
@@ -379,6 +386,7 @@ runs:
       env:
         OCR_LLM_URL: ${{ inputs.llm_url }}
         OCR_LLM_MODEL: ${{ inputs.llm_model }}
+        OCR_LLM_PROTOCOL: ${{ inputs.llm_protocol }}
         OCR_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
         OCR_LLM_AUTH_HEADER: ${{ inputs.llm_auth_header }}
         OCR_EXTRA_BODY: ${{ inputs.llm_extra_body }}
@@ -389,13 +397,14 @@ runs:
         case "$NORMALIZED_USE_ANTHROPIC" in
           ""|true|1|yes)
             OCR_USE_ANTHROPIC="true"
-            OCR_LLM_PROTOCOL="anthropic"
+            DEFAULT_PROTOCOL="anthropic"
             ;;
           *)
             OCR_USE_ANTHROPIC="false"
-            OCR_LLM_PROTOCOL="openai"
+            DEFAULT_PROTOCOL="openai"
             ;;
         esac
+        RESOLVED_PROTOCOL="${OCR_LLM_PROTOCOL:-$DEFAULT_PROTOCOL}"
         ocr config unset provider
         ocr config set llm.auth_token ""
         ocr config set llm.extra_headers ""
@@ -403,7 +412,7 @@ runs:
         ocr config set llm.url "$OCR_LLM_URL"
         ocr config set llm.model "$OCR_LLM_MODEL"
         ocr config set llm.use_anthropic "$OCR_USE_ANTHROPIC"
-        ocr config set llm.protocol "$OCR_LLM_PROTOCOL"
+        ocr config set llm.protocol "$RESOLVED_PROTOCOL"
         ocr config set llm.auth_header "$OCR_LLM_AUTH_HEADER"
         ocr config set llm.auth_token_cmd 'printf "%s" "$OCR_LLM_TOKEN"'
         ocr config set llm.extra_body "$OCR_EXTRA_BODY"
@@ -442,6 +451,7 @@ runs:
         # alike and a checkpoint survives a change that should have killed it.
         OCR_FP_LLM_URL: ${{ inputs.llm_url }}
         OCR_FP_LLM_MODEL: ${{ inputs.llm_model }}
+        OCR_FP_LLM_PROTOCOL: ${{ inputs.llm_protocol }}
         OCR_FP_LLM_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
         OCR_FP_LANGUAGE: ${{ inputs.language }}
         OCR_FP_LLM_EXTRA_BODY: ${{ inputs.llm_extra_body }}
@@ -574,6 +584,7 @@ runs:
               .update(JSON.stringify([
                 process.env.OCR_FP_LLM_URL,
                 process.env.OCR_FP_LLM_MODEL,
+                process.env.OCR_FP_LLM_PROTOCOL,
                 process.env.OCR_FP_LLM_USE_ANTHROPIC,
                 process.env.OCR_FP_LANGUAGE,
                 process.env.OCR_FP_LLM_EXTRA_BODY,
@@ -647,6 +658,7 @@ runs:
         OCR_LLM_URL: ${{ inputs.llm_url }}
         OCR_LLM_TOKEN: ${{ inputs.llm_auth_token }}
         OCR_LLM_MODEL: ${{ inputs.llm_model }}
+        OCR_LLM_PROTOCOL: ${{ inputs.llm_protocol }}
         OCR_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
         OCR_LLM_AUTH_HEADER: ${{ inputs.llm_auth_header }}
         OCR_LLM_EXTRA_HEADERS: ${{ inputs.llm_extra_headers }}

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -745,6 +745,49 @@ function testConfigurePreservesLegacyUseAnthropicResolution() {
   }
 }
 
+function testConfigureProtocolHonorsExplicitLlmProtocol() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  for (const protocol of ["openai-responses", "openai", "anthropic", "custom-protocol"]) {
+    const fixture = makeFixture();
+    try {
+      const values = inputValues({
+        llm_url: "https://llm.example.invalid/v1",
+        llm_model: "contract-model",
+        llm_protocol: protocol,
+        llm_use_anthropic: "false",
+        llm_auth_token: "protocol-token-sentinel",
+      });
+      const result = runStep(configure, values, fixture);
+      assert.strictEqual(result.status, 0, `Configure OCR failed for llm_protocol=${protocol}; ${resultDescription(result)}`);
+      const configured = configValues(configOperations(fixture));
+      assert.strictEqual(configured["llm.protocol"], protocol);
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+}
+
+function testConfigureProtocolHonorsEnvOverride() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+      llm_auth_token: "protocol-token-sentinel",
+    });
+    const result = runStep(configure, values, fixture, { OCR_LLM_PROTOCOL: "openai-responses" });
+    assert.strictEqual(result.status, 0, `Configure OCR failed with OCR_LLM_PROTOCOL env; ${resultDescription(result)}`);
+    const configured = configValues(configOperations(fixture));
+    assert.strictEqual(configured["llm.protocol"], "openai-responses");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
 function testConfigureClearsStaleExtraHeadersBeforeTokenCommand() {
   const configure = stepNamed("Configure OCR");
   assert.ok(configure, "action.yml must retain the Configure OCR step");
@@ -1009,6 +1052,7 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
     "Configure OCR": [
       "OCR_LLM_URL",
       "OCR_LLM_MODEL",
+      "OCR_LLM_PROTOCOL",
       "OCR_USE_ANTHROPIC",
       "OCR_LLM_AUTH_HEADER",
       "OCR_EXTRA_BODY",
@@ -1018,6 +1062,7 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
       "OCR_LLM_URL",
       "OCR_LLM_TOKEN",
       "OCR_LLM_MODEL",
+      "OCR_LLM_PROTOCOL",
       "OCR_USE_ANTHROPIC",
       "OCR_LLM_AUTH_HEADER",
       "OCR_LLM_EXTRA_HEADERS",
@@ -1102,6 +1147,8 @@ const TESTS = [
   ["Configure OCR neutralizes stale provider and static token", testConfigureNeutralizesStaleProviderAndStaticToken],
   ["Configure OCR sets a protocol consistent with use_anthropic", testConfigureProtocolTracksUseAnthropic],
   ["Configure OCR preserves legacy use_anthropic resolution", testConfigurePreservesLegacyUseAnthropicResolution],
+  ["Configure OCR honors explicit llm_protocol input", testConfigureProtocolHonorsExplicitLlmProtocol],
+  ["Configure OCR honors OCR_LLM_PROTOCOL env override", testConfigureProtocolHonorsEnvOverride],
   ["Configure OCR clears stale persisted extra headers", testConfigureClearsStaleExtraHeadersBeforeTokenCommand],
   ["Configure OCR clears stale persisted retry codes", testConfigureClearsStaleRetryCodesBeforeEndpointConfig],
   ["Run OpenCodeReview retains the extra-headers env override", testRunRetainsExtraHeadersEnvironmentOverride],


### PR DESCRIPTION
## Description

In `action.yml`, the `Configure OCR` step introduced in #1051 unconditionally set `llm.protocol` to `"openai"` whenever `llm_use_anthropic` was false, discarding any custom/Responses protocol set via environment variables (e.g. `OCR_LLM_PROTOCOL: openai-responses`). This caused reviews against models requiring the OpenAI Responses API (such as models with reasoning effort or function tools) to fail with `400 Bad Request` against `/v1/chat/completions`.

This PR:
1. Adds an optional `llm_protocol` input to `action.yml` (mapped to `OCR_LLM_PROTOCOL`), allowing workflows to explicitly configure protocols like `openai-responses`.
2. Resolves `llm.protocol` using `OCR_LLM_PROTOCOL` when provided (either via `llm_protocol` input or step `env: OCR_LLM_PROTOCOL`), and only falls back to `anthropic` / `openai` based on `llm_use_anthropic` when omitted.
3. Includes `OCR_FP_LLM_PROTOCOL` in the checkpoint range cache fingerprint so changing the protocol invalidates stale checkpoint hashes.
4. Forwards `OCR_LLM_PROTOCOL` into the `Run OpenCodeReview` step environment.
5. Adds contract tests verifying both explicit `llm_protocol` input and `OCR_LLM_PROTOCOL` environment override resolution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

- [x] `npm run test:github-actions` (all 26 action contract tests pass, including new `llm_protocol` contract tests)
- [x] `npm run test:update` passes
- [x] `npm run test:launcher` passes

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1134
