### PR TITLE
feat(diff): fetch missing commits on demand in shallow clones

### DIFF
--- a/cmd/opencodereview/delegate_cmd.go
+++ b/cmd/opencodereview/delegate_cmd.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/alibaba/open-code-review/internal/agent"
 	"github.com/alibaba/open-code-review/internal/config/rules"
@@ -101,11 +102,19 @@ func loadDelegateContext(opts delegateOptions) (*delegateContext, error) {
 	}
 	applyCLIExcludes(cc, splitPaths(opts.excludes))
 
-	// Security: reject ref-option injection.
+	// Security: reject ref-option injection. The shallow-clone recovery inside
+	// may substitute resolved SHAs into the options, so the validated values
+	// flow back into the delegate options before any provider is built (#634).
+	// The recovery may fetch from origin over the network; unlike review_cmd,
+	// this path has no caller-supplied context, so bound it so a hung origin
+	// cannot stall the validation step indefinitely.
 	reviewOpts := reviewOptions{from: opts.from, to: opts.to, commit: opts.commit}
-	if err := validateReviewRefs(cc.RepoDir, reviewOpts); err != nil {
+	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer fetchCancel()
+	if err := validateReviewRefs(fetchCtx, cc.GitRunner, cc.RepoDir, &reviewOpts); err != nil {
 		return nil, err
 	}
+	opts.from, opts.to, opts.commit = reviewOpts.from, reviewOpts.to, reviewOpts.commit
 
 	bg, err := resolveBackground(cc.RepoDir, opts.background, opts.backgroundFile, opts.commit)
 	if err != nil {

--- a/cmd/opencodereview/git_test.go
+++ b/cmd/opencodereview/git_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,7 +142,7 @@ func TestRequireGitRepo_Invalid(t *testing.T) {
 
 func TestValidateReviewRefs_ValidCommit(t *testing.T) {
 	dir := initTestGitRepo(t)
-	err := validateReviewRefs(dir, reviewOptions{commit: "HEAD"})
+	err := validateReviewRefs(context.Background(), nil, dir, &reviewOptions{commit: "HEAD"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -149,7 +150,7 @@ func TestValidateReviewRefs_ValidCommit(t *testing.T) {
 
 func TestValidateReviewRefs_InvalidCommit(t *testing.T) {
 	dir := initTestGitRepo(t)
-	err := validateReviewRefs(dir, reviewOptions{commit: "nonexistent-ref-xyz"})
+	err := validateReviewRefs(context.Background(), nil, dir, &reviewOptions{commit: "nonexistent-ref-xyz"})
 	if err == nil {
 		t.Fatal("expected error for invalid commit ref")
 	}
@@ -157,7 +158,7 @@ func TestValidateReviewRefs_InvalidCommit(t *testing.T) {
 
 func TestValidateReviewRefs_EmptySkipped(t *testing.T) {
 	dir := initTestGitRepo(t)
-	err := validateReviewRefs(dir, reviewOptions{})
+	err := validateReviewRefs(context.Background(), nil, dir, &reviewOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/alibaba/open-code-review/internal/agent"
 	"github.com/alibaba/open-code-review/internal/diff"
+	"github.com/alibaba/open-code-review/internal/gitcmd"
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/mcp"
 	"github.com/alibaba/open-code-review/internal/session"
@@ -128,7 +129,10 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 	applyCLIExcludes(cc, splitPaths(opts.excludes))
 
 	// Security (#112): reject ref-option injection before any git invocation.
-	if err := validateReviewRefs(cc.RepoDir, opts); err != nil {
+	// The shallow-clone recovery inside may substitute resolved SHAs into opts,
+	// which must happen before any provider is constructed (the first one is
+	// validateResumeIdentity below).
+	if err := validateReviewRefs(ctx, cc.GitRunner, cc.RepoDir, &opts); err != nil {
 		return err
 	}
 
@@ -458,29 +462,89 @@ func requireGitRepo(dir string) error {
 
 // validateReviewRefs rejects ref-option injection (#112): any --from/--to/
 // --commit value must be a real commit ref and must not start with '-'.
-func validateReviewRefs(repoDir string, opts reviewOptions) error {
-	refs := []struct {
+//
+// In a shallow clone (#634), a ref that fails raw resolution gets one
+// on-demand depth-1 fetch from origin before the verdict — the canonical
+// GitLab CI case (`GIT_DEPTH: "1"` single-branch clone, `--from
+// origin/$TARGET_BRANCH --to $CI_COMMIT_SHA`) dies right here without it.
+// Refs that resolve only through the fetch's fallback spellings (`origin/<name>`
+// or the ocr-fetch destination) are replaced in opts by their resolved SHAs:
+// the downstream `git diff`/`git show` call sites resolve refs raw and would
+// reject the bare spelling the flag carried. Non-shallow repositories, and
+// every path where refs resolve outright, keep today's behavior and commands.
+func validateReviewRefs(ctx context.Context, runner *gitcmd.Runner, repoDir string, opts *reviewOptions) error {
+	type refFlag struct {
 		flag string
 		ref  string
-	}{
+	}
+	refs := []refFlag{
 		{"--from", opts.from},
 		{"--to", opts.to},
 		{"--commit", opts.commit},
 	}
-	for _, item := range refs {
+	// resolveErr returns today's exact error for a ref that fails raw
+	// resolution (including git's own message when it printed one).
+	resolveErr := func(item refFlag) error {
+		out, err := runGitCmd(repoDir, "rev-parse", "--verify", "--end-of-options", item.ref+"^{commit}")
+		if err == nil {
+			return nil
+		}
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return fmt.Errorf("%s value %q is not a valid commit ref: %s", item.flag, item.ref, msg)
+		}
+		return fmt.Errorf("%s value %q is not a valid commit ref", item.flag, item.ref)
+	}
+
+	for i, item := range refs {
 		if item.ref == "" {
 			continue
 		}
 		if strings.HasPrefix(item.ref, "-") {
 			return fmt.Errorf("%s value %q is not a valid git ref: refs must not start with '-'", item.flag, item.ref)
 		}
-		if out, err := runGitCmd(repoDir, "rev-parse", "--verify", "--end-of-options", item.ref+"^{commit}"); err != nil {
-			msg := strings.TrimSpace(string(out))
-			if msg != "" {
-				return fmt.Errorf("%s value %q is not a valid commit ref: %s", item.flag, item.ref, msg)
-			}
-			return fmt.Errorf("%s value %q is not a valid commit ref", item.flag, item.ref)
+		if err := resolveErr(item); err == nil {
+			continue
 		}
+
+		// Shallow-clone recovery: fetch every remaining unresolved ref from
+		// origin once at depth 1, then retry. EnsureShallowRefs is a no-op
+		// (returning a nil map) unless the repo is shallow with an origin
+		// URL, so this never disturbs other repositories.
+		pending := make([]refFlag, 0, len(refs)-i)
+		for _, rest := range refs[i:] {
+			if rest.ref != "" {
+				pending = append(pending, rest)
+			}
+		}
+		spellings := make([]string, len(pending))
+		for j, rest := range pending {
+			spellings[j] = rest.ref
+		}
+		resolved, ferr := diff.EnsureShallowRefs(ctx, runner, repoDir, spellings)
+		if ferr != nil {
+			// Fetch context only; the verdict below stays today's error.
+			fmt.Fprintf(os.Stderr, "[ocr] shallow clone: on-demand fetch failed: %v\n", ferr)
+		}
+		for _, rest := range pending {
+			err := resolveErr(rest)
+			if err == nil {
+				continue // resolves raw now (or always did): no substitution
+			}
+			sha, ok := resolved[rest.ref]
+			if !ok {
+				return err
+			}
+			switch rest.flag {
+			case "--from":
+				opts.from = sha
+			case "--to":
+				opts.to = sha
+			case "--commit":
+				opts.commit = sha
+			}
+		}
+		return nil
 	}
 	return nil
 }

--- a/cmd/opencodereview/review_cmd_test.go
+++ b/cmd/opencodereview/review_cmd_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestValidateReviewRefsRejectsOptionLikeCommit(t *testing.T) {
-	err := validateReviewRefs(t.TempDir(), reviewOptions{commit: "-O./pwn.sh"})
+	err := validateReviewRefs(context.Background(), nil, t.TempDir(), &reviewOptions{commit: "-O./pwn.sh"})
 	if err == nil {
 		t.Fatal("expected option-like --commit ref to be rejected")
 	}
@@ -87,7 +88,7 @@ func TestReviewResultErrorUsesManifestTerminalState(t *testing.T) {
 }
 
 func TestValidateReviewRefsRejectsOptionLikeRangeRef(t *testing.T) {
-	err := validateReviewRefs(t.TempDir(), reviewOptions{to: "-O./pwn.sh"})
+	err := validateReviewRefs(context.Background(), nil, t.TempDir(), &reviewOptions{to: "-O./pwn.sh"})
 	if err == nil {
 		t.Fatal("expected option-like --to ref to be rejected")
 	}

--- a/cmd/opencodereview/review_shallow_test.go
+++ b/cmd/opencodereview/review_shallow_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Cmd-layer tests for the shallow-clone recovery in validateReviewRefs
+// (#634). Fixtures are throwaway repositories under t.TempDir() with a
+// file:// origin — hermetic, no network.
+
+// runGitFixture runs git in dir, failing the test on error, and returns
+// trimmed stdout.
+func runGitFixture(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git -C %s %v: %v\n%s", dir, args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// shallowFixture is an upstream repo plus a GIT_DEPTH=1 single-branch clone.
+type shallowFixture struct {
+	upstreamDir string
+	cloneDir    string
+	mainBranch  string
+	mainTip     string
+	featureTip  string
+}
+
+func newShallowFixture(t *testing.T) *shallowFixture {
+	t.Helper()
+	up := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		runGitFixture(t, up, args...)
+	}
+	write := func(name, content, msg string) {
+		t.Helper()
+		if err := execWriteFile(filepath.Join(up, name), content); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		runGitFixture(t, up, "add", name)
+		runGitFixture(t, up, "commit", "-q", "-m", msg)
+	}
+	write("f.txt", "c1\n", "c1")
+	write("f.txt", "c1\nc2\n", "c2")
+	write("f.txt", "c1\nc2\nc3\n", "c3")
+	mainBranch := runGitFixture(t, up, "rev-parse", "--abbrev-ref", "HEAD")
+	runGitFixture(t, up, "checkout", "-q", "-b", "feature")
+	write("feat.txt", "feat1\n", "feat1")
+	write("feat.txt", "feat1\nfeat2\n", "feat2")
+	featureTip := runGitFixture(t, up, "rev-parse", "HEAD")
+	runGitFixture(t, up, "checkout", "-q", mainBranch)
+	write("f.txt", "c1\nc2\nc3\nc4\n", "c4")
+	write("f.txt", "c1\nc2\nc3\nc4\nc5\n", "c5")
+	mainTip := runGitFixture(t, up, "rev-parse", "HEAD")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	parent := t.TempDir()
+	cmd := exec.Command("git", "-C", parent, "clone", "-q", "--depth", "1", "--single-branch", "--branch", "feature", "file://"+up, clone)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("shallow clone: %v\n%s", err, out)
+	}
+	return &shallowFixture{
+		upstreamDir: up,
+		cloneDir:    clone,
+		mainBranch:  mainBranch,
+		mainTip:     mainTip,
+		featureTip:  featureTip,
+	}
+}
+
+func execWriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// TestValidateReviewRefsShallowRetrySubstitutesSHA covers the retry branch:
+// `--from <bare target branch>` fails raw resolution in the GIT_DEPTH=1
+// clone, gets fetched at depth 1, resolves via the origin/<name> fallback,
+// and the resolved SHA replaces the flag value (the downstream diff/show
+// call sites are not fallback-aware). `--to <CI sha>` resolved raw and keeps
+// its spelling.
+func TestValidateReviewRefsShallowRetrySubstitutesSHA(t *testing.T) {
+	fx := newShallowFixture(t)
+	opts := reviewOptions{from: fx.mainBranch, to: fx.featureTip}
+
+	if err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts); err != nil {
+		t.Fatalf("validateReviewRefs in shallow clone: %v", err)
+	}
+	if opts.from != fx.mainTip {
+		t.Errorf("--from substituted to %q, want the main tip %q", opts.from, fx.mainTip)
+	}
+	if opts.to != fx.featureTip {
+		t.Errorf("--to = %q, want the raw spelling kept (%q)", opts.to, fx.featureTip)
+	}
+	// The N3 hand-off: the substituted value must resolve through a plain,
+	// non-fallback rev-parse (what `git diff`/`git show` will do with it).
+	if _, err := runGitCmd(fx.cloneDir, "rev-parse", "--verify", "--end-of-options", opts.from+"^{commit}"); err != nil {
+		t.Errorf("substituted --from %q does not resolve raw: %v", opts.from, err)
+	}
+}
+
+// TestValidateReviewRefsShallowOriginSpelling covers the canonical GitLab
+// spelling `--from origin/<target branch>`: it fails raw resolution (the
+// single-branch clone has no such tracking ref), gets fetched, and then
+// resolves under its own spelling — which every downstream raw `git diff`/
+// `git show` accepts, so it is deliberately NOT substituted. Only spellings
+// that resolve via the fallback (bare names, ocr-fetch SHAs) are replaced.
+func TestValidateReviewRefsShallowOriginSpelling(t *testing.T) {
+	fx := newShallowFixture(t)
+	opts := reviewOptions{from: "origin/" + fx.mainBranch, to: fx.featureTip}
+
+	if err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts); err != nil {
+		t.Fatalf("validateReviewRefs with origin/ spelling: %v", err)
+	}
+	if opts.from != "origin/"+fx.mainBranch {
+		t.Errorf("--from = %q, want the origin/ spelling kept (it resolves raw post-fetch)", opts.from)
+	}
+	// And the kept spelling must resolve raw now, which is what makes it safe
+	// downstream.
+	if _, err := runGitCmd(fx.cloneDir, "rev-parse", "--verify", "--end-of-options", opts.from+"^{commit}"); err != nil {
+		t.Errorf("--from %q does not resolve after recovery: %v", opts.from, err)
+	}
+}
+
+// TestValidateReviewRefsShallowToBareBranch covers the mixed case: the
+// origin/ spelling is kept while the bare to-side name — which resolves only
+// through the fallback — is substituted with its SHA.
+func TestValidateReviewRefsShallowToBareBranch(t *testing.T) {
+	fx := newShallowFixture(t)
+	opts := reviewOptions{from: "origin/" + fx.mainBranch, to: fx.mainBranch}
+
+	if err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts); err != nil {
+		t.Fatalf("validateReviewRefs with bare --to: %v", err)
+	}
+	if opts.from != "origin/"+fx.mainBranch {
+		t.Errorf("--from = %q, want the origin/ spelling kept", opts.from)
+	}
+	if opts.to != fx.mainTip {
+		t.Errorf("--to = %q, want the substituted main tip %q", opts.to, fx.mainTip)
+	}
+}
+
+// TestValidateReviewRefsShallowCommitMode covers `--commit <bare branch>`:
+// commit mode resolves a single commit, and the same recovery applies.
+func TestValidateReviewRefsShallowCommitMode(t *testing.T) {
+	fx := newShallowFixture(t)
+	opts := reviewOptions{commit: fx.mainBranch}
+
+	if err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts); err != nil {
+		t.Fatalf("validateReviewRefs --commit in shallow clone: %v", err)
+	}
+	if opts.commit != fx.mainTip {
+		t.Errorf("--commit substituted to %q, want %q", opts.commit, fx.mainTip)
+	}
+}
+
+// TestValidateReviewRefsShallowNoRemoteKeepsError pins the no-origin path:
+// today's exact error, no substitution, no recovery.
+func TestValidateReviewRefsShallowNoRemoteKeepsError(t *testing.T) {
+	fx := newShallowFixture(t)
+	runGitFixture(t, fx.cloneDir, "remote", "remove", "origin")
+	opts := reviewOptions{from: fx.mainBranch, to: fx.featureTip}
+
+	err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts)
+	if err == nil {
+		t.Fatal("expected today's error without an origin remote")
+	}
+	want := fmt.Sprintf("--from value %q is not a valid commit ref", fx.mainBranch)
+	if !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("error = %q, want prefix %q", err, want)
+	}
+	if opts.from != fx.mainBranch || opts.to != fx.featureTip {
+		t.Errorf("options were modified without recovery: %+v", opts)
+	}
+}
+
+// TestValidateReviewRefsShallowUnreachableOriginKeepsError pins the offline
+// path: the recovery fetch fails, the failure is reported as context, and the
+// verdict stays today's exact error.
+func TestValidateReviewRefsShallowUnreachableOriginKeepsError(t *testing.T) {
+	fx := newShallowFixture(t)
+	runGitFixture(t, fx.cloneDir, "remote", "set-url", "origin", "file:///ocr-634-nonexistent-origin")
+	opts := reviewOptions{from: fx.mainBranch, to: fx.featureTip}
+
+	err := validateReviewRefs(context.Background(), nil, fx.cloneDir, &opts)
+	if err == nil {
+		t.Fatal("expected today's error with an unreachable origin")
+	}
+	want := fmt.Sprintf("--from value %q is not a valid commit ref", fx.mainBranch)
+	if !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("error = %q, want prefix %q", err, want)
+	}
+	if opts.from != fx.mainBranch {
+		t.Errorf("--from was substituted despite the failed fetch: %q", opts.from)
+	}
+}

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -61,6 +61,15 @@ type Provider struct {
 	commit string // single commit hash/ref
 
 	mergeBase string // cached common ancestor for range mode
+
+	// Shallow on-demand fetch state (#634): deepenTried records the deepest
+	// fetch round attempted while recovering a missing merge-base (0 = the
+	// deepen loop never ran), and deepenDiag carries the last fetch failure
+	// for surfacing in rangeBaseError. Written only on the merge-base
+	// recovery path, which — like mergeBase itself — is not called
+	// concurrently on one Provider.
+	deepenTried int
+	deepenDiag  string
 }
 
 // NewProvider creates a Provider for range mode: from..to (via merge-base).
@@ -178,7 +187,7 @@ func (p *Provider) GetDiff(ctx context.Context) ([]model.Diff, error) {
 	case ModeRange:
 		base := p.MergeBase(ctx)
 		if base == "" {
-			return nil, fmt.Errorf("cannot find merge-base between %s and %s", p.from, p.to)
+			return nil, p.rangeBaseError()
 		}
 		out, stderr, err := p.runGitSplit(ctx, "-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-textconv", "--find-renames", "--src-prefix=a/", "--dst-prefix=b/", "--no-color", "-U"+fmt.Sprint(DiffContextLines), "--end-of-options", base, p.to, "--")
 		if err != nil {
@@ -404,10 +413,35 @@ func (p *Provider) filterDiffs(diffs []model.Diff) []model.Diff {
 
 func (p *Provider) computeMergeBase(ctx context.Context, from, to string) string {
 	out, err := p.runGit(ctx, "merge-base", "--end-of-options", from, to)
-	if err != nil {
-		return ""
+	if err == nil {
+		if base := strings.TrimSpace(out); base != "" {
+			return base
+		}
 	}
-	return strings.TrimSpace(out)
+	// Empty result: in a shallow clone (GitLab CI GIT_DEPTH=1) the common
+	// ancestor may simply not be cloned yet. Give the on-demand deepen loop a
+	// chance (#634) before letting the caller emit the usual error. The loop
+	// gates on shallowness and an origin URL, so non-shallow repositories pay
+	// one constant-time probe here and nothing else.
+	return p.deepenForMergeBase(ctx, from, to)
+}
+
+// rangeBaseError builds the range-mode failure for a missing merge-base. On
+// paths where the shallow deepen loop actually ran, it appends a hint about the
+// shallow-clone situation — including the fetch failure, when that is what
+// stopped the loop; on every other path the message is byte-identical to the
+// historical one.
+func (p *Provider) rangeBaseError() error {
+	base := fmt.Errorf("cannot find merge-base between %s and %s", p.from, p.to)
+	if p.deepenTried == 0 {
+		return base
+	}
+	if p.deepenDiag != "" {
+		return fmt.Errorf("%w (shallow clone: fetching from origin up to depth %d failed: %s)",
+			base, p.deepenTried, p.deepenDiag)
+	}
+	return fmt.Errorf("%w (shallow clone: fetched history from origin up to depth %d without finding a common ancestor; increase the clone depth (e.g. GIT_DEPTH) or use a full clone)",
+		base, p.deepenTried)
 }
 
 // RemoteIdentity returns a stable, credential-free identity string for the

--- a/internal/diff/git_shallow_test.go
+++ b/internal/diff/git_shallow_test.go
@@ -1,0 +1,624 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package diff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/gitcmd"
+)
+
+// Shallow-clone integration tests for on-demand fetch (#634).
+//
+// Every fixture is a throwaway repository under t.TempDir() wired to a
+// file:// origin: the tests are hermetic (no network, fixed trees, no timing
+// dependence) and never touch any repository outside their temp dirs.
+
+// upstreamFixture is the "origin" side: a main branch, a feature branch cut
+// from mergeBase, and a tag pointing at mergeBase.
+type upstreamFixture struct {
+	dir        string
+	mainBranch string // "main" or "master", git-version dependent
+	mainTip    string
+	mergeBase  string
+	featureTip string
+}
+
+// newUpstreamFixture builds main c1..c5 with feature cut at c3 plus feat1 and
+// feat2, and tag v1 at c3. The merge-base of the two branch tips is c3 (two
+// commits back on each side).
+func newUpstreamFixture(t *testing.T) *upstreamFixture {
+	t.Helper()
+	if skipNonUnixShallowFixture(t) {
+		return nil
+	}
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "f.txt", "c1\n", "c1")
+	writeCommit(t, repo, "f.txt", "c1\nc2\n", "c2")
+	writeCommit(t, repo, "f.txt", "c1\nc2\nc3\n", "c3")
+	mergeBase := gitOut(t, repo, "rev-parse", "HEAD")
+	mainBranch := gitOut(t, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", "-b", "feature")
+	runGitTest(t, repo, "tag", "v1")
+	writeCommit(t, repo, "feat.txt", "feat1\n", "feat1")
+	writeCommit(t, repo, "feat.txt", "feat1\nfeat2\n", "feat2")
+	featureTip := gitOut(t, repo, "rev-parse", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", mainBranch)
+	writeCommit(t, repo, "f.txt", "c1\nc2\nc3\nc4\n", "c4")
+	writeCommit(t, repo, "f.txt", "c1\nc2\nc3\nc4\nc5\n", "c5")
+	mainTip := gitOut(t, repo, "rev-parse", "HEAD")
+	return &upstreamFixture{
+		dir:        repo,
+		mainBranch: mainBranch,
+		mainTip:    mainTip,
+		mergeBase:  mergeBase,
+		featureTip: featureTip,
+	}
+}
+
+// newDeepUpstreamFixture builds main c1..c12 with feature cut at c4 plus three
+// commits, so the merge-base is eight commits back on the main side. This is
+// the shape that forces the deepen loop through several doubling rounds.
+func newDeepUpstreamFixture(t *testing.T) *upstreamFixture {
+	t.Helper()
+	if skipNonUnixShallowFixture(t) {
+		return nil
+	}
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "f.txt", "c1\n", "c1")
+	for i := 2; i <= 4; i++ {
+		writeCommit(t, repo, "f.txt", fmt.Sprintf("c1..c%d\n", i), fmt.Sprintf("c%d", i))
+	}
+	mergeBase := gitOut(t, repo, "rev-parse", "HEAD")
+	mainBranch := gitOut(t, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", "-b", "feature")
+	for i := 1; i <= 3; i++ {
+		writeCommit(t, repo, "feat.txt", fmt.Sprintf("feat%d\n", i), fmt.Sprintf("feat%d", i))
+	}
+	featureTip := gitOut(t, repo, "rev-parse", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", mainBranch)
+	for i := 5; i <= 12; i++ {
+		writeCommit(t, repo, "f.txt", fmt.Sprintf("c1..c%d\n", i), fmt.Sprintf("c%d", i))
+	}
+	mainTip := gitOut(t, repo, "rev-parse", "HEAD")
+	return &upstreamFixture{
+		dir:        repo,
+		mainBranch: mainBranch,
+		mainTip:    mainTip,
+		mergeBase:  mergeBase,
+		featureTip: featureTip,
+	}
+}
+
+// newShallowClone clones the fixture the way GitLab CI does with GIT_DEPTH=1:
+// single-branch, depth 1, feature checked out, and no main-side history or
+// tracking ref at all.
+func newShallowClone(t *testing.T, up *upstreamFixture) string {
+	t.Helper()
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGitTest(t, t.TempDir(), "clone", "-q", "--depth", "1", "--single-branch", "--branch", "feature", "file://"+up.dir, clone)
+	return clone
+}
+
+// skipNonUnixShallowFixture gates the file://-clone fixtures. The return value
+// lets callers bail out after the skip fired.
+func skipNonUnixShallowFixture(t *testing.T) bool {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("file:// shallow-clone fixture relies on a Unix-style path URL")
+		return true
+	}
+	return false
+}
+
+// ensureRefsForTest mirrors the cmd layer's validateReviewRefs recovery core:
+// one depth-1 fetch for the missing refs, then fallback resolution. It fails
+// the test when the fetch itself fails, matching the happy-path callers.
+func ensureRefsForTest(t *testing.T, repoDir string, refs ...string) map[string]string {
+	t.Helper()
+	resolved, err := EnsureShallowRefs(context.Background(), gitcmd.New(2), repoDir, refs)
+	if err != nil {
+		t.Fatalf("EnsureShallowRefs(%v): %v", refs, err)
+	}
+	return resolved
+}
+
+// TestShallowRangeReviewCanonicalGitLabCase is the #634 reproducer: a
+// GIT_DEPTH=1 single-branch clone reviewing `--from origin/<target> --to
+// <CI_COMMIT_SHA>`. It is driven through the real sequence (depth-1 ensure
+// fetch, SHA substitution, then the doubling deepen loop inside
+// computeMergeBase) because a single-shot fetch cannot exercise the loop's
+// round-by-round convergence.
+func TestShallowRangeReviewCanonicalGitLabCase(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	// Validation pass: origin/<target> fails raw resolution in the clone.
+	from := "origin/" + up.mainBranch
+	resolved := ensureRefsForTest(t, clone, from)
+	sha, ok := resolved[from]
+	if !ok {
+		t.Fatalf("origin/%s did not resolve after the ensure fetch (map: %v)", up.mainBranch, resolved)
+	}
+	if sha != up.mainTip {
+		t.Errorf("resolved %s = %s, want the main tip %s", from, sha, up.mainTip)
+	}
+
+	// The cmd layer keeps this spelling post-recovery (it resolves raw once
+	// the fetch created the tracking ref); --to <CI sha> resolved raw all
+	// along. The provider sees exactly what production would construct.
+	provider := NewProvider(clone, from, up.featureTip, gitcmd.New(2))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff in shallow clone: %v", err)
+	}
+	if got := provider.MergeBase(context.Background()); got != up.mergeBase {
+		t.Errorf("merge-base = %s, want %s (c3)", got, up.mergeBase)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("got %d diffs, want 1 (feat.txt): %+v", len(diffs), diffs)
+	}
+	if diffs[0].NewPath != "feat.txt" || diffs[0].Insertions != 2 {
+		t.Errorf("diff = %q (+%d), want feat.txt with 2 insertions", diffs[0].NewPath, diffs[0].Insertions)
+	}
+}
+
+// TestShallowRangeReviewBareFromName covers `--from main`: the bare spelling
+// neither resolves nor fetches without the origin/ mapping, and post-fetch it
+// only resolves through the origin/<name> fallback.
+func TestShallowRangeReviewBareFromName(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	resolved := ensureRefsForTest(t, clone, up.mainBranch)
+	sha, ok := resolved[up.mainBranch]
+	if !ok || sha != up.mainTip {
+		t.Fatalf("bare %s resolved to %v (want %s) after fetch", up.mainBranch, resolved, up.mainTip)
+	}
+	// The bare spelling itself must still refuse to resolve: substitution is
+	// what makes the downstream raw `git diff <base> <sha>` work.
+	if out, err := gitOutErr(t, clone, "rev-parse", "--verify", "--quiet", up.mainBranch+"^{commit}"); err == nil {
+		t.Errorf("bare %s unexpectedly resolves as %s; test no longer pins the fallback", up.mainBranch, out)
+	}
+
+	provider := NewProvider(clone, sha, up.featureTip, gitcmd.New(2))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff with substituted from-SHA: %v", err)
+	}
+	if len(diffs) != 1 || diffs[0].NewPath != "feat.txt" {
+		t.Fatalf("got %+v, want the feat.txt diff", diffs)
+	}
+}
+
+// TestShallowRangeReviewToHead covers `--to HEAD`: HEAD resolves raw (it is
+// the checked-out commit), and the deepen loop maps it to the current branch
+// for its feature-side want instead of fetching the remote's default branch.
+func TestShallowRangeReviewToHead(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	from := "origin/" + up.mainBranch
+	resolved := ensureRefsForTest(t, clone, from)
+
+	provider := NewProvider(clone, resolved[from], "HEAD", gitcmd.New(2))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff with --to HEAD: %v", err)
+	}
+	if got := provider.MergeBase(context.Background()); got != up.mergeBase {
+		t.Errorf("merge-base = %s, want %s", got, up.mergeBase)
+	}
+	if len(diffs) != 1 || diffs[0].NewPath != "feat.txt" {
+		t.Fatalf("got %+v, want the feat.txt diff", diffs)
+	}
+}
+
+// TestShallowRangeReviewFromCheckedOutToBareTargetBranch covers
+// `--from <checked-out branch> --to <bare target-branch name>` (validation
+// N3): the to-side bare name resolves only via the fallback, and the resolved
+// SHA must reach GetDiff's raw `git diff <base> <to>` — without the
+// substitution this spelling dies with "unknown revision".
+func TestShallowRangeReviewFromCheckedOutToBareTargetBranch(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	// "feature" resolves raw (it is checked out); only the to-side name needs
+	// the recovery, exactly like validateReviewRefs' pending set.
+	resolved := ensureRefsForTest(t, clone, up.mainBranch)
+	provider := NewProvider(clone, "feature", resolved[up.mainBranch], gitcmd.New(2))
+	diffs, err := provider.GetDiff(context.Background())
+	if err != nil {
+		t.Fatalf("GetDiff with bare to-side name substituted: %v", err)
+	}
+	if len(diffs) != 1 || diffs[0].NewPath != "f.txt" {
+		t.Fatalf("got %+v, want the f.txt diff of the main-side commits", diffs)
+	}
+	if diffs[0].Insertions != 2 {
+		t.Errorf("insertions = %d, want 2 (c4 and c5 lines)", diffs[0].Insertions)
+	}
+}
+
+// TestShallowRangeReviewTagRef pins the tag path: `+v1:refs/remotes/origin/v1`
+// also auto-creates refs/tags/v1 (git's tag auto-follow), `v1^{commit}`
+// resolves, and a range from the tag completes after deepening.
+func TestShallowRangeReviewTagRef(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	resolved := ensureRefsForTest(t, clone, "v1")
+	if resolved["v1"] != up.mergeBase {
+		t.Fatalf("v1 resolved to %v, want the tagged commit %s", resolved["v1"], up.mergeBase)
+	}
+	if got := gitOut(t, clone, "rev-parse", "--verify", "refs/tags/v1^{commit}"); got != up.mergeBase {
+		t.Errorf("refs/tags/v1 = %s, want auto-follow to pin %s", got, up.mergeBase)
+	}
+
+	provider := NewProvider(clone, resolved["v1"], up.featureTip, gitcmd.New(2))
+	if _, err := provider.GetDiff(context.Background()); err != nil {
+		t.Fatalf("GetDiff from tag ref in shallow clone: %v", err)
+	}
+	if got := provider.MergeBase(context.Background()); got != up.mergeBase {
+		t.Errorf("merge-base = %s, want the tagged commit %s", got, up.mergeBase)
+	}
+}
+
+// TestShallowRangeReviewDeepHistory forces the doubling loop through several
+// rounds: the merge-base is eight commits back on the main side of a
+// twelve-commit history, which a depth-1 clone cannot reach.
+func TestShallowRangeReviewDeepHistory(t *testing.T) {
+	up := newDeepUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	from := "origin/" + up.mainBranch
+	resolved := ensureRefsForTest(t, clone, from)
+	provider := NewProvider(clone, resolved[from], up.featureTip, gitcmd.New(2))
+	if _, err := provider.GetDiff(context.Background()); err != nil {
+		t.Fatalf("GetDiff with deep history: %v", err)
+	}
+	if got := provider.MergeBase(context.Background()); got != up.mergeBase {
+		t.Errorf("merge-base = %s, want %s", got, up.mergeBase)
+	}
+}
+
+// TestShallowRangeReviewBoundExhaustedHintsShallow pins the bounded-failure
+// contract: with the depth cap lowered by the test hook, exhausting the loop
+// keeps today's error text as the prefix and appends the shallow-clone hint.
+func TestShallowRangeReviewBoundExhaustedHintsShallow(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	orig := shallowDeepenMaxDepth
+	shallowDeepenMaxDepth = 2 // the 2-back merge-base needs D=4: one doomed round
+	t.Cleanup(func() { shallowDeepenMaxDepth = orig })
+
+	from := "origin/" + up.mainBranch
+	resolved := ensureRefsForTest(t, clone, from)
+	provider := NewProvider(clone, resolved[from], up.featureTip, gitcmd.New(2))
+	_, err := provider.GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail with the deepen bound exhausted")
+	}
+	wantPrefix := fmt.Sprintf("cannot find merge-base between %s and %s", resolved[from], up.featureTip)
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("error %q does not keep today's message as the prefix", err)
+	}
+	if !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("error %q does not mention the shallow-clone situation", err)
+	}
+	if !strings.Contains(err.Error(), "depth 2") {
+		t.Errorf("error %q does not report the attempted depth bound", err)
+	}
+}
+
+// TestShallowEnsureRejectedUnknownSHA pins the server-gated SHA-want edge: a
+// SHA the origin does not have makes the whole fetch fail atomically, the
+// error carries git's own diagnosis, and no refs are resolved.
+func TestShallowEnsureRejectedUnknownSHA(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	const unknown = "1234567890123456789012345678901234567890"
+	resolved, err := EnsureShallowRefs(context.Background(), gitcmd.New(2), clone, []string{unknown})
+	if err == nil {
+		t.Fatal("expected the fetch of an unknown SHA to fail")
+	}
+	if resolved != nil {
+		t.Errorf("resolved map = %v, want nil on fetch failure", resolved)
+	}
+	if !strings.Contains(err.Error(), "git fetch failed") {
+		t.Errorf("error %q lost the operation name", err)
+	}
+	// Anchor on the object id, not git's prose: the SHA is locale-proof and
+	// proves git's message survived.
+	if !strings.Contains(err.Error(), unknown) {
+		t.Errorf("error %q carries no message from git", err)
+	}
+}
+
+// TestShallowNoRemotePreservesTodayErrors pins the no-origin path: no fetch
+// is ever attempted (argv recorded through a delegating git shim) and the
+// provider keeps today's exact merge-base error, without the shallow hint.
+func TestShallowNoRemotePreservesTodayErrors(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+	runGitTest(t, clone, "remote", "remove", "origin")
+
+	// Validation layer: nothing to do, and nothing attempted.
+	resolved, err := EnsureShallowRefs(context.Background(), gitcmd.New(2), clone, []string{up.mainBranch})
+	if err != nil || resolved != nil {
+		t.Fatalf("EnsureShallowRefs without origin = (%v, %v), want (nil, nil)", resolved, err)
+	}
+
+	log := installRecordingGitShim(t)
+	provider := NewProvider(clone, up.mainBranch, "HEAD", gitcmd.New(2))
+	_, err = provider.GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail without the origin history")
+	}
+	want := fmt.Sprintf("cannot find merge-base between %s and HEAD", up.mainBranch)
+	if err.Error() != want {
+		t.Errorf("error = %q, want today's exact %q", err, want)
+	}
+	if fetches := grepShimLog(t, log, "fetch"); len(fetches) > 0 {
+		t.Errorf("git fetch attempted without an origin remote: %v", fetches)
+	}
+}
+
+// TestNonShallowRepoNeverFetches pins requirement 2: a full clone pays zero
+// new git invocations on the success path, and only the constant-time shallow
+// probe on the merge-base failure path — never a fetch.
+func TestNonShallowRepoNeverFetches(t *testing.T) {
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "a.txt", "one\n", "root")
+	mainBranch := gitOut(t, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", "-b", "feature")
+	writeCommit(t, repo, "b.txt", "side\n", "side change")
+
+	log := installRecordingGitShim(t)
+
+	// Success path: no shallow probe at all.
+	if _, err := NewProvider(repo, mainBranch, "feature", gitcmd.New(2)).GetDiff(context.Background()); err != nil {
+		t.Fatalf("GetDiff in full clone: %v", err)
+	}
+	for _, line := range readShimLog(t, log) {
+		if strings.Contains(line, "is-shallow-repository") {
+			t.Errorf("shallow probe run on a success path: %q", line)
+		}
+		if strings.HasPrefix(line, "fetch ") {
+			t.Errorf("git fetch run on a success path: %q", line)
+		}
+	}
+
+	// Failure path (unresolvable endpoint): today's exact error, one shallow
+	// probe allowed, still no fetch.
+	_, err := NewProvider(repo, mainBranch, "nonexistent-ref-xyz", gitcmd.New(2)).GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail for an unresolvable ref")
+	}
+	want := fmt.Sprintf("cannot find merge-base between %s and nonexistent-ref-xyz", mainBranch)
+	if err.Error() != want {
+		t.Errorf("error = %q, want today's exact %q", err, want)
+	}
+	if fetches := grepShimLog(t, log, "fetch"); len(fetches) > 0 {
+		t.Errorf("git fetch attempted in a non-shallow repository: %v", fetches)
+	}
+	probes := grepShimLog(t, log, "is-shallow-repository")
+	if len(probes) > 1 {
+		t.Errorf("shallow probe run %d times on the failure path, want exactly one", len(probes))
+	}
+}
+
+// TestShallowUnreachableOriginSurfacesGitFailure pins the offline path: refs
+// resolve (the ensure fetch ran while origin was still reachable), the
+// merge-base is missing, and every deepen round fails against the now
+// unreachable origin — today's error stays the prefix, the shallow hint and
+// git's own diagnosis ride along.
+func TestShallowUnreachableOriginSurfacesGitFailure(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	resolved := ensureRefsForTest(t, clone, "origin/"+up.mainBranch)
+	runGitTest(t, clone, "remote", "set-url", "origin", "file:///ocr-634-nonexistent-origin")
+
+	provider := NewProvider(clone, resolved["origin/"+up.mainBranch], up.featureTip, gitcmd.New(2))
+	_, err := provider.GetDiff(context.Background())
+	if err == nil {
+		t.Fatal("expected GetDiff to fail against an unreachable origin")
+	}
+	wantPrefix := "cannot find merge-base between " + resolved["origin/"+up.mainBranch] + " and " + up.featureTip
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("error %q does not keep today's message as the prefix", err)
+	}
+	if !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("error %q does not mention the shallow-clone situation", err)
+	}
+	if !strings.Contains(err.Error(), "depth 2 failed") {
+		t.Errorf("error %q does not surface the fetch failure with the bound", err)
+	}
+}
+
+// TestShallowFetchArgvOrderPinned guards the load-bearing argv order: every
+// fetch option must precede --end-of-options, which must precede origin and
+// the destination-bearing refspecs. The reversed order (any option after
+// --end-of-options) makes git parse the option as a refspec pathname and the
+// whole feature dies with rc=128 — pinned empirically in PLAN_VALIDATION N1.
+func TestShallowFetchArgvOrderPinned(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	// Recovery first (real git), then record every fetch the deepen loop
+	// issues while GetDiff recovers the merge-base.
+	ensureRefsForTest(t, clone, "origin/"+up.mainBranch)
+	log := installRecordingGitShim(t)
+	provider := NewProvider(clone, "origin/"+up.mainBranch, up.featureTip, gitcmd.New(2))
+	if _, err := provider.GetDiff(context.Background()); err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+
+	fetches := grepShimLog(t, log, "fetch ")
+	if len(fetches) == 0 {
+		t.Fatal("no deepen fetches recorded")
+	}
+	re := regexp.MustCompile(`^fetch --quiet --depth=[0-9]+ --end-of-options origin \+[^ ]+:[^ ]+( \+[^ ]+:[^ ]+)*$`)
+	for _, line := range fetches {
+		if !re.MatchString(line) {
+			t.Errorf("fetch argv %q does not match the pinned order (options, --end-of-options, origin, destination-bearing refspecs)", line)
+		}
+	}
+}
+
+// TestShallowGarbageRefKeepsTodayErrorNoDeepen pins the defensive guards of
+// the deepen loop: in a shallow clone WITH an origin, an endpoint that cannot
+// resolve at all (garbage ref) or a spelling that cannot form a want
+// ("origin/") must keep today's exact error — no shallow hint, since the loop
+// never started — and attempt no fetch.
+func TestShallowGarbageRefKeepsTodayErrorNoDeepen(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	log := installRecordingGitShim(t)
+	for _, tc := range []struct {
+		name string
+		to   string
+	}{
+		{name: "unresolvable endpoint", to: "no-such-ref-xyz"},
+		{name: "non-derivable spelling", to: "origin/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewProvider(clone, up.featureTip, tc.to, gitcmd.New(2)).GetDiff(context.Background())
+			if err == nil {
+				t.Fatal("expected GetDiff to fail")
+			}
+			want := fmt.Sprintf("cannot find merge-base between %s and %s", up.featureTip, tc.to)
+			if err.Error() != want {
+				t.Errorf("error = %q, want today's exact %q (no shallow hint)", err, want)
+			}
+		})
+	}
+	if fetches := grepShimLog(t, log, "fetch "); len(fetches) > 0 {
+		t.Errorf("git fetch attempted for unresolvable endpoints: %v", fetches)
+	}
+}
+
+// TestShallowEnsureNonDerivableSpellingSkipsFetch pins the EnsureShallowRefs
+// want-derivation guards: a spelling that cannot form a refspec ("origin/")
+// fetches nothing and resolves nothing on its own, yet a derivable ref in the
+// same list still fetches and resolves — and the depth-1 ensure fetch itself
+// is destination-bearing with the pinned argv order (the argv-order test only
+// records deepen fetches, since recovery runs before its shim is installed).
+func TestShallowEnsureNonDerivableSpellingSkipsFetch(t *testing.T) {
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	// Nothing derivable: no fetch at all.
+	log := installRecordingGitShim(t)
+	resolved, err := EnsureShallowRefs(context.Background(), gitcmd.New(2), clone, []string{"origin/"})
+	if err != nil || resolved != nil {
+		t.Fatalf("EnsureShallowRefs([origin/]) = (%v, %v), want (nil, nil)", resolved, err)
+	}
+	if fetches := grepShimLog(t, log, "fetch "); len(fetches) > 0 {
+		t.Fatalf("git fetch attempted with no derivable want: %v", fetches)
+	}
+
+	// Mixed list: the derivable ref fetches once (destination-bearing), the
+	// non-derivable spelling is skipped rather than failing the batch.
+	resolved, err = EnsureShallowRefs(context.Background(), gitcmd.New(2), clone, []string{up.mainBranch, "origin/"})
+	if err != nil {
+		t.Fatalf("EnsureShallowRefs mixed list: %v", err)
+	}
+	if resolved[up.mainBranch] != up.mainTip {
+		t.Errorf("resolved[%s] = %v, want the main tip %s", up.mainBranch, resolved[up.mainBranch], up.mainTip)
+	}
+	if _, ok := resolved["origin/"]; ok {
+		t.Errorf("non-derivable spelling resolved to %q", resolved["origin/"])
+	}
+	fetches := grepShimLog(t, log, "fetch ")
+	wantArgv := fmt.Sprintf("fetch --quiet --depth=1 --end-of-options origin +%s:refs/remotes/origin/%s", up.mainBranch, up.mainBranch)
+	if len(fetches) != 1 || fetches[0] != wantArgv {
+		t.Errorf("ensure fetch argv = %v, want exactly [%s]", fetches, wantArgv)
+	}
+}
+
+// ---- recording git shim ----
+
+// installRecordingGitShim puts a `git` at the front of PATH that appends every
+// invocation's arguments to a log file and then delegates to the real git, so
+// tests can assert which commands were (never) attempted without changing
+// git's behavior.
+func installRecordingGitShim(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim relies on a shebang script")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("locate git: %v", err)
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "git-argv.log")
+	shim := filepath.Join(dir, "git")
+	body := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + shQuote(log) + "\nexec " + shQuote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return log
+}
+
+// shQuote single-quotes s for safe embedding in the shim's shell script.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func readShimLog(t *testing.T, log string) []string {
+	t.Helper()
+	data, err := os.ReadFile(log)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read shim log: %v", err)
+	}
+	var lines []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func grepShimLog(t *testing.T, log, substr string) []string {
+	t.Helper()
+	var hits []string
+	for _, line := range readShimLog(t, log) {
+		if strings.Contains(line, substr) {
+			hits = append(hits, line)
+		}
+	}
+	return hits
+}
+
+// gitOutErr runs git and returns stdout and the error, for assertions that
+// pin a ref NOT resolving.
+func gitOutErr(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// errFakeFetch stands in for the exec error gitFailure wraps.
+func errFakeFetch() error { return errors.New("exit status 128") }

--- a/internal/diff/shallow.go
+++ b/internal/diff/shallow.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package diff
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/alibaba/open-code-review/internal/gitcmd"
+)
+
+// On-demand fetch support for shallow clones (#634).
+//
+// A CI checkout like GitLab's `GIT_DEPTH: "1"` single-branch clone has neither the
+// target-branch ref (`ocr review --from origin/main` fails rev-parse) nor enough
+// history for `merge-base(from, to)` to find a common ancestor. When that happens,
+// the missing refs and history are fetched from origin on demand instead of failing:
+//
+//   - Refs are fetched with destination-bearing refspecs (`+<src>:<dst>`). These are
+//     the only form that extends the clone: a bare-SHA or bare-branch want lands in
+//     FETCH_HEAD and is a silent no-op for a shallow boundary, while a destination
+//     refspec makes the server compute a shallow walk that deepens `.git/shallow`
+//     past the want.
+//   - History depth is bounded: one depth-1 fetch for missing refs (EnsureShallowRefs,
+//     used by CLI ref validation) plus a doubling deepen loop D in {2, 4, ..., cap}
+//     for the merge-base (computeMergeBase). No unconditional --unshallow.
+//   - Everything is conditional: the repo must be shallow, a ref or merge-base must
+//     actually be missing, and a raw `git remote get-url origin` must return a URL
+//     (RemoteIdentity is useless as this probe — it canonicalizes file:// remotes
+//     to ""). Non-shallow repositories gain zero git invocations on success paths.
+//   - Every fetch is a single invocation, argv-only, with all options before
+//     --end-of-options: after that marker git parses `--depth=<D>` as a refspec
+//     pathname and dies with rc=128 ("strange pathname blocked"). Refs therefore
+//     reach git as discrete argv entries, never through a shell.
+
+// shallowDeepenMaxDepth caps the doubling deepen loop. It is a package variable so
+// tests can lower the bound and exercise the exhausted path deterministically.
+var shallowDeepenMaxDepth = 1024
+
+// shallowFetchMu serializes fetch/deepen attempts within this process. Concurrent
+// OCR runs over one clone only ever add refs and deepen boundaries, but serializing
+// keeps in-process Providers from issuing divergent fetch sequences.
+var shallowFetchMu sync.Mutex
+
+// ocrFetchPrefix is the destination namespace for SHA-derived wants. It sits under
+// refs/remotes so remote-prune semantics stay untouched (prune only manages
+// refs/remotes/origin/*), without impersonating a real remote-tracking branch.
+const ocrFetchPrefix = "refs/remotes/ocr-fetch/"
+
+// shaLikeRe matches full hexadecimal object names (git's abbreviated range is 4..40;
+// a user-supplied review ref of 7..40 hex chars is far more likely a commit id than
+// a branch, and treating it as one is what makes `--to ${CI_COMMIT_SHA}` fetchable).
+var shaLikeRe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+
+// fetchWant is a derived fetch request for one review ref.
+type fetchWant struct {
+	// refspec is the destination-bearing refspec to hand `git fetch`.
+	refspec string
+	// alt is an additional local resolution spelling to try after the fetch:
+	// the ocr-fetch destination for SHA wants ("" when the want's destination
+	// is already covered by the `origin/<name>` fallback).
+	alt string
+}
+
+// shortSHA abbreviates an object name for the ocr-fetch destination ref.
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+// deriveFetchWant turns a review ref spelling into a destination-bearing fetch
+// want. It is pure; repo-dependent spellings (HEAD) must be mapped by
+// Provider.deriveWant first.
+//
+//   - SHA-looking refs: `+<sha>:refs/remotes/ocr-fetch/<sha[:12]>`. The short
+//     destination keeps ref names readable while staying unique for any two
+//     wants that differ within the first 12 chars (a collision only merges two
+//     fetch destinations of the same commit).
+//   - `origin/<name>`: `+<name>:refs/remotes/origin/<name>`, recreating the
+//     tracking ref a full clone would have.
+//   - bare `<name>` (branch or tag): `+<name>:refs/remotes/origin/<name>`.
+//     Tags additionally auto-create refs/tags/<name> as a side effect.
+//
+// HEAD is refused here on purpose: `+HEAD:...` fetches the remote's default
+// branch, which is the wrong side of the comparison whenever HEAD tracks
+// something else. Callers resolve HEAD to its branch name (or SHA when
+// detached) before deriving a want. Refs holding ":" cannot form a refspec,
+// and refs holding glob metacharacters ("*", "?", "[") would make git match
+// against the remote instead of fetching a literal name; the fetch rejects
+// them and behavior degrades to today's error.
+func deriveFetchWant(ref string) (fetchWant, bool) {
+	if ref == "" || ref == "HEAD" {
+		return fetchWant{}, false
+	}
+	if strings.ContainsAny(ref, ":*?[") || strings.HasPrefix(ref, "-") {
+		// Not expressible as a safe refspec: ':' breaks refspec parsing,
+		// '*'/'?'/'[' trigger glob matching on the remote (a want of '*'
+		// would fetch every matching ref into the clone), and '-' is
+		// option-like. validateReviewRefs rejects leading dashes long before
+		// this, but the library path must not assemble a broken or dangerous
+		// refspec either. None of these characters can appear in a valid
+		// refname (git-check-ref-format), so no literal ref is lost.
+		return fetchWant{}, false
+	}
+	if shaLikeRe.MatchString(ref) {
+		short := shortSHA(ref)
+		dst := ocrFetchPrefix + short
+		return fetchWant{refspec: "+" + ref + ":" + dst, alt: dst}, true
+	}
+	if name, ok := strings.CutPrefix(ref, "origin/"); ok {
+		if name == "" {
+			return fetchWant{}, false
+		}
+		return fetchWant{refspec: "+" + name + ":refs/remotes/origin/" + name}, true
+	}
+	return fetchWant{refspec: "+" + ref + ":refs/remotes/origin/" + ref}, true
+}
+
+// isShallowRepo reports whether the repository is a shallow clone. It is the
+// gate for every on-demand fetch, so it must stay a single constant-time probe.
+func (p *Provider) isShallowRepo(ctx context.Context) bool {
+	out, _, err := p.runGitSplit(ctx, "rev-parse", "--is-shallow-repository")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "true"
+}
+
+// originURL returns the raw configured URL of the origin remote, or "" when
+// there is none. Unlike RemoteIdentity it does not canonicalize local remotes
+// away: a file:// origin is a perfectly fetchable origin.
+func (p *Provider) originURL(ctx context.Context) string {
+	out, _, err := p.runGitSplit(ctx, "remote", "get-url", "origin")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// deriveWant maps a review ref to a fetch want, resolving HEAD repo-aware first:
+// on a branch, HEAD becomes that branch's name; detached, it becomes HEAD's own
+// SHA (always present locally, since it is checked out).
+func (p *Provider) deriveWant(ctx context.Context, ref string) (fetchWant, bool) {
+	if ref != "HEAD" {
+		return deriveFetchWant(ref)
+	}
+	if out, _, err := p.runGitSplit(ctx, "symbolic-ref", "--short", "HEAD"); err == nil {
+		if branch := strings.TrimSpace(out); branch != "" {
+			return deriveFetchWant(branch)
+		}
+	}
+	if out, _, err := p.runGitSplit(ctx, "rev-parse", "--verify", "--quiet", "HEAD^{commit}"); err == nil {
+		if sha := firstLine(out); sha != "" {
+			return deriveFetchWant(sha)
+		}
+	}
+	return fetchWant{}, false
+}
+
+// resolveRefWithFallback resolves ref to an immutable commit SHA, trying the raw
+// spelling first, then `origin/<ref>` (a bare branch name fetched into
+// refs/remotes/origin/<name> never resolves without the prefix), then the
+// want's ocr-fetch destination (the only local spelling a SHA-derived want can
+// resolve through).
+func (p *Provider) resolveRefWithFallback(ctx context.Context, ref string, want fetchWant) string {
+	if sha := p.resolveCommit(ctx, ref); sha != "" {
+		return sha
+	}
+	if sha := p.resolveCommit(ctx, "origin/"+ref); sha != "" {
+		return sha
+	}
+	if want.alt != "" {
+		if sha := p.resolveCommit(ctx, want.alt); sha != "" {
+			return sha
+		}
+	}
+	return ""
+}
+
+// fetchShallowDepth runs one bounded fetch from origin at the given depth.
+// Every option precedes --end-of-options (see the file comment); the refspecs
+// follow as positional arguments. Git's stderr is returned alongside the error
+// so callers can surface the actual failure instead of a bare exit status.
+func (p *Provider) fetchShallowDepth(ctx context.Context, depth int, wants []fetchWant) (string, error) {
+	args := make([]string, 0, 5+len(wants))
+	args = append(args, "fetch", "--quiet", fmt.Sprintf("--depth=%d", depth), "--end-of-options", "origin")
+	for _, w := range wants {
+		args = append(args, w.refspec)
+	}
+	_, stderr, err := p.runGitSplit(ctx, args...)
+	return stderr, err
+}
+
+// EnsureShallowRefs gives shallow clones a chance to resolve refs that failed
+// raw `rev-parse` by fetching them from origin once at depth 1 (#634). It
+// subsumes the fetch and the fallback retry: it returns a map from each
+// requested ref spelling to the commit SHA it resolved to after the fetch, so
+// the caller can substitute SHAs for spellings that only resolve through the
+// fallback (downstream `git diff`/`git show` call sites are not fallback-aware).
+//
+// Refs absent from the map simply did not resolve. A nil map with a nil error
+// means "nothing to do": the repository is not shallow, or has no origin URL —
+// in both cases the caller must keep today's behavior untouched. A non-nil
+// error is a fetch failure; the caller reports it as context and then fails
+// with today's ref-resolution error. The fetch is attempted once, never
+// retried.
+func EnsureShallowRefs(ctx context.Context, runner *gitcmd.Runner, repoDir string, refs []string) (map[string]string, error) {
+	p := &Provider{repoDir: repoDir, runner: runner}
+	if !p.isShallowRepo(ctx) || p.originURL(ctx) == "" {
+		return nil, nil
+	}
+
+	shallowFetchMu.Lock()
+	defer shallowFetchMu.Unlock()
+
+	var wants []fetchWant
+	seen := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		want, ok := p.deriveWant(ctx, ref)
+		if !ok || seen[want.refspec] {
+			continue
+		}
+		seen[want.refspec] = true
+		wants = append(wants, want)
+	}
+	if len(wants) == 0 {
+		return nil, nil
+	}
+	if stderr, err := p.fetchShallowDepth(ctx, 1, wants); err != nil {
+		return nil, gitFailure("git fetch", stderr, err)
+	}
+
+	resolved := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		want, ok := p.deriveWant(ctx, ref)
+		if !ok {
+			continue
+		}
+		if sha := p.resolveRefWithFallback(ctx, ref, want); sha != "" {
+			resolved[ref] = sha
+		}
+	}
+	return resolved, nil
+}
+
+// deepenForMergeBase tries to recover a merge-base that raw `git merge-base`
+// could not find in a shallow clone, by deepening both sides from origin with
+// a doubling depth budget. from/to are the comparison's ref spellings; the
+// loop operates on their resolved endpoint SHAs so bare branch names never
+// reach git un-substituted on this path.
+//
+// It returns the merge-base SHA ("" when still not found) plus a diagnostic
+// string holding the last fetch failure ("" when every round succeeded). The
+// Provider records the deepest round attempted so GetDiff can append a
+// shallow-clone hint only on paths where deepening actually ran.
+func (p *Provider) deepenForMergeBase(ctx context.Context, from, to string) string {
+	if !p.isShallowRepo(ctx) || p.originURL(ctx) == "" {
+		return ""
+	}
+	wantFrom, okFrom := p.deriveWant(ctx, from)
+	wantTo, okTo := p.deriveWant(ctx, to)
+	if !okFrom || !okTo {
+		return ""
+	}
+	shaFrom := p.resolveRefWithFallback(ctx, from, wantFrom)
+	shaTo := p.resolveRefWithFallback(ctx, to, wantTo)
+	// Without both endpoints as objects there is nothing to deepen toward; git
+	// already failed on the raw spellings, so the caller keeps today's error.
+	if shaFrom == "" || shaTo == "" || shaFrom == shaTo {
+		return ""
+	}
+
+	shallowFetchMu.Lock()
+	defer shallowFetchMu.Unlock()
+
+	for depth := 2; depth <= shallowDeepenMaxDepth; depth *= 2 {
+		p.deepenTried = depth
+		stderr, err := p.fetchShallowDepth(ctx, depth, []fetchWant{wantFrom, wantTo})
+		if err != nil {
+			// One failing want fails the whole fetch (git is atomic about it),
+			// and a depth budget cannot fix an unreachable or refusing origin:
+			// stop, surface the failure through the hint, keep today's error.
+			p.deepenDiag = fetchDiag(stderr, err)
+			return ""
+		}
+		if out, mbErr := p.runGit(ctx, "merge-base", "--end-of-options", shaFrom, shaTo); mbErr == nil {
+			if base := strings.TrimSpace(out); base != "" {
+				return base
+			}
+		}
+	}
+	return ""
+}
+
+// fetchDiag reduces a fetch failure to a compact, single-line diagnostic for
+// embedding in the shallow-clone hint.
+func fetchDiag(stderr string, err error) string {
+	diag := strings.TrimSpace(stderr)
+	if diag == "" {
+		if err == nil {
+			return ""
+		}
+		return err.Error()
+	}
+	// Keep the first line: fetch failures prefix progress noise with the fatal.
+	if line, _, ok := strings.Cut(diag, "\n"); ok && line != "" {
+		diag = strings.TrimSpace(line)
+	}
+	if len(diag) > 200 {
+		diag = diag[:200]
+		// Cutting by bytes can split the trailing rune. Git speaks the user's
+		// locale, so the hint can carry non-ASCII text (same concern as
+		// gitFailure's cut, #972); drop the partial sequence rather than
+		// embed invalid UTF-8 in the error.
+		for len(diag) > 0 {
+			if _, size := utf8.DecodeLastRuneInString(diag); size > 1 || diag[len(diag)-1] < utf8.RuneSelf {
+				break
+			}
+			diag = diag[:len(diag)-1]
+		}
+	}
+	return diag
+}

--- a/internal/diff/shallow_test.go
+++ b/internal/diff/shallow_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package diff
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/alibaba/open-code-review/internal/gitcmd"
+)
+
+func TestDeriveFetchWant(t *testing.T) {
+	full := "9a209cf5d9e256f40bde0313e25440252d1e9ead"
+	cases := []struct {
+		name       string
+		ref        string
+		wantOK     bool
+		refspec    string
+		wantResolv string
+	}{
+		{
+			name:       "full sha",
+			ref:        full,
+			wantOK:     true,
+			refspec:    "+" + full + ":" + ocrFetchPrefix + full[:12],
+			wantResolv: ocrFetchPrefix + full[:12],
+		},
+		{
+			name:       "short sha",
+			ref:        full[:12],
+			wantOK:     true,
+			refspec:    "+" + full[:12] + ":" + ocrFetchPrefix + full[:12],
+			wantResolv: ocrFetchPrefix + full[:12],
+		},
+		{
+			name:       "minimal abbreviation",
+			ref:        full[:7],
+			wantOK:     true,
+			refspec:    "+" + full[:7] + ":" + ocrFetchPrefix + full[:7],
+			wantResolv: ocrFetchPrefix + full[:7],
+		},
+		{
+			name:       "origin-prefixed name",
+			ref:        "origin/main",
+			wantOK:     true,
+			refspec:    "+main:refs/remotes/origin/main",
+			wantResolv: "",
+		},
+		{
+			name:       "origin-prefixed slashed name",
+			ref:        "origin/feature/x",
+			wantOK:     true,
+			refspec:    "+feature/x:refs/remotes/origin/feature/x",
+			wantResolv: "",
+		},
+		{
+			name:       "bare branch name",
+			ref:        "main",
+			wantOK:     true,
+			refspec:    "+main:refs/remotes/origin/main",
+			wantResolv: "",
+		},
+		{
+			name:       "bare tag name",
+			ref:        "v1.2.3",
+			wantOK:     true,
+			refspec:    "+v1.2.3:refs/remotes/origin/v1.2.3",
+			wantResolv: "",
+		},
+		// HEAD is refused: `+HEAD:...` would fetch the remote's default
+		// branch, the wrong side of the comparison. Callers map HEAD to its
+		// branch (or SHA) before deriving a want.
+		{name: "head refused", ref: "HEAD"},
+		{name: "empty refused", ref: ""},
+		{name: "origin slash alone refused", ref: "origin/"},
+		// A colon cannot appear in a refspec source; a leading dash is
+		// injection-shaped (validateReviewRefs rejects it far earlier).
+		{name: "colon refused", ref: "main:refs/x"},
+		{name: "leading dash refused", ref: "-O./pwn.sh"},
+		// Glob metacharacters make git match against the remote instead of
+		// fetching a literal name: a want of '*' would fetch every matching
+		// ref. None of these can appear in a valid refname, so no literal
+		// ref is lost by refusing them.
+		{name: "star refused", ref: "*"},
+		{name: "star in name refused", ref: "refs/heads/*"},
+		{name: "question mark refused", ref: "mai?"},
+		{name: "bracket refused", ref: "mai[n]"},
+		{name: "glob after origin prefix refused", ref: "origin/refs/heads/*"},
+		// Uppercase hex is not a SHA spelling in git; it stays a (bogus) ref
+		// name and the fetch degrades to today's error.
+		{
+			name:    "uppercase hex is a name",
+			ref:     "ABCDEF1234",
+			wantOK:  true,
+			refspec: "+ABCDEF1234:refs/remotes/origin/ABCDEF1234",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := deriveFetchWant(tc.ref)
+			if ok != tc.wantOK {
+				t.Fatalf("deriveFetchWant(%q) ok = %v, want %v", tc.ref, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.refspec != tc.refspec {
+				t.Errorf("refspec = %q, want %q", got.refspec, tc.refspec)
+			}
+			if got.alt != tc.wantResolv {
+				t.Errorf("alt = %q, want %q", got.alt, tc.wantResolv)
+			}
+		})
+	}
+}
+
+// TestDeriveWantMapsHeadToBranch pins the repo-aware HEAD mapping: on a branch
+// the want addresses that branch, never `+HEAD:...`.
+func TestDeriveWantMapsHeadToBranch(t *testing.T) {
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "a.txt", "one\n", "root")
+	branch := gitOut(t, repo, "rev-parse", "--abbrev-ref", "HEAD")
+
+	p := NewWorkspaceProvider(repo, nil)
+	want, ok := p.deriveWant(context.Background(), "HEAD")
+	if !ok {
+		t.Fatal("deriveWant(HEAD) refused on a checked-out branch")
+	}
+	if want.refspec != "+"+branch+":refs/remotes/origin/"+branch {
+		t.Errorf("refspec = %q, want the current branch %q", want.refspec, branch)
+	}
+}
+
+// TestDeriveWantMapsDetachedHeadToSHA pins the detached-HEAD mapping: HEAD's
+// own SHA is always present locally, so the SHA path can deepen its history.
+func TestDeriveWantMapsDetachedHeadToSHA(t *testing.T) {
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "a.txt", "one\n", "root")
+	head := gitOut(t, repo, "rev-parse", "HEAD")
+	runGitTest(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	p := NewWorkspaceProvider(repo, nil)
+	want, ok := p.deriveWant(context.Background(), "HEAD")
+	if !ok {
+		t.Fatal("deriveWant(HEAD) refused on a detached HEAD")
+	}
+	if want.refspec != "+"+head+":"+ocrFetchPrefix+head[:12] {
+		t.Errorf("refspec = %q, want the HEAD SHA %q", want.refspec, head)
+	}
+}
+
+// TestResolveRefWithFallbackChain pins the resolution order the recovery
+// relies on: raw spelling first, then origin/<name> (bare names never resolve
+// without the prefix after a fetch), then the want's ocr-fetch destination
+// (the only local spelling of a SHA-derived want). The alt leg is shadowed in
+// the integration paths — once a fetch lands the object, the raw spelling
+// resolves by object-id lookup — so only a direct call with a fabricated want
+// can pin it. All resolution is real git against update-ref-created refs.
+func TestResolveRefWithFallbackChain(t *testing.T) {
+	repo := initBareRepo(t)
+	writeCommit(t, repo, "a.txt", "one\n", "root")
+	tip := gitOut(t, repo, "rev-parse", "HEAD")
+	branch := gitOut(t, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	// What a fetch leaves behind: a remote-tracking ref for the bare name and
+	// an ocr-fetch destination for a SHA-derived want.
+	runGitTest(t, repo, "update-ref", "refs/remotes/origin/"+branch, tip)
+	const alt = "refs/remotes/ocr-fetch/deadbeefcafe"
+	runGitTest(t, repo, "update-ref", alt, tip)
+	p := NewWorkspaceProvider(repo, nil)
+
+	// Raw spelling wins even when an alt is available.
+	if got := p.resolveRefWithFallback(context.Background(), "HEAD", fetchWant{alt: alt}); got != tip {
+		t.Errorf("raw leg: got %q, want %q", got, tip)
+	}
+	// Bare branch name: only origin/<name> resolves.
+	if got := p.resolveRefWithFallback(context.Background(), branch, fetchWant{}); got != tip {
+		t.Errorf("origin/ leg: bare %q got %q, want %q via the tracking ref", branch, got, tip)
+	}
+	// SHA spelling that is not an object: only the want's alt resolves.
+	shaWant := fetchWant{refspec: "+0000deadbeef:" + alt, alt: alt}
+	if got := p.resolveRefWithFallback(context.Background(), "0000deadbeef", shaWant); got != tip {
+		t.Errorf("alt leg: got %q, want %q via %s", got, tip, alt)
+	}
+	// Nothing resolves: "" (callers keep today's error).
+	if got := p.resolveRefWithFallback(context.Background(), "no-such-ref", fetchWant{}); got != "" {
+		t.Errorf("unresolvable ref returned %q, want empty", got)
+	}
+}
+
+// TestEnsureShallowRefsNonRepoIsNoop pins the gate against directories that
+// are not git repositories at all: no error, no fetch, nothing resolved.
+func TestEnsureShallowRefsNonRepoIsNoop(t *testing.T) {
+	resolved, err := EnsureShallowRefs(context.Background(), gitcmd.New(2), t.TempDir(), []string{"main"})
+	if err != nil || resolved != nil {
+		t.Fatalf("EnsureShallowRefs on a non-repo = (%v, %v), want (nil, nil)", resolved, err)
+	}
+}
+
+func TestIsShallowRepo(t *testing.T) {
+	if skipNonUnixShallowFixture(t) {
+		return
+	}
+	up := newUpstreamFixture(t)
+	clone := newShallowClone(t, up)
+
+	shallow := NewWorkspaceProvider(clone, nil)
+	if !shallow.isShallowRepo(context.Background()) {
+		t.Error("depth-1 clone reported as not shallow")
+	}
+
+	full := NewWorkspaceProvider(up.dir, nil)
+	if full.isShallowRepo(context.Background()) {
+		t.Error("upstream full clone reported as shallow")
+	}
+}
+
+// TestFetchDiag covers the reduction of a fetch failure to a compact hint.
+func TestFetchDiag(t *testing.T) {
+	if got := fetchDiag("fatal: remote error: upload-pack: not our ref 1234\n", errFakeFetch()); !strings.Contains(got, "not our ref") {
+		t.Errorf("diag %q lost git's message", got)
+	}
+	if got := fetchDiag("", errFakeFetch()); got == "" {
+		t.Error("empty stderr must fall back to the error text")
+	}
+	if got := fetchDiag("", nil); got != "" {
+		t.Errorf("nil error with empty stderr must yield empty diag, got %q", got)
+	}
+	long := "fatal: " + strings.Repeat("x", 400)
+	if got := fetchDiag(long, errFakeFetch()); len(got) > 202 {
+		t.Errorf("diag is %d bytes, truncation is not bounding it", len(got))
+	}
+	// A byte cut must not split the trailing rune: git speaks the user's
+	// locale (#972 precedent in gitFailure), so the hint has to stay valid
+	// UTF-8 even when truncated mid-multibyte.
+	mb := "fatal: " + strings.Repeat("あ", 100) // allow-non-english: multibyte truncation fixture (#972 rune-boundary concern)
+	if got := fetchDiag(mb, nil); !utf8.ValidString(got) {
+		t.Errorf("truncated diag is not valid UTF-8: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Range-mode review (`--from … --to …`) requires every commit between merge-base and head to exist locally. Shallow checkouts — GitLab CI commonly sets `GIT_DEPTH: "1"` to reduce server load — therefore fail before any review starts: target-branch refs do not resolve and `git merge-base` comes back empty. This lets the diff layer fetch exactly what is missing from `origin`, on demand, so shallow clones work without raising `GIT_DEPTH` or switching to a full checkout.

Fixes #634.

## How it works

The behavior is strictly conditional on **repo is shallow AND a ref/merge-base is actually missing AND an `origin` remote exists** — non-shallow repositories issue no new git commands on success paths, and repositories without a usable remote keep today's exact errors.

- **Destination-bearing refspecs everywhere.** Wants are always `+<ref>:<destination>` forms: SHA → `refs/remotes/ocr-fetch/<short>`, `origin/<name>` → `refs/remotes/origin/<name>`, bare name → `refs/remotes/origin/<name>`. This is the only form that both creates the ref a later `rev-parse` can find in a `--single-branch` clone and extends the shallow boundary when deepening — a bare SHA or branch name on the fetch line is a silent no-op once the object is present, and `+HEAD:…` fetches the remote's *default* branch, so `HEAD` is mapped to the current branch (`symbolic-ref --short HEAD`; detached HEAD falls back to its SHA).
- **Fallback resolution + SHA substitution.** After the fetch, refs resolve as `<ref>` → `origin/<ref>` → the ocr-fetch destination. Spellings that only resolve through the fallback are substituted with their resolved SHAs so downstream `git diff`/`git show` call sites (which are not fallback-aware) keep working.
- **Bounded deepen for merge-base.** A missing merge-base triggers one `--depth` doubling loop (2→1024, both endpoints as destination-bearing wants, merge-base recomputed each round) inside `computeMergeBase`. If it still fails, the existing error gains a shallow-aware hint — only on the path where the loop actually ran.
- A package-level mutex serializes fetch/deepen within one process (several `Provider` instances share a clone per run).

## What does not change

- Non-shallow repos: zero new git invocations on success paths (pinned by an argv-recording test).
- No remote / unreachable remote / fetch failure: today's error messages with the underlying git failure surfaced.
- No full `--unshallow`, no new user-facing flags; the trigger is automatic and scoped to the shallow case.

## Testing

New integration suite builds real upstream fixtures (`main` + `feature`, tags) and `git clone --depth 1 --single-branch --branch feature file://…` clones, then exercises the actual code paths: the canonical GitLab spelling `--from origin/<target> --to $CI_COMMIT_SHA`, bare branch names, `--to HEAD`, tag auto-follow, deep history requiring the deepen loop, depth-cap exhaustion with the hint, no-remote negatives with no fetch attempted (argv recording), unreachable-origin error surfacing, and the `validateReviewRefs` recovery branch. `make check` and `make test` (race) green; coverage for the new/changed functions ≥ 90% (package `internal/diff` 93.8%).