### PR TITLE
fix(pages): fix duplicate heading navigation in tools page TOC

### DIFF
--- a/pages/src/components/MarkdownRenderer.test.tsx
+++ b/pages/src/components/MarkdownRenderer.test.tsx
@@ -4,6 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { LanguageProvider } from '../i18n';
+import { extractHeadings } from '../utils/extractHeadings';
 import MarkdownRenderer from './MarkdownRenderer';
 
 describe('MarkdownRenderer heading IDs', () => {
@@ -18,5 +19,47 @@ describe('MarkdownRenderer heading IDs', () => {
     expect(heading.getAttribute('id')).toBe('what-the-skill-does');
     expect(heading.textContent).not.toContain('{#what-the-skill-does}');
     expect(screen.getByRole('heading', { name: 'Публикация', level: 4 }).getAttribute('id')).toBe('service-account');
+  });
+
+  it('renders unique IDs for repeated headings', () => {
+    render(
+      <LanguageProvider>
+        <MarkdownRenderer content={'## Schema\n\n## Schema\n\n### Output\n\n### Output'} />
+      </LanguageProvider>,
+    );
+
+    expect(screen.getAllByRole('heading', { name: 'Schema' }).map((heading) => heading.id)).toEqual([
+      'schema',
+      'schema-2',
+    ]);
+    expect(screen.getAllByRole('heading', { name: 'Output' }).map((heading) => heading.id)).toEqual([
+      'output',
+      'output-2',
+    ]);
+  });
+
+  it('keeps rendered heading IDs aligned with the TOC extraction', () => {
+    const content = [
+      'Setext title',
+      '=============',
+      '',
+      '## Schema',
+      '',
+      '~~~',
+      '## Fake heading inside a code block',
+      '~~~',
+      '',
+      '## Schema',
+      '### Output',
+      '### Output',
+    ].join('\n');
+    const { container } = render(
+      <LanguageProvider>
+        <MarkdownRenderer content={content} />
+      </LanguageProvider>,
+    );
+
+    const renderedTocHeadingIds = Array.from(container.querySelectorAll('h2, h3')).map((heading) => heading.id);
+    expect(renderedTocHeadingIds).toEqual(extractHeadings(content).map(({ id }) => id));
   });
 });

--- a/pages/src/components/MarkdownRenderer.tsx
+++ b/pages/src/components/MarkdownRenderer.tsx
@@ -8,7 +8,7 @@ import DOMPurify from 'dompurify';
 import { useTranslation } from '../i18n';
 import { useCopyToast } from '../hooks/useCopyToast';
 import copyIcon from '../assets/icons/icon-copy.svg';
-import { generateHeadingId, parseExplicitHeadingId } from '../utils/headingId';
+import { extractHeadingInfo, generateHeadingId, parseExplicitHeadingId } from '../utils/headingId';
 
 type Mermaid = typeof import('mermaid')['default'];
 
@@ -72,6 +72,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   const html = useMemo(() => {
     // Custom renderer to generate heading IDs matching the TOC extraction logic
     const renderer = new Renderer();
+    const headingIds = extractHeadingInfo(content).map(({ id }) => id);
+    let headingIndex = 0;
     renderer.image = function ({ href, title, text }: { href: string; title?: string | null; text: string }) {
       const escapeAttr = (s: string) => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
       const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
@@ -79,7 +81,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
     };
     renderer.heading = function ({ text, depth }: { text: string; depth: number }) {
       const { text: headingText, id: explicitId } = parseExplicitHeadingId(text);
-      const id = explicitId ?? generateHeadingId(headingText);
+      const id = headingIds[headingIndex++] ?? (explicitId ?? generateHeadingId(headingText));
       // Escape id attribute value to prevent XSS
       const safeId = id.replace(/"/g, '&quot;');
       return `<h${depth} id="${safeId}">${headingText}</h${depth}>\n`;

--- a/pages/src/utils/extractHeadings.ts
+++ b/pages/src/utils/extractHeadings.ts
@@ -2,30 +2,8 @@
 // Copyright 2026 alibaba/open-code-review Contributors
 
 /* ─── Extract headings from markdown for right TOC ─── */
-import { generateHeadingId, parseExplicitHeadingId } from './headingId';
+import { extractHeadingInfo } from './headingId';
 
 export function extractHeadings(markdown: string): { id: string; text: string; level: number }[] {
-  const headings: { id: string; text: string; level: number }[] = [];
-  const lines = markdown.split('\n');
-  let inCodeBlock = false;
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-    const match = line.match(/^(#{2,3})\s+(.+)$/);
-    if (match) {
-      const level = match[1].length;
-      const { text: headingText, id: explicitId } = parseExplicitHeadingId(match[2]);
-      // Strip markdown link syntax [text](url) → text, then strip other formatting
-      const text = headingText
-        .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
-        .replace(/[`*_[\]()]/g, '')
-        .trim();
-      const id = explicitId ?? generateHeadingId(text);
-      headings.push({ id, text, level });
-    }
-  }
-  return headings;
+  return extractHeadingInfo(markdown).filter(({ level }) => level === 2 || level === 3);
 }

--- a/pages/src/utils/headingId.test.ts
+++ b/pages/src/utils/headingId.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { extractHeadings } from './extractHeadings';
-import { parseExplicitHeadingId } from './headingId';
+import { createHeadingIdResolver, extractHeadingInfo, parseExplicitHeadingId } from './headingId';
 
 describe('explicit heading IDs', () => {
   it('separates a trailing explicit ID from the visible heading text', () => {
@@ -20,6 +20,36 @@ describe('explicit heading IDs', () => {
   it('uses the explicit ID in the table of contents without exposing its marker', () => {
     expect(extractHeadings('## Что делает навк {#what-the-skill-does}')).toEqual([
       { id: 'what-the-skill-does', text: 'Что делает навк', level: 2 },
+    ]);
+  });
+
+  it('assigns unique IDs to repeated headings', () => {
+    expect(extractHeadings('## Schema\n\n## Schema\n\n### Output\n\n### Output')).toEqual([
+      { id: 'schema', text: 'Schema', level: 2 },
+      { id: 'schema-2', text: 'Schema', level: 2 },
+      { id: 'output', text: 'Output', level: 3 },
+      { id: 'output-2', text: 'Output', level: 3 },
+    ]);
+  });
+
+  it('avoids collisions between generated suffixes and later headings', () => {
+    const resolveHeadingId = createHeadingIdResolver();
+    expect(resolveHeadingId('schema')).toBe('schema');
+    expect(resolveHeadingId('schema-2')).toBe('schema-2');
+    expect(resolveHeadingId('schema')).toBe('schema-3');
+  });
+
+  it('keeps TOC IDs aligned when hidden heading levels repeat a title', () => {
+    expect(extractHeadings('#### Schema\n\n## Schema')).toEqual([
+      { id: 'schema-2', text: 'Schema', level: 2 },
+    ]);
+  });
+
+  it('parses setext headings and tilde-fenced code like the Markdown renderer', () => {
+    expect(extractHeadingInfo('Title\n=====\n\n## Schema\n\n~~~\n## Fake\n~~~\n\n## Schema')).toEqual([
+      { id: 'title', text: 'Title', level: 1 },
+      { id: 'schema', text: 'Schema', level: 2 },
+      { id: 'schema-2', text: 'Schema', level: 2 },
     ]);
   });
 });

--- a/pages/src/utils/headingId.ts
+++ b/pages/src/utils/headingId.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 alibaba/open-code-review Contributors
 
 import DOMPurify from 'dompurify';
+import { Marked, type Token, type Tokens } from 'marked';
 
 const explicitHeadingIdPattern = /\s+\{#([a-zA-Z0-9][a-zA-Z0-9_.:-]*)\}\s*$/;
 
@@ -31,4 +32,74 @@ export function generateHeadingId(text: string): string {
     .replace(/[`*_[\]()]/g, '')
     .trim();
   return plain.toLowerCase().replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Creates a per-document heading ID resolver that keeps every rendered heading
+ * addressable, even when a document repeats the same title (for example,
+ * several "Schema" or "Output" sections).
+ */
+export function createHeadingIdResolver(): (baseId: string) => string {
+  const usedIds = new Set<string>();
+
+  return (baseId: string) => {
+    if (!usedIds.has(baseId)) {
+      usedIds.add(baseId);
+      return baseId;
+    }
+
+    let suffix = 2;
+    let candidate = `${baseId}-${suffix}`;
+    while (usedIds.has(candidate)) {
+      suffix += 1;
+      candidate = `${baseId}-${suffix}`;
+    }
+    usedIds.add(candidate);
+    return candidate;
+  };
+}
+
+export interface HeadingInfo {
+  id: string;
+  text: string;
+  level: number;
+}
+
+function normalizeHeadingText(text: string): string {
+  return text
+    .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+    .replace(/[`*_[\]()]/g, '')
+    .trim();
+}
+
+/**
+ * Walk the same Markdown token stream used by the renderer so all heading IDs
+ * are resolved in exactly the same order, including setext headings and nested
+ * tokens inside blockquotes/lists.
+ */
+export function extractHeadingInfo(markdown: string): HeadingInfo[] {
+  const parser = new Marked({ gfm: true, breaks: false });
+  const headings: HeadingInfo[] = [];
+  const resolveHeadingId = createHeadingIdResolver();
+
+  const visit = (tokens: Token[]) => {
+    for (const token of tokens) {
+      if (token.type === 'heading') {
+        const heading = token as Tokens.Heading;
+        const { text: headingText, id: explicitId } = parseExplicitHeadingId(heading.text);
+        const text = normalizeHeadingText(headingText);
+        headings.push({
+          id: resolveHeadingId(explicitId ?? generateHeadingId(text)),
+          text,
+          level: heading.depth,
+        });
+      }
+      if ('tokens' in token && Array.isArray(token.tokens)) {
+        visit(token.tokens);
+      }
+    }
+  };
+
+  visit(parser.lexer(markdown));
+  return headings;
 }


### PR DESCRIPTION
## Description

### Problem

The tools page contains repeated section headings such as `Schema`, `Output`, and `Constraints`. These headings were assigned identical DOM IDs, causing:

- Every duplicate TOC entry to navigate to the first matching section.
- Multiple duplicate entries to appear highlighted at the same time.

### Solution

- Generate unique heading IDs per document by suffixing repeated IDs, e.g. `schema`, `schema-2`.
- Share the same ID resolution logic between TOC extraction and Markdown rendering.
- Account for headings outside the visible TOC levels so anchor IDs remain aligned.
- Add regression tests covering repeated headings and hidden heading-level collisions.

### Verification

- Frontend tests: 23 passed
- TypeScript typecheck passed
- Frontend build passed
- `make check` passed
- `make test` passed