### PR TITLE
fix(tool): repair serialized code_comment arguments instead of losing the batch

### DIFF
--- a/cmd/opencodereview/sarif_test.go
+++ b/cmd/opencodereview/sarif_test.go
@@ -586,37 +586,6 @@ func TestSarifResultFromComment_FixesWithEmptyPath(t *testing.T) {
 	}
 }
 
-// TestSarifResultFromComment_NoFixWhenSuggestionWithheld records the far end of
-// the serialized-comments repair. When that repair may have cut a suggestion_code
-// short it clears the field (see tool.flagSuspectTruncations) precisely because
-// this function gates fixes on it being non-empty — a truncated suggestion is
-// syntactically incomplete code, and a SARIF fix is machine-applicable. The
-// comment must still be reported in full; only the fix is withheld.
-func TestSarifResultFromComment_NoFixWhenSuggestionWithheld(t *testing.T) {
-	c := model.LlmComment{
-		Path:         "a.go",
-		Content:      "use a literal",
-		ExistingCode: "old code",
-		// Cleared by the repair because it was suspect.
-		SuggestionCode: "",
-		StartLine:      3,
-		EndLine:        3,
-		Category:       "bug",
-		Severity:       "high",
-	}
-	result := sarifResultFromComment(c)
-	if result.Fixes != nil {
-		t.Errorf("Fixes must be nil when the suggestion was withheld, got %+v", result.Fixes)
-	}
-	// The finding itself is not the casualty: it keeps its location and message.
-	if result.Message.Text != "use a literal" {
-		t.Errorf("message = %q, want the comment reported in full", result.Message.Text)
-	}
-	if len(result.Locations) != 1 {
-		t.Fatalf("locations = %+v, want the comment still anchored", result.Locations)
-	}
-}
-
 // --- partialFingerprints stability ---
 
 func TestSarifFingerprints_Stable(t *testing.T) {

--- a/cmd/opencodereview/sarif_test.go
+++ b/cmd/opencodereview/sarif_test.go
@@ -586,6 +586,37 @@ func TestSarifResultFromComment_FixesWithEmptyPath(t *testing.T) {
 	}
 }
 
+// TestSarifResultFromComment_NoFixWhenSuggestionWithheld records the far end of
+// the serialized-comments repair. When that repair may have cut a suggestion_code
+// short it clears the field (see tool.flagSuspectTruncations) precisely because
+// this function gates fixes on it being non-empty — a truncated suggestion is
+// syntactically incomplete code, and a SARIF fix is machine-applicable. The
+// comment must still be reported in full; only the fix is withheld.
+func TestSarifResultFromComment_NoFixWhenSuggestionWithheld(t *testing.T) {
+	c := model.LlmComment{
+		Path:         "a.go",
+		Content:      "use a literal",
+		ExistingCode: "old code",
+		// Cleared by the repair because it was suspect.
+		SuggestionCode: "",
+		StartLine:      3,
+		EndLine:        3,
+		Category:       "bug",
+		Severity:       "high",
+	}
+	result := sarifResultFromComment(c)
+	if result.Fixes != nil {
+		t.Errorf("Fixes must be nil when the suggestion was withheld, got %+v", result.Fixes)
+	}
+	// The finding itself is not the casualty: it keeps its location and message.
+	if result.Message.Text != "use a literal" {
+		t.Errorf("message = %q, want the comment reported in full", result.Message.Text)
+	}
+	if len(result.Locations) != 1 {
+		t.Fatalf("locations = %+v, want the comment still anchored", result.Locations)
+	}
+}
+
 // --- partialFingerprints stability ---
 
 func TestSarifFingerprints_Stable(t *testing.T) {

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -610,15 +610,15 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		telemetry.PrintToolCallStarted(t.Name(), args)
 		_, toolSpan := telemetry.StartToolSpan(ctx, t.Name())
 
-		comments, repairedChars, errMsg := tool.ParseCommentsWithPath(args, newPath)
-		if repairedChars > 0 {
+		comments, repair, errMsg := tool.ParseCommentsWithPath(args, newPath)
+		if repair != nil {
 			// The batch survived only because the deterministic repair ran. The
 			// model sees a plain success, so this warning is the sole record
 			// that a schema violation happened at all — without it the repair
-			// would silently absorb an unbounded number of them.
-			r.RecordWarning("comment_args_repaired", newPath, fmt.Sprintf(
-				"comments arrived as a serialized string instead of an array; "+
-					"repaired %d unescaped character(s)", repairedChars))
+			// would silently absorb an unbounded number of them. The message
+			// also names any value the repair may have truncated, which is
+			// otherwise unobservable in every output format.
+			r.RecordWarning("comment_args_repaired", newPath, repair.Message())
 		}
 		if errMsg != "" {
 			dur := time.Since(startTime)

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -610,7 +610,16 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 		telemetry.PrintToolCallStarted(t.Name(), args)
 		_, toolSpan := telemetry.StartToolSpan(ctx, t.Name())
 
-		comments, errMsg := tool.ParseCommentsWithPath(args, newPath)
+		comments, repairedChars, errMsg := tool.ParseCommentsWithPath(args, newPath)
+		if repairedChars > 0 {
+			// The batch survived only because the deterministic repair ran. The
+			// model sees a plain success, so this warning is the sole record
+			// that a schema violation happened at all — without it the repair
+			// would silently absorb an unbounded number of them.
+			r.RecordWarning("comment_args_repaired", newPath, fmt.Sprintf(
+				"comments arrived as a serialized string instead of an array; "+
+					"repaired %d unescaped character(s)", repairedChars))
+		}
 		if errMsg != "" {
 			dur := time.Since(startTime)
 			toolErr := fmt.Errorf("%s", errMsg)

--- a/internal/llmloop/loop.go
+++ b/internal/llmloop/loop.go
@@ -612,12 +612,9 @@ func (r *Runner) executeToolCall(ctx context.Context, newPath string, call llm.T
 
 		comments, repair, errMsg := tool.ParseCommentsWithPath(args, newPath)
 		if repair != nil {
-			// The batch survived only because the deterministic repair ran. The
-			// model sees a plain success, so this warning is the sole record
-			// that a schema violation happened at all — without it the repair
-			// would silently absorb an unbounded number of them. The message
-			// also names any value the repair may have truncated, which is
-			// otherwise unobservable in every output format.
+			// The model sees a plain success, so this warning is the only record
+			// that its `comments` violated the array schema — without it the
+			// repair would absorb an unbounded number of them unobserved.
 			r.RecordWarning("comment_args_repaired", newPath, repair.Message())
 		}
 		if errMsg != "" {

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -865,3 +865,79 @@ func TestMainLoopStopUnknownValue(t *testing.T) {
 		t.Error("an unrecognized stop reuses the StopNone catch-all; the collapsed message is back")
 	}
 }
+
+// TestExecuteToolCall_CodeCommentRepairedArgsWarns covers the caller half of the
+// deterministic repair: the model gets a plain success, so the run warning is
+// the only record that its `comments` violated the array schema. Without it the
+// repair would absorb an unbounded number of violations unobserved.
+func TestExecuteToolCall_CodeCommentRepairedArgsWarns(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+
+	r := NewRunner(Deps{Tools: reg, CommentCollector: collector})
+
+	// `comments` serialized into a string, with a prose quote left unescaped —
+	// the observed failure shape.
+	serialized := `[{"content":"the name suggests "a trusted proxy exists" here","existing_code":"foo","path":"Auth.java"}]`
+	argsJSON, err := json.Marshal(map[string]any{"comments": serialized})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := r.executeToolCall(context.Background(), "Auth.java", llm.ToolCall{
+		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(argsJSON)},
+	}, nil, "")
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("result = %+v, want the batch recovered", cp)
+	}
+
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("collected %d comments, want 1", len(comments))
+	}
+	if !strings.Contains(comments[0].Content, `"a trusted proxy exists"`) {
+		t.Errorf("quoted term lost: %q", comments[0].Content)
+	}
+
+	warnings := r.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want exactly one", warnings)
+	}
+	if warnings[0].Type != "comment_args_repaired" || warnings[0].File != "Auth.java" {
+		t.Errorf("warning = %+v, want comment_args_repaired on Auth.java", warnings[0])
+	}
+	if !strings.Contains(warnings[0].Message, "serialized string") {
+		t.Errorf("warning message = %q", warnings[0].Message)
+	}
+}
+
+// TestExecuteToolCall_CodeCommentWellFormedArgsDoesNotWarn is the contrast that
+// keeps the test above honest: a schema-conformant batch must produce no
+// warning, so comment_args_repaired counts real violations only.
+func TestExecuteToolCall_CodeCommentWellFormedArgsDoesNotWarn(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+
+	r := NewRunner(Deps{Tools: reg, CommentCollector: collector})
+
+	argsJSON, err := json.Marshal(map[string]any{"comments": []any{
+		map[string]any{"content": "issue", "existing_code": "foo", "path": "a.go"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := r.executeToolCall(context.Background(), "a.go", llm.ToolCall{
+		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(argsJSON)},
+	}, nil, "")
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("result = %+v", cp)
+	}
+	if w := r.Warnings(); len(w) != 0 {
+		t.Errorf("warnings = %+v, want none", w)
+	}
+}

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -866,10 +866,8 @@ func TestMainLoopStopUnknownValue(t *testing.T) {
 	}
 }
 
-// TestExecuteToolCall_CodeCommentRepairedArgsWarns covers the caller half of the
-// deterministic repair: the model gets a plain success, so the run warning is
-// the only record that its `comments` violated the array schema. Without it the
-// repair would absorb an unbounded number of violations unobserved.
+// The model gets a plain success, so the run warning is the only record that its
+// `comments` violated the array schema.
 func TestExecuteToolCall_CodeCommentRepairedArgsWarns(t *testing.T) {
 	collector := tool.NewCommentCollector()
 	reg := tool.NewRegistry()
@@ -913,12 +911,10 @@ func TestExecuteToolCall_CodeCommentRepairedArgsWarns(t *testing.T) {
 	}
 }
 
-// TestExecuteToolCall_CodeCommentSuspectRepairWarnsWithField covers the case the
-// count alone cannot express: the repair held up structurally but may have cut a
-// value short. The model still sees a plain success, so unless the warning names
-// the suspect field a truncated recovery is indistinguishable from a clean one in
-// every output format — stderr, JSON and SARIF all carry only this message.
-func TestExecuteToolCall_CodeCommentSuspectRepairWarnsWithField(t *testing.T) {
+// The far side of the accept/decline decision: a refused batch must reach the
+// model as a failure, since that error is what makes it resend. No warning
+// either, because nothing was papered over.
+func TestExecuteToolCall_CodeCommentSuspectRepairReportsTheError(t *testing.T) {
 	collector := tool.NewCommentCollector()
 	reg := tool.NewRegistry()
 	reg.Register(&tool.CodeCommentProvider{Collector: collector})
@@ -937,34 +933,20 @@ func TestExecuteToolCall_CodeCommentSuspectRepairWarnsWithField(t *testing.T) {
 	cp := r.executeToolCall(context.Background(), "a.go", llm.ToolCall{
 		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(argsJSON)},
 	}, nil, "")
-	if cp.Data != tool.CommentSucceed {
-		t.Fatalf("result = %+v, want the batch recovered", cp)
+	if !strings.Contains(cp.Data, "invalid character") {
+		t.Fatalf("result = %+v, want the parser wording that makes the model retry", cp)
 	}
 
-	comments := collector.Comments()
-	if len(comments) != 1 {
-		t.Fatalf("collected %d comments, want 1", len(comments))
+	if got := collector.Comments(); len(got) != 0 {
+		t.Errorf("collected %+v, want nothing from a refused batch", got)
 	}
-	// The finding survives; only the unsafe fix hint is gone.
-	if comments[0].SuggestionCode != "" {
-		t.Errorf("suggestion_code = %q, want it withheld from every auto-apply path",
-			comments[0].SuggestionCode)
-	}
-
-	warnings := r.Warnings()
-	if len(warnings) != 1 {
-		t.Fatalf("warnings = %+v, want exactly one", warnings)
-	}
-	for _, want := range []string{"suggestion_code may be truncated", "withheld 1 suggestion_code"} {
-		if !strings.Contains(warnings[0].Message, want) {
-			t.Errorf("warning %q does not report %q", warnings[0].Message, want)
-		}
+	if w := r.Warnings(); len(w) != 0 {
+		t.Errorf("warnings = %+v, want none — a refused repair papers over nothing", w)
 	}
 }
 
-// TestExecuteToolCall_CodeCommentWellFormedArgsDoesNotWarn is the contrast that
-// keeps the test above honest: a schema-conformant batch must produce no
-// warning, so comment_args_repaired counts real violations only.
+// The contrast that keeps the tests above honest: a conformant batch must warn
+// nothing, so comment_args_repaired counts real violations only.
 func TestExecuteToolCall_CodeCommentWellFormedArgsDoesNotWarn(t *testing.T) {
 	collector := tool.NewCommentCollector()
 	reg := tool.NewRegistry()

--- a/internal/llmloop/loop_test.go
+++ b/internal/llmloop/loop_test.go
@@ -913,6 +913,55 @@ func TestExecuteToolCall_CodeCommentRepairedArgsWarns(t *testing.T) {
 	}
 }
 
+// TestExecuteToolCall_CodeCommentSuspectRepairWarnsWithField covers the case the
+// count alone cannot express: the repair held up structurally but may have cut a
+// value short. The model still sees a plain success, so unless the warning names
+// the suspect field a truncated recovery is indistinguishable from a clean one in
+// every output format — stderr, JSON and SARIF all carry only this message.
+func TestExecuteToolCall_CodeCommentSuspectRepairWarnsWithField(t *testing.T) {
+	collector := tool.NewCommentCollector()
+	reg := tool.NewRegistry()
+	reg.Register(&tool.CodeCommentProvider{Collector: collector})
+	reg.Freeze()
+
+	r := NewRunner(Deps{Tools: reg, CommentCollector: collector})
+
+	// The suggestion's closing quote is missing, so the repair reads the comma
+	// after it as a terminator.
+	serialized := `[{"content":"use a literal","suggestion_code":"x = "y","existing_code":"z","path":"a.go"}]`
+	argsJSON, err := json.Marshal(map[string]any{"comments": serialized})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp := r.executeToolCall(context.Background(), "a.go", llm.ToolCall{
+		Function: llm.FunctionCall{Name: "code_comment", Arguments: string(argsJSON)},
+	}, nil, "")
+	if cp.Data != tool.CommentSucceed {
+		t.Fatalf("result = %+v, want the batch recovered", cp)
+	}
+
+	comments := collector.Comments()
+	if len(comments) != 1 {
+		t.Fatalf("collected %d comments, want 1", len(comments))
+	}
+	// The finding survives; only the unsafe fix hint is gone.
+	if comments[0].SuggestionCode != "" {
+		t.Errorf("suggestion_code = %q, want it withheld from every auto-apply path",
+			comments[0].SuggestionCode)
+	}
+
+	warnings := r.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want exactly one", warnings)
+	}
+	for _, want := range []string{"suggestion_code may be truncated", "withheld 1 suggestion_code"} {
+		if !strings.Contains(warnings[0].Message, want) {
+			t.Errorf("warning %q does not report %q", warnings[0].Message, want)
+		}
+	}
+}
+
 // TestExecuteToolCall_CodeCommentWellFormedArgsDoesNotWarn is the contrast that
 // keeps the test above honest: a schema-conformant batch must produce no
 // warning, so comment_args_repaired counts real violations only.

--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -72,24 +72,29 @@ func (p *CodeCommentProvider) Execute(_ context.Context, args map[string]any) (s
 // ParseCommentsWithPath is like ParseComments but uses defaultPath as a fallback
 // when individual comment objects omit the path field.
 //
-// repairedChars is non-zero when `comments` arrived as a serialized string that
-// only parsed after the deterministic repair (see comment_args_repair.go). The
-// comments themselves are unaffected; callers report it so a schema violation
-// the framework papers over still leaves a trace.
-func ParseCommentsWithPath(args map[string]any, defaultPath string) (comments []model.LlmComment, repairedChars int, errMsg string) {
+// repair is non-nil when `comments` arrived as a serialized string that only
+// parsed after the deterministic repair (see comment_args_repair.go). The
+// comments themselves are unaffected apart from suggestion_code values the
+// repair judged unsafe; callers report it so a schema violation the framework
+// papers over still leaves a trace.
+func ParseCommentsWithPath(args map[string]any, defaultPath string) (comments []model.LlmComment, repair *CommentRepair, errMsg string) {
 	return parseCommentsInner(args, defaultPath)
 }
 
 // ParseComments extracts LlmComment entries from tool call arguments without writing
 // to the Collector. Returns parsed comments and an error message (empty on success).
+//
+// The repair description is discarded because this path has no warning channel
+// today. A future caller that starts carrying real traffic should switch to
+// ParseCommentsWithPath rather than inherit silent repairs.
 func ParseComments(args map[string]any) ([]model.LlmComment, string) {
 	comments, _, errMsg := parseCommentsInner(args, "")
 	return comments, errMsg
 }
 
-func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmComment, int, string) {
+func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmComment, *CommentRepair, string) {
 	var rawComments []any
-	repairedChars := 0
+	var repair *CommentRepair
 	if arr, ok := args["comments"].([]any); ok && len(arr) > 0 {
 		rawComments = arr
 	} else if s, ok := args["comments"].(string); ok && s != "" {
@@ -98,21 +103,21 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 			// practice fails to parse over an unescaped prose quote, taking the
 			// whole batch with it. Try the deterministic repair before giving
 			// up, and keep the original error when it does not hold up.
-			entries, escaped := parseRepairedComments(s)
+			entries, rep := parseRepairedComments(s)
 			if entries == nil {
 				// Keep the wording — and specifically "invalid character" — as
 				// the parser produced it. That phrasing is what leads the model
 				// to regenerate the batch; describing the violation instead
 				// makes it resend the same broken string.
-				return nil, 0, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
+				return nil, nil, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
 			}
 			rawComments = entries
-			repairedChars = escaped
+			repair = rep
 		}
 	}
 	if len(rawComments) == 0 {
 		raw, _ := json.Marshal(args)
-		return nil, 0, fmt.Sprintf("Error: 'comments' array is required. Got args: %s", string(raw))
+		return nil, nil, fmt.Sprintf("Error: 'comments' array is required. Got args: %s", string(raw))
 	}
 
 	var comments []model.LlmComment
@@ -155,7 +160,7 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 
 		comments = append(comments, cm)
 	}
-	return comments, repairedChars, ""
+	return comments, repair, ""
 }
 
 func normalizeCodeCommentCategory(category string) string {

--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -71,29 +71,48 @@ func (p *CodeCommentProvider) Execute(_ context.Context, args map[string]any) (s
 
 // ParseCommentsWithPath is like ParseComments but uses defaultPath as a fallback
 // when individual comment objects omit the path field.
-func ParseCommentsWithPath(args map[string]any, defaultPath string) ([]model.LlmComment, string) {
-	comments, errMsg := parseCommentsInner(args, defaultPath)
-	return comments, errMsg
+//
+// repairedChars is non-zero when `comments` arrived as a serialized string that
+// only parsed after the deterministic repair (see comment_args_repair.go). The
+// comments themselves are unaffected; callers report it so a schema violation
+// the framework papers over still leaves a trace.
+func ParseCommentsWithPath(args map[string]any, defaultPath string) (comments []model.LlmComment, repairedChars int, errMsg string) {
+	return parseCommentsInner(args, defaultPath)
 }
 
 // ParseComments extracts LlmComment entries from tool call arguments without writing
 // to the Collector. Returns parsed comments and an error message (empty on success).
 func ParseComments(args map[string]any) ([]model.LlmComment, string) {
-	return parseCommentsInner(args, "")
+	comments, _, errMsg := parseCommentsInner(args, "")
+	return comments, errMsg
 }
 
-func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmComment, string) {
+func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmComment, int, string) {
 	var rawComments []any
+	repairedChars := 0
 	if arr, ok := args["comments"].([]any); ok && len(arr) > 0 {
 		rawComments = arr
 	} else if s, ok := args["comments"].(string); ok && s != "" {
 		if err := json.Unmarshal([]byte(s), &rawComments); err != nil {
-			return nil, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
+			// The schema declares an array; a string is a violation that in
+			// practice fails to parse over an unescaped prose quote, taking the
+			// whole batch with it. Try the deterministic repair before giving
+			// up, and keep the original error when it does not hold up.
+			entries, escaped := parseRepairedComments(s)
+			if entries == nil {
+				// Keep the wording — and specifically "invalid character" — as
+				// the parser produced it. That phrasing is what leads the model
+				// to regenerate the batch; describing the violation instead
+				// makes it resend the same broken string.
+				return nil, 0, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
+			}
+			rawComments = entries
+			repairedChars = escaped
 		}
 	}
 	if len(rawComments) == 0 {
 		raw, _ := json.Marshal(args)
-		return nil, fmt.Sprintf("Error: 'comments' array is required. Got args: %s", string(raw))
+		return nil, 0, fmt.Sprintf("Error: 'comments' array is required. Got args: %s", string(raw))
 	}
 
 	var comments []model.LlmComment
@@ -136,7 +155,7 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 
 		comments = append(comments, cm)
 	}
-	return comments, ""
+	return comments, repairedChars, ""
 }
 
 func normalizeCodeCommentCategory(category string) string {

--- a/internal/tool/code_comment.go
+++ b/internal/tool/code_comment.go
@@ -73,10 +73,9 @@ func (p *CodeCommentProvider) Execute(_ context.Context, args map[string]any) (s
 // when individual comment objects omit the path field.
 //
 // repair is non-nil when `comments` arrived as a serialized string that only
-// parsed after the deterministic repair (see comment_args_repair.go). The
-// comments themselves are unaffected apart from suggestion_code values the
-// repair judged unsafe; callers report it so a schema violation the framework
-// papers over still leaves a trace.
+// parsed after the deterministic repair (see comment_args_repair.go). It reports a
+// schema violation, not a change to the findings: a repair is accepted only when
+// no recovered value looks cut short.
 func ParseCommentsWithPath(args map[string]any, defaultPath string) (comments []model.LlmComment, repair *CommentRepair, errMsg string) {
 	return parseCommentsInner(args, defaultPath)
 }
@@ -99,16 +98,14 @@ func parseCommentsInner(args map[string]any, defaultPath string) ([]model.LlmCom
 		rawComments = arr
 	} else if s, ok := args["comments"].(string); ok && s != "" {
 		if err := json.Unmarshal([]byte(s), &rawComments); err != nil {
-			// The schema declares an array; a string is a violation that in
-			// practice fails to parse over an unescaped prose quote, taking the
-			// whole batch with it. Try the deterministic repair before giving
-			// up, and keep the original error when it does not hold up.
+			// A string here is a schema violation that in practice fails to
+			// parse and takes the whole batch with it. Try the repair first.
 			entries, rep := parseRepairedComments(s)
 			if entries == nil {
-				// Keep the wording — and specifically "invalid character" — as
-				// the parser produced it. That phrasing is what leads the model
-				// to regenerate the batch; describing the violation instead
-				// makes it resend the same broken string.
+				// Keep "invalid character" as the parser produced it: that
+				// phrasing is what leads the model to regenerate the batch,
+				// while naming the schema violation instead makes it resend the
+				// same broken string.
 				return nil, nil, fmt.Sprintf("Error: failed to parse 'comments' JSON string: %v", err)
 			}
 			rawComments = entries

--- a/internal/tool/comment_args_repair.go
+++ b/internal/tool/comment_args_repair.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package tool
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// The code_comment schema declares `comments` as an array, but a model
+// occasionally serializes that array into a string instead. The nested string
+// then needs one more level of escaping than the model applied, and the level
+// it drops is almost always a double quote inside prose — Chinese review text
+// quotes a term with "..." where the JSON string needs \"...\". The batch then
+// fails to parse and every comment in it is lost.
+//
+// The damage is mechanical and so is the fix: a bare quote inside a JSON string
+// is either that string's terminator or content the model forgot to escape, and
+// the two are told apart by what follows. Repairing it here keeps the findings
+// instead of discarding a whole batch over a punctuation mark.
+
+// contentFieldPattern counts the comment objects the original text described.
+// It matches the field name only in key position, so a `"content":` appearing
+// inside prose inflates the count and makes the repair check stricter — which
+// errs toward rejecting a repair, never toward accepting a lossy one.
+var contentFieldPattern = regexp.MustCompile(`"content"\s*:`)
+
+// controlEscapes maps the bare control characters that are illegal inside a
+// JSON string to their escaped form.
+var controlEscapes = map[byte]string{
+	'\n': `\n`,
+	'\r': `\r`,
+	'\t': `\t`,
+}
+
+// repairSerializedComments escapes what makes a model-serialized `comments`
+// string invalid JSON — prose double quotes and bare control characters — and
+// returns the repaired text with the number of characters it escaped.
+//
+// A bare '"' inside a JSON string is either the end of that string or content
+// that should have been escaped. A real terminator is always followed by ',',
+// '}', ']', ':' or the end of the text; anything else means the quote belongs
+// to the content. In `the name suggests "a trusted proxy exists" but ...` the
+// first quote is followed by a letter and the second by another word, so both
+// fail that test and both get escaped. The reported failures were all Chinese
+// review prose, where quoting a term this way is the norm rather than the
+// exception — which is why one test fixture keeps that language.
+//
+// Scanning byte by byte is safe for UTF-8: continuation bytes are all >= 0x80
+// and so can never be mistaken for the ASCII characters this looks at.
+//
+// A zero count means the text was already well-formed in these two respects,
+// and the caller should treat the original parse error as final rather than
+// re-parsing identical text.
+func repairSerializedComments(s string) (string, int) {
+	var b strings.Builder
+	b.Grow(len(s) + 16)
+
+	escaped := 0
+	inString := false
+	for i := 0; i < len(s); {
+		c := s[i]
+		if !inString {
+			if c == '"' {
+				inString = true
+			}
+			b.WriteByte(c)
+			i++
+			continue
+		}
+
+		switch {
+		case c == '\\':
+			// Copy an existing escape pair verbatim. A trailing lone backslash
+			// is left alone for the parser to reject.
+			b.WriteByte(c)
+			i++
+			if i < len(s) {
+				b.WriteByte(s[i])
+				i++
+			}
+		case c == '"':
+			if next := nextSignificantByte(s, i+1); next < 0 || isJSONStructural(s[next]) {
+				inString = false
+				b.WriteByte(c)
+			} else {
+				b.WriteString(`\"`)
+				escaped++
+			}
+			i++
+		case controlEscapes[c] != "":
+			b.WriteString(controlEscapes[c])
+			escaped++
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String(), escaped
+}
+
+// nextSignificantByte returns the index of the first non-whitespace byte at or
+// after i, or -1 when nothing but whitespace remains.
+func nextSignificantByte(s string, i int) int {
+	for ; i < len(s); i++ {
+		switch s[i] {
+		case ' ', '\t', '\r', '\n':
+		default:
+			return i
+		}
+	}
+	return -1
+}
+
+// isJSONStructural reports whether b can legally follow a string's closing
+// quote in JSON.
+func isJSONStructural(b byte) bool {
+	switch b {
+	case ',', '}', ']', ':':
+		return true
+	}
+	return false
+}
+
+// repairedCommentsAcceptable reports whether a repaired batch still carries
+// every comment the original text described.
+//
+// Parsing again is not enough on its own: a misjudged terminator can yield JSON
+// that is valid but wrong, most plausibly by merging two comments into one. So
+// each entry must keep a non-empty content, and the entry count must not fall
+// below the number of `"content":` fields in the original text. The count is
+// what rules out a silent merge; without it a repair could halve a batch and
+// still look successful.
+func repairedCommentsAcceptable(entries []any, original string) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for _, raw := range entries {
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		content, _ := obj["content"].(string)
+		if strings.TrimSpace(content) == "" {
+			return false
+		}
+	}
+	return len(entries) >= len(contentFieldPattern.FindAllStringIndex(original, -1))
+}
+
+// parseRepairedComments attempts the deterministic repair of a serialized
+// `comments` string and returns the recovered entries plus the number of
+// characters escaped. It returns (nil, 0) when the text needed no repair, the
+// repair still did not parse, or the result failed the preservation check — in
+// every one of those cases the caller must keep reporting the original parse
+// error.
+func parseRepairedComments(s string) ([]any, int) {
+	repaired, escaped := repairSerializedComments(s)
+	if escaped == 0 {
+		return nil, 0
+	}
+	var entries []any
+	if err := json.Unmarshal([]byte(repaired), &entries); err != nil {
+		return nil, 0
+	}
+	if !repairedCommentsAcceptable(entries, s) {
+		return nil, 0
+	}
+	return entries, escaped
+}

--- a/internal/tool/comment_args_repair.go
+++ b/internal/tool/comment_args_repair.go
@@ -11,26 +11,22 @@ import (
 )
 
 // The code_comment schema declares `comments` as an array, but a model
-// occasionally serializes that array into a string instead. The nested string
-// then needs one more level of escaping than the model applied, and the level
-// it drops is almost always a double quote inside prose — Chinese review text
-// quotes a term with "..." where the JSON string needs \"...\". The batch then
-// fails to parse and every comment in it is lost.
+// occasionally serializes it into a string, which then needs one more level of
+// escaping than the model applied. The level it drops is almost always a double
+// quote inside prose, so the batch fails to parse and every comment is lost.
 //
-// The damage is mechanical and so is the fix: a bare quote inside a JSON string
-// is either that string's terminator or content the model forgot to escape, and
-// the two are told apart by what follows. Repairing it here keeps the findings
-// instead of discarding a whole batch over a punctuation mark.
+// A bare quote inside a JSON string is either that string's terminator or content
+// the model forgot to escape, and what follows tells the two apart.
 
-// contentFieldPattern counts the comment objects the original text described.
-// It matches the field name only in key position, so a `"content":` appearing
-// inside prose inflates the count and makes the repair check stricter — which
-// errs toward rejecting a repair, never toward accepting a lossy one.
+// contentFieldPattern counts the comment objects the original text described. A
+// `"content":` inside prose inflates the count and so makes the check stricter,
+// which is the safe direction.
 var contentFieldPattern = regexp.MustCompile(`"content"\s*:`)
 
-// knownCommentFields is the set of field names the code_comment schema defines.
-// A repaired batch carrying anything else means the scan re-read a stretch of
-// prose as structure — see repairedCommentsAcceptable.
+// knownCommentFields holds every field the code_comment schema defines, plus
+// thinking, which parseCommentsInner also copies through. Anything else in a
+// repaired batch means the scan re-read prose as structure — see
+// repairedCommentsAcceptable.
 var knownCommentFields = map[string]struct{}{
 	"content":         {},
 	"existing_code":   {},
@@ -42,8 +38,7 @@ var knownCommentFields = map[string]struct{}{
 }
 
 // escapeControl returns the JSON escape for a control character. JSON forbids
-// every byte below 0x20 inside a string, so the ones without a short form get
-// the \u00XX escape rather than being left to fail the parse.
+// every byte below 0x20 in a string, so those without a short form get \u00XX.
 func escapeControl(c byte) string {
 	switch c {
 	case '\n':
@@ -89,24 +84,17 @@ func isHexDigit(c byte) bool {
 }
 
 // repairSerializedComments escapes what makes a model-serialized `comments`
-// string invalid JSON — prose double quotes and bare control characters — and
-// returns the repaired text with the number of characters it escaped.
+// string invalid JSON — prose quotes, bare control characters, illegal
+// backslashes — and returns the repaired text plus the number of characters it
+// escaped. A zero count means nothing needed escaping, so the caller must treat
+// the original parse error as final rather than re-parse identical text.
 //
-// A bare '"' inside a JSON string is either the end of that string or content
-// that should have been escaped. A real terminator is always followed by ',',
-// '}', ']', ':' or the end of the text; anything else means the quote belongs
-// to the content. In `the name suggests "a trusted proxy exists" but ...` the
-// first quote is followed by a letter and the second by another word, so both
-// fail that test and both get escaped. The reported failures were all Chinese
-// review prose, where quoting a term this way is the norm rather than the
-// exception — which is why one test fixture keeps that language.
+// A real terminator is always followed by ',', '}', ']', ':' or the end of the
+// text; a quote followed by anything else is content and gets escaped. So the
+// scan never misses a genuine terminator, and its only possible error is ending a
+// string early — which the acceptance checks are built to catch.
 //
-// Scanning byte by byte is safe for UTF-8: continuation bytes are all >= 0x80
-// and so can never be mistaken for the ASCII characters this looks at.
-//
-// A zero count means the text was already well-formed in these two respects,
-// and the caller should treat the original parse error as final rather than
-// re-parsing identical text.
+// Scanning byte by byte is safe for UTF-8: continuation bytes are all >= 0x80.
 func repairSerializedComments(s string) (string, int) {
 	var b strings.Builder
 	b.Grow(len(s) + 16)
@@ -127,24 +115,17 @@ func repairSerializedComments(s string) (string, int) {
 		switch {
 		case c == '\\':
 			if isLegalEscape(s, i+1) {
-				// A real escape pair; copy it verbatim.
 				b.WriteByte(c)
 				i++
 				b.WriteByte(s[i])
 				i++
 				break
 			}
-			// The dropped escaping level hits backslashes too, not just quotes:
-			// prose citing a regex (\d), a Windows path (C:\Users) or a literal
-			// \n leaves a backslash that opens no valid sequence. Escaping it
-			// recovers a batch that would otherwise be lost to the same root
-			// cause as the quotes.
-			//
-			// A backslash followed by b/f/n/r/t/u is a legal escape and is left
-			// alone above, so `C:\bin` still decodes to a backspace rather than
-			// the path the prose meant. JSON gives no way to tell those apart,
-			// and inventing one would corrupt genuine escapes — which are far
-			// more common in this field than Windows paths.
+			// The dropped escaping level hits backslashes too: prose citing \d or
+			// C:\Users leaves one that opens no valid sequence. A backslash before
+			// b/f/n/r/t/u is legal and is left alone above, so `C:\bin` still
+			// decodes to a backspace — JSON cannot tell those apart, and guessing
+			// would corrupt genuine escapes.
 			b.WriteString(`\\`)
 			escaped++
 			i++
@@ -192,30 +173,18 @@ func isJSONStructural(b byte) bool {
 	return false
 }
 
-// repairedCommentsAcceptable reports whether a repaired batch still carries
-// every comment the original text described.
+// repairedCommentsAcceptable reports whether a repaired batch still carries every
+// comment the original text described. Parsing again is not enough on its own: a
+// misjudged terminator can yield JSON that is valid but wrong.
 //
-// Parsing again is not enough on its own: a misjudged terminator can yield JSON
-// that is valid but wrong. Three things have to hold.
+// Every entry must keep a non-empty content, and the entry count must not fall
+// below the number of `"content":` fields in the original — that rules out a
+// repair that fused two comments by ending a string early. No entry may carry a
+// field the schema does not define, since prose re-read as structure almost never
+// spells a real field name.
 //
-// Every entry keeps a non-empty content, and the entry count does not fall below
-// the number of `"content":` fields in the original text — that rules out a
-// repair that merged two comments by ending a string early, which would
-// otherwise halve a batch and still look successful.
-//
-// No entry carries a field the schema does not define. When the scan ends a
-// string too early, the prose after it is re-read as structure, and a stretch of
-// review text almost never spells a real field name — so an unknown key is the
-// signature of exactly that mistake.
-//
-// A window remains, and narrowing it further is not possible from local
-// evidence: `"a word", "existing_code":"x"` inside prose is byte-for-byte
-// indistinguishable from a genuine string terminator followed by the next
-// field, so a repair can still truncate a value when the prose happens to spell
-// a real field name right after a quoted term. The checks above shrink that to
-// prose citing this schema's own field names in that exact shape; anything else
-// either fails to parse or trips the unknown-field check. Callers get the
-// original parse error in those cases, which is the safe direction.
+// Passing here is necessary but not sufficient: hasSuspectTruncation runs after
+// this and rejects cut values that these checks let through.
 func repairedCommentsAcceptable(entries []any, original string) bool {
 	if len(entries) == 0 {
 		return false
@@ -238,151 +207,71 @@ func repairedCommentsAcceptable(entries []any, original string) bool {
 	return len(entries) >= len(contentFieldPattern.FindAllStringIndex(original, -1))
 }
 
-const (
-	suggestionCodeField = "suggestion_code"
-	pathField           = "path"
-)
+// commentTextFields are the string-valued fields checked for truncation.
+//
+// thinking is deliberately absent: a cut thinking reaches the JSON output only,
+// with no terminal or viewer rendering, so suspecting it would forfeit a sound
+// recovery over a diagnostic string.
+var commentTextFields = []string{"content", "existing_code", "suggestion_code", "path"}
 
-// commentTextFields are the string-valued fields worth checking for truncation.
-// The order is fixed so the warning text never depends on map iteration order.
+// hasOddQuotes reports whether v carries an odd number of double quotes — the
+// signature of a value cut short at a misjudged terminator.
 //
-// thinking is deliberately absent even though knownCommentFields accepts it and
-// parseCommentsInner copies it through. That set answers whether a field is
-// legal; this one answers whether its truncation needs acting on, and the two
-// questions have different answers here. A truncated thinking costs nothing —
-// it reaches the JSON output only, with no terminal or viewer rendering — while
-// suspecting it would drop a perfectly good suggestion_code from the same entry,
-// since the drop is per-entry. Checking it would trade a real fix hint for a
-// diagnostic string's last few characters.
-var commentTextFields = []string{"content", "existing_code", suggestionCodeField, pathField}
-
-// hasOddQuotes reports whether v carries an odd number of double quotes, which
-// is the signature of a value cut short at a misjudged terminator.
+// Number a value's quotes q1..qN as the scan meets them: it escapes qi unless qi
+// is followed by ',' '}' ']' or ':', where it reads qi as the terminator. A value
+// cut at qi keeps i-1 quotes, so the cut is visible precisely when i is even.
+// Prose puts it there — a term is quoted with a pair, and only a closing quote is
+// followed by punctuation. Odd i slips through, but needs a closing quote with no
+// opening quote before it in the same value, which prose does not produce.
 //
-// The argument is structural, not statistical. A terminator is only ever
-// misjudged at a quote followed by ',' '}' ']' or ':' — and in prose only a
-// *closing* quote is followed by punctuation, since an opening quote is followed
-// by the term itself. Prose quotes a term with a pair, so the closing quote is
-// the even-numbered one and a value cut there keeps an odd number of quotes. A
-// value the repair read correctly keeps whole pairs, hence an even number.
-//
-// The parity holds for prose, which is where the reported failures live. A code
-// snippet can legitimately carry an odd number of quotes, so such a value is
-// flagged with nothing lost. That false positive costs one warning plus, for
-// suggestion_code, a fix suggestion the model can restate — never a change to
-// the comment itself.
+// Code can legitimately carry an odd count, and the check is batch-wide: such a
+// batch is declined even when the repair only escaped control characters and made
+// no quote judgement at all. Nothing regresses — that is the outcome it had before
+// this repair existed — but a lossless recovery is forgone.
 func hasOddQuotes(v string) bool {
 	return strings.Count(v, `"`)%2 == 1
 }
 
-// flagSuspectTruncations reports the fields of a repaired batch that a misjudged
-// terminator may have cut short, and withholds the two whose truncation has a
-// consequence past being hard to read.
-//
-// suggestion_code is dropped whenever *any* field of the same entry is suspect,
-// not only when it is suspect itself. It is the value a consumer can apply — both
-// the SARIF `fixes` array and the GitHub ```suggestion block gate on it being
-// non-empty — and the deleted region it replaces comes from StartLine/EndLine,
-// which are derived from existing_code. So a truncated existing_code is just as
-// dangerous as a truncated suggestion: matchConsecutive compares whole lines, so
-// the cut anchor cannot match anything and every deterministic resolver declines;
-// the LLM re-location that follows then guesses from a mutilated excerpt and
-// writes line numbers anyway, which is the failure resolver.go describes as
-// "looking located while pointing at an unrelated line". A fix built on those
-// numbers deletes the wrong region. Dropping the suggestion closes that path for
-// the whole entry and costs only a hint the model can restate.
-//
-// A suspect path is deleted so parseCommentsInner falls back to defaultPath — the
-// file under review, which is where the comment came from. A truncated path is
-// non-empty, so without this it would suppress that fallback and travel into the
-// SARIF artifactLocation URI and the fingerprint while naming a file that does
-// not exist. When defaultPath is empty too the comment is dropped downstream,
-// which is the right outcome: a comment whose path is corrupt cannot be placed.
-//
-// content and existing_code are reported and left intact. Prose cut short is
-// still worth reading, and existing_code is the anchor every resolver needs —
-// removing it would lose the position outright rather than protect it.
-func flagSuspectTruncations(entries []any) (suspects []string, droppedSuggestions, droppedPaths int) {
-	suspect := make(map[string]bool, len(commentTextFields))
+// hasSuspectTruncation reports whether any entry carries a value a misjudged
+// terminator may have cut short. Such a batch is refused outright rather than
+// partially recovered: matchConsecutive compares whole lines, so a cut
+// existing_code matches nothing, every deterministic resolver declines, and the
+// LLM re-location then spends a call guessing line numbers from a mutilated
+// excerpt. The original parse error instead makes the model resend the batch with
+// its anchor, its suggestion_code and a deterministic position intact.
+func hasSuspectTruncation(entries []any) bool {
 	for _, raw := range entries {
 		obj, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
-		entrySuspect := false
 		for _, field := range commentTextFields {
-			v, ok := obj[field].(string)
-			if !ok || !hasOddQuotes(v) {
-				continue
-			}
-			suspect[field] = true
-			entrySuspect = true
-			if field == pathField {
-				delete(obj, pathField)
-				droppedPaths++
+			if v, ok := obj[field].(string); ok && hasOddQuotes(v) {
+				return true
 			}
 		}
-		if !entrySuspect {
-			continue
-		}
-		if _, ok := obj[suggestionCodeField].(string); ok {
-			delete(obj, suggestionCodeField)
-			droppedSuggestions++
-		}
 	}
-	for _, field := range commentTextFields {
-		if suspect[field] {
-			suspects = append(suspects, field)
-		}
-	}
-	return suspects, droppedSuggestions, droppedPaths
+	return false
 }
 
-// CommentRepair records what the deterministic repair did to a serialized
-// `comments` argument. Callers report it so a schema violation the framework
-// papers over still leaves a trace; a nil value means no repair ran.
+// CommentRepair records that the deterministic repair ran on a serialized
+// `comments` argument; nil means it did not. Callers report it so a schema
+// violation the framework papers over still leaves a trace. A count is all it
+// needs, because an accepted repair is an intact one — see hasSuspectTruncation.
 type CommentRepair struct {
-	// EscapedChars counts the characters the repair escaped.
 	EscapedChars int
-	// SuspectFields names the fields whose repaired value carries an odd number
-	// of quotes — see hasOddQuotes. Without this the warning could not tell a
-	// clean recovery from a truncated one, and the truncation would be
-	// unobservable in every output format.
-	SuspectFields []string
-	// DroppedSuggestions counts the suggestion_code values withheld because
-	// something in their entry was suspect.
-	DroppedSuggestions int
-	// DroppedPaths counts the suspect path values replaced by the file under
-	// review.
-	DroppedPaths int
 }
 
 // Message renders the repair as a single warning line.
 func (r *CommentRepair) Message() string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "comments arrived as a serialized string instead of an array; "+
+	return fmt.Sprintf("comments arrived as a serialized string instead of an array; "+
 		"repaired %d unescaped character(s)", r.EscapedChars)
-	if len(r.SuspectFields) > 0 {
-		fmt.Fprintf(&b, "; %s may be truncated at a misjudged string terminator",
-			strings.Join(r.SuspectFields, ", "))
-	}
-	if r.DroppedSuggestions > 0 {
-		fmt.Fprintf(&b, "; withheld %d suggestion_code value(s) so no auto-apply "+
-			"consumer can offer them", r.DroppedSuggestions)
-	}
-	if r.DroppedPaths > 0 {
-		fmt.Fprintf(&b, "; %d suspect path(s) fell back to the file under review",
-			r.DroppedPaths)
-	}
-	return b.String()
 }
 
 // parseRepairedComments attempts the deterministic repair of a serialized
-// `comments` string and returns the recovered entries plus a description of what
-// the repair did. It returns (nil, nil) when the text needed no repair, the
-// repair still did not parse, or the result failed the preservation check — in
-// every one of those cases the caller must keep reporting the original parse
-// error.
+// `comments` string. It returns (nil, nil) when the text needed no repair, the
+// repair still did not parse, or the result failed a check — in every one of those
+// cases the caller must keep reporting the original parse error.
 func parseRepairedComments(s string) ([]any, *CommentRepair) {
 	repaired, escaped := repairSerializedComments(s)
 	if escaped == 0 {
@@ -395,11 +284,8 @@ func parseRepairedComments(s string) ([]any, *CommentRepair) {
 	if !repairedCommentsAcceptable(entries, s) {
 		return nil, nil
 	}
-	suspects, droppedSuggestions, droppedPaths := flagSuspectTruncations(entries)
-	return entries, &CommentRepair{
-		EscapedChars:       escaped,
-		SuspectFields:      suspects,
-		DroppedSuggestions: droppedSuggestions,
-		DroppedPaths:       droppedPaths,
+	if hasSuspectTruncation(entries) {
+		return nil, nil
 	}
+	return entries, &CommentRepair{EscapedChars: escaped}
 }

--- a/internal/tool/comment_args_repair.go
+++ b/internal/tool/comment_args_repair.go
@@ -27,12 +27,64 @@ import (
 // errs toward rejecting a repair, never toward accepting a lossy one.
 var contentFieldPattern = regexp.MustCompile(`"content"\s*:`)
 
-// controlEscapes maps the bare control characters that are illegal inside a
-// JSON string to their escaped form.
-var controlEscapes = map[byte]string{
-	'\n': `\n`,
-	'\r': `\r`,
-	'\t': `\t`,
+// knownCommentFields is the set of field names the code_comment schema defines.
+// A repaired batch carrying anything else means the scan re-read a stretch of
+// prose as structure — see repairedCommentsAcceptable.
+var knownCommentFields = map[string]struct{}{
+	"content":         {},
+	"existing_code":   {},
+	"suggestion_code": {},
+	"category":        {},
+	"severity":        {},
+	"path":            {},
+	"thinking":        {},
+}
+
+// escapeControl returns the JSON escape for a control character. JSON forbids
+// every byte below 0x20 inside a string, so the ones without a short form get
+// the \u00XX escape rather than being left to fail the parse.
+func escapeControl(c byte) string {
+	switch c {
+	case '\n':
+		return `\n`
+	case '\r':
+		return `\r`
+	case '\t':
+		return `\t`
+	case '\b':
+		return `\b`
+	case '\f':
+		return `\f`
+	}
+	const hex = "0123456789abcdef"
+	return `\u00` + string([]byte{hex[c>>4], hex[c&0x0f]})
+}
+
+// isLegalEscape reports whether s[i] opens a valid JSON escape sequence, given
+// that s[i-1] is a backslash. \u additionally requires four hex digits.
+func isLegalEscape(s string, i int) bool {
+	if i >= len(s) {
+		return false
+	}
+	switch s[i] {
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+		return true
+	case 'u':
+		if i+5 > len(s) {
+			return false
+		}
+		for _, c := range []byte(s[i+1 : i+5]) {
+			if !isHexDigit(c) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 }
 
 // repairSerializedComments escapes what makes a model-serialized `comments`
@@ -73,14 +125,28 @@ func repairSerializedComments(s string) (string, int) {
 
 		switch {
 		case c == '\\':
-			// Copy an existing escape pair verbatim. A trailing lone backslash
-			// is left alone for the parser to reject.
-			b.WriteByte(c)
-			i++
-			if i < len(s) {
+			if isLegalEscape(s, i+1) {
+				// A real escape pair; copy it verbatim.
+				b.WriteByte(c)
+				i++
 				b.WriteByte(s[i])
 				i++
+				break
 			}
+			// The dropped escaping level hits backslashes too, not just quotes:
+			// prose citing a regex (\d), a Windows path (C:\Users) or a literal
+			// \n leaves a backslash that opens no valid sequence. Escaping it
+			// recovers a batch that would otherwise be lost to the same root
+			// cause as the quotes.
+			//
+			// A backslash followed by b/f/n/r/t/u is a legal escape and is left
+			// alone above, so `C:\bin` still decodes to a backspace rather than
+			// the path the prose meant. JSON gives no way to tell those apart,
+			// and inventing one would corrupt genuine escapes — which are far
+			// more common in this field than Windows paths.
+			b.WriteString(`\\`)
+			escaped++
+			i++
 		case c == '"':
 			if next := nextSignificantByte(s, i+1); next < 0 || isJSONStructural(s[next]) {
 				inString = false
@@ -90,8 +156,8 @@ func repairSerializedComments(s string) (string, int) {
 				escaped++
 			}
 			i++
-		case controlEscapes[c] != "":
-			b.WriteString(controlEscapes[c])
+		case c < 0x20:
+			b.WriteString(escapeControl(c))
 			escaped++
 			i++
 		default:
@@ -129,11 +195,26 @@ func isJSONStructural(b byte) bool {
 // every comment the original text described.
 //
 // Parsing again is not enough on its own: a misjudged terminator can yield JSON
-// that is valid but wrong, most plausibly by merging two comments into one. So
-// each entry must keep a non-empty content, and the entry count must not fall
-// below the number of `"content":` fields in the original text. The count is
-// what rules out a silent merge; without it a repair could halve a batch and
-// still look successful.
+// that is valid but wrong. Three things have to hold.
+//
+// Every entry keeps a non-empty content, and the entry count does not fall below
+// the number of `"content":` fields in the original text — that rules out a
+// repair that merged two comments by ending a string early, which would
+// otherwise halve a batch and still look successful.
+//
+// No entry carries a field the schema does not define. When the scan ends a
+// string too early, the prose after it is re-read as structure, and a stretch of
+// review text almost never spells a real field name — so an unknown key is the
+// signature of exactly that mistake.
+//
+// A window remains, and narrowing it further is not possible from local
+// evidence: `"a word", "existing_code":"x"` inside prose is byte-for-byte
+// indistinguishable from a genuine string terminator followed by the next
+// field, so a repair can still truncate a value when the prose happens to spell
+// a real field name right after a quoted term. The checks above shrink that to
+// prose citing this schema's own field names in that exact shape; anything else
+// either fails to parse or trips the unknown-field check. Callers get the
+// original parse error in those cases, which is the safe direction.
 func repairedCommentsAcceptable(entries []any, original string) bool {
 	if len(entries) == 0 {
 		return false
@@ -146,6 +227,11 @@ func repairedCommentsAcceptable(entries []any, original string) bool {
 		content, _ := obj["content"].(string)
 		if strings.TrimSpace(content) == "" {
 			return false
+		}
+		for field := range obj {
+			if _, known := knownCommentFields[field]; !known {
+				return false
+			}
 		}
 	}
 	return len(entries) >= len(contentFieldPattern.FindAllStringIndex(original, -1))

--- a/internal/tool/comment_args_repair.go
+++ b/internal/tool/comment_args_repair.go
@@ -5,6 +5,7 @@ package tool
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -237,23 +238,168 @@ func repairedCommentsAcceptable(entries []any, original string) bool {
 	return len(entries) >= len(contentFieldPattern.FindAllStringIndex(original, -1))
 }
 
+const (
+	suggestionCodeField = "suggestion_code"
+	pathField           = "path"
+)
+
+// commentTextFields are the string-valued fields worth checking for truncation.
+// The order is fixed so the warning text never depends on map iteration order.
+//
+// thinking is deliberately absent even though knownCommentFields accepts it and
+// parseCommentsInner copies it through. That set answers whether a field is
+// legal; this one answers whether its truncation needs acting on, and the two
+// questions have different answers here. A truncated thinking costs nothing —
+// it reaches the JSON output only, with no terminal or viewer rendering — while
+// suspecting it would drop a perfectly good suggestion_code from the same entry,
+// since the drop is per-entry. Checking it would trade a real fix hint for a
+// diagnostic string's last few characters.
+var commentTextFields = []string{"content", "existing_code", suggestionCodeField, pathField}
+
+// hasOddQuotes reports whether v carries an odd number of double quotes, which
+// is the signature of a value cut short at a misjudged terminator.
+//
+// The argument is structural, not statistical. A terminator is only ever
+// misjudged at a quote followed by ',' '}' ']' or ':' — and in prose only a
+// *closing* quote is followed by punctuation, since an opening quote is followed
+// by the term itself. Prose quotes a term with a pair, so the closing quote is
+// the even-numbered one and a value cut there keeps an odd number of quotes. A
+// value the repair read correctly keeps whole pairs, hence an even number.
+//
+// The parity holds for prose, which is where the reported failures live. A code
+// snippet can legitimately carry an odd number of quotes, so such a value is
+// flagged with nothing lost. That false positive costs one warning plus, for
+// suggestion_code, a fix suggestion the model can restate — never a change to
+// the comment itself.
+func hasOddQuotes(v string) bool {
+	return strings.Count(v, `"`)%2 == 1
+}
+
+// flagSuspectTruncations reports the fields of a repaired batch that a misjudged
+// terminator may have cut short, and withholds the two whose truncation has a
+// consequence past being hard to read.
+//
+// suggestion_code is dropped whenever *any* field of the same entry is suspect,
+// not only when it is suspect itself. It is the value a consumer can apply — both
+// the SARIF `fixes` array and the GitHub ```suggestion block gate on it being
+// non-empty — and the deleted region it replaces comes from StartLine/EndLine,
+// which are derived from existing_code. So a truncated existing_code is just as
+// dangerous as a truncated suggestion: matchConsecutive compares whole lines, so
+// the cut anchor cannot match anything and every deterministic resolver declines;
+// the LLM re-location that follows then guesses from a mutilated excerpt and
+// writes line numbers anyway, which is the failure resolver.go describes as
+// "looking located while pointing at an unrelated line". A fix built on those
+// numbers deletes the wrong region. Dropping the suggestion closes that path for
+// the whole entry and costs only a hint the model can restate.
+//
+// A suspect path is deleted so parseCommentsInner falls back to defaultPath — the
+// file under review, which is where the comment came from. A truncated path is
+// non-empty, so without this it would suppress that fallback and travel into the
+// SARIF artifactLocation URI and the fingerprint while naming a file that does
+// not exist. When defaultPath is empty too the comment is dropped downstream,
+// which is the right outcome: a comment whose path is corrupt cannot be placed.
+//
+// content and existing_code are reported and left intact. Prose cut short is
+// still worth reading, and existing_code is the anchor every resolver needs —
+// removing it would lose the position outright rather than protect it.
+func flagSuspectTruncations(entries []any) (suspects []string, droppedSuggestions, droppedPaths int) {
+	suspect := make(map[string]bool, len(commentTextFields))
+	for _, raw := range entries {
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		entrySuspect := false
+		for _, field := range commentTextFields {
+			v, ok := obj[field].(string)
+			if !ok || !hasOddQuotes(v) {
+				continue
+			}
+			suspect[field] = true
+			entrySuspect = true
+			if field == pathField {
+				delete(obj, pathField)
+				droppedPaths++
+			}
+		}
+		if !entrySuspect {
+			continue
+		}
+		if _, ok := obj[suggestionCodeField].(string); ok {
+			delete(obj, suggestionCodeField)
+			droppedSuggestions++
+		}
+	}
+	for _, field := range commentTextFields {
+		if suspect[field] {
+			suspects = append(suspects, field)
+		}
+	}
+	return suspects, droppedSuggestions, droppedPaths
+}
+
+// CommentRepair records what the deterministic repair did to a serialized
+// `comments` argument. Callers report it so a schema violation the framework
+// papers over still leaves a trace; a nil value means no repair ran.
+type CommentRepair struct {
+	// EscapedChars counts the characters the repair escaped.
+	EscapedChars int
+	// SuspectFields names the fields whose repaired value carries an odd number
+	// of quotes — see hasOddQuotes. Without this the warning could not tell a
+	// clean recovery from a truncated one, and the truncation would be
+	// unobservable in every output format.
+	SuspectFields []string
+	// DroppedSuggestions counts the suggestion_code values withheld because
+	// something in their entry was suspect.
+	DroppedSuggestions int
+	// DroppedPaths counts the suspect path values replaced by the file under
+	// review.
+	DroppedPaths int
+}
+
+// Message renders the repair as a single warning line.
+func (r *CommentRepair) Message() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "comments arrived as a serialized string instead of an array; "+
+		"repaired %d unescaped character(s)", r.EscapedChars)
+	if len(r.SuspectFields) > 0 {
+		fmt.Fprintf(&b, "; %s may be truncated at a misjudged string terminator",
+			strings.Join(r.SuspectFields, ", "))
+	}
+	if r.DroppedSuggestions > 0 {
+		fmt.Fprintf(&b, "; withheld %d suggestion_code value(s) so no auto-apply "+
+			"consumer can offer them", r.DroppedSuggestions)
+	}
+	if r.DroppedPaths > 0 {
+		fmt.Fprintf(&b, "; %d suspect path(s) fell back to the file under review",
+			r.DroppedPaths)
+	}
+	return b.String()
+}
+
 // parseRepairedComments attempts the deterministic repair of a serialized
-// `comments` string and returns the recovered entries plus the number of
-// characters escaped. It returns (nil, 0) when the text needed no repair, the
+// `comments` string and returns the recovered entries plus a description of what
+// the repair did. It returns (nil, nil) when the text needed no repair, the
 // repair still did not parse, or the result failed the preservation check — in
 // every one of those cases the caller must keep reporting the original parse
 // error.
-func parseRepairedComments(s string) ([]any, int) {
+func parseRepairedComments(s string) ([]any, *CommentRepair) {
 	repaired, escaped := repairSerializedComments(s)
 	if escaped == 0 {
-		return nil, 0
+		return nil, nil
 	}
 	var entries []any
 	if err := json.Unmarshal([]byte(repaired), &entries); err != nil {
-		return nil, 0
+		return nil, nil
 	}
 	if !repairedCommentsAcceptable(entries, s) {
-		return nil, 0
+		return nil, nil
 	}
-	return entries, escaped
+	suspects, droppedSuggestions, droppedPaths := flagSuspectTruncations(entries)
+	return entries, &CommentRepair{
+		EscapedChars:       escaped,
+		SuspectFields:      suspects,
+		DroppedSuggestions: droppedSuggestions,
+		DroppedPaths:       droppedPaths,
+	}
 }

--- a/internal/tool/comment_args_repair_test.go
+++ b/internal/tool/comment_args_repair_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/alibaba/open-code-review/internal/config/toolsconfig"
 )
 
 // These fixtures are the observed shape of the failure: `comments` arrives as a
@@ -412,85 +414,58 @@ func TestParseRepairedComments_DeclinesWhenNothingToEscape(t *testing.T) {
 	}
 }
 
-// TestParseComments_SuspectSuggestionIsDroppedNotApplied covers the one field
-// whose truncation has a consequence beyond being hard to read. A suggestion_code
-// cut short at a misjudged terminator is syntactically incomplete code, and both
-// the SARIF `fixes` array and the GitHub ```suggestion block gate on it being
-// non-empty — so leaving it in place puts that code one click away from being
-// committed. Clearing it closes every such consumer without any of them knowing
-// about this check, while the comment itself still reaches the reviewer.
-func TestParseComments_SuspectSuggestionIsDroppedNotApplied(t *testing.T) {
-	// The trailing quote of the suggestion is missing, so the repair reads the
-	// following comma as a terminator and cuts `x = "y` short.
-	serialized := `[{"content":"use a literal","suggestion_code":"x = "y","existing_code":"z","path":"a.go"}]`
+// assertDeclined is the shared assertion for a batch the repair must refuse: no
+// comments, no repair description, and the parser's own wording handed back so
+// the model regenerates the batch instead of resending the broken string.
+func assertDeclined(t *testing.T, serialized, why string) {
+	t.Helper()
 	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
-	if errMsg != "" {
-		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
+	if errMsg == "" {
+		t.Fatalf("repair was accepted (%d comments); want it declined because %s",
+			len(comments), why)
 	}
-	if len(comments) != 1 {
-		t.Fatalf("recovered %d comments, want 1 — the comment is not the casualty", len(comments))
+	if len(comments) != 0 || repair != nil {
+		t.Errorf("comments=%d repair=%+v; want nothing recovered", len(comments), repair)
 	}
-	if comments[0].SuggestionCode != "" {
-		t.Errorf("suggestion_code = %q, want it dropped so no consumer can apply it",
-			comments[0].SuggestionCode)
-	}
-	// The rest of the finding is untouched: dropping the suggestion costs a fix
-	// hint, not the review comment.
-	if comments[0].Content != "use a literal" {
-		t.Errorf("content = %q, want it intact", comments[0].Content)
-	}
-	if comments[0].ExistingCode != "z" || comments[0].Path != "a.go" {
-		t.Errorf("existing_code = %q, path = %q; both should survive",
-			comments[0].ExistingCode, comments[0].Path)
-	}
-	if repair == nil {
-		t.Fatal("a repair that dropped a value must still be reported")
-	}
-	if repair.DroppedSuggestions != 1 {
-		t.Errorf("DroppedSuggestions = %d, want 1", repair.DroppedSuggestions)
-	}
-	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "suggestion_code" {
-		t.Errorf("SuspectFields = %v, want [suggestion_code]", repair.SuspectFields)
+	if !strings.Contains(errMsg, "invalid character") {
+		t.Errorf("a declined repair must fall back to the parser wording, got %q", errMsg)
 	}
 }
 
-// TestParseComments_SuspectContentIsReportedNotAltered pins the other half of the
-// policy: a content cut short is still worth reading, so it is named in the
-// warning and otherwise left exactly as recovered.
-func TestParseComments_SuspectContentIsReportedNotAltered(t *testing.T) {
-	serialized := `[{"content":"call it "hard", "path":"a.go"}]`
-	comments, repair, errMsg := ParseCommentsWithPath(
-		map[string]any{"comments": serialized}, "fallback.go")
-	if errMsg != "" {
-		t.Fatalf("expected the batch to be recovered, got error: %s", errMsg)
-	}
-	if len(comments) != 1 || comments[0].Content != `call it "hard` {
-		t.Fatalf("content = %q, want the truncated text left as recovered", comments[0].Content)
-	}
-	if repair == nil {
-		t.Fatal("a suspect value must be reported")
-	}
-	if repair.DroppedSuggestions != 0 {
-		t.Errorf("DroppedSuggestions = %d, want 0 — only suggestion_code is dropped",
-			repair.DroppedSuggestions)
-	}
-	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "content" {
-		t.Errorf("SuspectFields = %v, want [content]", repair.SuspectFields)
-	}
-	// The whole point of the field list: without it a truncated recovery is
-	// indistinguishable from a clean one in every output format.
-	if !strings.Contains(repair.Message(), "content may be truncated") {
-		t.Errorf("warning does not name the suspect value: %q", repair.Message())
-	}
+// One case per checked field, each feeding a value the scan cuts short. All must
+// be refused rather than partially recovered: a cut existing_code matches nothing
+// (matchConsecutive compares whole lines) so the position gets guessed, a cut
+// suggestion_code is incomplete code that SARIF `fixes` and the GitHub
+// ```suggestion block would still offer, and a cut path is non-empty enough to
+// suppress the defaultPath fallback. The original error resends the batch intact.
+
+func TestParseComments_SuspectSuggestionRejectsTheBatch(t *testing.T) {
+	assertDeclined(t,
+		`[{"content":"use a literal","suggestion_code":"x = "y","existing_code":"z","path":"a.go"}]`,
+		"suggestion_code may be cut short")
 }
 
-// TestParseComments_CleanRepairReportsNoSuspect is the contrast that keeps the
-// detector honest. Every one of these is the actually-observed failure shape —
-// the quotes are all present and only the escaping level was dropped — and none
-// of them loses anything, so flagging one would cost a real suggestion for
-// nothing.
-func TestParseComments_CleanRepairReportsNoSuspect(t *testing.T) {
+func TestParseComments_SuspectContentRejectsTheBatch(t *testing.T) {
+	assertDeclined(t, `[{"content":"call it "hard", "path":"a.go"}]`,
+		"content may be cut short")
+}
+
+func TestParseComments_SuspectExistingCodeRejectsTheBatch(t *testing.T) {
+	assertDeclined(t,
+		`[{"content":"ok","existing_code":"s := "v","suggestion_code":"q","path":"a.go"}]`,
+		"existing_code may be cut short")
+}
+
+func TestParseComments_SuspectPathRejectsTheBatch(t *testing.T) {
+	assertDeclined(t, `[{"content":"ok","path":"a.go"x","existing_code":"z"}]`,
+		"path may be cut short")
+}
+
+// TestParseComments_CleanRepairIsAcceptedIntact is the contrast that keeps the
+// detector honest: every fixture here is an actually-observed failure shape, so
+// suspecting one would make the repair decline the batches it exists to save.
+func TestParseComments_CleanRepairIsAcceptedIntact(t *testing.T) {
 	for _, tc := range []struct{ name, serialized string }{
 		{"prose quote in english", proseQuoteEnglish},
 		{"prose quote in chinese", proseQuoteChinese},
@@ -509,89 +484,24 @@ func TestParseComments_CleanRepairReportsNoSuspect(t *testing.T) {
 			if repair == nil {
 				t.Fatal("a repaired batch must be reported")
 			}
-			if len(repair.SuspectFields) != 0 {
-				t.Errorf("SuspectFields = %v, want none for a clean recovery", repair.SuspectFields)
-			}
-			if repair.DroppedSuggestions != 0 {
-				t.Errorf("DroppedSuggestions = %d, want 0", repair.DroppedSuggestions)
-			}
-			// A clean recovery must keep its suggestion, or the detector would be
-			// silently discarding valid fixes.
+			// An accepted batch is intact by construction, so its suggestion must
+			// survive — a dropped one would mean the repair is lossy after all.
 			for _, cm := range comments {
 				if strings.Contains(tc.serialized, `"suggestion_code"`) && cm.SuggestionCode == "" {
-					t.Errorf("suggestion_code was dropped from a clean batch: %+v", cm)
+					t.Errorf("suggestion_code missing from an accepted batch: %+v", cm)
 				}
 			}
 		})
 	}
 }
 
-// TestParseComments_SuspectExistingCodeAlsoWithholdsSuggestion covers the reason
-// the drop is per-entry rather than per-field. A truncated existing_code cannot
-// match anything — matchConsecutive compares whole lines — so every deterministic
-// resolver declines and the LLM re-location guesses line numbers from a mutilated
-// excerpt. A fix assembled from those numbers deletes the wrong region, so the
-// suggestion has to go even though the suggestion itself looks fine.
-func TestParseComments_SuspectExistingCodeAlsoWithholdsSuggestion(t *testing.T) {
-	serialized := `[{"content":"ok","existing_code":"s := "v","suggestion_code":"q","path":"a.go"}]`
-	comments, repair, errMsg := ParseCommentsWithPath(
-		map[string]any{"comments": serialized}, "fallback.go")
-	if errMsg != "" {
-		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
-	}
-	if len(comments) != 1 {
-		t.Fatalf("recovered %d comments, want 1", len(comments))
-	}
-	if comments[0].SuggestionCode != "" {
-		t.Errorf("suggestion_code = %q, want it withheld — its deleted region would "+
-			"come from the truncated anchor", comments[0].SuggestionCode)
-	}
-	// The anchor itself stays: every resolver needs it, and removing it would lose
-	// the position outright instead of protecting it.
-	if comments[0].ExistingCode != `s := "v` {
-		t.Errorf("existing_code = %q, want it left as recovered", comments[0].ExistingCode)
-	}
-	if repair.DroppedSuggestions != 1 {
-		t.Errorf("DroppedSuggestions = %d, want 1", repair.DroppedSuggestions)
-	}
-	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "existing_code" {
-		t.Errorf("SuspectFields = %v, want [existing_code]", repair.SuspectFields)
-	}
-}
-
-// TestParseComments_SuspectPathFallsBackToFileUnderReview pins the one field that
-// would otherwise be written out verbatim. A truncated path is non-empty, so it
-// would suppress the defaultPath fallback and name a file that does not exist in
-// the SARIF artifactLocation URI and the fingerprint.
-func TestParseComments_SuspectPathFallsBackToFileUnderReview(t *testing.T) {
-	// The path value keeps an odd quote, the signature of a misjudged terminator.
-	serialized := `[{"content":"ok","path":"a.go"x","existing_code":"z"}]`
-	comments, repair, errMsg := ParseCommentsWithPath(
-		map[string]any{"comments": serialized}, "fallback.go")
-	if errMsg != "" {
-		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
-	}
-	if len(comments) != 1 {
-		t.Fatalf("recovered %d comments, want 1", len(comments))
-	}
-	if comments[0].Path != "fallback.go" {
-		t.Errorf("path = %q, want the file under review", comments[0].Path)
-	}
-	if repair.DroppedPaths != 1 {
-		t.Errorf("DroppedPaths = %d, want 1", repair.DroppedPaths)
-	}
-	if !strings.Contains(repair.Message(), "fell back to the file under review") {
-		t.Errorf("warning does not report the fallback: %q", repair.Message())
-	}
-}
-
-// TestParseComments_TruncatedThinkingCostsNoSuggestion pins the decision to leave
+// TestParseComments_TruncatedThinkingStillAccepted pins the decision to leave
 // thinking out of commentTextFields. Adding it looks like a completeness win —
-// knownCommentFields accepts the field and it does carry prose — but because the
-// drop is per-entry, suspecting it would take a perfectly good suggestion_code
-// down with it. A truncated thinking reaches the JSON output only, with no
-// terminal or viewer rendering, so that trade is backwards.
-func TestParseComments_TruncatedThinkingCostsNoSuggestion(t *testing.T) {
+// knownCommentFields accepts the field and it does carry prose — but suspecting
+// it would refuse the whole batch over a value that reaches the JSON output only,
+// with no terminal or viewer rendering. That trade is backwards, so a cut
+// thinking is the one truncation this path tolerates.
+func TestParseComments_TruncatedThinkingStillAccepted(t *testing.T) {
 	serialized := `[{"content":"ok","thinking":"because of "this","suggestion_code":"q","existing_code":"z","path":"a.go"}]`
 	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
@@ -602,14 +512,11 @@ func TestParseComments_TruncatedThinkingCostsNoSuggestion(t *testing.T) {
 		t.Fatalf("recovered %d comments, want 1", len(comments))
 	}
 	if comments[0].SuggestionCode != "q" {
-		t.Errorf("suggestion_code = %q, want it kept — a truncated thinking is not "+
-			"a reason to withhold a usable fix", comments[0].SuggestionCode)
+		t.Errorf("suggestion_code = %q, want it kept — a cut thinking is not a reason "+
+			"to refuse a usable batch", comments[0].SuggestionCode)
 	}
-	if repair.DroppedSuggestions != 0 {
-		t.Errorf("DroppedSuggestions = %d, want 0", repair.DroppedSuggestions)
-	}
-	if len(repair.SuspectFields) != 0 {
-		t.Errorf("SuspectFields = %v, want none — thinking is not checked", repair.SuspectFields)
+	if repair == nil {
+		t.Fatal("a repaired batch must be reported")
 	}
 }
 
@@ -633,38 +540,101 @@ func TestHasOddQuotes(t *testing.T) {
 }
 
 func TestCommentRepairMessage(t *testing.T) {
-	// A clean repair says only what it escaped, so the common case stays terse.
-	clean := (&CommentRepair{EscapedChars: 2}).Message()
-	if !strings.Contains(clean, "repaired 2 unescaped character(s)") {
-		t.Errorf("clean message = %q", clean)
+	// Every accepted repair is an intact one, so the message reports the schema
+	// violation and the escape count and nothing else. It must not imply loss.
+	msg := (&CommentRepair{EscapedChars: 2}).Message()
+	if !strings.Contains(msg, "repaired 2 unescaped character(s)") {
+		t.Errorf("message = %q", msg)
 	}
-	if strings.Contains(clean, "truncated") || strings.Contains(clean, "withheld") {
-		t.Errorf("a clean repair must not mention truncation: %q", clean)
+	if !strings.Contains(msg, "serialized string instead of an array") {
+		t.Errorf("message must name the schema violation: %q", msg)
 	}
-
-	full := (&CommentRepair{
-		EscapedChars:       3,
-		SuspectFields:      []string{"content", "suggestion_code", "path"},
-		DroppedSuggestions: 1,
-		DroppedPaths:       2,
-	}).Message()
-	for _, want := range []string{
-		"repaired 3 unescaped character(s)",
-		"content, suggestion_code, path may be truncated",
-		"withheld 1 suggestion_code value(s)",
-		"2 suspect path(s) fell back to the file under review",
-	} {
-		if !strings.Contains(full, want) {
-			t.Errorf("message %q missing %q", full, want)
+	for _, forbidden := range []string{"truncated", "withheld", "fell back"} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("an accepted repair is intact and must not mention %q: %q", forbidden, msg)
 		}
 	}
 }
 
-func TestFlagSuspectTruncations_SkipsNonObjectEntries(t *testing.T) {
-	// repairedCommentsAcceptable rejects these before the flagger runs, but it
-	// must not panic if it ever sees one.
-	suspects, dropped, droppedPaths := flagSuspectTruncations([]any{"not an object", 42, nil})
-	if len(suspects) != 0 || dropped != 0 || droppedPaths != 0 {
-		t.Errorf("suspects=%v dropped=%d droppedPaths=%d; want all empty", suspects, dropped, droppedPaths)
+func TestHasSuspectTruncation(t *testing.T) {
+	t.Run("skips non-object entries", func(t *testing.T) {
+		// repairedCommentsAcceptable rejects these first, but this must not panic
+		// if it ever sees one.
+		if hasSuspectTruncation([]any{"not an object", 42, nil}) {
+			t.Error("entries that are not objects carry no suspect value")
+		}
+	})
+
+	t.Run("detects a cut value in any checked field", func(t *testing.T) {
+		for _, field := range commentTextFields {
+			entries := []any{map[string]any{"content": "ok", field: `cut "here`}}
+			if !hasSuspectTruncation(entries) {
+				t.Errorf("a cut %s must be detected", field)
+			}
+		}
+	})
+
+	t.Run("ignores thinking", func(t *testing.T) {
+		entries := []any{map[string]any{"content": "ok", "thinking": `cut "here`}}
+		if hasSuspectTruncation(entries) {
+			t.Error("thinking is deliberately unchecked; see commentTextFields")
+		}
+	})
+
+	t.Run("accepts whole pairs", func(t *testing.T) {
+		entries := []any{map[string]any{"content": `a "term" and "another"`, "path": "a.go"}}
+		if hasSuspectTruncation(entries) {
+			t.Error("values keeping whole pairs are not suspect")
+		}
+	})
+}
+
+// TestKnownCommentFieldsCoversTheSchema stops the allow-list from drifting from
+// the shipped schema: a field the schema defines but this set omits would make
+// repairedCommentsAcceptable reject every batch that uses it.
+//
+// It covers the embedded default only. A caller pointing --tools at a custom file
+// with extra comment fields still loses the repair, accepted here because the
+// failure direction is safe — the batch falls back to the original error.
+func TestKnownCommentFieldsCoversTheSchema(t *testing.T) {
+	entries, err := toolsconfig.Load("")
+	if err != nil {
+		t.Fatalf("load embedded tools config: %v", err)
+	}
+	var def struct {
+		Parameters struct {
+			Properties struct {
+				Comments struct {
+					Items struct {
+						Properties map[string]json.RawMessage `json:"properties"`
+					} `json:"items"`
+				} `json:"comments"`
+			} `json:"properties"`
+		} `json:"parameters"`
+	}
+	found := false
+	for _, e := range entries {
+		if e.Name != CodeComment.Name() {
+			continue
+		}
+		if err := json.Unmarshal(e.Definition, &def); err != nil {
+			t.Fatalf("unmarshal %s definition: %v", e.Name, err)
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("%s is not in the embedded tools config", CodeComment.Name())
+	}
+
+	schemaFields := def.Parameters.Properties.Comments.Items.Properties
+	if len(schemaFields) == 0 {
+		t.Fatal("no comment fields parsed out of the schema; the shape must have changed")
+	}
+	for field := range schemaFields {
+		if _, known := knownCommentFields[field]; !known {
+			t.Errorf("schema defines %q but knownCommentFields omits it, so any repaired "+
+				"batch using that field would be rejected", field)
+		}
 	}
 }

--- a/internal/tool/comment_args_repair_test.go
+++ b/internal/tool/comment_args_repair_test.go
@@ -4,6 +4,7 @@
 package tool
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -135,6 +136,161 @@ func TestParseComments_RepairRejectedWhenABatchEntryEndsUpEmpty(t *testing.T) {
 	}
 	if !strings.Contains(errMsg, "invalid character") {
 		t.Errorf("rejected repair must fall back to the parser wording, got %q", errMsg)
+	}
+}
+
+func TestParseComments_RepairsIllegalBackslashEscape(t *testing.T) {
+	// The dropped escaping level hits backslashes as well as quotes. Prose that
+	// cites a regex or a Windows path leaves a backslash opening no valid
+	// sequence, which failed the whole batch before.
+	for _, tc := range []struct {
+		name, serialized, want string
+	}{
+		{
+			name:       "regex in prose",
+			serialized: `[{"content":"the pattern \d+ only matches digits","path":"a.go"}]`,
+			want:       `the pattern \d+ only matches digits`,
+		},
+		{
+			// \U and \s open no valid sequence. A segment starting with one of
+			// b/f/n/r/t/u would be a legal escape and is left alone by design —
+			// see the note in repairSerializedComments.
+			name:       "windows path in prose",
+			serialized: `[{"content":"the path C:\Users\src is invalid","path":"a.go"}]`,
+			want:       `the path C:\Users\src is invalid`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			comments, repaired, errMsg := ParseCommentsWithPath(
+				map[string]any{"comments": tc.serialized}, "fallback.go")
+			if errMsg != "" {
+				t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+			}
+			if repaired == 0 {
+				t.Error("repaired = 0, want the illegal escape counted")
+			}
+			if len(comments) != 1 || comments[0].Content != tc.want {
+				t.Fatalf("content = %q, want %q", comments[0].Content, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseComments_RepairsAllControlCharacters(t *testing.T) {
+	// JSON forbids every byte below 0x20, not just the three with short escapes.
+	serialized := "[{\"content\":\"bell\x07 and vtab\x0b here\",\"path\":\"a.go\"}]"
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+	}
+	if repaired != 2 {
+		t.Errorf("repaired = %d, want 2", repaired)
+	}
+	if len(comments) != 1 || comments[0].Content != "bell\x07 and vtab\x0b here" {
+		t.Fatalf("content = %q, want the control characters preserved", comments[0].Content)
+	}
+}
+
+func TestParseComments_RepairRejectedWhenProseBecameAField(t *testing.T) {
+	// Ending a string early re-reads the prose after it as structure. Review
+	// text almost never spells a real field name, so the stray key is the
+	// signature of that mistake and the batch is refused rather than emitted
+	// with a truncated value.
+	serialized := `[{"content":"the flag is named "verbose", "and it defaults to true":"yes"}]`
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg == "" {
+		t.Fatalf("repair was accepted (%d comments, %d escaped); want it declined "+
+			"because prose was re-read as a field name", len(comments), repaired)
+	}
+	if !strings.Contains(errMsg, "invalid character") {
+		t.Errorf("rejected repair must fall back to the parser wording, got %q", errMsg)
+	}
+}
+
+func TestIsLegalEscape(t *testing.T) {
+	// Getting this wrong in either direction is costly: too strict corrupts
+	// genuine escapes, too loose leaves the batch unparseable.
+	for _, tc := range []struct {
+		in   string // the text after the backslash
+		want bool
+	}{
+		{`"`, true}, {`\`, true}, {`/`, true},
+		{"b", true}, {"f", true}, {"n", true}, {"r", true}, {"t", true},
+		{"u0041", true}, {"uFFFF", true}, {"uabcd", true},
+		{"u00", false},   // too few hex digits
+		{"u00zz", false}, // not hex
+		{"uD8", false},   // truncated
+		{"d", false},     // regex \d
+		{"U0041", false}, // uppercase U is not the escape
+		{"x41", false},   // \x is not JSON
+		{"", false},      // nothing follows the backslash
+		{" ", false},     // space
+	} {
+		if got := isLegalEscape(tc.in, 0); got != tc.want {
+			t.Errorf("isLegalEscape(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+	// Index past the end must not panic.
+	if isLegalEscape("n", 5) {
+		t.Error("out-of-range index must report false")
+	}
+}
+
+func TestEscapeControl(t *testing.T) {
+	for _, tc := range []struct {
+		in   byte
+		want string
+	}{
+		{'\n', `\n`}, {'\r', `\r`}, {'\t', `\t`}, {'\b', `\b`}, {'\f', `\f`},
+		{0x00, `\u0000`}, {0x07, `\u0007`}, {0x0b, `\u000b`}, {0x1f, `\u001f`},
+	} {
+		if got := escapeControl(tc.in); got != tc.want {
+			t.Errorf("escapeControl(%#x) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// Every escape it produces has to be one the JSON parser accepts.
+	for c := byte(0); c < 0x20; c++ {
+		var target string
+		blob := `["` + escapeControl(c) + `"]`
+		if err := json.Unmarshal([]byte(blob), &[]*string{&target}); err != nil {
+			t.Errorf("escapeControl(%#x) produced unparseable JSON %q: %v", c, blob, err)
+		}
+	}
+}
+
+func TestRepairSerializedComments_PreservesUnicodeEscape(t *testing.T) {
+	// \u sequences are legal and must survive untouched, or a repair would
+	// mangle content it was supposed to rescue.
+	in := `[{"content":"snowman ☃ and a quote "here"","path":"a.go"}]`
+	out, escaped := repairSerializedComments(in)
+	if escaped != 2 {
+		t.Fatalf("escaped = %d, want 2 (only the prose quotes)", escaped)
+	}
+	if !strings.Contains(out, `☃`) {
+		t.Errorf("unicode escape was rewritten: %q", out)
+	}
+}
+
+func TestRepairedCommentsAcceptable_RejectsUnknownField(t *testing.T) {
+	original := `[{"content":"first"}]`
+	withStray := []any{map[string]any{
+		"content":        "first",
+		"not a real key": "swallowed prose",
+	}}
+	if repairedCommentsAcceptable(withStray, original) {
+		t.Error("an entry carrying a field the schema does not define must be rejected")
+	}
+
+	// Every documented field must stay acceptable, or the guard would reject
+	// legitimate batches.
+	full := []any{map[string]any{
+		"content": "first", "existing_code": "x", "suggestion_code": "y",
+		"category": "bug", "severity": "high", "path": "a.go", "thinking": "why",
+	}}
+	if !repairedCommentsAcceptable(full, original) {
+		t.Error("a batch using only schema fields must be accepted")
 	}
 }
 

--- a/internal/tool/comment_args_repair_test.go
+++ b/internal/tool/comment_args_repair_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package tool
+
+import (
+	"strings"
+	"testing"
+)
+
+// These fixtures are the observed shape of the failure: `comments` arrives as a
+// serialized string whose prose quotes a term with an unescaped double quote.
+// Raw string literals express that directly — the quote needs no Go-level
+// escaping, so what appears here is exactly what reached the parser.
+
+const proseQuoteEnglish = `[{"content":"the name suggests "a trusted proxy exists" but the call returns the opposite","existing_code":"boolean ok = cfg.isEmpty();","path":"Auth.java"}]`
+
+// The real failures were all Chinese review prose, and the byte-wise scan has to
+// stay correct across multi-byte runes, so one fixture keeps that language.
+const proseQuoteChinese = `[{"content":"变量名暗示的是"存在可信代理"，但调用返回的是相反的结果。","existing_code":"boolean ok = cfg.isEmpty();","path":"Auth.java"}]` // allow-non-english: encoding fixture — the reported failures occur only in Chinese prose, and multi-byte runes are what make the byte-wise scan worth testing
+
+const twoCommentsWithProseQuotes = `[{"content":"the counter changed from "files finished" to "files started"","path":"a.go"},{"content":"the flag reads as "proxy present" but means the opposite","path":"b.go"}]`
+
+func TestParseComments_RepairsUnescapedProseQuote(t *testing.T) {
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": proseQuoteEnglish}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+	}
+	if repaired != 2 {
+		t.Errorf("escaped character count = %d, want 2 (both prose quotes)", repaired)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1", len(comments))
+	}
+	// The quoted term must survive verbatim: the repair escapes the quote for
+	// JSON, it does not delete it from the text.
+	if !strings.Contains(comments[0].Content, `"a trusted proxy exists"`) {
+		t.Errorf("quoted term lost from content: %q", comments[0].Content)
+	}
+	if comments[0].Path != "Auth.java" {
+		t.Errorf("path = %q, want Auth.java", comments[0].Path)
+	}
+	if comments[0].ExistingCode != "boolean ok = cfg.isEmpty();" {
+		t.Errorf("existing_code = %q", comments[0].ExistingCode)
+	}
+}
+
+func TestParseComments_RepairsProseQuoteAcrossMultiByteRunes(t *testing.T) {
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": proseQuoteChinese}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+	}
+	if repaired != 2 {
+		t.Errorf("escaped character count = %d, want 2", repaired)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1", len(comments))
+	}
+	// A byte-wise scan that mishandled UTF-8 would corrupt or truncate this.
+	if !strings.HasSuffix(comments[0].Content, "相反的结果。") { // allow-non-english: asserts the multi-byte fixture above round-trips intact
+		t.Errorf("multi-byte content did not survive the repair: %q", comments[0].Content)
+	}
+}
+
+func TestParseComments_RepairsBareControlCharacter(t *testing.T) {
+	// A literal newline inside a JSON string is illegal; the model meant \n.
+	serialized := "[{\"content\":\"first line\nsecond line\",\"path\":\"a.go\"}]"
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+	}
+	if repaired != 1 {
+		t.Errorf("escaped character count = %d, want 1", repaired)
+	}
+	if len(comments) != 1 || comments[0].Content != "first line\nsecond line" {
+		t.Fatalf("content = %q, want the newline preserved", comments[0].Content)
+	}
+}
+
+func TestParseComments_RepairKeepsEveryCommentInTheBatch(t *testing.T) {
+	// The count check exists for exactly this case: a repair that merged these
+	// two comments into one would still produce valid JSON.
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": twoCommentsWithProseQuotes}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+	}
+	if repaired != 6 {
+		t.Errorf("escaped character count = %d, want 6", repaired)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("recovered %d comments, want 2 (a merge must be rejected)", len(comments))
+	}
+	if comments[0].Path != "a.go" || comments[1].Path != "b.go" {
+		t.Errorf("paths = %q, %q; want a.go, b.go", comments[0].Path, comments[1].Path)
+	}
+}
+
+func TestParseComments_UnrepairableKeepsOriginalParserWording(t *testing.T) {
+	// Structurally truncated: escaping the prose quote cannot make this parse.
+	serialized := `[{"content":"say "hi""},{"content"`
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if len(comments) != 0 || repaired != 0 {
+		t.Fatalf("comments=%d repaired=%d; want the repair to decline", len(comments), repaired)
+	}
+	// The phrasing is load-bearing: "invalid character" is what leads the model
+	// to regenerate the batch instead of resending the same broken string.
+	if !strings.Contains(errMsg, "failed to parse 'comments' JSON string") {
+		t.Errorf("error message lost its original wording: %q", errMsg)
+	}
+	if !strings.Contains(errMsg, "invalid character") {
+		t.Errorf("error message must keep the parser's %q phrasing, got %q", "invalid character", errMsg)
+	}
+}
+
+func TestParseComments_RepairRejectedWhenABatchEntryEndsUpEmpty(t *testing.T) {
+	// The repair recovers the first comment and the text parses, but the second
+	// entry carries no content. Parsing again is therefore not sufficient on its
+	// own: a repair is only accepted when every entry still says something, so
+	// this whole batch falls back to the original error rather than emitting a
+	// blank finding.
+	serialized := `[{"content":"say "hi" loudly"},{"content":""}]`
+	comments, repaired, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg == "" {
+		t.Fatalf("repair was accepted (%d comments, %d escaped); want it declined "+
+			"because one entry lost its content", len(comments), repaired)
+	}
+	if repaired != 0 {
+		t.Errorf("repaired = %d, want 0 when the repair is rejected", repaired)
+	}
+	if !strings.Contains(errMsg, "invalid character") {
+		t.Errorf("rejected repair must fall back to the parser wording, got %q", errMsg)
+	}
+}
+
+func TestParseComments_WellFormedInputReportsNoRepair(t *testing.T) {
+	t.Run("native array", func(t *testing.T) {
+		args := map[string]any{"comments": []any{
+			map[string]any{"content": "issue", "path": "a.go"},
+		}}
+		comments, repaired, errMsg := ParseCommentsWithPath(args, "fallback.go")
+		if errMsg != "" || len(comments) != 1 {
+			t.Fatalf("comments=%d errMsg=%q", len(comments), errMsg)
+		}
+		if repaired != 0 {
+			t.Errorf("repaired = %d, want 0 for a schema-conformant array", repaired)
+		}
+	})
+
+	t.Run("correctly escaped string", func(t *testing.T) {
+		// Still a schema violation, but it parses on its own — nothing to repair.
+		serialized := `[{"content":"the name suggests \"ok\"","path":"a.go"}]`
+		comments, repaired, errMsg := ParseCommentsWithPath(
+			map[string]any{"comments": serialized}, "fallback.go")
+		if errMsg != "" || len(comments) != 1 {
+			t.Fatalf("comments=%d errMsg=%q", len(comments), errMsg)
+		}
+		if repaired != 0 {
+			t.Errorf("repaired = %d, want 0 when the string already parses", repaired)
+		}
+		if comments[0].Content != `the name suggests "ok"` {
+			t.Errorf("content = %q", comments[0].Content)
+		}
+	})
+}
+
+func TestRepairSerializedComments_LeavesWellFormedJSONByteIdentical(t *testing.T) {
+	// Anything that already parses must come back untouched, so enabling the
+	// repair cannot change the result of a batch that was fine.
+	cases := []string{
+		`[{"content":"plain","path":"a.go"}]`,
+		`[{"content":"escaped \"term\" here","path":"a.go"}]`,
+		`[{"content":"newline \n tab \t done","path":"a.go"}]`,
+		`[ { "content" : "spaced out" } , { "content" : "second" } ]`,
+		`[{"content":"trailing colon in prose: see","suggestion_code":"x := 1"}]`,
+		`[{"content":"brace } and bracket ] inside prose","path":"a.go"}]`,
+		`[]`,
+	}
+	for _, in := range cases {
+		out, escaped := repairSerializedComments(in)
+		if escaped != 0 {
+			t.Errorf("escaped %d characters in already-valid input %q", escaped, in)
+		}
+		if out != in {
+			t.Errorf("repair rewrote valid input\n  in:  %q\n  out: %q", in, out)
+		}
+	}
+}
+
+func TestRepairedCommentsAcceptable(t *testing.T) {
+	original := `[{"content":"first"},{"content":"second"}]`
+
+	t.Run("rejects a merged batch", func(t *testing.T) {
+		// One entry recovered where the original described two: the repair
+		// swallowed a terminator and fused them.
+		merged := []any{map[string]any{"content": "first second"}}
+		if repairedCommentsAcceptable(merged, original) {
+			t.Error("a batch that lost a comment must be rejected")
+		}
+	})
+
+	t.Run("accepts a complete batch", func(t *testing.T) {
+		full := []any{
+			map[string]any{"content": "first"},
+			map[string]any{"content": "second"},
+		}
+		if !repairedCommentsAcceptable(full, original) {
+			t.Error("a batch preserving both comments must be accepted")
+		}
+	})
+
+	t.Run("rejects empty content", func(t *testing.T) {
+		blank := []any{
+			map[string]any{"content": "first"},
+			map[string]any{"content": "   "},
+		}
+		if repairedCommentsAcceptable(blank, original) {
+			t.Error("a blank content means the repair mangled a value")
+		}
+	})
+
+	t.Run("rejects non-object entries", func(t *testing.T) {
+		if repairedCommentsAcceptable([]any{"first", "second"}, original) {
+			t.Error("string entries are not comments")
+		}
+	})
+
+	t.Run("rejects an empty batch", func(t *testing.T) {
+		if repairedCommentsAcceptable(nil, original) {
+			t.Error("an empty batch preserves nothing")
+		}
+	})
+}
+
+func TestParseRepairedComments_DeclinesWhenNothingToEscape(t *testing.T) {
+	// Valid JSON reaches this helper only when the caller already failed to
+	// parse it, so "nothing to escape" means the failure is something else and
+	// re-parsing identical text would be pointless.
+	entries, escaped := parseRepairedComments(`[{"content":"fine"}]`)
+	if entries != nil || escaped != 0 {
+		t.Errorf("entries=%v escaped=%d; want a decline", entries, escaped)
+	}
+}

--- a/internal/tool/comment_args_repair_test.go
+++ b/internal/tool/comment_args_repair_test.go
@@ -22,14 +22,23 @@ const proseQuoteChinese = `[{"content":"变量名暗示的是"存在可信代理
 
 const twoCommentsWithProseQuotes = `[{"content":"the counter changed from "files finished" to "files started"","path":"a.go"},{"content":"the flag reads as "proxy present" but means the opposite","path":"b.go"}]`
 
+// escapedCount reads the escaped-character count out of a repair description,
+// reporting zero for a declined repair so assertions stay compact.
+func escapedCount(r *CommentRepair) int {
+	if r == nil {
+		return 0
+	}
+	return r.EscapedChars
+}
+
 func TestParseComments_RepairsUnescapedProseQuote(t *testing.T) {
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": proseQuoteEnglish}, "fallback.go")
 	if errMsg != "" {
 		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 	}
-	if repaired != 2 {
-		t.Errorf("escaped character count = %d, want 2 (both prose quotes)", repaired)
+	if escapedCount(repair) != 2 {
+		t.Errorf("escaped character count = %d, want 2 (both prose quotes)", escapedCount(repair))
 	}
 	if len(comments) != 1 {
 		t.Fatalf("recovered %d comments, want 1", len(comments))
@@ -48,13 +57,13 @@ func TestParseComments_RepairsUnescapedProseQuote(t *testing.T) {
 }
 
 func TestParseComments_RepairsProseQuoteAcrossMultiByteRunes(t *testing.T) {
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": proseQuoteChinese}, "fallback.go")
 	if errMsg != "" {
 		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 	}
-	if repaired != 2 {
-		t.Errorf("escaped character count = %d, want 2", repaired)
+	if escapedCount(repair) != 2 {
+		t.Errorf("escaped character count = %d, want 2", escapedCount(repair))
 	}
 	if len(comments) != 1 {
 		t.Fatalf("recovered %d comments, want 1", len(comments))
@@ -68,13 +77,13 @@ func TestParseComments_RepairsProseQuoteAcrossMultiByteRunes(t *testing.T) {
 func TestParseComments_RepairsBareControlCharacter(t *testing.T) {
 	// A literal newline inside a JSON string is illegal; the model meant \n.
 	serialized := "[{\"content\":\"first line\nsecond line\",\"path\":\"a.go\"}]"
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
 	if errMsg != "" {
 		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 	}
-	if repaired != 1 {
-		t.Errorf("escaped character count = %d, want 1", repaired)
+	if escapedCount(repair) != 1 {
+		t.Errorf("escaped character count = %d, want 1", escapedCount(repair))
 	}
 	if len(comments) != 1 || comments[0].Content != "first line\nsecond line" {
 		t.Fatalf("content = %q, want the newline preserved", comments[0].Content)
@@ -84,13 +93,13 @@ func TestParseComments_RepairsBareControlCharacter(t *testing.T) {
 func TestParseComments_RepairKeepsEveryCommentInTheBatch(t *testing.T) {
 	// The count check exists for exactly this case: a repair that merged these
 	// two comments into one would still produce valid JSON.
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": twoCommentsWithProseQuotes}, "fallback.go")
 	if errMsg != "" {
 		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 	}
-	if repaired != 6 {
-		t.Errorf("escaped character count = %d, want 6", repaired)
+	if escapedCount(repair) != 6 {
+		t.Errorf("escaped character count = %d, want 6", escapedCount(repair))
 	}
 	if len(comments) != 2 {
 		t.Fatalf("recovered %d comments, want 2 (a merge must be rejected)", len(comments))
@@ -103,10 +112,10 @@ func TestParseComments_RepairKeepsEveryCommentInTheBatch(t *testing.T) {
 func TestParseComments_UnrepairableKeepsOriginalParserWording(t *testing.T) {
 	// Structurally truncated: escaping the prose quote cannot make this parse.
 	serialized := `[{"content":"say "hi""},{"content"`
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
-	if len(comments) != 0 || repaired != 0 {
-		t.Fatalf("comments=%d repaired=%d; want the repair to decline", len(comments), repaired)
+	if len(comments) != 0 || escapedCount(repair) != 0 {
+		t.Fatalf("comments=%d repaired=%d; want the repair to decline", len(comments), escapedCount(repair))
 	}
 	// The phrasing is load-bearing: "invalid character" is what leads the model
 	// to regenerate the batch instead of resending the same broken string.
@@ -125,14 +134,14 @@ func TestParseComments_RepairRejectedWhenABatchEntryEndsUpEmpty(t *testing.T) {
 	// this whole batch falls back to the original error rather than emitting a
 	// blank finding.
 	serialized := `[{"content":"say "hi" loudly"},{"content":""}]`
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
 	if errMsg == "" {
 		t.Fatalf("repair was accepted (%d comments, %d escaped); want it declined "+
-			"because one entry lost its content", len(comments), repaired)
+			"because one entry lost its content", len(comments), escapedCount(repair))
 	}
-	if repaired != 0 {
-		t.Errorf("repaired = %d, want 0 when the repair is rejected", repaired)
+	if escapedCount(repair) != 0 {
+		t.Errorf("repaired = %d, want 0 when the repair is rejected", escapedCount(repair))
 	}
 	if !strings.Contains(errMsg, "invalid character") {
 		t.Errorf("rejected repair must fall back to the parser wording, got %q", errMsg)
@@ -161,12 +170,12 @@ func TestParseComments_RepairsIllegalBackslashEscape(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			comments, repaired, errMsg := ParseCommentsWithPath(
+			comments, repair, errMsg := ParseCommentsWithPath(
 				map[string]any{"comments": tc.serialized}, "fallback.go")
 			if errMsg != "" {
 				t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 			}
-			if repaired == 0 {
+			if escapedCount(repair) == 0 {
 				t.Error("repaired = 0, want the illegal escape counted")
 			}
 			if len(comments) != 1 || comments[0].Content != tc.want {
@@ -179,13 +188,13 @@ func TestParseComments_RepairsIllegalBackslashEscape(t *testing.T) {
 func TestParseComments_RepairsAllControlCharacters(t *testing.T) {
 	// JSON forbids every byte below 0x20, not just the three with short escapes.
 	serialized := "[{\"content\":\"bell\x07 and vtab\x0b here\",\"path\":\"a.go\"}]"
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
 	if errMsg != "" {
 		t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
 	}
-	if repaired != 2 {
-		t.Errorf("repaired = %d, want 2", repaired)
+	if escapedCount(repair) != 2 {
+		t.Errorf("repaired = %d, want 2", escapedCount(repair))
 	}
 	if len(comments) != 1 || comments[0].Content != "bell\x07 and vtab\x0b here" {
 		t.Fatalf("content = %q, want the control characters preserved", comments[0].Content)
@@ -198,11 +207,11 @@ func TestParseComments_RepairRejectedWhenProseBecameAField(t *testing.T) {
 	// signature of that mistake and the batch is refused rather than emitted
 	// with a truncated value.
 	serialized := `[{"content":"the flag is named "verbose", "and it defaults to true":"yes"}]`
-	comments, repaired, errMsg := ParseCommentsWithPath(
+	comments, repair, errMsg := ParseCommentsWithPath(
 		map[string]any{"comments": serialized}, "fallback.go")
 	if errMsg == "" {
 		t.Fatalf("repair was accepted (%d comments, %d escaped); want it declined "+
-			"because prose was re-read as a field name", len(comments), repaired)
+			"because prose was re-read as a field name", len(comments), escapedCount(repair))
 	}
 	if !strings.Contains(errMsg, "invalid character") {
 		t.Errorf("rejected repair must fall back to the parser wording, got %q", errMsg)
@@ -299,25 +308,25 @@ func TestParseComments_WellFormedInputReportsNoRepair(t *testing.T) {
 		args := map[string]any{"comments": []any{
 			map[string]any{"content": "issue", "path": "a.go"},
 		}}
-		comments, repaired, errMsg := ParseCommentsWithPath(args, "fallback.go")
+		comments, repair, errMsg := ParseCommentsWithPath(args, "fallback.go")
 		if errMsg != "" || len(comments) != 1 {
 			t.Fatalf("comments=%d errMsg=%q", len(comments), errMsg)
 		}
-		if repaired != 0 {
-			t.Errorf("repaired = %d, want 0 for a schema-conformant array", repaired)
+		if escapedCount(repair) != 0 {
+			t.Errorf("repaired = %d, want 0 for a schema-conformant array", escapedCount(repair))
 		}
 	})
 
 	t.Run("correctly escaped string", func(t *testing.T) {
 		// Still a schema violation, but it parses on its own — nothing to repair.
 		serialized := `[{"content":"the name suggests \"ok\"","path":"a.go"}]`
-		comments, repaired, errMsg := ParseCommentsWithPath(
+		comments, repair, errMsg := ParseCommentsWithPath(
 			map[string]any{"comments": serialized}, "fallback.go")
 		if errMsg != "" || len(comments) != 1 {
 			t.Fatalf("comments=%d errMsg=%q", len(comments), errMsg)
 		}
-		if repaired != 0 {
-			t.Errorf("repaired = %d, want 0 when the string already parses", repaired)
+		if escapedCount(repair) != 0 {
+			t.Errorf("repaired = %d, want 0 when the string already parses", escapedCount(repair))
 		}
 		if comments[0].Content != `the name suggests "ok"` {
 			t.Errorf("content = %q", comments[0].Content)
@@ -397,8 +406,265 @@ func TestParseRepairedComments_DeclinesWhenNothingToEscape(t *testing.T) {
 	// Valid JSON reaches this helper only when the caller already failed to
 	// parse it, so "nothing to escape" means the failure is something else and
 	// re-parsing identical text would be pointless.
-	entries, escaped := parseRepairedComments(`[{"content":"fine"}]`)
-	if entries != nil || escaped != 0 {
-		t.Errorf("entries=%v escaped=%d; want a decline", entries, escaped)
+	entries, repair := parseRepairedComments(`[{"content":"fine"}]`)
+	if entries != nil || repair != nil {
+		t.Errorf("entries=%v repair=%+v; want a decline", entries, repair)
+	}
+}
+
+// TestParseComments_SuspectSuggestionIsDroppedNotApplied covers the one field
+// whose truncation has a consequence beyond being hard to read. A suggestion_code
+// cut short at a misjudged terminator is syntactically incomplete code, and both
+// the SARIF `fixes` array and the GitHub ```suggestion block gate on it being
+// non-empty — so leaving it in place puts that code one click away from being
+// committed. Clearing it closes every such consumer without any of them knowing
+// about this check, while the comment itself still reaches the reviewer.
+func TestParseComments_SuspectSuggestionIsDroppedNotApplied(t *testing.T) {
+	// The trailing quote of the suggestion is missing, so the repair reads the
+	// following comma as a terminator and cuts `x = "y` short.
+	serialized := `[{"content":"use a literal","suggestion_code":"x = "y","existing_code":"z","path":"a.go"}]`
+	comments, repair, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1 — the comment is not the casualty", len(comments))
+	}
+	if comments[0].SuggestionCode != "" {
+		t.Errorf("suggestion_code = %q, want it dropped so no consumer can apply it",
+			comments[0].SuggestionCode)
+	}
+	// The rest of the finding is untouched: dropping the suggestion costs a fix
+	// hint, not the review comment.
+	if comments[0].Content != "use a literal" {
+		t.Errorf("content = %q, want it intact", comments[0].Content)
+	}
+	if comments[0].ExistingCode != "z" || comments[0].Path != "a.go" {
+		t.Errorf("existing_code = %q, path = %q; both should survive",
+			comments[0].ExistingCode, comments[0].Path)
+	}
+	if repair == nil {
+		t.Fatal("a repair that dropped a value must still be reported")
+	}
+	if repair.DroppedSuggestions != 1 {
+		t.Errorf("DroppedSuggestions = %d, want 1", repair.DroppedSuggestions)
+	}
+	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "suggestion_code" {
+		t.Errorf("SuspectFields = %v, want [suggestion_code]", repair.SuspectFields)
+	}
+}
+
+// TestParseComments_SuspectContentIsReportedNotAltered pins the other half of the
+// policy: a content cut short is still worth reading, so it is named in the
+// warning and otherwise left exactly as recovered.
+func TestParseComments_SuspectContentIsReportedNotAltered(t *testing.T) {
+	serialized := `[{"content":"call it "hard", "path":"a.go"}]`
+	comments, repair, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("expected the batch to be recovered, got error: %s", errMsg)
+	}
+	if len(comments) != 1 || comments[0].Content != `call it "hard` {
+		t.Fatalf("content = %q, want the truncated text left as recovered", comments[0].Content)
+	}
+	if repair == nil {
+		t.Fatal("a suspect value must be reported")
+	}
+	if repair.DroppedSuggestions != 0 {
+		t.Errorf("DroppedSuggestions = %d, want 0 — only suggestion_code is dropped",
+			repair.DroppedSuggestions)
+	}
+	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "content" {
+		t.Errorf("SuspectFields = %v, want [content]", repair.SuspectFields)
+	}
+	// The whole point of the field list: without it a truncated recovery is
+	// indistinguishable from a clean one in every output format.
+	if !strings.Contains(repair.Message(), "content may be truncated") {
+		t.Errorf("warning does not name the suspect value: %q", repair.Message())
+	}
+}
+
+// TestParseComments_CleanRepairReportsNoSuspect is the contrast that keeps the
+// detector honest. Every one of these is the actually-observed failure shape —
+// the quotes are all present and only the escaping level was dropped — and none
+// of them loses anything, so flagging one would cost a real suggestion for
+// nothing.
+func TestParseComments_CleanRepairReportsNoSuspect(t *testing.T) {
+	for _, tc := range []struct{ name, serialized string }{
+		{"prose quote in english", proseQuoteEnglish},
+		{"prose quote in chinese", proseQuoteChinese},
+		{"two comments", twoCommentsWithProseQuotes},
+		{"quoted term ends the value", `[{"content":"rename it to "files_started"","existing_code":"x","path":"a.go"}]`},
+		{"quoted term in code", `[{"content":"ok","suggestion_code":"fmt.Println("done")","existing_code":"x","path":"a.go"}]`},
+		{"quoted terms in two fields", `[{"content":"use "true"","suggestion_code":"x := "y"","path":"a.go"}]`},
+		{"illegal escape only", `[{"content":"the pattern \d+ only matches digits","path":"a.go"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			comments, repair, errMsg := ParseCommentsWithPath(
+				map[string]any{"comments": tc.serialized}, "fallback.go")
+			if errMsg != "" {
+				t.Fatalf("expected the repair to recover the batch, got error: %s", errMsg)
+			}
+			if repair == nil {
+				t.Fatal("a repaired batch must be reported")
+			}
+			if len(repair.SuspectFields) != 0 {
+				t.Errorf("SuspectFields = %v, want none for a clean recovery", repair.SuspectFields)
+			}
+			if repair.DroppedSuggestions != 0 {
+				t.Errorf("DroppedSuggestions = %d, want 0", repair.DroppedSuggestions)
+			}
+			// A clean recovery must keep its suggestion, or the detector would be
+			// silently discarding valid fixes.
+			for _, cm := range comments {
+				if strings.Contains(tc.serialized, `"suggestion_code"`) && cm.SuggestionCode == "" {
+					t.Errorf("suggestion_code was dropped from a clean batch: %+v", cm)
+				}
+			}
+		})
+	}
+}
+
+// TestParseComments_SuspectExistingCodeAlsoWithholdsSuggestion covers the reason
+// the drop is per-entry rather than per-field. A truncated existing_code cannot
+// match anything — matchConsecutive compares whole lines — so every deterministic
+// resolver declines and the LLM re-location guesses line numbers from a mutilated
+// excerpt. A fix assembled from those numbers deletes the wrong region, so the
+// suggestion has to go even though the suggestion itself looks fine.
+func TestParseComments_SuspectExistingCodeAlsoWithholdsSuggestion(t *testing.T) {
+	serialized := `[{"content":"ok","existing_code":"s := "v","suggestion_code":"q","path":"a.go"}]`
+	comments, repair, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1", len(comments))
+	}
+	if comments[0].SuggestionCode != "" {
+		t.Errorf("suggestion_code = %q, want it withheld — its deleted region would "+
+			"come from the truncated anchor", comments[0].SuggestionCode)
+	}
+	// The anchor itself stays: every resolver needs it, and removing it would lose
+	// the position outright instead of protecting it.
+	if comments[0].ExistingCode != `s := "v` {
+		t.Errorf("existing_code = %q, want it left as recovered", comments[0].ExistingCode)
+	}
+	if repair.DroppedSuggestions != 1 {
+		t.Errorf("DroppedSuggestions = %d, want 1", repair.DroppedSuggestions)
+	}
+	if len(repair.SuspectFields) != 1 || repair.SuspectFields[0] != "existing_code" {
+		t.Errorf("SuspectFields = %v, want [existing_code]", repair.SuspectFields)
+	}
+}
+
+// TestParseComments_SuspectPathFallsBackToFileUnderReview pins the one field that
+// would otherwise be written out verbatim. A truncated path is non-empty, so it
+// would suppress the defaultPath fallback and name a file that does not exist in
+// the SARIF artifactLocation URI and the fingerprint.
+func TestParseComments_SuspectPathFallsBackToFileUnderReview(t *testing.T) {
+	// The path value keeps an odd quote, the signature of a misjudged terminator.
+	serialized := `[{"content":"ok","path":"a.go"x","existing_code":"z"}]`
+	comments, repair, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1", len(comments))
+	}
+	if comments[0].Path != "fallback.go" {
+		t.Errorf("path = %q, want the file under review", comments[0].Path)
+	}
+	if repair.DroppedPaths != 1 {
+		t.Errorf("DroppedPaths = %d, want 1", repair.DroppedPaths)
+	}
+	if !strings.Contains(repair.Message(), "fell back to the file under review") {
+		t.Errorf("warning does not report the fallback: %q", repair.Message())
+	}
+}
+
+// TestParseComments_TruncatedThinkingCostsNoSuggestion pins the decision to leave
+// thinking out of commentTextFields. Adding it looks like a completeness win —
+// knownCommentFields accepts the field and it does carry prose — but because the
+// drop is per-entry, suspecting it would take a perfectly good suggestion_code
+// down with it. A truncated thinking reaches the JSON output only, with no
+// terminal or viewer rendering, so that trade is backwards.
+func TestParseComments_TruncatedThinkingCostsNoSuggestion(t *testing.T) {
+	serialized := `[{"content":"ok","thinking":"because of "this","suggestion_code":"q","existing_code":"z","path":"a.go"}]`
+	comments, repair, errMsg := ParseCommentsWithPath(
+		map[string]any{"comments": serialized}, "fallback.go")
+	if errMsg != "" {
+		t.Fatalf("the batch must still be recovered, got error: %s", errMsg)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("recovered %d comments, want 1", len(comments))
+	}
+	if comments[0].SuggestionCode != "q" {
+		t.Errorf("suggestion_code = %q, want it kept — a truncated thinking is not "+
+			"a reason to withhold a usable fix", comments[0].SuggestionCode)
+	}
+	if repair.DroppedSuggestions != 0 {
+		t.Errorf("DroppedSuggestions = %d, want 0", repair.DroppedSuggestions)
+	}
+	if len(repair.SuspectFields) != 0 {
+		t.Errorf("SuspectFields = %v, want none — thinking is not checked", repair.SuspectFields)
+	}
+}
+
+func TestHasOddQuotes(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"no quotes at all", false},
+		{`a pair "here"`, false},
+		{`two pairs "a" and "b"`, false},
+		{`cut short "here`, true},
+		{`x = "y`, true},
+		{`three "a" "b" "c`, true},
+	} {
+		if got := hasOddQuotes(tc.in); got != tc.want {
+			t.Errorf("hasOddQuotes(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCommentRepairMessage(t *testing.T) {
+	// A clean repair says only what it escaped, so the common case stays terse.
+	clean := (&CommentRepair{EscapedChars: 2}).Message()
+	if !strings.Contains(clean, "repaired 2 unescaped character(s)") {
+		t.Errorf("clean message = %q", clean)
+	}
+	if strings.Contains(clean, "truncated") || strings.Contains(clean, "withheld") {
+		t.Errorf("a clean repair must not mention truncation: %q", clean)
+	}
+
+	full := (&CommentRepair{
+		EscapedChars:       3,
+		SuspectFields:      []string{"content", "suggestion_code", "path"},
+		DroppedSuggestions: 1,
+		DroppedPaths:       2,
+	}).Message()
+	for _, want := range []string{
+		"repaired 3 unescaped character(s)",
+		"content, suggestion_code, path may be truncated",
+		"withheld 1 suggestion_code value(s)",
+		"2 suspect path(s) fell back to the file under review",
+	} {
+		if !strings.Contains(full, want) {
+			t.Errorf("message %q missing %q", full, want)
+		}
+	}
+}
+
+func TestFlagSuspectTruncations_SkipsNonObjectEntries(t *testing.T) {
+	// repairedCommentsAcceptable rejects these before the flagger runs, but it
+	// must not panic if it ever sees one.
+	suspects, dropped, droppedPaths := flagSuspectTruncations([]any{"not an object", 42, nil})
+	if len(suspects) != 0 || dropped != 0 || droppedPaths != 0 {
+		t.Errorf("suspects=%v dropped=%d droppedPaths=%d; want all empty", suspects, dropped, droppedPaths)
 	}
 }


### PR DESCRIPTION
## Problem

The `code_comment` schema declares `comments` as an array, but a model occasionally serializes that array into a string. The nested string then needs one more level of escaping than the model applies, and the level it drops is almost always a double quote inside prose — review text quoting a term with `"..."` where the JSON string needs `\"...\"`. `json.Unmarshal` fails and **every comment in the batch is lost**.

Measured across 194 benchmark runs (4540 tool calls):

| `comments` argument | calls | outcome |
|---|---:|---|
| native array (schema-conformant) | 307 | all succeeded |
| serialized string | 13 | **all failed** |

A clean split — so the existing string fallback path recovered nothing at all. Those 13 batches held 37 comments; roughly half eventually resurfaced because the model happened to re-file them later in the run, and the rest were gone. Neither the framework nor the report showed why.

## Fix

The damage is mechanical, so the repair is too. A bare `"` inside a JSON string is either that string's terminator or content that should have been escaped, and what follows tells them apart: a real terminator is always followed by `,` `}` `]` `:` or the end of the text. Escaping the rest — plus backslashes that open no legal escape, plus control characters — recovers **12 of the 13 real batches, 34 comments**. The remaining one has C++ braces that happen to mimic a terminator and keeps the previous behaviour.

Scanning proceeds byte by byte, which is safe for UTF-8 since continuation bytes are all `>= 0x80`.

### Acceptance checks

A repaired batch is only accepted when all of these hold, because parsing again is not sufficient on its own — a misjudged terminator can yield JSON that is valid but wrong:

1. it parses and is an array;
2. every entry keeps a non-empty `content`;
3. the entry count did not fall below the number of `"content":` fields in the original text — this rules out a repair that merged two comments by ending a string early;
4. no entry carries a field the schema does not define — when a string ends too early the prose after it is re-read as structure, and review text almost never spells a real field name, so a stray key is the signature of exactly that mistake.

Check 4 was added after check 1–3 were found insufficient: `[{"content":"the field is named "path", "existing_code":"x"}]` parses, keeps one non-empty entry and an unchanged count, while `content` is silently truncated. Verified to reject nothing across all 13 real samples.

When any check fails, the original parser error is returned and the batch is reported exactly as before.

### Known limits, documented in the code

- **A window remains and cannot be closed from local evidence.** Inside prose, `"a word", "existing_code":"x"` is byte-for-byte identical to a genuine terminator followed by the next field. Check 4 shrinks this to prose citing this schema's own field names in that exact shape; anything else either fails to parse or trips the unknown-field check.
- **A backslash before `b`/`f`/`n`/`r`/`t`/`u` is a legal escape and is left untouched**, so `C:\bin` still decodes to a backspace rather than the path the prose meant. JSON offers no way to tell those apart, and genuine escapes are far more common in this field than Windows paths.

## Error message wording is deliberately unchanged

When the repair does not hold up, the parser's original error is returned verbatim. Its `invalid character` phrasing is load-bearing: replaying the 13 real failures against the model shows that phrasing makes it regenerate the batch (13/13), while describing the schema violation instead ("`comments` must be a native JSON array, not a string") makes it resend the same broken string (4/13). Both the code comments and a test assertion pin this down so the wording is not "improved" later.

## Observability

The model sees a plain success when a repair works, so a `comment_args_repaired` run warning is the only record that a violation happened — without it the repair would absorb an unbounded number of them unobserved. It uses the same channel as the existing `comment_refiled`, and doubles as a direct schema-violation rate metric (expect roughly 13 per 320 `code_comment` calls).

`ParseComments` (the registry-direct path used by `CodeCommentProvider.Execute`) discards the repair count, since that path has no warning channel today. Worth revisiting if that path starts carrying real traffic.

## Tests

- Prose-quote repair in English and in Chinese (the reported failures were all Chinese prose, and multi-byte runes are what make the byte-wise scan worth testing).
- Illegal backslash escapes (`\d`, `C:\Users\src`), the full `0x00`–`0x1F` control range, and an exhaustive assertion that every escape produced is one the JSON parser accepts.
- Each acceptance check rejecting its own failure mode: merged batch, empty content, non-object entries, unknown field.
- Byte-identical output for input that was already well-formed, so enabling the repair cannot change a batch that was fine.
- 19 table-driven cases for `\uXXXX` validation, including short, non-hex and uppercase-`U` forms.
- Caller-side coverage that a repair warns and a conformant batch does not.

`make check`, `make test` (full suite under `-race`) and `make coverage` (91.3%, threshold 90%) all pass. Every function in the repair unit is at 100% statement coverage.