### PR TITLE
feat(review): reuse completed findings across pushes via --reuse-from

### DIFF
--- a/cmd/opencodereview/flags_test.go
+++ b/cmd/opencodereview/flags_test.go
@@ -65,6 +65,30 @@ func TestParseReviewFlags_PreviewWithResume(t *testing.T) {
 	}
 }
 
+func TestParseReviewFlags_ReuseFrom(t *testing.T) {
+	opts, err := parseReviewFlags([]string{"--from", "main", "--to", "feature", "--reuse-from", "ocr-result.json"})
+	if err != nil {
+		t.Fatalf("parseReviewFlags: %v", err)
+	}
+	if opts.reuseFrom != "ocr-result.json" {
+		t.Errorf("reuseFrom = %q, want ocr-result.json", opts.reuseFrom)
+	}
+}
+
+func TestParseReviewFlags_ReuseWithResumeRejected(t *testing.T) {
+	_, err := parseReviewFlags([]string{"--from", "main", "--to", "feature", "--reuse-from", "prev.json", "--resume", "session-123"})
+	if err == nil {
+		t.Fatal("expected error for --reuse-from with --resume")
+	}
+}
+
+func TestParseReviewFlags_PreviewWithReuseFromRejected(t *testing.T) {
+	_, err := parseReviewFlags([]string{"--from", "main", "--to", "feature", "--reuse-from", "prev.json", "--preview"})
+	if err == nil {
+		t.Fatal("expected error for --preview with --reuse-from")
+	}
+}
+
 func TestParseReviewFlags_InvalidAudience(t *testing.T) {
 	_, err := parseReviewFlags([]string{"--audience", "robot"})
 	if err == nil {

--- a/cmd/opencodereview/reuse_from.go
+++ b/cmd/opencodereview/reuse_from.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alibaba/open-code-review/internal/diff"
+	"github.com/alibaba/open-code-review/internal/model"
+	"github.com/alibaba/open-code-review/internal/session"
+)
+
+// reuseSource is the exported shape of a previous run's `--format json` output
+// file. It carries exactly what the reuse join needs: the run manifest (coverage
+// fingerprints plus repository identity) and the flat comment list, both of
+// which every result file already publishes.
+type reuseSource struct {
+	Manifest  *session.RunManifest `json:"manifest"`
+	Comments  []model.LlmComment   `json:"comments"`
+	SessionID string               `json:"session_id"`
+}
+
+// loadReuseState reads a previous run's JSON output file and synthesizes a
+// ResumeState for the fingerprint reuse engine (applyResume). Unlike a real
+// resume, nothing here is admitted or validated as a checkpoint lineage: no
+// ValidateOptions, no ValidateResume — the cross-push case those would reject
+// (different refs, rule config, provider) is the normal case for reuse, and the
+// trust boundary is the repository identity below plus the diff fingerprint
+// itself, which embeds mode and both path spellings.
+//
+// Every failure is a warning plus a nil state, never an error: a missing,
+// unreadable, malformed or foreign-repository source degrades to today's full
+// review. The caller prints the warnings; both are nil when the state loads.
+func loadReuseState(ctx context.Context, repoDir, path string) (*session.ResumeState, []string) {
+	var warnings []string
+	warn := func(format string, args ...any) (*session.ResumeState, []string) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+		return nil, warnings
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return warn("cannot read reuse source: %v", err)
+	}
+	var src reuseSource
+	if err := json.Unmarshal(data, &src); err != nil {
+		return warn("not a valid previous-run JSON output: %v", err)
+	}
+	if src.Manifest == nil {
+		return warn("previous-run output has no manifest; nothing to reuse")
+	}
+	if src.Manifest.SchemaVersion != session.ManifestSchemaVersion {
+		return warn("unsupported manifest schema version %q (want %q)",
+			src.Manifest.SchemaVersion, session.ManifestSchemaVersion)
+	}
+	if !sameRepositoryIdentity(ctx, repoDir, src.Manifest.Repository.IdentitySHA256) {
+		return warn("previous run reviewed a different repository; nothing to reuse")
+	}
+
+	// Join: comments are grouped by their exact path, and every coverage item
+	// the parent settled as completed or reused contributes one checkpoint
+	// keyed by its fingerprint. A fingerprint match implies the identical
+	// old/new path strings, so the group for CoverageItem.Path is exactly the
+	// comment set the parent settled for that item; a completed item with zero
+	// comments is still reusable (there was simply nothing to say).
+	commentsByPath := make(map[string][]model.LlmComment, len(src.Comments))
+	for _, c := range src.Comments {
+		commentsByPath[c.Path] = append(commentsByPath[c.Path], c)
+	}
+	items := make(map[string]session.ResumeItem)
+	for _, bucket := range [][]session.CoverageItem{src.Manifest.Coverage.Completed, src.Manifest.Coverage.Reused} {
+		for _, cov := range bucket {
+			if cov.Fingerprint == "" {
+				continue
+			}
+			if _, exists := items[cov.Fingerprint]; exists {
+				continue
+			}
+			items[cov.Fingerprint] = session.ResumeItem{
+				FilePath:    cov.Path,
+				OldPath:     cov.OldPath,
+				NewPath:     cov.Path,
+				Fingerprint: cov.Fingerprint,
+				Comments:    commentsByPath[cov.Path],
+			}
+		}
+	}
+
+	// "reuse:<run_id>" self-describes the source in session events and
+	// resume.resumed_from. Finalize rejects an empty run_id, but a hand-edited
+	// file may lack one; the file name keeps the id unique and meaningful.
+	runID := src.Manifest.RunID
+	if runID == "" {
+		runID = filepath.Base(path)
+	}
+	return &session.ResumeState{
+		SessionID: "reuse:" + runID,
+		RepoDir:   repoDir,
+		Items:     items,
+		Manifest:  src.Manifest,
+		Closed:    true,
+		Model:     src.Manifest.Execution.Model,
+	}, warnings
+}
+
+// sameRepositoryIdentity reports whether the identity the source run recorded
+// matches the current repository. Both sides use the digest the run itself
+// records (agent applyInputIdentity): sha256-hex of the canonicalized origin
+// remote, with no origin remote yielding the empty string on both sides — two
+// remote-less repositories therefore match, which mirrors the resume identity
+// contract; the diff fingerprint still requires byte-identical content and
+// paths before anything is actually reused.
+func sameRepositoryIdentity(ctx context.Context, repoDir, recordedSHA string) bool {
+	current := ""
+	if id := diff.NewWorkspaceProvider(repoDir, nil).RemoteIdentity(ctx); id != "" {
+		sum := sha256.Sum256([]byte(id))
+		current = hex.EncodeToString(sum[:])
+	}
+	return current == recordedSHA
+}

--- a/cmd/opencodereview/reuse_from_test.go
+++ b/cmd/opencodereview/reuse_from_test.go
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/open-code-review/internal/model"
+	"github.com/alibaba/open-code-review/internal/session"
+)
+
+// writeReuseSource writes a previous run's JSON output file in the exact shape
+// the producer (jsonOutput) publishes, so the loader is tested against the real
+// round trip rather than a hand-rolled lookalike.
+func writeReuseSource(t *testing.T, name string, out jsonOutput) string {
+	t.Helper()
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal reuse source: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write reuse source: %v", err)
+	}
+	return path
+}
+
+// validReuseOutput builds a source manifest with the given repository digest
+// and coverage entries, mirroring what a completed range run publishes.
+func validReuseOutput(identitySHA string, completed, reused []session.CoverageItem, comments []model.LlmComment) jsonOutput {
+	return jsonOutput{
+		Status:   "complete",
+		Comments: comments,
+		Manifest: &session.RunManifest{
+			SchemaVersion: session.ManifestSchemaVersion,
+			RunID:         "run-42",
+			Operation:     session.OperationReview,
+			TerminalState: session.StateComplete,
+			Repository:    session.ManifestRepository{IdentitySHA256: identitySHA},
+			Input:         session.ManifestInput{Mode: session.InputModeRange},
+			Execution:     session.ManifestExecution{Model: "claude-old"},
+			Coverage: session.Coverage{
+				Selected:  append(append([]session.CoverageItem{}, completed...), reused...),
+				Completed: completed,
+				Reused:    reused,
+			},
+		},
+	}
+}
+
+func TestLoadReuseStateValidJoin(t *testing.T) {
+	// A plain temp dir has no origin remote, and the manifest records no
+	// repository identity: empty versus empty is a match.
+	repoDir := t.TempDir()
+	completed := []session.CoverageItem{
+		{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-a"},
+		{ItemID: "id-renamed", Path: "moved.go", OldPath: "old.go", Fingerprint: "fp-renamed"},
+		{ItemID: "id-empty-fp", Path: "no-fp.go", Fingerprint: ""},
+	}
+	reused := []session.CoverageItem{
+		{ItemID: "id-b", Path: "b.go", Fingerprint: "fp-b"},
+		// A settled item with zero comments: no comment list is not "no verdict".
+		{ItemID: "id-c", Path: "c.go", Fingerprint: "fp-c"},
+	}
+	comments := []model.LlmComment{
+		{Path: "a.go", Content: "first about a.go"},
+		{Path: "b.go", Content: "about b.go"},
+		{Path: "a.go", Content: "second about a.go"},
+		// A comment for a path no coverage item settled is not a checkpoint;
+		// the join is driven by coverage, not by the comment list.
+		{Path: "uncovered.go", Content: "orphan"},
+	}
+	path := writeReuseSource(t, "ocr-result.json", validReuseOutput("", completed, reused, comments))
+
+	state, warnings := loadReuseState(context.Background(), repoDir, path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if state == nil {
+		t.Fatal("expected a reuse state")
+	}
+	if state.SessionID != "reuse:run-42" {
+		t.Errorf("SessionID = %q, want reuse:run-42", state.SessionID)
+	}
+	if !state.Closed || state.Model != "claude-old" || state.Manifest == nil || state.Manifest.RunID != "run-42" {
+		t.Errorf("state = %+v manifest = %+v, want closed state carrying the source manifest", state, state.Manifest)
+	}
+	if got := len(state.Items); got != 4 {
+		t.Fatalf("items = %d, want 4 (empty fingerprints are skipped)", got)
+	}
+	a, ok := state.Items["fp-a"]
+	if !ok {
+		t.Fatal("fp-a missing from items")
+	}
+	if a.FilePath != "a.go" || a.NewPath != "a.go" || a.OldPath != "" || a.Fingerprint != "fp-a" {
+		t.Errorf("fp-a item = %+v", a)
+	}
+	if len(a.Comments) != 2 || a.Comments[0].Content != "first about a.go" || a.Comments[1].Content != "second about a.go" {
+		t.Errorf("fp-a comments = %+v, want both a.go comments grouped by exact path", a.Comments)
+	}
+	renamed := state.Items["fp-renamed"]
+	if renamed.OldPath != "old.go" || renamed.NewPath != "moved.go" {
+		t.Errorf("fp-renamed item = %+v, want old/new paths carried from coverage", renamed)
+	}
+	// A settled item with zero comments is still a reusable checkpoint.
+	c := state.Items["fp-c"]
+	if len(c.Comments) != 0 {
+		t.Errorf("fp-c comments = %+v, want none", c.Comments)
+	}
+	// The coverage the loader recorded must make each item reusable.
+	if _, ok := state.ReusableItem("fp-a"); !ok {
+		t.Error("fp-a must be reusable through the resume engine's coverage gate")
+	}
+	if _, ok := state.ReusableItem("fp-missing"); ok {
+		t.Error("an unknown fingerprint must not be reusable")
+	}
+}
+
+func TestLoadReuseStateDuplicateFingerprintAcrossBucketsIsOneItem(t *testing.T) {
+	repoDir := t.TempDir()
+	item := session.CoverageItem{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-a"}
+	path := writeReuseSource(t, "ocr-result.json",
+		validReuseOutput("", []session.CoverageItem{item}, []session.CoverageItem{item}, nil))
+
+	state, warnings := loadReuseState(context.Background(), repoDir, path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if got := len(state.Items); got != 1 {
+		t.Fatalf("items = %d, want 1 for a duplicated fingerprint", got)
+	}
+}
+
+func TestLoadReuseStateDegradations(t *testing.T) {
+	repoDir := t.TempDir()
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		path        func(t *testing.T) string
+		wantWarning string
+	}{
+		{
+			name: "missing file",
+			path: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "does-not-exist.json")
+			},
+			wantWarning: "cannot read reuse source",
+		},
+		{
+			name: "invalid json",
+			path: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ocr-result.json")
+				if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantWarning: "not a valid previous-run JSON output",
+		},
+		{
+			name: "empty file is invalid json",
+			path: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ocr-result.json")
+				if err := os.WriteFile(path, nil, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantWarning: "not a valid previous-run JSON output",
+		},
+		{
+			name: "manifest absent",
+			path: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ocr-result.json")
+				if err := os.WriteFile(path, []byte(`{"status":"complete","comments":[]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantWarning: "no manifest",
+		},
+		{
+			name: "unsupported schema version",
+			path: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ocr-result.json")
+				if err := os.WriteFile(path, []byte(`{"manifest":{"schema_version":"ocr.run-manifest/v0","run_id":"r","operation":"review"}}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantWarning: "unsupported manifest schema version",
+		},
+		{
+			name: "repository identity mismatch",
+			path: func(t *testing.T) string {
+				completed := []session.CoverageItem{{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-a"}}
+				return writeReuseSource(t, "ocr-result.json",
+					validReuseOutput(strings.Repeat("ab", 32), completed, nil, nil))
+			},
+			wantWarning: "different repository",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state, warnings := loadReuseState(ctx, repoDir, tc.path(t))
+			if state != nil {
+				t.Errorf("state = %+v, want nil for a degraded source", state)
+			}
+			if len(warnings) != 1 || !strings.Contains(warnings[0], tc.wantWarning) {
+				t.Errorf("warnings = %v, want one containing %q", warnings, tc.wantWarning)
+			}
+		})
+	}
+}
+
+func TestLoadReuseStateIdentityDerivation(t *testing.T) {
+	// The digest the loader compares is sha256-hex of the canonicalized origin
+	// remote — the same value a run records in repository.identity_sha256.
+	// Canonicalization drops the userinfo, lowercases the host and trims the
+	// trailing ".git" while preserving path case.
+	repoDir := initTestGitRepo(t)
+	gitIn(t, repoDir, "remote", "add", "origin", "https://User@GitHub.com/acme/Widget.git")
+	sum := sha256.Sum256([]byte("github.com/acme/Widget"))
+	digest := hex.EncodeToString(sum[:])
+	completed := []session.CoverageItem{{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-a"}}
+
+	t.Run("matching canonical identity is accepted", func(t *testing.T) {
+		path := writeReuseSource(t, "ocr-result.json", validReuseOutput(digest, completed, nil, nil))
+		state, warnings := loadReuseState(context.Background(), repoDir, path)
+		if len(warnings) != 0 || state == nil {
+			t.Fatalf("state = %v warnings = %v, want a loaded state with no warnings", state, warnings)
+		}
+	})
+
+	t.Run("different remote is rejected", func(t *testing.T) {
+		other := sha256.Sum256([]byte("github.com/acme/other"))
+		path := writeReuseSource(t, "ocr-result.json",
+			validReuseOutput(hex.EncodeToString(other[:]), completed, nil, nil))
+		state, warnings := loadReuseState(context.Background(), repoDir, path)
+		if state != nil || len(warnings) != 1 {
+			t.Fatalf("state = %v warnings = %v, want nil state with one warning", state, warnings)
+		}
+	})
+
+	t.Run("recorded identity without origin remote is rejected", func(t *testing.T) {
+		// The current repo has an origin here, so an empty recorded digest must
+		// not match; only empty-versus-empty is a match.
+		path := writeReuseSource(t, "ocr-result.json", validReuseOutput("", completed, nil, nil))
+		state, warnings := loadReuseState(context.Background(), repoDir, path)
+		if state != nil || len(warnings) != 1 {
+			t.Fatalf("state = %v warnings = %v, want nil state with one warning", state, warnings)
+		}
+	})
+}
+
+func TestLoadReuseStateSessionIDFallback(t *testing.T) {
+	repoDir := t.TempDir()
+	out := validReuseOutput("", []session.CoverageItem{{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-a"}}, nil, nil)
+	out.Manifest.RunID = "" // hand-edited file with no run_id
+	path := writeReuseSource(t, "prev-run.json", out)
+
+	state, warnings := loadReuseState(context.Background(), repoDir, path)
+	if len(warnings) != 0 || state == nil {
+		t.Fatalf("state = %v warnings = %v, want a loaded state with no warnings", state, warnings)
+	}
+	if want := "reuse:prev-run.json"; state.SessionID != want {
+		t.Errorf("SessionID = %q, want %q (file base name fallback)", state.SessionID, want)
+	}
+}
+
+// TestReuseFromNeverTriggersResumeGates pins the wiring invariant: a reuse-only
+// run keeps opts.resume empty, so loadReviewResumeState (the sole caller of
+// ResumeState.ValidateOptions) returns before loading anything and
+// validateResumeIdentity (the sole caller of ValidateResume) sees a nil state.
+// The synthetic reuse state therefore cannot be rejected by the strict gates
+// that exist to reject the cross-push case reuse is designed for.
+func TestReuseFromNeverTriggersResumeGates(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := initResumeRepo(t)
+	// A deliberately bogus reuse source: even when the file is unusable the
+	// strict gates must not fire, because the wiring never hands it to them.
+	opts := reviewOptions{from: "HEAD~1", to: "HEAD", reuseFrom: filepath.Join(t.TempDir(), "prev.json")}
+
+	state, err := loadReviewResumeState(repoDir, opts)
+	if err != nil {
+		t.Fatalf("loadReviewResumeState: %v (a reuse-only run must not enter the resume path)", err)
+	}
+	if state != nil {
+		t.Fatal("a reuse-only run must not load a resume state")
+	}
+
+	cc := resumeTestContext(repoDir)
+	rt := &llmRuntime{Provider: "anthropic", Model: "claude"}
+	sealed, err := validateResumeIdentity(context.Background(), cc, opts, rt, state)
+	if err != nil {
+		t.Fatalf("validateResumeIdentity: %v (a nil resume state must short-circuit)", err)
+	}
+	if sealed != nil {
+		t.Error("a reuse-only run must not seal its input to a resume admission")
+	}
+}
+
+// TestLoadReuseStateCommentsReachAgentOutput drives the loader's state through
+// the agent's reuse engine end to end at the unit level: the comments the join
+// grouped must be exactly the comments applyResume carries into the collector.
+func TestLoadReuseStateCommentsReachAgentOutput(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	completed := []session.CoverageItem{{ItemID: "id-a", Path: "a.go", Fingerprint: "fp-agent"}}
+	comments := []model.LlmComment{{Path: "a.go", Content: "carried", StartLine: 3, EndLine: 3}}
+	path := writeReuseSource(t, "ocr-result.json", validReuseOutput("", completed, nil, comments))
+
+	state, warnings := loadReuseState(context.Background(), repoDir, path)
+	if len(warnings) != 0 || state == nil {
+		t.Fatalf("state = %v warnings = %v, want a loaded state", state, warnings)
+	}
+	if _, ok := state.Items["fp-agent"]; !ok {
+		t.Fatal("fp-agent missing from items")
+	}
+	// The collector carry itself is covered by the agent-side reuse tests; here
+	// the contract is that ReusableItem (what applyResume calls) returns the
+	// joined comments unchanged.
+	item, ok := state.ReusableItem("fp-agent")
+	if !ok || len(item.Comments) != 1 || item.Comments[0].Content != "carried" {
+		t.Fatalf("ReusableItem = %+v ok=%v, want the joined comment", item, ok)
+	}
+}
+
+// TestReuseFromWiringEndToEnd is the only test that traverses
+// executeReviewContext's --reuse-from wiring: the flag must reach
+// loadReuseState, its warnings must reach stderr, and the synthesized state
+// must reach agent.Args.Reuse. Every other test in this change exercises the
+// loader or the agent directly, so deleting the wiring block in review_cmd.go
+// would leave the flag parsing into a silent no-op with the whole suite green.
+//
+// A first run publishes a real result file over the fake Anthropic server; a
+// second run over the same range with --reuse-from must reuse every item —
+// the parent manifest's fingerprints match what the child recomputes — without
+// a single new LLM request (not even the grouping call: dispatch never starts).
+func TestReuseFromWiringEndToEnd(t *testing.T) {
+	repoDir := retryTestRepo(t)
+	srv := newFakeLLM()
+	startFakeLLM(t, srv)
+
+	run := func(extra ...string) (string, string, error) {
+		t.Helper()
+		args := append([]string{"--repo", repoDir, "--from", "HEAD~1", "--to", "HEAD", "--format", "json"}, extra...)
+		var out string
+		var err error
+		errOut := captureStderr(t, func() {
+			out = captureStdout(t, func() {
+				err = runReview(args)
+			})
+		})
+		return out, errOut, err
+	}
+
+	// Run 1: a real completed range review; its published JSON is the artifact
+	// a gate loop feeds back through --reuse-from.
+	first, _, err := run()
+	if err != nil {
+		t.Fatalf("first review: %v", err)
+	}
+	prevPath := filepath.Join(t.TempDir(), "ocr-result.json")
+	if err := os.WriteFile(prevPath, []byte(first), 0o644); err != nil {
+		t.Fatalf("write reuse source: %v", err)
+	}
+	attemptsAfterFirst := srv.attemptCounts()
+	srv.mu.Lock()
+	groupingAfterFirst := srv.groupingCalls
+	srv.mu.Unlock()
+
+	// Run 2: same range, everything reusable. In json mode progress lines are
+	// redirected to stderr, so stdout stays one parseable document.
+	second, secondErrOut, err := run("--reuse-from", prevPath)
+	if err != nil {
+		t.Fatalf("reuse review: %v\nstderr: %s", err, secondErrOut)
+	}
+	var reused jsonOutput
+	if err := json.Unmarshal([]byte(second), &reused); err != nil {
+		t.Fatalf("unmarshal reuse run output: %v\n%s", err, second)
+	}
+	if reused.Manifest == nil || reused.Resume == nil {
+		t.Fatalf("output must carry manifest and resume: %s", second)
+	}
+	if len(reused.Manifest.Coverage.Reused) != len(markers) || len(reused.Manifest.Coverage.Completed) != 0 {
+		t.Fatalf("coverage reused=%d completed=%d, want %d reused and 0 completed",
+			len(reused.Manifest.Coverage.Reused), len(reused.Manifest.Coverage.Completed), len(markers))
+	}
+	if !strings.HasPrefix(reused.Resume.ResumedFrom, "reuse:") ||
+		reused.Resume.ReusedFiles != int64(len(markers)) || reused.Resume.RerunFiles != 0 {
+		t.Fatalf("resume info = %+v, want a reuse: source with everything reused", reused.Resume)
+	}
+	if want := fmt.Sprintf("reusing %d file(s), reviewing 0 file(s)", len(markers)); !strings.Contains(secondErrOut, want) {
+		t.Errorf("stderr must report the reuse line %q:\n%s", want, secondErrOut)
+	}
+	if !strings.Contains(secondErrOut, "[ocr] Reuse reuse:") {
+		t.Errorf("stderr must label the source as Reuse, not Resume:\n%s", secondErrOut)
+	}
+	// A fully reused run must not touch the model at all.
+	if got := srv.attemptCounts(); !reflect.DeepEqual(got, attemptsAfterFirst) {
+		t.Errorf("LLM attempts changed on an all-reused run: got %v, want %v", got, attemptsAfterFirst)
+	}
+	srv.mu.Lock()
+	groupingCalls := srv.groupingCalls
+	srv.mu.Unlock()
+	if groupingCalls != groupingAfterFirst {
+		t.Errorf("grouping calls = %d after the reuse run, want unchanged %d", groupingCalls, groupingAfterFirst)
+	}
+
+	// Degraded source: the CI artifact vanished between pushes. The wiring must
+	// warn on stderr and the run must degrade to today's full review.
+	missing := filepath.Join(t.TempDir(), "vanished.json")
+	third, thirdErrOut, err := run("--reuse-from", missing)
+	if err != nil {
+		t.Fatalf("a degraded reuse source must not fail the run: %v\nstderr: %s", err, thirdErrOut)
+	}
+	if !strings.Contains(thirdErrOut, "[ocr] WARNING [reuse_from]") {
+		t.Errorf("stderr must carry the reuse_from warning:\n%s", thirdErrOut)
+	}
+	var degraded jsonOutput
+	if err := json.Unmarshal([]byte(third), &degraded); err != nil {
+		t.Fatalf("unmarshal degraded run output: %v\n%s", err, third)
+	}
+	if degraded.Manifest == nil || len(degraded.Manifest.Coverage.Reused) != 0 || len(degraded.Manifest.Coverage.Completed) != len(markers) {
+		t.Fatalf("degraded coverage reused=%d completed=%d, want 0/%d (full fresh review)",
+			len(degraded.Manifest.Coverage.Reused), len(degraded.Manifest.Coverage.Completed), len(markers))
+	}
+	// And "full review" means the model actually saw the files again.
+	if got := srv.attemptCounts(); len(got) == 0 || !moreAttempts(got, attemptsAfterFirst) {
+		t.Errorf("LLM attempts = %v after the degraded run, want more than %v", got, attemptsAfterFirst)
+	}
+}
+
+// moreAttempts reports whether every count in got is at least the count in want
+// and the total grew.
+func moreAttempts(got, want map[string]int) bool {
+	total := 0
+	for file, n := range got {
+		if n < want[file] {
+			return false
+		}
+		total += n - want[file]
+	}
+	return total > 0
+}

--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -35,6 +35,7 @@ type reviewOptions struct {
 	to              string
 	commit          string
 	resume          string
+	reuseFrom       string
 	excludes        string
 	outputFormat    string
 	audience        string
@@ -74,6 +75,9 @@ var reviewCmd = &cobra.Command{
 
   # Resume a previous range review
   ocr review --from master --to dev-ref --resume <session-id>
+
+  # Reuse findings from a previous run's JSON output (cross-push)
+  ocr review --from master --to dev-ref --reuse-from ocr-result.json
 
   # Output JSON format
   ocr review --format json
@@ -145,6 +149,21 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 	resumeState, err := loadReviewResumeState(cc.RepoDir, opts)
 	if err != nil {
 		return err
+	}
+
+	// --reuse-from synthesizes a reuse index from a previous run's JSON output.
+	// It must stay mutually exclusive with --resume (flag validation), and the
+	// gate below keeps opts.resume empty on this path, so the strict resume
+	// machinery above (loadReviewResumeState) and below (validateResumeIdentity)
+	// never sees the synthetic state. A degraded source only warns: the run
+	// proceeds as today's full review.
+	var reuseState *session.ResumeState
+	if opts.reuseFrom != "" && opts.resume == "" {
+		state, reuseWarnings := loadReuseState(ctx, cc.RepoDir, opts.reuseFrom)
+		for _, w := range reuseWarnings {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING [reuse_from] %s: %s\n", sanitizeTerminal(opts.reuseFrom), sanitizeTerminal(w))
+		}
+		reuseState = state
 	}
 
 	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, llm.ResolveOptions{
@@ -228,6 +247,7 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 		Background:            opts.background,
 		GitRunner:             cc.GitRunner,
 		Resume:                resumeState,
+		Reuse:                 reuseState,
 		SealedInput:           sealedInput,
 		MaxTokensBudget:       int64(opts.maxTokensBudget),
 		SkipFilter:            opts.noFilter,

--- a/cmd/opencodereview/shared_flags.go
+++ b/cmd/opencodereview/shared_flags.go
@@ -128,6 +128,12 @@ func validateReviewOptions(opts *reviewOptions) error {
 	if opts.preview && opts.resume != "" {
 		return fmt.Errorf("--preview and --resume cannot be used together")
 	}
+	if opts.reuseFrom != "" && opts.resume != "" {
+		return fmt.Errorf("--reuse-from and --resume cannot be used together")
+	}
+	if opts.preview && opts.reuseFrom != "" {
+		return fmt.Errorf("--preview and --reuse-from cannot be used together")
+	}
 	if err := validateAudience(opts.audience); err != nil {
 		return err
 	}
@@ -206,6 +212,7 @@ func registerReviewFlags(cmd *cobra.Command, opts *reviewOptions) {
 	addDiffFlags(cmd, &opts.from, &opts.to, &opts.commit)
 	cmd.Flags().StringVar(&opts.resume, "resume", "", "resume from a previous review session id")
 	cmd.RegisterFlagCompletionFunc("resume", completeSessionIDs)
+	cmd.Flags().StringVar(&opts.reuseFrom, "reuse-from", "", "reuse completed findings from a previous run's JSON output file (e.g. the artifact uploaded by the GitHub Action); files whose diff is unchanged are not re-reviewed")
 	addExcludeFlag(cmd, &opts.excludes)
 	addOutputFlags(cmd, &opts.outputFormat, &opts.audience)
 	addOutputPathFlag(cmd, &opts.outputPath)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -137,6 +137,13 @@ type Args struct {
 	// Resume is an optional read-only checkpoint index from a previous review session.
 	Resume *session.ResumeState
 
+	// Reuse is an optional read-only reuse index synthesized from a previous
+	// run's JSON output (--reuse-from). It feeds the same fingerprint reuse
+	// engine as Resume (applyResume) but carries no resume contract: no
+	// ValidateOptions/ValidateResume admission, no lineage, no parent run id.
+	// It is consulted only when Resume is nil.
+	Reuse *session.ResumeState
+
 	// SealedInput pins this run to commit endpoints a pre-flight resolve already
 	// froze, instead of resolving From/To/Commit again. Set only on the resume
 	// path, where admission compared an identity derived from those endpoints:
@@ -840,6 +847,11 @@ func (a *Agent) recordContextFailure(err error) {
 
 func (a *Agent) applyResume(diffs []model.Diff) []model.Diff {
 	resume := a.args.Resume
+	source := "Resume"
+	if resume == nil {
+		resume = a.args.Reuse
+		source = "Reuse"
+	}
 	if resume == nil {
 		return diffs
 	}
@@ -877,7 +889,7 @@ func (a *Agent) applyResume(diffs []model.Diff) []model.Diff {
 		PreviousModel: resume.Model,
 		CurrentModel:  a.args.Model,
 	}
-	fmt.Fprintf(stdout.Writer(), "[ocr] Resume %s: reusing %d file(s), reviewing %d file(s)\n", resume.SessionID, reused, rerun)
+	fmt.Fprintf(stdout.Writer(), "[ocr] %s %s: reusing %d file(s), reviewing %d file(s)\n", source, resume.SessionID, reused, rerun)
 	return toDispatch
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/alibaba/open-code-review/internal/llm"
 	"github.com/alibaba/open-code-review/internal/model"
 	"github.com/alibaba/open-code-review/internal/session"
+	"github.com/alibaba/open-code-review/internal/stdout"
 	"github.com/alibaba/open-code-review/internal/tool"
 )
 
@@ -1238,5 +1240,367 @@ func TestAgent_TokenAccumulation(t *testing.T) {
 	}
 	if a.TotalOutputTokens() != 5 {
 		t.Errorf("TotalOutputTokens = %d, want 5", a.TotalOutputTokens())
+	}
+}
+
+// --- --reuse-from (Args.Reuse) tests ---
+
+// TestApplyResumeWithReuseState mirrors TestApplyResumeReusesCompletedItems
+// AcrossModels for Args.Reuse: same engine, distinct source labeling. A reuse
+// state carries a "reuse:<run>" session id, which must flow into ResumeInfo
+// unchanged while the reused comments land in the collector.
+func TestApplyResumeWithReuseState(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	diffs := []model.Diff{
+		{OldPath: "a.go", NewPath: "a.go", Diff: "+a", Insertions: 1},
+		{OldPath: "b.go", NewPath: "b.go", Diff: "+b", Insertions: 1},
+		// A deleted file is never reusable, whatever the reuse state says: it
+		// always dispatches.
+		{NewPath: "gone.go", IsDeleted: true, Deletions: 5},
+	}
+	fp := reviewItemFingerprint(session.ReviewModeRange, diffs[0])
+	reuse := &session.ResumeState{
+		SessionID: "reuse:old-run",
+		Model:     "anthropic-model",
+		Items: map[string]session.ResumeItem{
+			fp: {
+				FilePath:    "a.go",
+				OldPath:     "a.go",
+				NewPath:     "a.go",
+				Fingerprint: fp,
+				Comments: []model.LlmComment{{
+					Path:    "a.go",
+					Content: "cached comment",
+				}},
+			},
+		},
+		Manifest: &session.RunManifest{
+			SchemaVersion: session.ManifestSchemaVersion,
+			Coverage:      session.Coverage{Completed: []session.CoverageItem{{ItemID: fp, Fingerprint: fp}}},
+		},
+		Closed: true,
+	}
+	collector := tool.NewCommentCollector()
+	sess := session.New(t.TempDir(), "feature", "openai-model", session.SessionOptions{
+		ReviewMode: session.ReviewModeRange,
+		DiffFrom:   "main",
+		DiffTo:     "feature",
+		Operation:  session.OperationReview,
+	})
+	defer sess.Finalize()
+	a := New(Args{
+		From:             "main",
+		To:               "feature",
+		Model:            "openai-model",
+		CommentCollector: collector,
+		Reuse:            reuse,
+		Session:          sess,
+	})
+
+	var buf bytes.Buffer
+	restore := stdout.Swap(&buf)
+	toDispatch := a.applyResume(diffs)
+	restore()
+
+	if len(toDispatch) != 2 || toDispatch[0].NewPath != "b.go" || !toDispatch[1].IsDeleted {
+		t.Fatalf("toDispatch = %+v, want b.go plus the deleted file", toDispatch)
+	}
+	comments := collector.Comments()
+	if len(comments) != 1 || comments[0].Content != "cached comment" {
+		t.Fatalf("comments = %+v", comments)
+	}
+	info := a.ResumeInfo()
+	if info == nil || info.ReusedFiles != 1 || info.RerunFiles != 1 ||
+		info.ResumedFrom != "reuse:old-run" ||
+		info.PreviousModel != "anthropic-model" || info.CurrentModel != "openai-model" {
+		t.Fatalf("ResumeInfo = %+v", info)
+	}
+	// The deleted file dispatches but is not reviewable, so it stays out of the
+	// "reviewing" count.
+	if want := "[ocr] Reuse reuse:old-run: reusing 1 file(s), reviewing 1 file(s)\n"; buf.String() != want {
+		t.Errorf("print = %q, want %q", buf.String(), want)
+	}
+}
+
+// TestApplyResumeResumeTakesPrecedenceOverReuse pins the precedence when both
+// states are present: --resume is the strict path, so its state and its
+// "[ocr] Resume" labeling must win over the synthetic reuse state.
+func TestApplyResumeResumeTakesPrecedenceOverReuse(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	diffs := []model.Diff{{OldPath: "a.go", NewPath: "a.go", Diff: "+a", Insertions: 1}}
+	fp := reviewItemFingerprint(session.ReviewModeRange, diffs[0])
+	coverage := session.Coverage{Completed: []session.CoverageItem{{ItemID: fp, Fingerprint: fp}}}
+	resume := &session.ResumeState{
+		SessionID: "old-session",
+		Items:     map[string]session.ResumeItem{},
+		Manifest:  &session.RunManifest{Coverage: coverage},
+	}
+	reuse := &session.ResumeState{
+		SessionID: "reuse:other-run",
+		Items: map[string]session.ResumeItem{
+			fp: {FilePath: "a.go", NewPath: "a.go", Fingerprint: fp},
+		},
+		Manifest: &session.RunManifest{Coverage: coverage},
+	}
+	sess := session.New(t.TempDir(), "feature", "m", session.SessionOptions{
+		ReviewMode: session.ReviewModeRange,
+		Operation:  session.OperationReview,
+	})
+	defer sess.Finalize()
+	a := New(Args{
+		From:    "main",
+		To:      "feature",
+		Resume:  resume,
+		Reuse:   reuse,
+		Session: sess,
+	})
+
+	var buf bytes.Buffer
+	restore := stdout.Swap(&buf)
+	toDispatch := a.applyResume(diffs)
+	restore()
+
+	// resume has no checkpoint for fp, so the file dispatches — the reuse
+	// state must not step in as a fallback while a resume is in charge.
+	if len(toDispatch) != 1 {
+		t.Fatalf("toDispatch = %+v, want the file re-dispatched", toDispatch)
+	}
+	if info := a.ResumeInfo(); info == nil || info.ResumedFrom != "old-session" {
+		t.Fatalf("ResumeInfo = %+v, want the resume session as source", info)
+	}
+	if want := "[ocr] Resume old-session: reusing 0 file(s), reviewing 1 file(s)\n"; buf.String() != want {
+		t.Errorf("print = %q, want %q", buf.String(), want)
+	}
+}
+
+// newReuseFlowAgent mirrors newManifestFlowAgentWithClient for Args.Reuse: a
+// dispatch-ready agent whose reuse source is a synthetic reuse state, with no
+// ResumedFrom lineage (reuse runs are not resumes).
+func newReuseFlowAgent(t *testing.T, diffs []model.Diff, reuse *session.ResumeState, client llm.LLMClient) *Agent {
+	t.Helper()
+	setTestHome(t, t.TempDir())
+	repoDir := t.TempDir()
+	sh := session.New(repoDir, "feature", "fake", session.SessionOptions{
+		ReviewMode: session.ReviewModeRange,
+		DiffFrom:   "main",
+		DiffTo:     "feature",
+		Operation:  session.OperationReview,
+	})
+	t.Cleanup(func() { _ = sh.Finalize() })
+	a := New(Args{
+		RepoDir:    repoDir,
+		From:       "main",
+		To:         "feature",
+		ReviewMode: session.ReviewModeRange,
+		LLMClient:  client,
+		Model:      "fake",
+		Session:    sh,
+		Reuse:      reuse,
+		Template: template.Template{
+			MaxTokens:           100000,
+			MaxToolRequestTimes: 5,
+			MainTask: template.LlmConversation{
+				Messages: []template.ChatMessage{{Role: "user", Content: "Review {{diffs}}"}},
+			},
+		},
+		MainToolDefs: []llm.ToolDef{{
+			Type: "function",
+			Function: llm.FunctionDef{
+				Name:        "task_done",
+				Description: "finish the review",
+			},
+		}},
+	})
+	a.diffs = diffs
+	a.currentDate = "2026-09-02 12:00"
+	return a
+}
+
+// reuseStateFor builds the synthetic state loadReuseState would produce for
+// the given fingerprints (items keyed by fingerprint, coverage vouching for
+// them in the parent manifest).
+func reuseStateFor(sessionID string, diffs []model.Diff) *session.ResumeState {
+	items := make(map[string]session.ResumeItem, len(diffs))
+	coverage := make([]session.CoverageItem, 0, len(diffs))
+	for _, d := range diffs {
+		fp := reviewItemFingerprint(session.ReviewModeRange, d)
+		items[fp] = session.ResumeItem{
+			FilePath:    d.NewPath,
+			OldPath:     d.OldPath,
+			NewPath:     d.NewPath,
+			Fingerprint: fp,
+		}
+		coverage = append(coverage, session.CoverageItem{ItemID: fp, Path: d.NewPath, Fingerprint: fp})
+	}
+	return &session.ResumeState{
+		SessionID: sessionID,
+		RepoDir:   "elsewhere",
+		Model:     "parent-model",
+		Items:     items,
+		Manifest: &session.RunManifest{
+			SchemaVersion: session.ManifestSchemaVersion,
+			RunID:         strings.TrimPrefix(sessionID, "reuse:"),
+			Operation:     session.OperationReview,
+			Coverage:      session.Coverage{Completed: coverage},
+		},
+		Closed: true,
+	}
+}
+
+// sessionEventPath returns the JSONL path of the agent's persisted session.
+func sessionEventPath(t *testing.T, a *Agent) string {
+	t.Helper()
+	path, err := session.SessionFilePath(a.args.RepoDir, a.session.SessionID)
+	if err != nil {
+		t.Fatalf("SessionFilePath: %v", err)
+	}
+	return path
+}
+
+// TestReuseFlowMovedToReusesUnchangedFileReviewsChangedFresh is the headline
+// scenario: the reuse source was produced by a run with different --from/--to,
+// an unchanged file's fingerprint still matches (the fingerprint covers only
+// mode/paths/diff text), and only the genuinely changed file reaches the LLM.
+func TestReuseFlowMovedToReusesUnchangedFileReviewsChangedFresh(t *testing.T) {
+	// The parent reviewed unchanged.go as it stands and settled a finding.
+	unchanged := model.Diff{OldPath: "unchanged.go", NewPath: "unchanged.go", Diff: "+stable", Insertions: 1}
+	changed := model.Diff{OldPath: "changed.go", NewPath: "changed.go", Diff: "+changed-now", Insertions: 1}
+	reuse := reuseStateFor("reuse:parent-run", []model.Diff{unchanged})
+	// A moved --to: the parent ran main..feature-1, this run reviews main..feature-2.
+	// Fingerprints do not involve the refs, so the match survives the move.
+	reuse.DiffFrom, reuse.DiffTo = "main", "feature-1"
+	const reusedFinding = "PARENT_FINDING_ABOUT_UNCHANGED_GO"
+	fp := reviewItemFingerprint(session.ReviewModeRange, unchanged)
+	carried := reuse.Items[fp]
+	carried.Comments = []model.LlmComment{{Path: "unchanged.go", Content: reusedFinding}}
+	reuse.Items[fp] = carried
+
+	spy := &promptSpy{}
+	a := newReuseFlowAgent(t, []model.Diff{unchanged, changed}, reuse, spy)
+	a.args.To = "feature-2"
+
+	comments, err := a.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	var merged bool
+	for _, c := range comments {
+		if c.Content == reusedFinding {
+			merged = true
+		}
+	}
+	if !merged {
+		t.Fatalf("reused finding must be merged into the output, got %+v", comments)
+	}
+	// Exactly one dispatch, for changed.go — unchanged.go was reused, so it is
+	// neither re-reviewed nor mentioned to the model.
+	spy.mu.Lock()
+	prompts := append([]string(nil), spy.prompts...)
+	spy.mu.Unlock()
+	if len(prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1 (changed.go only)", len(prompts))
+	}
+	for _, prompt := range prompts {
+		if strings.Contains(prompt, reusedFinding) {
+			t.Error("a reused finding must not enter a new LLM context")
+		}
+		if strings.Contains(prompt, "unchanged.go") {
+			t.Error("a reused file must not be sent to the model again")
+		}
+	}
+
+	manifest := finishManifestFlow(t, a)
+	if len(manifest.Coverage.Reused) != 1 || manifest.Coverage.Reused[0].Path != "unchanged.go" {
+		t.Fatalf("reused coverage = %+v, want unchanged.go", manifest.Coverage.Reused)
+	}
+	if len(manifest.Coverage.Completed) != 1 || manifest.Coverage.Completed[0].Path != "changed.go" {
+		t.Fatalf("completed coverage = %+v, want changed.go reviewed fresh", manifest.Coverage.Completed)
+	}
+	if manifest.ParentRunID != "" {
+		t.Errorf("parent_run_id = %q, want empty: reuse carries no lineage", manifest.ParentRunID)
+	}
+	if info := a.ResumeInfo(); info == nil || info.ResumedFrom != "reuse:parent-run" || info.ReusedFiles != 1 || info.RerunFiles != 1 {
+		t.Fatalf("ResumeInfo = %+v, want reuse:parent-run with 1 reused and 1 rerun", info)
+	}
+	// The reuse source id is asserted on the persisted review_item_reused event
+	// and nowhere in the run manifest (schema v1 coverage has no source field).
+	raw, err := os.ReadFile(sessionEventPath(t, a))
+	if err != nil {
+		t.Fatalf("read session events: %v", err)
+	}
+	events := string(raw)
+	if !strings.Contains(events, `"type":"review_item_reused"`) {
+		t.Error("session must record a review_item_reused event")
+	}
+	if !strings.Contains(events, `"sourceSessionId":"reuse:parent-run"`) {
+		t.Error("review_item_reused must carry the reuse: source id")
+	}
+}
+
+// TestReuseFlowModeMismatchNeverMatches pins the structural exclusion: the
+// fingerprint's first field is the review mode, so a range-mode source cannot
+// match a commit-mode run even for byte-identical diffs.
+func TestReuseFlowModeMismatchNeverMatches(t *testing.T) {
+	diffs := []model.Diff{
+		{OldPath: "a.go", NewPath: "a.go", Diff: "+a", Insertions: 1},
+		{OldPath: "b.go", NewPath: "b.go", Diff: "+b", Insertions: 1},
+	}
+	reuse := reuseStateFor("reuse:parent-run", diffs)
+	spy := &promptSpy{}
+	a := newReuseFlowAgent(t, diffs, reuse, spy)
+	// Recast the run as commit mode: same paths, same diff text, other mode.
+	a.args.From, a.args.To, a.args.Commit = "", "", "abc123"
+	a.args.ReviewMode = session.ReviewModeCommit
+
+	if _, err := a.dispatchSubtasks(context.Background()); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if info := a.ResumeInfo(); info == nil || info.ReusedFiles != 0 || info.RerunFiles != 2 {
+		t.Fatalf("ResumeInfo = %+v, want 0 reused and 2 rerun", info)
+	}
+	manifest := finishManifestFlow(t, a)
+	if len(manifest.Coverage.Reused) != 0 || len(manifest.Coverage.Completed) != 2 {
+		t.Fatalf("coverage reused=%d completed=%d, want 0/2 — a range source must not match a commit run",
+			len(manifest.Coverage.Reused), len(manifest.Coverage.Completed))
+	}
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.prompts) != 2 {
+		t.Fatalf("prompts = %d, want 2 (every file reviewed fresh)", len(spy.prompts))
+	}
+}
+
+// TestReuseFlowAllReusedDispatchesNothing covers the fully-reused run: no
+// group is formed, nothing is dispatched, the reused comments are the result,
+// and the run completes with every item in coverage.reused.
+func TestReuseFlowAllReusedDispatchesNothing(t *testing.T) {
+	diffs := []model.Diff{
+		{OldPath: "a.go", NewPath: "a.go", Diff: "+a", Insertions: 1},
+		{OldPath: "b.go", NewPath: "b.go", Diff: "+b", Insertions: 1},
+	}
+	reuse := reuseStateFor("reuse:parent-run", diffs)
+	for fp, item := range reuse.Items {
+		item.Comments = []model.LlmComment{{Path: item.NewPath, Content: "carried " + item.NewPath}}
+		reuse.Items[fp] = item
+	}
+	spy := &promptSpy{}
+	a := newReuseFlowAgent(t, diffs, reuse, spy)
+
+	comments, err := a.dispatchSubtasks(context.Background())
+	if err != nil {
+		t.Fatalf("an all-reused dispatch must succeed: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments = %d, want both carried comment sets", len(comments))
+	}
+	spy.mu.Lock()
+	if len(spy.prompts) != 0 {
+		t.Fatalf("prompts = %d, want 0: a reused file must never reach the LLM", len(spy.prompts))
+	}
+	spy.mu.Unlock()
+
+	manifest := finishManifestFlow(t, a)
+	if manifest.TerminalState != session.StateComplete || len(manifest.Coverage.Reused) != 2 {
+		t.Fatalf("manifest terminal=%q reused=%d, want complete with 2 reused", manifest.TerminalState, len(manifest.Coverage.Reused))
 	}
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `--reuse-from <file>` flag to `ocr review` that takes a **previous run's JSON output** as a reuse source: items whose content fingerprint matches a completed item in that source are reused (previous comments carried over, recorded in `coverage.reused` and `review_item_reused` events) instead of re-reviewed, so review-gate loops stop re-reviewing byte-identical files on every push.

Fixes #854 (implementing the `--reuse-from` half the issue narrowed to on 2026-08-20; the relax-`ValidateOptions` half was explicitly dropped there and `--resume` semantics are untouched by this PR).

## Background

`--resume` already implements fingerprint reuse (`sha256(mode \0 oldPath \0 newPath \0 diffText)`), but it is strict crash recovery: the resumed session's `--from`/`--to` must match exactly and the session store must exist locally. In a PR gate loop the head moves every push and CI runners are ephemeral, so resume can never apply — every round re-reviews the full range (the issue measures 19 gate rounds at ~2M tokens each, the majority on byte-identical files).

## How it works

- The loader (`cmd/opencodereview/reuse_from.go`) reads the previous run's `--format json` output — the manifest (coverage fingerprints + repository identity) and the flat comment list, both already published by every run — and synthesizes a `ResumeState` for the existing reuse engine in `applyResume`.
- **Fingerprint match is the safety story**: the fingerprint embeds mode and both path spellings plus the full diff text, so any change to a file (including base drift after a rebase) invalidates the match and forces a fresh review. A moved `--to` is therefore fine — untouched files keep byte-identical diffs.
- **Trust boundary**: a source whose recorded repository identity (sha256 of the canonical remote) differs from the current repo is rejected; mode mismatches can never match structurally.
- **Degradation, not failure**: a missing, unreadable, malformed, wrong-schema, or different-repo source produces an `[ocr] WARNING` and today's full review — never a hard error.
- `--resume` keeps its strict semantics (`ValidateOptions`/`ValidateResume` never fire on the reuse path); `--reuse-from` is mutually exclusive with `--resume` and `--preview`.
- Reused items never reach the LLM (pinned by a prompt-spy test); the run prints `[ocr] Reuse <id>: reusing N file(s), reviewing M file(s)` and `resume.resumed_from` carries the `reuse:<run_id>` source in JSON output.

A CI workflow can wire this by uploading the result JSON of each run and passing it to the next push's review — the reference GitHub Action flow already uploads that artifact.

## Testing

`make check`, `make test` (race), and `make coverage` (91.0% ≥ 90) green. New tests cover the loader gate matrix (unreadable/invalid JSON/nil manifest/schema mismatch/wrong repo/empty-vs-empty identity), the moved-`--to` headline scenario (unchanged file reused with its comments, changed file reviewed fresh), mode-mismatch structural exclusion, all-reused (`dispatched == 0`), mutual exclusions, and an end-to-end wiring test (mutation-verified: deleting the wiring fails the test) asserting zero LLM calls for a fully-reused run and warning+full-review for a degraded source. `loadReuseState`, `sameRepositoryIdentity`, and `applyResume` at 100% line coverage.