### PR TITLE
fix(ci): restore npm provenance by publishing from GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,13 @@ jobs:
 
   npm-publish:
     needs: release
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
       image: node:24
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
 
@@ -214,7 +215,7 @@ jobs:
             if [ "$already" = "$VERSION" ]; then
               echo "Skip: ${pkg_name}@${VERSION} already published"
             else
-              npm publish "$pkg_dir" --access public
+              npm publish "$pkg_dir" --access public --provenance
               echo "Published: ${pkg_name}@${VERSION}"
             fi
           done
@@ -237,7 +238,7 @@ jobs:
           if [ "$already" = "$VERSION" ]; then
             echo "Skip: ${pkg_name}@${VERSION} already published"
           else
-            npm publish --access public
+            npm publish --access public --provenance
             echo "Published: ${pkg_name}@${VERSION}"
           fi
         env:


### PR DESCRIPTION
## Summary

Restores npm provenance attestation for all published packages (`@alibaba-group/open-code-review` plus the six `@alibaba-group/ocr-*` platform packages) by moving the lightweight `npm-publish` job back to a GitHub-hosted runner with `id-token: write` and passing `--provenance` to both `npm publish` invocations.

Fixes #1137.

## Background

Provenance was added in 365c9ee (OIDC trusted publishing) and worked while publishes ran on `ubuntu-latest` (last attested release: 1.3.1). When the release pipeline moved to self-hosted runners (76b4d5a), `npm publish --provenance` started failing with E422 — npm provenance rejects OIDC tokens minted outside GitHub-hosted runners — so f577742 dropped the flag and the `id-token` permission. Every release since v1.3.4 has published without attestation, which downstream trust tools (e.g. mise/aube `no-downgrade`) now flag as a supply-chain trust downgrade, breaking installs.

## Change

- `npm-publish` job: `runs-on: self-hosted` → `ubuntu-latest` (the build and release jobs stay self-hosted, untouched).
- `npm-publish` permissions: add `id-token: write` (keeps `contents: read`).
- Both `npm publish` commands gain `--provenance`.

The `node:24` container, `.npmrc`/`NODE_AUTH_TOKEN` auth, and the already-published skip guard are unchanged. A publish whose OIDC token is unavailable now fails loudly instead of silently shipping without provenance.

## Validation

- `make test` green (including the `internal/release` tests that pin release.yml content).
- YAML parse check; grep-verified: exactly one `runs-on` changed, `--provenance` appears on both publishes, `id-token: write` scoped to the two jobs that need it.
- The green tick itself is observable on npmjs.org after the next tag release.