### PR TITLE
fix(diff): propagate untracked file listing errors

### DIFF
--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -620,8 +620,11 @@ func (p *Provider) untrackedFileDiffs(ctx context.Context) ([]string, error) {
 }
 
 func (p *Provider) untrackedFilesList(ctx context.Context) ([]string, error) {
-	out, err := p.runGit(ctx, "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard")
-	if err != nil || out == "" {
+	out, stderr, err := p.runGitSplit(ctx, "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, gitFailure("git ls-files", stderr, err)
+	}
+	if out == "" {
 		return nil, nil
 	}
 	patterns := p.loadGitignorePatterns()

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -134,6 +134,17 @@ func TestGetDiff_WorkspaceFailureSurfacesFallbackMessage(t *testing.T) {
 	}
 }
 
+func TestUntrackedFilesListPropagatesGitFailure(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "missing-repo")
+
+	provider := NewWorkspaceProvider(repo, nil)
+
+	_, err := provider.untrackedFilesList(context.Background())
+	if err == nil {
+		t.Fatal("expected untrackedFilesList to return git error")
+	}
+}
+
 // shimGit puts a fake `git` at the front of PATH for the duration of the test.
 func shimGit(t *testing.T, body string) {
 	t.Helper()

--- a/internal/diff/git_error_test.go
+++ b/internal/diff/git_error_test.go
@@ -134,6 +134,11 @@ func TestGetDiff_WorkspaceFailureSurfacesFallbackMessage(t *testing.T) {
 	}
 }
 
+// TestUntrackedFilesListPropagatesGitFailure separates the two cases the old
+// `if err != nil || out == ""` folded together: a repository with no untracked
+// files, and git failing to enumerate them at all. The second one used to
+// return an empty list, so a workspace review carried on with the untracked
+// half of its input missing and no way for the caller to notice.
 func TestUntrackedFilesListPropagatesGitFailure(t *testing.T) {
 	repo := filepath.Join(t.TempDir(), "missing-repo")
 
@@ -142,6 +147,11 @@ func TestUntrackedFilesListPropagatesGitFailure(t *testing.T) {
 	_, err := provider.untrackedFilesList(context.Background())
 	if err == nil {
 		t.Fatal("expected untrackedFilesList to return git error")
+	}
+	// Pins gitFailure rather than any error: a bare fmt.Errorf would satisfy the
+	// check above while dropping git's own diagnosis, which is the #972 regression.
+	if got := err.Error(); !strings.Contains(got, "git ls-files failed") {
+		t.Errorf("error %q lost the operation name", got)
 	}
 }
 


### PR DESCRIPTION
## Description

In workspace mode, untracked files are collected with `git ls-files --others --exclude-standard`.

Previously, a failure from this command was handled the same way as a successful command that returned no files:

```go
if err != nil || out == "" {
    return nil, nil
}
```

As a result, callers could not distinguish between "there are no untracked files" and "Git failed to enumerate untracked files". If the command fails after the tracked workspace diff has already been collected, workspace diff collection may continue without knowing that the untracked-file portion of the input could not be collected.

This PR separates these two cases. `git ls-files` is now executed through `runGitSplit`, and failures are propagated with `gitFailure`, consistent with the error handling used by other Git operations in the diff provider. A successful command with an empty result still means there are no untracked files, as before.

A regression test verifies that a failed Git invocation in `untrackedFilesList` returns an error instead of being silently treated as an empty result.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

Added `TestUntrackedFilesListPropagatesGitFailure`, which forces the Git invocation to fail and verifies that `untrackedFilesList` returns an error.

Verified locally with:

```bash
make check
make test
make build
```

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

No related issue. This was found while reviewing the workspace diff error-handling path.