### PR TITLE
feat(tool): include arguments in failure details

### DIFF
--- a/cmd/opencodereview/budget_output_test.go
+++ b/cmd/opencodereview/budget_output_test.go
@@ -195,6 +195,7 @@ func TestEmitFailureUsage_JSONEmitsStructuredRecord(t *testing.T) {
 			ToolCallNumber: 1,
 			ToolName:       "file_read",
 			FilePath:       "missing.go",
+			Arguments:      `{"file_path":"missing.go"}`,
 			Error:          "file not found",
 		}},
 	}
@@ -226,6 +227,9 @@ func TestEmitFailureUsage_JSONEmitsStructuredRecord(t *testing.T) {
 	}
 	if out.ToolCalls.FailureByTool["file_read"] != 1 {
 		t.Errorf("failure_by_tool = %+v, want file_read=1", out.ToolCalls.FailureByTool)
+	}
+	if got := out.ToolCalls.FailureDetails[0].Arguments; got != `{"file_path":"missing.go"}` {
+		t.Errorf("failure arguments = %q, want raw tool arguments", got)
 	}
 	if out.LLM == nil || out.LLM.Provider != "openai" || out.LLM.Model != "gpt-5.4" {
 		t.Fatalf("llm = %+v", out.LLM)

--- a/cmd/opencodereview/emit_run_result_test.go
+++ b/cmd/opencodereview/emit_run_result_test.go
@@ -113,6 +113,36 @@ func TestEmitRunResult_JSONNoFiles(t *testing.T) {
 	}
 }
 
+func TestEmitRunResult_JSONIncludesToolFailureArguments(t *testing.T) {
+	ag := &mockResultProvider{
+		filesReviewed: 1,
+		toolCalls:     map[string]int64{"code_search": 1},
+		toolFailures: []llmloop.ToolFailureDetail{{
+			ToolCallNumber: 1,
+			ToolName:       "code_search",
+			FilePath:       "file.go",
+			Arguments:      `{"search_text":"needle"}`,
+			Error:          "git grep failed",
+		}},
+	}
+	got := captureStdout(t, func() {
+		if err := emitRunResult(context.Background(), ag, nil, time.Now(), "json", "developer", nil, nil, os.Stdout, nil); err != nil {
+			t.Fatalf("emitRunResult: %v", err)
+		}
+	})
+
+	var out jsonOutput
+	if err := json.Unmarshal([]byte(got), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ToolCalls == nil || len(out.ToolCalls.FailureDetails) != 1 {
+		t.Fatalf("tool call failures = %+v, want one", out.ToolCalls)
+	}
+	if got := out.ToolCalls.FailureDetails[0].Arguments; got != `{"search_text":"needle"}` {
+		t.Errorf("failure arguments = %q, want raw tool arguments", got)
+	}
+}
+
 func TestEmitRunResult_JSONLLMIdentityNamedProvider(t *testing.T) {
 	ag := &mockResultProvider{filesReviewed: 1}
 	identity := &jsonLLMIdentity{Provider: "anthropic", Model: "claude-opus-4-6"}

--- a/cmd/opencodereview/output.go
+++ b/cmd/opencodereview/output.go
@@ -641,8 +641,8 @@ func outputJSONNoFiles(traceID string, llmIdentity *jsonLLMIdentity, out io.Writ
 
 // emitFailureUsage writes a best-effort structured usage record to stderr when
 // a review fails, so the outer caller still sees the cost of the failed attempt.
-// It carries only token/tool-call tallies and elapsed, never credentials or
-// prompts.
+// It carries token/tool-call diagnostics and elapsed. Failed tool-call details
+// include the raw arguments returned by the LLM.
 //
 // A plain aggregate budget stop does NOT reach here: it is a controlled coverage
 // truncation, so it yields terminal_state=partial and a nil error. It only

--- a/cmd/opencodereview/output_helpers_test.go
+++ b/cmd/opencodereview/output_helpers_test.go
@@ -291,6 +291,7 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 		ToolCallNumber: 2,
 		ToolName:       "file_read",
 		FilePath:       "b.go",
+		Arguments:      `{"path":"missing.go"}`,
 		Error:          "file not found",
 	}}
 	err := outputJSONWithWarnings(comments, warnings, 5, 100, 50, 150, 10, 5, 3*time.Second, "summary", map[string]int64{"file_read": 3}, failures, "trace-xyz-789", nil, "", nil, false, nil, os.Stdout, nil, nil)
@@ -303,9 +304,6 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 
 	var buf bytes.Buffer
 	_, _ = buf.ReadFrom(r)
-	if bytes.Contains(buf.Bytes(), []byte(`"arguments"`)) {
-		t.Fatalf("failure details must not expose tool arguments: %s", buf.String())
-	}
 	if !bytes.Contains(buf.Bytes(), []byte(`"failure"`)) {
 		t.Fatalf("tool_calls must use the failure field: %s", buf.String())
 	}
@@ -336,7 +334,8 @@ func TestOutputJSONWithWarnings(t *testing.T) {
 		t.Errorf("failure_by_tool = %+v, want file_read=1", out.ToolCalls.FailureByTool)
 	}
 	failure := out.ToolCalls.FailureDetails[0]
-	if failure.ToolCallNumber != 2 || failure.ToolName != "file_read" || failure.FilePath != "b.go" || failure.Error != "file not found" {
+	if failure.ToolCallNumber != 2 || failure.ToolName != "file_read" || failure.FilePath != "b.go" ||
+		failure.Arguments != `{"path":"missing.go"}` || failure.Error != "file not found" {
 		t.Errorf("failure detail = %+v", failure)
 	}
 	if out.TraceID != "trace-xyz-789" {
@@ -411,7 +410,7 @@ func TestOutputJSONNoFiles(t *testing.T) {
 
 func TestNewJSONToolCalls_FailureByTool(t *testing.T) {
 	failures := []llmloop.ToolFailureDetail{
-		{ToolName: "code_search"},
+		{ToolName: "code_search", Arguments: `{"search_text":"needle"}`},
 		{ToolName: "file_read"},
 		{ToolName: "file_read"},
 		{ToolName: "file_find"},
@@ -425,6 +424,9 @@ func TestNewJSONToolCalls_FailureByTool(t *testing.T) {
 	}
 	if got.FailureByTool["code_search"] != 1 || got.FailureByTool["file_read"] != 2 || got.FailureByTool["file_find"] != 3 {
 		t.Errorf("failure_by_tool = %+v, want code_search=1 file_read=2 file_find=3", got.FailureByTool)
+	}
+	if got.FailureDetails[0].Arguments != `{"search_text":"needle"}` {
+		t.Errorf("failure arguments = %q, want preserved detail arguments", got.FailureDetails[0].Arguments)
 	}
 }
 

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -106,7 +106,9 @@ type ToolFailureDetail struct {
 	ToolCallNumber int64  `json:"tool_call_number"`
 	ToolName       string `json:"tool_name"`
 	FilePath       string `json:"file_path,omitempty"`
-	Error          string `json:"error"`
+	// Arguments is the raw tool-call argument string returned by the LLM.
+	Arguments string `json:"arguments"`
+	Error     string `json:"error"`
 }
 
 // NewRunner returns a Runner bound to the given dependencies.
@@ -212,6 +214,7 @@ func (r *Runner) recordToolFailure(number int64, name, filePath, errMsg string,
 		ToolCallNumber: number,
 		ToolName:       name,
 		FilePath:       filePath,
+		Arguments:      rawArguments,
 		Error:          errMsg,
 	}
 

--- a/internal/llmloop/loop_execute_test.go
+++ b/internal/llmloop/loop_execute_test.go
@@ -69,6 +69,9 @@ func TestExecuteToolCall_DynamicExecuteError(t *testing.T) {
 	if failure.ToolCallNumber != 1 || failure.ToolName != "dyn_fail" || failure.FilePath != "file.go" {
 		t.Errorf("failure identity = %+v", failure)
 	}
+	if failure.Arguments != `{"query":"needle"}` {
+		t.Errorf("failure arguments = %q, want raw tool arguments", failure.Arguments)
+	}
 	if failure.Error != "boom" {
 		t.Errorf("failure details = %+v", failure)
 	}
@@ -179,6 +182,9 @@ func TestExecuteToolCall_DynamicParseError(t *testing.T) {
 	}
 	if !strings.Contains(failures[0].Error, "Error parsing tool arguments") {
 		t.Errorf("parse failure details = %+v", failures[0])
+	}
+	if failures[0].Arguments != `{bad` {
+		t.Errorf("parse failure arguments = %q, want malformed raw arguments", failures[0].Arguments)
 	}
 }
 

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -580,8 +580,12 @@ func TestExecuteToolCall_ArgumentsEdgeCases(t *testing.T) {
 				}
 			}
 			failures := r.ToolFailures()
-			if tt.wantFailure && len(failures) != 1 {
-				t.Errorf("ToolFailures() = %+v, want one failure", failures)
+			if tt.wantFailure {
+				if len(failures) != 1 {
+					t.Errorf("ToolFailures() = %+v, want one failure", failures)
+				} else if failures[0].Arguments != tt.arguments {
+					t.Errorf("failure arguments = %q, want %q", failures[0].Arguments, tt.arguments)
+				}
 			}
 			if !tt.wantFailure && len(failures) != 0 {
 				t.Errorf("ToolFailures() = %+v, want no failures", failures)

--- a/internal/llmloop/runner_test.go
+++ b/internal/llmloop/runner_test.go
@@ -145,10 +145,11 @@ func TestToolFailures_AreOrderedAndSnapshotIsolated(t *testing.T) {
 		t.Fatalf("ToolFailures() = %+v, want call numbers 1, 2", failures)
 	}
 	failures[0].Error = "mutated"
+	failures[0].Arguments = "mutated"
 
 	again := r.ToolFailures()
-	if again[0].Error != "first" {
-		t.Errorf("ToolFailures snapshot mutated internal state: error = %q", again[0].Error)
+	if again[0].Error != "first" || again[0].Arguments != `{}` {
+		t.Errorf("ToolFailures snapshot mutated internal state: %+v", again[0])
 	}
 }
 

--- a/internal/session/history_test.go
+++ b/internal/session/history_test.go
@@ -519,7 +519,8 @@ func TestAddToolFailure(t *testing.T) {
 		t.Fatalf("len = %d", len(rec.ToolResults))
 	}
 	result := rec.ToolResults[0]
-	if result.ToolName != "code_search" || result.OK || result.Result != "git grep failed" {
+	if result.ToolName != "code_search" || result.Arguments != `{"search_text":"needle"}` ||
+		result.OK || result.Result != "git grep failed" {
 		t.Errorf("failure result = %+v", result)
 	}
 	if result.Duration != 25*time.Millisecond {
@@ -542,6 +543,9 @@ func TestAddToolFailure(t *testing.T) {
 	}
 	if ok, _ := persisted["ok"].(bool); ok {
 		t.Errorf("persisted failure has ok=true: %+v", persisted)
+	}
+	if got, _ := persisted["arguments"].(string); got != `{"search_text":"needle"}` {
+		t.Errorf("persisted arguments = %q, want raw tool arguments", got)
 	}
 	if got := int64(persisted["duration_ms"].(float64)); got != 25 {
 		t.Errorf("persisted duration_ms = %d, want 25", got)


### PR DESCRIPTION
## Description

#1144 made registered-tool execution failures observable in terminal output, session JSONL, and the final JSON report.

However, each `failure_details` entry only identifies the failed tool call and its error. It does not include the arguments that triggered the failure, so JSON consumers must correlate the failure with session records to reconstruct the original input.

This PR:

- adds `arguments` to `ToolFailureDetail`
- captures the raw JSON-encoded arguments directly from `llm.ToolCall.Function.Arguments`
- includes the arguments in both normal result JSON and failure-usage JSON
- preserves empty and malformed argument payloads without parsing or re-serializing them
- verifies argument propagation through registered-tool failures, shared result output, failure output, and session persistence
- leaves text and SARIF output unchanged because they do not expose `failure_details`

Example JSON output:

```json
"failure_details": [
  {
    "tool_call_number": 2,
    "tool_name": "code_search",
    "file_path": "src/Base/Parameter.cpp",
    "arguments": "{\"search_text\":\"BaseParameter\",\"file_patterns\":[\"src/\"]}",
    "error": "git grep failed: exit status 129: error: unknown option `max-count'"
  }
]
```

The arguments are intentionally preserved as the raw string returned by the LLM. They are not normalized, redacted, or truncated, matching the argument representation already stored in session JSONL. The field remains present when the raw value is empty because an empty argument payload is itself useful failure context.

## Testing

- `make check`
- `make test`
