### PR TITLE
fix(tool): report tool call failures

### DIFF
--- a/cmd/opencodereview/budget_output_test.go
+++ b/cmd/opencodereview/budget_output_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/alibaba/open-code-review/internal/agent"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 )
@@ -152,15 +153,32 @@ func TestEmitFailureUsage_TextEmitsStructuredRecord(t *testing.T) {
 		outputTokens:  500,
 		totalTokens:   1500,
 		toolCalls:     map[string]int64{"file_read": 3, "code_comment": 2},
-		sessionID:     "sess-fail-1",
+		toolFailures: []llmloop.ToolFailureDetail{
+			{ToolName: "file_read"},
+			{ToolName: "code_comment"},
+		},
+		sessionID: "sess-fail-1",
 	}
 	got := captureStderr(t, func() {
 		emitFailureUsage(ag, 42*time.Second, "text", nil, nil)
 	})
-	for _, want := range []string{"usage on failure", "1500 total tokens", "5 tool calls", "budget_exceeded=false", "sess-fail-1"} {
+	for _, want := range []string{"usage on failure", "1500 total tokens", "5 tool calls, 2 failed", "budget_exceeded=false", "sess-fail-1"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("stderr missing %q; got %q", want, got)
 		}
+	}
+}
+
+func TestEmitFailureUsage_TextOmitsZeroToolFailures(t *testing.T) {
+	ag := &mockResultProvider{toolCalls: map[string]int64{"file_read": 2}}
+	got := captureStderr(t, func() {
+		emitFailureUsage(ag, time.Second, "text", nil, nil)
+	})
+	if !strings.Contains(got, "2 tool calls, elapsed") {
+		t.Errorf("stderr missing unchanged zero-failure summary; got %q", got)
+	}
+	if strings.Contains(got, "0 failed") {
+		t.Errorf("stderr should omit zero tool failures; got %q", got)
 	}
 }
 
@@ -173,6 +191,12 @@ func TestEmitFailureUsage_JSONEmitsStructuredRecord(t *testing.T) {
 		outputTokens:  80,
 		totalTokens:   280,
 		toolCalls:     map[string]int64{"file_read": 1},
+		toolFailures: []llmloop.ToolFailureDetail{{
+			ToolCallNumber: 1,
+			ToolName:       "file_read",
+			FilePath:       "missing.go",
+			Error:          "file not found",
+		}},
 	}
 	identity := &jsonLLMIdentity{Provider: "openai", Model: "gpt-5.4"}
 	got := captureStderr(t, func() {
@@ -196,6 +220,12 @@ func TestEmitFailureUsage_JSONEmitsStructuredRecord(t *testing.T) {
 	}
 	if out.ToolCalls == nil || out.ToolCalls.Total != 1 {
 		t.Errorf("tool_calls.total = %v, want 1", out.ToolCalls)
+	}
+	if out.ToolCalls.Failure != 1 || len(out.ToolCalls.FailureDetails) != 1 {
+		t.Errorf("tool call failures = %+v, want one", out.ToolCalls)
+	}
+	if out.ToolCalls.FailureByTool["file_read"] != 1 {
+		t.Errorf("failure_by_tool = %+v, want file_read=1", out.ToolCalls.FailureByTool)
 	}
 	if out.LLM == nil || out.LLM.Provider != "openai" || out.LLM.Model != "gpt-5.4" {
 		t.Fatalf("llm = %+v", out.LLM)

--- a/cmd/opencodereview/emit_run_result_test.go
+++ b/cmd/opencodereview/emit_run_result_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/alibaba/open-code-review/internal/agent"
 	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 )
@@ -32,22 +33,26 @@ type mockResultProvider struct {
 	warnings         []agent.AgentWarning
 	projectSummary   string
 	toolCalls        map[string]int64
+	toolFailures     []llmloop.ToolFailureDetail
 	resumeInfo       *agent.ResumeInfo
 	sessionID        string
 	budgetExceeded   bool
 	manifest         *session.RunManifest
 }
 
-func (m *mockResultProvider) Diffs() []model.Diff               { return m.diffs }
-func (m *mockResultProvider) FilesReviewed() int64              { return m.filesReviewed }
-func (m *mockResultProvider) TotalInputTokens() int64           { return m.inputTokens }
-func (m *mockResultProvider) TotalOutputTokens() int64          { return m.outputTokens }
-func (m *mockResultProvider) TotalTokensUsed() int64            { return m.totalTokens }
-func (m *mockResultProvider) TotalCacheReadTokens() int64       { return m.cacheReadTokens }
-func (m *mockResultProvider) TotalCacheWriteTokens() int64      { return m.cacheWriteTokens }
-func (m *mockResultProvider) Warnings() []agent.AgentWarning    { return m.warnings }
-func (m *mockResultProvider) ProjectSummary() string            { return m.projectSummary }
-func (m *mockResultProvider) ToolCalls() map[string]int64       { return m.toolCalls }
+func (m *mockResultProvider) Diffs() []model.Diff            { return m.diffs }
+func (m *mockResultProvider) FilesReviewed() int64           { return m.filesReviewed }
+func (m *mockResultProvider) TotalInputTokens() int64        { return m.inputTokens }
+func (m *mockResultProvider) TotalOutputTokens() int64       { return m.outputTokens }
+func (m *mockResultProvider) TotalTokensUsed() int64         { return m.totalTokens }
+func (m *mockResultProvider) TotalCacheReadTokens() int64    { return m.cacheReadTokens }
+func (m *mockResultProvider) TotalCacheWriteTokens() int64   { return m.cacheWriteTokens }
+func (m *mockResultProvider) Warnings() []agent.AgentWarning { return m.warnings }
+func (m *mockResultProvider) ProjectSummary() string         { return m.projectSummary }
+func (m *mockResultProvider) ToolCalls() map[string]int64    { return m.toolCalls }
+func (m *mockResultProvider) ToolFailures() []llmloop.ToolFailureDetail {
+	return m.toolFailures
+}
 func (m *mockResultProvider) ResumeInfo() *agent.ResumeInfo     { return m.resumeInfo }
 func (m *mockResultProvider) SessionID() string                 { return m.sessionID }
 func (m *mockResultProvider) BudgetExceeded() bool              { return m.budgetExceeded }

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/alibaba/open-code-review/internal/agent"
 	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/alibaba/open-code-review/internal/suggestdiff"
@@ -277,8 +278,35 @@ type jsonSummary struct {
 }
 
 type jsonToolCalls struct {
-	Total  int64            `json:"total"`
-	ByTool map[string]int64 `json:"by_tool"`
+	Total          int64                       `json:"total"`
+	ByTool         map[string]int64            `json:"by_tool"`
+	Failure        int64                       `json:"failure"`
+	FailureByTool  map[string]int64            `json:"failure_by_tool"`
+	FailureDetails []llmloop.ToolFailureDetail `json:"failure_details"`
+}
+
+func newJSONToolCalls(toolCalls map[string]int64, failures []llmloop.ToolFailureDetail) *jsonToolCalls {
+	var total int64
+	for _, count := range toolCalls {
+		total += count
+	}
+	failureByTool := make(map[string]int64)
+	for _, failure := range failures {
+		failureByTool[failure.ToolName]++
+	}
+	if toolCalls == nil {
+		toolCalls = make(map[string]int64)
+	}
+	if failures == nil {
+		failures = make([]llmloop.ToolFailureDetail, 0)
+	}
+	return &jsonToolCalls{
+		Total:          total,
+		ByTool:         toolCalls,
+		Failure:        int64(len(failures)),
+		FailureByTool:  failureByTool,
+		FailureDetails: failures,
+	}
 }
 
 type jsonLLMIdentity struct {
@@ -309,8 +337,9 @@ type jsonOutput struct {
 
 func outputJSON(comments []model.LlmComment) error {
 	out := jsonOutput{
-		Status:   "success",
-		Comments: comments,
+		Status:    "success",
+		ToolCalls: newJSONToolCalls(nil, nil),
+		Comments:  comments,
 	}
 	if len(comments) == 0 {
 		out.Message = "No comments generated. Looks good to me."
@@ -322,7 +351,8 @@ func outputJSON(comments []model.LlmComment) error {
 
 func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentWarning,
 	filesReviewed, inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens int64,
-	duration time.Duration, projectSummary string, toolCalls map[string]int64, traceID string, resumeInfo *agent.ResumeInfo, sessionID string,
+	duration time.Duration, projectSummary string, toolCalls map[string]int64, toolFailures []llmloop.ToolFailureDetail,
+	traceID string, resumeInfo *agent.ResumeInfo, sessionID string,
 	manifest *session.RunManifest, budgetExceeded bool, llmIdentity *jsonLLMIdentity, out io.Writer,
 	retryReport *llm.RetryReport, groups []agent.FileGroupInfo) error {
 	publishedWarnings := warningsForOutput(warnings, manifest)
@@ -349,18 +379,7 @@ func outputJSONWithWarnings(comments []model.LlmComment, warnings []agent.AgentW
 		Manifest:       manifest,
 		RetryReport:    retryReport,
 	}
-	var total int64
-	for _, v := range toolCalls {
-		total += v
-	}
-	byTool := toolCalls
-	if byTool == nil {
-		byTool = make(map[string]int64)
-	}
-	payload.ToolCalls = &jsonToolCalls{
-		Total:  total,
-		ByTool: byTool,
-	}
+	payload.ToolCalls = newJSONToolCalls(toolCalls, toolFailures)
 	if manifest != nil {
 		payload.Status = string(manifest.TerminalState)
 		payload.Message = manifestMessage(manifest, len(comments))
@@ -608,14 +627,12 @@ func manifestMessage(manifest *session.RunManifest, findings int) string {
 
 func outputJSONNoFiles(traceID string, llmIdentity *jsonLLMIdentity, out io.Writer) error {
 	payload := jsonOutput{
-		Status:   "skipped",
-		LLM:      llmIdentity,
-		TraceID:  traceID,
-		Message:  "No supported files changed.",
-		Comments: []model.LlmComment{},
-		ToolCalls: &jsonToolCalls{
-			ByTool: map[string]int64{},
-		},
+		Status:    "skipped",
+		LLM:       llmIdentity,
+		TraceID:   traceID,
+		Message:   "No supported files changed.",
+		Comments:  []model.LlmComment{},
+		ToolCalls: newJSONToolCalls(nil, nil),
 	}
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
@@ -649,10 +666,8 @@ func outputJSONNoFiles(traceID string, llmIdentity *jsonLLMIdentity, out io.Writ
 // was skipped, so the report is never duplicated and never silently dropped.
 func emitFailureUsage(ag ResultProvider, duration time.Duration, outputFormat string, llmIdentity *jsonLLMIdentity,
 	retryReport *llm.RetryReport) {
-	var toolTotal int64
-	for _, v := range ag.ToolCalls() {
-		toolTotal += v
-	}
+	toolCallSummary := newJSONToolCalls(ag.ToolCalls(), ag.ToolFailures())
+	toolTotal := toolCallSummary.Total
 	budgetExceeded := ag.BudgetExceeded()
 	if outputFormat == "json" {
 		out := jsonOutput{
@@ -668,10 +683,7 @@ func emitFailureUsage(ag ResultProvider, duration time.Duration, outputFormat st
 				Elapsed:          duration.Round(time.Second).String(),
 				BudgetExceeded:   budgetExceeded,
 			},
-			ToolCalls: &jsonToolCalls{
-				Total:  toolTotal,
-				ByTool: ag.ToolCalls(),
-			},
+			ToolCalls:   toolCallSummary,
 			SessionID:   ag.SessionID(),
 			RetryReport: retryReport,
 		}
@@ -680,9 +692,14 @@ func emitFailureUsage(ag ResultProvider, duration time.Duration, outputFormat st
 		_ = enc.Encode(out)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "[ocr] usage on failure: %d file(s), %d input + %d output = %d total tokens, %d tool calls, elapsed %s, budget_exceeded=%v",
+	fmt.Fprintf(os.Stderr, "[ocr] usage on failure: %d file(s), %d input + %d output = %d total tokens, %d tool calls",
 		ag.FilesReviewed(), ag.TotalInputTokens(), ag.TotalOutputTokens(), ag.TotalTokensUsed(),
-		toolTotal, duration.Round(time.Second).String(), budgetExceeded)
+		toolTotal)
+	if toolCallSummary.Failure > 0 {
+		fmt.Fprintf(os.Stderr, ", %d failed", toolCallSummary.Failure)
+	}
+	fmt.Fprintf(os.Stderr, ", elapsed %s, budget_exceeded=%v",
+		duration.Round(time.Second).String(), budgetExceeded)
 	if id := ag.SessionID(); id != "" {
 		fmt.Fprintf(os.Stderr, ", session %s", id)
 	}

--- a/cmd/opencodereview/output_helpers_test.go
+++ b/cmd/opencodereview/output_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/alibaba/open-code-review/internal/agent"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 )
 
@@ -173,7 +174,7 @@ func TestOutputJSONWithWarnings_NoCommentsSubtaskError(t *testing.T) {
 	os.Stdout = w
 
 	warnings := []agent.AgentWarning{{Type: "subtask_error", File: "x.go", Message: "fail"}}
-	err := outputJSONWithWarnings(nil, warnings, 1, 10, 5, 15, 0, 0, time.Second, "", nil, "abc123trace", nil, "", nil, false, nil, os.Stdout, nil, nil)
+	err := outputJSONWithWarnings(nil, warnings, 1, 10, 5, 15, 0, 0, time.Second, "", nil, nil, "abc123trace", nil, "", nil, false, nil, os.Stdout, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 
@@ -286,7 +287,13 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 
 	comments := []model.LlmComment{{Path: "b.go", Content: "test"}}
 	warnings := []agent.AgentWarning{{Type: "subtask_error", File: "c.go", Message: "failed"}}
-	err := outputJSONWithWarnings(comments, warnings, 5, 100, 50, 150, 10, 5, 3*time.Second, "summary", map[string]int64{"file_read": 3}, "trace-xyz-789", nil, "", nil, false, nil, os.Stdout, nil, nil)
+	failures := []llmloop.ToolFailureDetail{{
+		ToolCallNumber: 2,
+		ToolName:       "file_read",
+		FilePath:       "b.go",
+		Error:          "file not found",
+	}}
+	err := outputJSONWithWarnings(comments, warnings, 5, 100, 50, 150, 10, 5, 3*time.Second, "summary", map[string]int64{"file_read": 3}, failures, "trace-xyz-789", nil, "", nil, false, nil, os.Stdout, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 
@@ -296,6 +303,15 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 
 	var buf bytes.Buffer
 	_, _ = buf.ReadFrom(r)
+	if bytes.Contains(buf.Bytes(), []byte(`"arguments"`)) {
+		t.Fatalf("failure details must not expose tool arguments: %s", buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"failure"`)) {
+		t.Fatalf("tool_calls must use the failure field: %s", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte(`"failure_count"`)) {
+		t.Fatalf("tool_calls must not emit the legacy failure_count field: %s", buf.String())
+	}
 
 	var out jsonOutput
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
@@ -313,6 +329,16 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 	if out.ToolCalls == nil || out.ToolCalls.Total != 3 {
 		t.Errorf("ToolCalls.Total = %v", out.ToolCalls)
 	}
+	if out.ToolCalls.Failure != 1 || len(out.ToolCalls.FailureDetails) != 1 {
+		t.Fatalf("ToolCalls failures = %+v", out.ToolCalls)
+	}
+	if out.ToolCalls.FailureByTool["file_read"] != 1 {
+		t.Errorf("failure_by_tool = %+v, want file_read=1", out.ToolCalls.FailureByTool)
+	}
+	failure := out.ToolCalls.FailureDetails[0]
+	if failure.ToolCallNumber != 2 || failure.ToolName != "file_read" || failure.FilePath != "b.go" || failure.Error != "file not found" {
+		t.Errorf("failure detail = %+v", failure)
+	}
 	if out.TraceID != "trace-xyz-789" {
 		t.Errorf("trace_id = %q, want trace-xyz-789", out.TraceID)
 	}
@@ -324,7 +350,7 @@ func TestOutputJSONWithWarnings_NoCommentsNoErrors(t *testing.T) {
 	os.Stdout = w
 
 	warnings := []agent.AgentWarning{{Type: "warning", Message: "something"}}
-	err := outputJSONWithWarnings(nil, warnings, 2, 50, 20, 70, 0, 0, time.Second, "", nil, "", nil, "", nil, false, nil, os.Stdout, nil, nil)
+	err := outputJSONWithWarnings(nil, warnings, 2, 50, 20, 70, 0, 0, time.Second, "", nil, nil, "", nil, "", nil, false, nil, os.Stdout, nil, nil)
 	_ = w.Close()
 	os.Stdout = old
 
@@ -377,6 +403,28 @@ func TestOutputJSONNoFiles(t *testing.T) {
 	}
 	if out.LLM == nil || out.LLM.Provider != "anthropic" || out.LLM.Model != "claude-opus-4-6" {
 		t.Fatalf("llm = %+v", out.LLM)
+	}
+	if out.ToolCalls == nil || out.ToolCalls.Failure != 0 || out.ToolCalls.FailureByTool == nil || len(out.ToolCalls.FailureByTool) != 0 || out.ToolCalls.FailureDetails == nil || len(out.ToolCalls.FailureDetails) != 0 {
+		t.Errorf("empty tool failure fields = %+v", out.ToolCalls)
+	}
+}
+
+func TestNewJSONToolCalls_FailureByTool(t *testing.T) {
+	failures := []llmloop.ToolFailureDetail{
+		{ToolName: "code_search"},
+		{ToolName: "file_read"},
+		{ToolName: "file_read"},
+		{ToolName: "file_find"},
+		{ToolName: "file_find"},
+		{ToolName: "file_find"},
+	}
+
+	got := newJSONToolCalls(nil, failures)
+	if got.Failure != 6 {
+		t.Fatalf("failure = %d, want 6", got.Failure)
+	}
+	if got.FailureByTool["code_search"] != 1 || got.FailureByTool["file_read"] != 2 || got.FailureByTool["file_find"] != 3 {
+		t.Errorf("failure_by_tool = %+v, want code_search=1 file_read=2 file_find=3", got.FailureByTool)
 	}
 }
 

--- a/cmd/opencodereview/shared.go
+++ b/cmd/opencodereview/shared.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alibaba/open-code-review/internal/diff"
 	"github.com/alibaba/open-code-review/internal/gitcmd"
 	"github.com/alibaba/open-code-review/internal/llm"
+	"github.com/alibaba/open-code-review/internal/llmloop"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
 	"github.com/alibaba/open-code-review/internal/stdout"
@@ -604,6 +605,7 @@ type ResultProvider interface {
 	// that skipped / failed the summary phase.
 	ProjectSummary() string
 	ToolCalls() map[string]int64
+	ToolFailures() []llmloop.ToolFailureDetail
 	// SessionID returns the persisted session identifier so callers can show it
 	// in JSON output or failure diagnostics. Returns "" when no session was
 	// created.
@@ -705,7 +707,7 @@ func emitRunResult(
 		return outputJSONWithWarnings(comments, ag.Warnings(), ag.FilesReviewed(),
 			ag.TotalInputTokens(), ag.TotalOutputTokens(), ag.TotalTokensUsed(),
 			ag.TotalCacheReadTokens(), ag.TotalCacheWriteTokens(), duration,
-			ag.ProjectSummary(), ag.ToolCalls(), traceID, resumeInfo, ag.SessionID(), manifest, ag.BudgetExceeded(), llmIdentity, out, retryReport, groups)
+			ag.ProjectSummary(), ag.ToolCalls(), ag.ToolFailures(), traceID, resumeInfo, ag.SessionID(), manifest, ag.BudgetExceeded(), llmIdentity, out, retryReport, groups)
 	}
 	if outputFormat == "sarif" {
 		return outputSARIF(comments, Version, ag.Warnings(), manifest, out)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -491,6 +491,9 @@ func (a *Agent) Warnings() []AgentWarning { return a.runner.Warnings() }
 // ToolCalls returns per-tool call counts accumulated during review.
 func (a *Agent) ToolCalls() map[string]int64 { return a.runner.ToolCalls() }
 
+// ToolFailures returns failed registered-tool calls accumulated during review.
+func (a *Agent) ToolFailures() []llmloop.ToolFailureDetail { return a.runner.ToolFailures() }
+
 // BudgetExceeded reports whether the aggregate token budget gate stopped
 // dispatch before all files were reviewed. The run still returns the partial
 // comments collected up to that point (and a nil error), so those results are

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -91,11 +92,21 @@ type Runner struct {
 	warnings              []AgentWarning
 	toolCallsMu           sync.Mutex
 	toolCalls             map[string]int64
+	toolCallSequence      int64
+	toolFailures          []ToolFailureDetail
 	// bg tracks every background goroutine that can still issue an LLM
 	// request after RunPerFile returned. WaitBackground joins them so a
 	// retry-report Freeze at the run boundary cannot observe an
 	// un-finalized request. See WaitBackground.
 	bg sync.WaitGroup
+}
+
+// ToolFailureDetail describes one failed registered-tool invocation.
+type ToolFailureDetail struct {
+	ToolCallNumber int64  `json:"tool_call_number"`
+	ToolName       string `json:"tool_name"`
+	FilePath       string `json:"file_path,omitempty"`
+	Error          string `json:"error"`
 }
 
 // NewRunner returns a Runner bound to the given dependencies.
@@ -172,13 +183,45 @@ func (r *Runner) ToolCalls() map[string]int64 {
 	return out
 }
 
-func (r *Runner) recordToolCall(name string) {
+// ToolFailures returns failed tool calls ordered by their global call number.
+func (r *Runner) ToolFailures() []ToolFailureDetail {
 	r.toolCallsMu.Lock()
+	defer r.toolCallsMu.Unlock()
+
+	out := append([]ToolFailureDetail(nil), r.toolFailures...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ToolCallNumber < out[j].ToolCallNumber
+	})
+	return out
+}
+
+func (r *Runner) recordToolCall(name string) int64 {
+	r.toolCallsMu.Lock()
+	defer r.toolCallsMu.Unlock()
 	if r.toolCalls == nil {
 		r.toolCalls = make(map[string]int64)
 	}
 	r.toolCalls[name]++
+	r.toolCallSequence++
+	return r.toolCallSequence
+}
+
+func (r *Runner) recordToolFailure(number int64, name, filePath, errMsg string,
+	rec *session.TaskRecord, rawArguments string, duration time.Duration) {
+	detail := ToolFailureDetail{
+		ToolCallNumber: number,
+		ToolName:       name,
+		FilePath:       filePath,
+		Error:          errMsg,
+	}
+
+	r.toolCallsMu.Lock()
+	r.toolFailures = append(r.toolFailures, detail)
 	r.toolCallsMu.Unlock()
+
+	if rec != nil {
+		rec.AddToolFailure(name, rawArguments, errMsg, duration)
+	}
 }
 
 // RecordUsage adds the prompt/completion/cache tokens reported by an LLM
@@ -516,38 +559,6 @@ func graceRoundToolDefs(defs []llm.ToolDef) []llm.ToolDef {
 func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.ToolCall, rec *session.TaskRecord, thinking string) tool.TaskCheckpoint {
 	t := tool.OfName(call.Function.Name)
 
-	if !t.IsKnown() {
-		p, ok := r.deps.Tools.Get(call.Function.Name)
-		if !ok {
-			return tool.Of(tool.NotAvailableMsg)
-		}
-		r.recordToolCall(call.Function.Name)
-		dynArgs, err := parseToolArgs(call.Function.Arguments)
-		if err != nil {
-			return tool.Of(fmt.Sprintf("Error parsing tool arguments for %s: %v", call.Function.Name, err))
-		}
-		telemetry.PrintToolCallStarted(call.Function.Name, dynArgs)
-		_, toolSpan := telemetry.StartToolSpan(ctx, call.Function.Name)
-		startTime := time.Now()
-		result, err := p.Execute(ctx, dynArgs)
-		dur := time.Since(startTime)
-		if err != nil {
-			telemetry.RecordToolResult(toolSpan, call.Function.Name, dur.Milliseconds(), err)
-			toolSpan.End()
-			telemetry.RecordToolCall(ctx, call.Function.Name, dur, false)
-			telemetry.PrintToolCallError(call.Function.Name, err)
-			return tool.Of(fmt.Sprintf("Error executing tool %s: %v", call.Function.Name, err))
-		}
-		telemetry.RecordToolResult(toolSpan, call.Function.Name, dur.Milliseconds(), nil)
-		toolSpan.End()
-		telemetry.RecordToolCall(ctx, call.Function.Name, dur, true)
-		telemetry.PrintToolCallFinished(call.Function.Name, dur)
-		if rec != nil {
-			rec.AddToolResult(call.Function.Name, call.Function.Arguments, result)
-		}
-		return tool.Of(result)
-	}
-
 	if t == tool.TaskDone {
 		args, err := parseToolArgs(call.Function.Arguments)
 		if err != nil {
@@ -571,16 +582,23 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		}
 	}
 
-	p := lookupTool(r.deps.Tools, t)
-	if p == nil {
+	toolName := call.Function.Name
+	p, found := r.deps.Tools.Get(toolName)
+	if !found {
 		return tool.Of(tool.NotAvailableMsg)
 	}
 
-	r.recordToolCall(t.Name())
+	toolCallNumber := r.recordToolCall(toolName)
+	callStarted := time.Now()
 
 	args, err := parseToolArgs(call.Function.Arguments)
 	if err != nil {
-		return tool.Of(fmt.Sprintf("Error parsing tool arguments for %s: %v", t.Name(), err))
+		errMsg := fmt.Sprintf("Error parsing tool arguments for %s: %v", toolName, err)
+		telemetry.PrintToolCallStarted(toolName, nil)
+		telemetry.PrintToolCallError(toolName, fmt.Errorf("%s", errMsg))
+		r.recordToolFailure(toolCallNumber, toolName, newPath, errMsg,
+			rec, call.Function.Arguments, time.Since(callStarted))
+		return tool.Of(errMsg)
 	}
 
 	startTime := time.Now()
@@ -592,9 +610,13 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		comments, errMsg := tool.ParseCommentsWithPath(args, newPath)
 		if errMsg != "" {
 			dur := time.Since(startTime)
-			telemetry.RecordToolResult(toolSpan, t.Name(), dur.Milliseconds(), fmt.Errorf("%s", errMsg))
+			toolErr := fmt.Errorf("%s", errMsg)
+			telemetry.RecordToolResult(toolSpan, t.Name(), dur.Milliseconds(), toolErr)
 			toolSpan.End()
 			telemetry.RecordToolCall(ctx, t.Name(), dur, false)
+			r.recordToolFailure(toolCallNumber, toolName, newPath, errMsg,
+				rec, call.Function.Arguments, dur)
+			telemetry.PrintToolCallError(t.Name(), toolErr)
 			return tool.Of(errMsg)
 		}
 
@@ -702,22 +724,24 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 	}
 
 	// Synchronous path for all other tools
-	telemetry.PrintToolCallStarted(t.Name(), args)
-	_, toolSpan := telemetry.StartToolSpan(ctx, t.Name())
+	telemetry.PrintToolCallStarted(toolName, args)
+	_, toolSpan := telemetry.StartToolSpan(ctx, toolName)
 	result, err := p.Execute(ctx, args)
 	dur := time.Since(startTime)
 	ok := err == nil
-	telemetry.RecordToolResult(toolSpan, t.Name(), dur.Milliseconds(), err)
+	telemetry.RecordToolResult(toolSpan, toolName, dur.Milliseconds(), err)
 	toolSpan.End()
-	telemetry.RecordToolCall(ctx, t.Name(), dur, ok)
+	telemetry.RecordToolCall(ctx, toolName, dur, ok)
 
 	if err != nil {
-		telemetry.PrintToolCallError(t.Name(), err)
-		return tool.Of(fmt.Sprintf("Error executing tool %s: %v", t.Name(), err))
+		r.recordToolFailure(toolCallNumber, toolName, newPath, err.Error(),
+			rec, call.Function.Arguments, dur)
+		telemetry.PrintToolCallError(toolName, err)
+		return tool.Of(fmt.Sprintf("Error executing tool %s: %v", toolName, err))
 	}
-	telemetry.PrintToolCallFinished(t.Name(), dur)
+	telemetry.PrintToolCallFinished(toolName, dur)
 	if rec != nil {
-		rec.AddToolResult(t.Name(), call.Function.Arguments, result)
+		rec.AddToolResult(toolName, call.Function.Arguments, result)
 	}
 	return tool.Of(result)
 }
@@ -790,14 +814,4 @@ func parseToolArgs(raw string) (map[string]any, error) {
 		args = make(map[string]any)
 	}
 	return args, nil
-}
-
-// lookupTool returns the provider for a given tool from the registry, or
-// nil when not registered.
-func lookupTool(reg *tool.Registry, t tool.Tool) tool.Provider {
-	p, ok := reg.Get(t.Name())
-	if !ok {
-		return nil
-	}
-	return p
 }

--- a/internal/llmloop/loop_execute_test.go
+++ b/internal/llmloop/loop_execute_test.go
@@ -4,19 +4,22 @@
 package llmloop
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
+	"github.com/alibaba/open-code-review/internal/stdout"
 	"github.com/alibaba/open-code-review/internal/tool"
 )
 
-// erroringProvider is a dynamic tool provider whose Execute always fails, used
-// to drive executeToolCall's dynamic-tool error branch.
+// erroringProvider is a dynamic tool provider whose Execute always fails.
 type erroringProvider struct {
 	tool tool.Tool
 }
@@ -42,20 +45,35 @@ func TestExecuteToolCall_DynamicNotRegistered(t *testing.T) {
 	}
 }
 
-// TestExecuteToolCall_DynamicExecuteError covers the dynamic-tool branch where
-// the provider's Execute returns an error.
+// TestExecuteToolCall_DynamicExecuteError verifies newly registered tools use
+// the common failure-observation path without tool-specific instrumentation.
 func TestExecuteToolCall_DynamicExecuteError(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Register(&erroringProvider{tool: tool.Dynamic("dyn_fail")})
 	reg.Freeze()
 	r := NewRunner(Deps{Tools: reg, CommentCollector: tool.NewCommentCollector()})
 
+	rec := &session.TaskRecord{}
 	cp := r.executeToolCall(context.Background(), "file.go", llm.ToolCall{
-		Function: llm.FunctionCall{Name: "dyn_fail", Arguments: `{}`},
-	}, nil, "")
+		Function: llm.FunctionCall{Name: "dyn_fail", Arguments: `{"query":"needle"}`},
+	}, rec, "")
 
 	if !strings.Contains(cp.Data, "Error executing tool dyn_fail") {
 		t.Errorf("cp.Data = %q, want execute-error message", cp.Data)
+	}
+	failures := r.ToolFailures()
+	if len(failures) != 1 {
+		t.Fatalf("ToolFailures() = %+v, want one failure", failures)
+	}
+	failure := failures[0]
+	if failure.ToolCallNumber != 1 || failure.ToolName != "dyn_fail" || failure.FilePath != "file.go" {
+		t.Errorf("failure identity = %+v", failure)
+	}
+	if failure.Error != "boom" {
+		t.Errorf("failure details = %+v", failure)
+	}
+	if len(rec.ToolResults) != 1 || rec.ToolResults[0].OK || rec.ToolResults[0].Result != "boom" {
+		t.Errorf("session tool failure = %+v", rec.ToolResults)
 	}
 }
 
@@ -81,6 +99,9 @@ func TestExecuteToolCall_DynamicSuccessRecordsResult(t *testing.T) {
 	}
 	if rec.ToolResults[0].ToolName != "dyn_ok" || rec.ToolResults[0].Result != "ok" {
 		t.Errorf("recorded result = %+v, want dyn_ok/ok", rec.ToolResults[0])
+	}
+	if !rec.ToolResults[0].OK {
+		t.Errorf("successful result marked failed: %+v", rec.ToolResults[0])
 	}
 }
 
@@ -128,19 +149,80 @@ func TestCollectPendingComments_AwaitsPool(t *testing.T) {
 	}
 }
 
-// TestExecuteToolCall_DynamicParseError covers the dynamic-tool branch where
-// the arguments string fails to parse.
+// TestExecuteToolCall_DynamicParseError verifies malformed calls to registered
+// tools are captured by the same failure-observation path.
 func TestExecuteToolCall_DynamicParseError(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Register(&argsCapturingProvider{tool: tool.Dynamic("dyn_ok")})
 	reg.Freeze()
 	r := NewRunner(Deps{Tools: reg, CommentCollector: tool.NewCommentCollector()})
 
-	cp := r.executeToolCall(context.Background(), "file.go", llm.ToolCall{
-		Function: llm.FunctionCall{Name: "dyn_ok", Arguments: `{bad`},
-	}, nil, "")
+	var cp tool.TaskCheckpoint
+	progress, errOut := captureToolTerminal(t, func() {
+		cp = r.executeToolCall(context.Background(), "file.go", llm.ToolCall{
+			Function: llm.FunctionCall{Name: "dyn_ok", Arguments: `{bad`},
+		}, nil, "")
+	})
 
 	if !strings.Contains(cp.Data, "Error parsing tool arguments for dyn_ok") {
 		t.Errorf("cp.Data = %q, want parse-error message", cp.Data)
 	}
+	if !strings.Contains(progress, "[ocr]   ▶ dyn_ok") {
+		t.Errorf("progress = %q, want tool start", progress)
+	}
+	if !strings.Contains(errOut, "[ocr]   ✘ dyn_ok failed: Error parsing tool arguments for dyn_ok") {
+		t.Errorf("stderr = %q, want terminal parse failure", errOut)
+	}
+	failures := r.ToolFailures()
+	if len(failures) != 1 || failures[0].ToolName != "dyn_ok" || failures[0].ToolCallNumber != 1 {
+		t.Errorf("ToolFailures() = %+v, want dyn_ok tool call 1", failures)
+	}
+	if !strings.Contains(failures[0].Error, "Error parsing tool arguments") {
+		t.Errorf("parse failure details = %+v", failures[0])
+	}
+}
+
+func TestExecuteToolCall_CodeCommentValidationErrorPrintsTerminalFailure(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: tool.NewCommentCollector()})
+	reg.Freeze()
+	r := NewRunner(Deps{Tools: reg, CommentCollector: tool.NewCommentCollector()})
+
+	progress, errOut := captureToolTerminal(t, func() {
+		r.executeToolCall(context.Background(), "file.go", llm.ToolCall{
+			Function: llm.FunctionCall{Name: tool.CodeComment.Name(), Arguments: `{}`},
+		}, nil, "")
+	})
+
+	if !strings.Contains(progress, "[ocr]   ▶ code_comment") {
+		t.Errorf("progress = %q, want tool start", progress)
+	}
+	if !strings.Contains(errOut, "[ocr]   ✘ code_comment failed: Error: 'comments' array is required") {
+		t.Errorf("stderr = %q, want terminal validation failure", errOut)
+	}
+}
+
+func captureToolTerminal(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	var progress bytes.Buffer
+	restoreProgress := stdout.Swap(&progress)
+	defer restoreProgress()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	errBytes, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return progress.String(), string(errBytes)
 }

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -494,18 +494,21 @@ func TestExecuteToolCall_ArgumentsEdgeCases(t *testing.T) {
 		wantContains   string // substring expected in cp.Data ("" = skip)
 		wantComment    string // if non-empty, expect one collected comment with this path
 		wantNonNilArgs bool   // dynamic tool: Execute must receive a non-nil args map
+		wantFailure    bool
 	}{
 		{
 			name:         "null args on code_comment (issue #382)",
 			toolName:     "code_comment",
 			arguments:    `null`,
 			wantContains: "'comments' array is required",
+			wantFailure:  true,
 		},
 		{
 			name:         "empty object on code_comment",
 			toolName:     "code_comment",
 			arguments:    `{}`,
 			wantContains: "'comments' array is required",
+			wantFailure:  true,
 		},
 		{
 			name:        "valid args uses per-item path",
@@ -518,12 +521,14 @@ func TestExecuteToolCall_ArgumentsEdgeCases(t *testing.T) {
 			toolName:     "code_comment",
 			arguments:    ``,
 			wantContains: "Error parsing tool arguments",
+			wantFailure:  true,
 		},
 		{
 			name:         "malformed json args",
 			toolName:     "code_comment",
 			arguments:    `{"comments":`,
 			wantContains: "Error parsing tool arguments",
+			wantFailure:  true,
 		},
 		{
 			name:           "null args on dynamic tool",
@@ -573,6 +578,13 @@ func TestExecuteToolCall_ArgumentsEdgeCases(t *testing.T) {
 				if dyn.gotArgs == nil {
 					t.Error("dynamic tool Execute received nil args map, want non-nil empty map")
 				}
+			}
+			failures := r.ToolFailures()
+			if tt.wantFailure && len(failures) != 1 {
+				t.Errorf("ToolFailures() = %+v, want one failure", failures)
+			}
+			if !tt.wantFailure && len(failures) != 0 {
+				t.Errorf("ToolFailures() = %+v, want no failures", failures)
 			}
 		})
 	}

--- a/internal/llmloop/runner_test.go
+++ b/internal/llmloop/runner_test.go
@@ -116,9 +116,15 @@ func TestRecordWarning(t *testing.T) {
 func TestRecordToolCall(t *testing.T) {
 	t_tempDir = t.TempDir()
 	r := newTestRunner(&fakeLLMClient{}, template.Template{})
-	r.recordToolCall("file_read")
-	r.recordToolCall("file_read")
-	r.recordToolCall("code_comment")
+	if got := r.recordToolCall("file_read"); got != 1 {
+		t.Errorf("first tool call number = %d, want 1", got)
+	}
+	if got := r.recordToolCall("file_read"); got != 2 {
+		t.Errorf("second tool call number = %d, want 2", got)
+	}
+	if got := r.recordToolCall("code_comment"); got != 3 {
+		t.Errorf("third tool call number = %d, want 3", got)
+	}
 
 	calls := r.ToolCalls()
 	if calls["file_read"] != 2 {
@@ -126,6 +132,23 @@ func TestRecordToolCall(t *testing.T) {
 	}
 	if calls["code_comment"] != 1 {
 		t.Errorf("code_comment = %d, want 1", calls["code_comment"])
+	}
+}
+
+func TestToolFailures_AreOrderedAndSnapshotIsolated(t *testing.T) {
+	r := NewRunner(Deps{})
+	r.recordToolFailure(2, "tool_b", "b.go", "second", nil, `{}`, 0)
+	r.recordToolFailure(1, "tool_a", "a.go", "first", nil, `{}`, 0)
+
+	failures := r.ToolFailures()
+	if len(failures) != 2 || failures[0].ToolCallNumber != 1 || failures[1].ToolCallNumber != 2 {
+		t.Fatalf("ToolFailures() = %+v, want call numbers 1, 2", failures)
+	}
+	failures[0].Error = "mutated"
+
+	again := r.ToolFailures()
+	if again[0].Error != "first" {
+		t.Errorf("ToolFailures snapshot mutated internal state: error = %q", again[0].Error)
 	}
 }
 

--- a/internal/scan/agent.go
+++ b/internal/scan/agent.go
@@ -224,6 +224,9 @@ func (a *Agent) Warnings() []llmloop.AgentWarning { return a.runner.Warnings() }
 // ToolCalls returns per-tool call counts accumulated during scan.
 func (a *Agent) ToolCalls() map[string]int64 { return a.runner.ToolCalls() }
 
+// ToolFailures returns failed registered-tool calls accumulated during scan.
+func (a *Agent) ToolFailures() []llmloop.ToolFailureDetail { return a.runner.ToolFailures() }
+
 // BudgetExceeded reports whether the aggregate token budget gate stopped
 // dispatch before every file was reviewed. Diagnostic only: scan still returns
 // its partial comments and a nil error, and the value reaches output solely as

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -123,6 +123,8 @@ type ToolResultRecord struct {
 	ToolName  string
 	Arguments string
 	Result    string
+	OK        bool
+	Duration  time.Duration
 }
 
 // SessionOptions holds optional metadata for a new session.
@@ -507,15 +509,26 @@ func (sh *SessionHistory) LLMFailures() int64 {
 // AddToolResult appends a tool call result to this task record and writes a
 // tool_call record to the JSONL stream.
 func (tr *TaskRecord) AddToolResult(toolName, arguments, result string) {
+	tr.addToolResult(toolName, arguments, result, true, 0)
+}
+
+// AddToolFailure appends and persists a failed tool call result.
+func (tr *TaskRecord) AddToolFailure(toolName, arguments, result string, duration time.Duration) {
+	tr.addToolResult(toolName, arguments, result, false, duration)
+}
+
+func (tr *TaskRecord) addToolResult(toolName, arguments, result string, ok bool, duration time.Duration) {
 	tr.ToolResults = append(tr.ToolResults, ToolResultRecord{
 		ToolName:  toolName,
 		Arguments: arguments,
 		Result:    result,
+		OK:        ok,
+		Duration:  duration,
 	})
 
 	if fs := tr.fileSession; fs != nil {
 		if p := fs.session.persist; p != nil {
-			p.WriteToolCall(fs.FilePath, tr.Type, toolName, arguments, result, true, 0)
+			p.WriteToolCall(fs.FilePath, tr.Type, toolName, arguments, result, ok, duration)
 		}
 	}
 }

--- a/internal/session/history_test.go
+++ b/internal/session/history_test.go
@@ -501,4 +501,49 @@ func TestAddToolResult(t *testing.T) {
 	if tr.Result != "package main" {
 		t.Errorf("Result = %q", tr.Result)
 	}
+	if !tr.OK {
+		t.Error("successful tool result marked failed")
+	}
+}
+
+func TestAddToolFailure(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := New(repoDir, "main", "model", SessionOptions{})
+	fs := sh.GetOrCreateFileSession("file.go")
+	rec := fs.AppendTaskRecord(MainTask, nil)
+
+	rec.AddToolFailure("code_search", `{"search_text":"needle"}`, "git grep failed", 25*time.Millisecond)
+
+	if len(rec.ToolResults) != 1 {
+		t.Fatalf("len = %d", len(rec.ToolResults))
+	}
+	result := rec.ToolResults[0]
+	if result.ToolName != "code_search" || result.OK || result.Result != "git grep failed" {
+		t.Errorf("failure result = %+v", result)
+	}
+	if result.Duration != 25*time.Millisecond {
+		t.Errorf("Duration = %s, want 25ms", result.Duration)
+	}
+
+	if err := sh.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	records := readJSONLRecords(t, sessionJSONLPath(t, repoDir, sh.SessionID))
+	var persisted map[string]any
+	for _, record := range records {
+		if record["type"] == "tool_call" {
+			persisted = record
+			break
+		}
+	}
+	if persisted == nil {
+		t.Fatal("failed tool call was not persisted")
+	}
+	if ok, _ := persisted["ok"].(bool); ok {
+		t.Errorf("persisted failure has ok=true: %+v", persisted)
+	}
+	if got := int64(persisted["duration_ms"].(float64)); got != 25 {
+		t.Errorf("persisted duration_ms = %d, want 25", got)
+	}
 }

--- a/internal/tool/code_search.go
+++ b/internal/tool/code_search.go
@@ -50,7 +50,7 @@ func (p *CodeSearchProvider) Execute(ctx context.Context, args map[string]any) (
 
 	result, err := p.gitGrep(ctx, searchText, caseSensitive, usePerlRegexp, patterns)
 	if err != nil {
-		return "", fmt.Errorf("code_search failed: %w", err)
+		return "", err
 	}
 	return result, nil
 }
@@ -152,16 +152,25 @@ func (p *CodeSearchProvider) gitGrep(ctx context.Context, searchText string, cas
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return "code_search timed out. Try narrowing file_patterns to a more specific path.", nil
+			return "", fmt.Errorf("git grep timed out; try narrowing file_patterns to a more specific path: %w", err)
 		}
 		if errors.Is(err, context.Canceled) {
 			return "", err
 		}
 		if outStr == "" {
-			if errStr == "" {
+			var exitErr *exec.ExitError
+			exitCode := -1
+			if errors.As(err, &exitErr) {
+				exitCode = exitErr.ExitCode()
+			}
+			if errStr == "" && exitCode == 1 {
 				return "No matches found", nil
 			}
-			return fmt.Sprintf("Error: %s", strings.TrimSpace(errStr)), nil
+			trimmedErr := trimGitUsage(errStr, exitCode)
+			if trimmedErr == "" {
+				return "", fmt.Errorf("git grep failed: %w", err)
+			}
+			return "", fmt.Errorf("git grep failed: %w: %s", err, trimmedErr)
 		}
 	}
 
@@ -226,6 +235,16 @@ func (p *CodeSearchProvider) gitGrep(ctx context.Context, searchText string, cas
 	}
 
 	return sb.String(), nil
+}
+
+func trimGitUsage(stderr string, exitCode int) string {
+	stderr = strings.TrimSpace(stderr)
+	if exitCode == 129 {
+		if idx := strings.IndexByte(stderr, '\n'); idx >= 0 {
+			stderr = stderr[:idx]
+		}
+	}
+	return strings.TrimSpace(stderr)
 }
 
 func isNotGitRepoError(err error, stderr string) bool {

--- a/internal/tool/code_search_test.go
+++ b/internal/tool/code_search_test.go
@@ -281,11 +281,14 @@ func TestGitGrep_InvalidRef_ReturnsError(t *testing.T) {
 	dir := setupTestRepo(t)
 	p := NewCodeSearch(&FileReader{RepoDir: dir, Ref: "nonexistent_ref_abc123", Mode: ModeCommit})
 	result, err := p.gitGrep(context.Background(), "Hello", false, false, nil)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected invalid ref to return an error")
 	}
-	if !strings.Contains(result, "Error:") {
-		t.Errorf("expected error message for invalid ref, got: %s", result)
+	if result != "" {
+		t.Errorf("expected empty result for invalid ref, got: %s", result)
+	}
+	if !strings.Contains(err.Error(), "git grep failed") {
+		t.Errorf("expected git grep failure, got: %v", err)
 	}
 }
 
@@ -293,11 +296,65 @@ func TestGitGrep_PerlRegexp_InvalidPattern_ReturnsError(t *testing.T) {
 	dir := setupTestRepo(t)
 	p := NewCodeSearch(&FileReader{RepoDir: dir, Ref: "", Mode: ModeWorkspace})
 	result, err := p.gitGrep(context.Background(), "(unclosed", false, true, nil)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected invalid perl regexp to return an error")
 	}
-	if !strings.Contains(result, "Error:") {
-		t.Errorf("expected error message for invalid perl regexp, got: %s", result)
+	if result != "" {
+		t.Errorf("expected empty result for invalid perl regexp, got: %s", result)
+	}
+	if !strings.Contains(err.Error(), "git grep failed") {
+		t.Errorf("expected git grep failure, got: %v", err)
+	}
+}
+
+func TestTrimGitUsage(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "English",
+			stderr: "error: unknown option `max-count'\nusage: git grep [<options>]\n\n    --cached",
+			want:   "error: unknown option `max-count'",
+		},
+		{
+			name:   "Chinese",
+			stderr: "\u9519\u8bef\uff1a\u672a\u77e5\u9009\u9879 `max-count'\n\u7528\u6cd5\uff1agit grep [<\u9009\u9879>]\n\n    --cached",
+			want:   "\u9519\u8bef\uff1a\u672a\u77e5\u9009\u9879 `max-count'",
+		},
+		{
+			name:   "French",
+			stderr: "erreur : option inconnue `max-count'\nutilisation : git grep [<options>]\n\n    --cached",
+			want:   "erreur : option inconnue `max-count'",
+		},
+		{
+			name:   "Japanese",
+			stderr: "\u30a8\u30e9\u30fc: \u4e0d\u660e\u306a\u30aa\u30d7\u30b7\u30e7\u30f3 `max-count'\n\u4f7f\u7528\u6cd5: git grep [<\u30aa\u30d7\u30b7\u30e7\u30f3>]\n\n    --cached",
+			want:   "\u30a8\u30e9\u30fc: \u4e0d\u660e\u306a\u30aa\u30d7\u30b7\u30e7\u30f3 `max-count'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimGitUsage(tt.stderr, 129); got != tt.want {
+				t.Errorf("trimGitUsage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimGitUsage_PreservesDiagnosticWithoutUsage(t *testing.T) {
+	stderr := "fatal: ambiguous argument 'missing': unknown revision\nhint: verify the revision name"
+	got := trimGitUsage(stderr, 128)
+	if got != stderr {
+		t.Errorf("trimGitUsage() = %q, want %q", got, stderr)
+	}
+}
+
+func TestTrimGitUsage_WhitespaceOnly(t *testing.T) {
+	if got := trimGitUsage(" \n\t", 129); got != "" {
+		t.Errorf("trimGitUsage() = %q, want empty string", got)
 	}
 }
 
@@ -430,6 +487,24 @@ func TestCodeSearchProvider_Execute_Found(t *testing.T) {
 	}
 	if !strings.Contains(got, "hello.go") {
 		t.Errorf("expected hello.go in result, got: %s", got)
+	}
+}
+
+func TestCodeSearchProvider_Execute_PropagatesGitFailure(t *testing.T) {
+	dir := setupTestRepo(t)
+	p := NewCodeSearch(&FileReader{RepoDir: dir, Ref: "nonexistent_ref_abc123", Mode: ModeCommit})
+
+	got, err := p.Execute(context.Background(), map[string]any{
+		"search_text": "Hello",
+	})
+	if err == nil {
+		t.Fatal("expected git grep failure to propagate from Execute")
+	}
+	if got != "" {
+		t.Errorf("expected empty result on git grep failure, got: %s", got)
+	}
+	if !strings.Contains(err.Error(), "git grep failed") {
+		t.Errorf("expected git grep failure, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

Tool execution failures were not consistently observable in terminal output or the final JSON report.

In particular, `code_search` converted `git grep` execution errors into successful string results. With Git 2.34.1, the unsupported `--max-count` option caused `git grep` to exit with status 129, but the terminal displayed the tool call as successful and the final JSON only counted the invocation.

This PR:

- propagates actual `git grep` execution failures from `code_search`
- preserves exit code 1 with empty stderr as the normal “No matches found” result
- removes the verbose `git grep` usage text while retaining the actionable error
- records failures through the common registered-tool execution path, covering existing and future registered tools
- persists failed tool calls in session JSONL with `ok: false`
- adds `failure`, `failure_by_tool`, and ordered `failure_details` to the final JSON output
- keeps tool arguments out of failure details

Example JSON output:

```json
"tool_calls": {
  "total": 5,
  "by_tool": {
    "code_search": 2,
    "file_read": 3
  },
  "failure": 1,
  "failure_by_tool": {
    "code_search": 1
  },
  "failure_details": [
    {
      "tool_call_number": 2,
      "tool_name": "code_search",
      "file_path": "src/Base/Parameter.cpp",
      "error": "git grep failed: exit status 129: error: unknown option `max-count'"
    }
  ]
}
```

## Testing

- `make check`
- `make test`
- Manually reproduced and verified the failure with Git 2.34.1.
