### PR TITLE
feat(action): first-class review controls (effort, max_tokens_budget, llm_reasoning_effort) and live progress

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,14 @@ inputs:
       are still published, and the review exits 0.
     required: false
     default: ''
+  stream_progress:
+    description: >-
+      Stream live [ocr] review progress to the workflow log (human audience
+      on stderr) instead of staying silent until the run finishes. One of:
+      true, false (case-insensitive). false (default) keeps the silent
+      agent-audience run with stderr captured to a log file.
+    required: false
+    default: 'false'
   upload_artifacts:
     description: >-
       Upload raw JSON result and stderr as workflow artifacts. Must be the
@@ -336,6 +344,7 @@ runs:
         REVIEW_TASK_TIMEOUT: ${{ inputs.review_task_timeout }}
         EFFORT_INPUT: ${{ inputs.effort }}
         MAX_TOKENS_BUDGET_INPUT: ${{ inputs.max_tokens_budget }}
+        STREAM_PROGRESS_INPUT: ${{ inputs.stream_progress }}
       shell: bash
       run: |
         if [[ ! "$REVIEW_TASK_TIMEOUT" =~ ^[0-9]+$ ]]; then
@@ -386,6 +395,20 @@ runs:
           fi
         fi
         echo "MAX_TOKENS_BUDGET=$NORMALIZED_MAX_TOKENS_BUDGET" >> "$GITHUB_ENV"
+
+        # Display-only toggle: 'true' streams human-audience progress lines to
+        # the workflow log, 'false' keeps the silent agent-audience run. It
+        # changes nothing the review would say, so it stays out of the
+        # checkpoint config fingerprint.
+        NORMALIZED_STREAM_PROGRESS="$(printf '%s' "$STREAM_PROGRESS_INPUT" | tr '[:upper:]' '[:lower:]')"
+        case "$NORMALIZED_STREAM_PROGRESS" in
+          true|false) ;;
+          *)
+            echo "::error::stream_progress must be one of: true, false (got '$STREAM_PROGRESS_INPUT')"
+            exit 1
+            ;;
+        esac
+        echo "STREAM_PROGRESS=$NORMALIZED_STREAM_PROGRESS" >> "$GITHUB_ENV"
 
     - name: Install OpenCodeReview
       shell: bash
@@ -729,15 +752,36 @@ runs:
           echo "::error::Validated review_task_timeout is missing; the Validate inputs step must complete first"
           exit 1
         fi
-        ARGS=(--from "${RANGE_FROM:-$MERGE_BASE}" --to "${HEAD_SHA}" --audience agent --format json --timeout "$REVIEW_TASK_TIMEOUT")
+        ARGS=(--from "${RANGE_FROM:-$MERGE_BASE}" --to "${HEAD_SHA}")
+        # stream_progress 'false' (default): agent audience, stderr captured to
+        # the log file without a live tee. Opt-in 'true': no --audience agent,
+        # so human-audience routing sends [ocr] progress lines to stderr; a
+        # FIFO feeds a background tee so progress streams live into the
+        # workflow log while still landing in the file for artifacts and the
+        # posting step. The tee is a real background job rather than process
+        # substitution so `wait` below guarantees the file is fully flushed
+        # before anything reads it. Neither mode disturbs $?.
+        [ "${STREAM_PROGRESS:-false}" = "true" ] || ARGS+=(--audience agent)
+        ARGS+=(--format json --timeout "$REVIEW_TASK_TIMEOUT")
         [ -n "$OCR_REVIEW_CONCURRENCY" ] && ARGS+=(--concurrency "$OCR_REVIEW_CONCURRENCY")
         [ -n "$OCR_BACKGROUND" ] && ARGS+=(--background "$OCR_BACKGROUND")
         [ -n "$OCR_RULE" ] && ARGS+=(--rule "$OCR_RULE")
         [ -n "${EFFORT:-}" ] && ARGS+=(--effort "$EFFORT")
         [ -n "${MAX_TOKENS_BUDGET:-}" ] && ARGS+=(--max-tokens-budget "$MAX_TOKENS_BUDGET")
         set +e
-        ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log
-        OCR_EXIT_CODE=$?
+        if [ "${STREAM_PROGRESS:-false}" = "true" ]; then
+          OCR_STDERR_FIFO="$(mktemp -u)"
+          mkfifo "$OCR_STDERR_FIFO" || exit 1
+          tee /tmp/ocr-stderr.log < "$OCR_STDERR_FIFO" >&2 &
+          TEE_PID=$!
+          ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2> "$OCR_STDERR_FIFO"
+          OCR_EXIT_CODE=$?
+          wait "$TEE_PID"
+          rm -f "$OCR_STDERR_FIFO"
+        else
+          ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log
+          OCR_EXIT_CODE=$?
+        fi
         set -e
         echo "OCR_EXIT_CODE=$OCR_EXIT_CODE" >> "$GITHUB_ENV"
         echo "=== OCR result ==="

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,21 @@ inputs:
   rule:
     description: Path to a custom rules JSON file passed to `ocr review --rule`.
     required: false
+  effort:
+    description: >-
+      Review effort preset passed to `ocr review --effort`. One of: low,
+      medium, high (case-insensitive). Empty keeps the CLI default (the
+      configured value, or medium).
+    required: false
+    default: ''
+  max_tokens_budget:
+    description: >-
+      Total token cap passed to `ocr review --max-tokens-budget`. Base-10
+      integer; empty or 0 means unlimited. Once the cap is exceeded, dispatch
+      stops, skipped files are reported as failed(budget), partial results
+      are still published, and the review exits 0.
+    required: false
+    default: ''
   upload_artifacts:
     description: >-
       Upload raw JSON result and stderr as workflow artifacts. Must be the
@@ -316,9 +331,11 @@ runs:
         echo "MERGE_BASE=$MERGE_BASE" >> "$GITHUB_ENV"
         echo "Reviewing ${HEAD_SHA} from merge-base ${MERGE_BASE} (base origin/${BASE_REF})"
 
-    - name: Validate review_task_timeout
+    - name: Validate inputs
       env:
         REVIEW_TASK_TIMEOUT: ${{ inputs.review_task_timeout }}
+        EFFORT_INPUT: ${{ inputs.effort }}
+        MAX_TOKENS_BUDGET_INPUT: ${{ inputs.max_tokens_budget }}
       shell: bash
       run: |
         if [[ ! "$REVIEW_TASK_TIMEOUT" =~ ^[0-9]+$ ]]; then
@@ -339,6 +356,36 @@ runs:
           exit 1
         fi
         echo "REVIEW_TASK_TIMEOUT=$REVIEW_TASK_TIMEOUT_NUMBER" >> "$GITHUB_ENV"
+
+        # Empty keeps the CLI default; otherwise one of the named presets.
+        # Normalized to lowercase so the Run step appends a value `ocr review
+        # --effort` accepts verbatim.
+        NORMALIZED_EFFORT="$(printf '%s' "$EFFORT_INPUT" | tr '[:upper:]' '[:lower:]')"
+        case "$NORMALIZED_EFFORT" in
+          ""|low|medium|high) ;;
+          *)
+            echo "::error::effort must be one of: low, medium, high (got '$EFFORT_INPUT')"
+            exit 1
+            ;;
+        esac
+        echo "EFFORT=$NORMALIZED_EFFORT" >> "$GITHUB_ENV"
+
+        # Empty or 0 means unlimited; both normalize to empty so the Run step
+        # simply omits the flag.
+        NORMALIZED_MAX_TOKENS_BUDGET="$MAX_TOKENS_BUDGET_INPUT"
+        if [[ -n "$NORMALIZED_MAX_TOKENS_BUDGET" ]]; then
+          if [[ ! "$NORMALIZED_MAX_TOKENS_BUDGET" =~ ^[0-9]+$ ]]; then
+            echo "::error::max_tokens_budget must be a base-10 integer >= 0 (empty or 0 = unlimited)"
+            exit 1
+          fi
+          while [[ "$NORMALIZED_MAX_TOKENS_BUDGET" == 0* && "$NORMALIZED_MAX_TOKENS_BUDGET" != "0" ]]; do
+            NORMALIZED_MAX_TOKENS_BUDGET="${NORMALIZED_MAX_TOKENS_BUDGET#0}"
+          done
+          if [[ "$NORMALIZED_MAX_TOKENS_BUDGET" == "0" ]]; then
+            NORMALIZED_MAX_TOKENS_BUDGET=""
+          fi
+        fi
+        echo "MAX_TOKENS_BUDGET=$NORMALIZED_MAX_TOKENS_BUDGET" >> "$GITHUB_ENV"
 
     - name: Install OpenCodeReview
       shell: bash
@@ -364,6 +411,16 @@ runs:
           (( OCR_VERSION_MAJOR == 1 && OCR_VERSION_MINOR < 9 )) ||
           (( OCR_VERSION_MAJOR == 1 && OCR_VERSION_MINOR == 9 && OCR_VERSION_PATCH < 6 )); then
           echo "::error::Installed OpenCodeReview ${OCR_VERSION_LINE} is unsupported; v1.9.6 or newer is required"
+          exit 1
+        fi
+
+        # --effort was introduced in v1.10.0; reject an explicit effort input
+        # on older releases instead of letting the CLI fail on an unknown flag.
+        # max_tokens_budget predates the v1.9.6 floor and llm_reasoning_effort
+        # rides extra_body, so neither needs a gate.
+        if [ -n "${EFFORT:-}" ] &&
+          (( OCR_VERSION_MAJOR < 1 || (OCR_VERSION_MAJOR == 1 && OCR_VERSION_MINOR < 10) )); then
+          echo "::error::The effort input requires OpenCodeReview v1.10.0 or newer"
           exit 1
         fi
 
@@ -449,6 +506,11 @@ runs:
         # A timeout change shifts which runs finish and which are cut short, so
         # it shifts the partial/complete distribution the checkpoint gates on.
         OCR_FP_LLM_TIMEOUT: ${{ inputs.llm_timeout }}
+        # Effort shifts how many rounds a review runs and the budget caps how
+        # much it may spend; both change what a review would say, so both
+        # invalidate the checkpoint.
+        OCR_FP_EFFORT: ${{ inputs.effort }}
+        OCR_FP_MAX_TOKENS_BUDGET: ${{ inputs.max_tokens_budget }}
         # Extra headers can point the same `llm_model` string at a different
         # backend model or a different provider entirely, so they change what a
         # review would say and must invalidate the checkpoint. Their VALUES can
@@ -579,6 +641,8 @@ runs:
                 process.env.OCR_FP_LLM_EXTRA_BODY,
                 process.env.OCR_FP_LLM_AUTH_HEADER,
                 process.env.OCR_FP_LLM_TIMEOUT,
+                process.env.OCR_FP_EFFORT,
+                process.env.OCR_FP_MAX_TOKENS_BUDGET,
                 extraHeadersDigest,
                 process.env.OCR_FP_RULE,
                 process.env.OCR_FP_ROUTE_SEVERITY_BELOW,
@@ -662,13 +726,15 @@ runs:
       run: |
         export OCR_LLM_TIMEOUT="${OCR_LLM_TIMEOUT:-300}"
         if [ -z "${REVIEW_TASK_TIMEOUT:-}" ]; then
-          echo "::error::Validated review_task_timeout is missing; the timeout validation step must complete first"
+          echo "::error::Validated review_task_timeout is missing; the Validate inputs step must complete first"
           exit 1
         fi
         ARGS=(--from "${RANGE_FROM:-$MERGE_BASE}" --to "${HEAD_SHA}" --audience agent --format json --timeout "$REVIEW_TASK_TIMEOUT")
         [ -n "$OCR_REVIEW_CONCURRENCY" ] && ARGS+=(--concurrency "$OCR_REVIEW_CONCURRENCY")
         [ -n "$OCR_BACKGROUND" ] && ARGS+=(--background "$OCR_BACKGROUND")
         [ -n "$OCR_RULE" ] && ARGS+=(--rule "$OCR_RULE")
+        [ -n "${EFFORT:-}" ] && ARGS+=(--effort "$EFFORT")
+        [ -n "${MAX_TOKENS_BUDGET:-}" ] && ARGS+=(--max-tokens-budget "$MAX_TOKENS_BUDGET")
         set +e
         ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log
         OCR_EXIT_CODE=$?

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,26 @@ inputs:
   llm_extra_body:
     description: >-
       extra_body JSON for LLM requests. No env var exists for this, so it is
-      written via `ocr config set llm.extra_body`.
+      written via `ocr config set llm.extra_body`. The default disables
+      thinking mode for compatibility with various LLM providers; override it
+      with provider-specific JSON when a model needs different behavior. An
+      explicit reasoning_effort key here wins over the llm_reasoning_effort
+      input.
     required: false
     default: '{"thinking": {"type": "disabled"}}'
+  llm_reasoning_effort:
+    description: >-
+      Reasoning depth for the model (one of: minimal, low, medium, high, max;
+      case-insensitive), merged into the request body as reasoning_effort via
+      llm.extra_body — no CLI support beyond the published versions is needed.
+      OpenAI-compatible protocols only (e.g. GLM-5.x, OpenAI reasoning
+      models); the Anthropic API rejects unknown body fields, so the action
+      fails fast when this is set on the Anthropic protocol — steer Anthropic
+      thinking through an explicit llm_extra_body key instead. Empty
+      (default) sends nothing. An explicit reasoning_effort key in
+      llm_extra_body wins over this input.
+    required: false
+    default: ''
   language:
     description: >-
       Review output language, written via `ocr config set language`
@@ -71,7 +88,7 @@ inputs:
     description: >-
       Review effort preset passed to `ocr review --effort`. One of: low,
       medium, high (case-insensitive). Empty keeps the CLI default (the
-      configured value, or medium).
+      configured value, or medium). Requires OpenCodeReview v1.10.0 or newer.
     required: false
     default: ''
   max_tokens_budget:
@@ -86,8 +103,9 @@ inputs:
     description: >-
       Stream live [ocr] review progress to the workflow log (human audience
       on stderr) instead of staying silent until the run finishes. One of:
-      true, false (case-insensitive). false (default) keeps the silent
-      agent-audience run with stderr captured to a log file.
+      true, false (case-insensitive); empty falls back to false. false
+      (default) keeps the silent agent-audience run with stderr captured to
+      a log file. Requires OpenCodeReview v1.9.8 or newer when enabled.
     required: false
     default: 'false'
   upload_artifacts:
@@ -344,6 +362,7 @@ runs:
         REVIEW_TASK_TIMEOUT: ${{ inputs.review_task_timeout }}
         EFFORT_INPUT: ${{ inputs.effort }}
         MAX_TOKENS_BUDGET_INPUT: ${{ inputs.max_tokens_budget }}
+        LLM_REASONING_EFFORT_INPUT: ${{ inputs.llm_reasoning_effort }}
         STREAM_PROGRESS_INPUT: ${{ inputs.stream_progress }}
       shell: bash
       run: |
@@ -396,12 +415,27 @@ runs:
         fi
         echo "MAX_TOKENS_BUDGET=$NORMALIZED_MAX_TOKENS_BUDGET" >> "$GITHUB_ENV"
 
+        # Empty leaves the request body untouched; otherwise the union of the
+        # OpenAI and GLM vocabularies, normalized to lowercase for the
+        # extra_body injection in the Configure OCR step (which uses node,
+        # guaranteed on PATH by the Actions runtime).
+        NORMALIZED_LLM_REASONING_EFFORT="$(printf '%s' "$LLM_REASONING_EFFORT_INPUT" | tr '[:upper:]' '[:lower:]')"
+        case "$NORMALIZED_LLM_REASONING_EFFORT" in
+          ""|minimal|low|medium|high|max) ;;
+          *)
+            echo "::error::llm_reasoning_effort must be one of: minimal, low, medium, high, max (got '$LLM_REASONING_EFFORT_INPUT')"
+            exit 1
+            ;;
+        esac
+        echo "LLM_REASONING_EFFORT=$NORMALIZED_LLM_REASONING_EFFORT" >> "$GITHUB_ENV"
+
         # Display-only toggle: 'true' streams human-audience progress lines to
         # the workflow log, 'false' keeps the silent agent-audience run. It
         # changes nothing the review would say, so it stays out of the
         # checkpoint config fingerprint.
         NORMALIZED_STREAM_PROGRESS="$(printf '%s' "$STREAM_PROGRESS_INPUT" | tr '[:upper:]' '[:lower:]')"
         case "$NORMALIZED_STREAM_PROGRESS" in
+          "") NORMALIZED_STREAM_PROGRESS=false ;;
           true|false) ;;
           *)
             echo "::error::stream_progress must be one of: true, false (got '$STREAM_PROGRESS_INPUT')"
@@ -447,6 +481,16 @@ runs:
           exit 1
         fi
 
+        # Human-audience progress only moved to stderr in v1.9.8 (66d71b2); on
+        # older releases stream_progress drops --audience agent and progress
+        # lines interleave into the stdout JSON, corrupting the result file.
+        if [ "${STREAM_PROGRESS:-false}" = "true" ] &&
+          (( OCR_VERSION_MAJOR < 1 || (OCR_VERSION_MAJOR == 1 && OCR_VERSION_MINOR < 9) ||
+             (OCR_VERSION_MAJOR == 1 && OCR_VERSION_MINOR == 9 && OCR_VERSION_PATCH < 8) )); then
+          echo "::error::The stream_progress input requires OpenCodeReview v1.9.8 or newer"
+          exit 1
+        fi
+
         # Resolved version (not the spec, which is usually "latest"). It feeds
         # the checkpoint fingerprint so an OCR upgrade invalidates checkpoints
         # taken by the previous version. The gate above already guarantees a
@@ -476,6 +520,14 @@ runs:
             OCR_LLM_PROTOCOL="openai"
             ;;
         esac
+        # reasoning_effort is OpenAI-compatible vocabulary; the Anthropic API
+        # rejects unknown body fields, so fail fast instead of breaking every
+        # request. Anthropic thinking control goes through an explicit
+        # llm_extra_body key instead.
+        if [ -n "${LLM_REASONING_EFFORT:-}" ] && [ "$OCR_LLM_PROTOCOL" = "anthropic" ]; then
+          echo "::error::llm_reasoning_effort is supported only with OpenAI-compatible protocols"
+          exit 1
+        fi
         ocr config unset provider
         ocr config set llm.auth_token ""
         ocr config set llm.extra_headers ""
@@ -486,7 +538,37 @@ runs:
         ocr config set llm.protocol "$OCR_LLM_PROTOCOL"
         ocr config set llm.auth_header "$OCR_LLM_AUTH_HEADER"
         ocr config set llm.auth_token_cmd 'printf "%s" "$OCR_LLM_TOKEN"'
-        ocr config set llm.extra_body "$OCR_EXTRA_BODY"
+        # reasoning_effort rides the existing extra_body merge, so any
+        # published CLI version supports it. An explicit reasoning_effort key
+        # in llm_extra_body wins over the input — the hand-written body is the
+        # more specific intent. The value was validated and normalized by the
+        # Validate inputs step. node (not jq) does the merge: the Actions
+        # runtime guarantees node on PATH even inside container jobs, while jq
+        # is only preinstalled on GitHub-hosted images. An explicitly empty
+        # extra_body parses as an empty object so the merge still lands.
+        EFFECTIVE_EXTRA_BODY="$OCR_EXTRA_BODY"
+        if [ -n "${LLM_REASONING_EFFORT:-}" ]; then
+          EFFECTIVE_EXTRA_BODY="$(printf '%s' "$EFFECTIVE_EXTRA_BODY" | node -e '
+            let raw = "";
+            process.stdin.on("data", (chunk) => (raw += chunk)).on("end", () => {
+              let body;
+              try {
+                body = raw ? JSON.parse(raw) : {};
+              } catch (error) {
+                // stderr escapes the command substitution, so the workflow
+                // command reaches the log; the non-zero exit fails the step.
+                console.error(`::error::llm_extra_body is not valid JSON: ${error.message}`);
+                process.exit(1);
+              }
+              if (body === null || typeof body !== "object" || Array.isArray(body)) {
+                console.error("::error::llm_extra_body must be a JSON object");
+                process.exit(1);
+              }
+              if (body.reasoning_effort === undefined) body.reasoning_effort = process.env.LLM_REASONING_EFFORT;
+              process.stdout.write(JSON.stringify(body));
+            });')"
+        fi
+        ocr config set llm.extra_body "$EFFECTIVE_EXTRA_BODY"
         ocr config set language "$OCR_LANGUAGE"
 
     - name: Resolve review range
@@ -525,15 +607,20 @@ runs:
         OCR_FP_LLM_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
         OCR_FP_LANGUAGE: ${{ inputs.language }}
         OCR_FP_LLM_EXTRA_BODY: ${{ inputs.llm_extra_body }}
+        # Normalized by Validate inputs, so spellings that mean the same thing
+        # (HIGH vs high, '0' vs '' vs '00') hash identically and keep the
+        # checkpoint.
+        OCR_FP_LLM_REASONING_EFFORT: ${{ env.LLM_REASONING_EFFORT }}
         OCR_FP_LLM_AUTH_HEADER: ${{ inputs.llm_auth_header }}
         # A timeout change shifts which runs finish and which are cut short, so
         # it shifts the partial/complete distribution the checkpoint gates on.
         OCR_FP_LLM_TIMEOUT: ${{ inputs.llm_timeout }}
         # Effort shifts how many rounds a review runs and the budget caps how
         # much it may spend; both change what a review would say, so both
-        # invalidate the checkpoint.
-        OCR_FP_EFFORT: ${{ inputs.effort }}
-        OCR_FP_MAX_TOKENS_BUDGET: ${{ inputs.max_tokens_budget }}
+        # invalidate the checkpoint. Both read the values Validate inputs
+        # normalized into the environment, not the raw inputs.
+        OCR_FP_EFFORT: ${{ env.EFFORT }}
+        OCR_FP_MAX_TOKENS_BUDGET: ${{ env.MAX_TOKENS_BUDGET }}
         # Extra headers can point the same `llm_model` string at a different
         # backend model or a different provider entirely, so they change what a
         # review would say and must invalidate the checkpoint. Their VALUES can
@@ -662,6 +749,7 @@ runs:
                 process.env.OCR_FP_LLM_USE_ANTHROPIC,
                 process.env.OCR_FP_LANGUAGE,
                 process.env.OCR_FP_LLM_EXTRA_BODY,
+                process.env.OCR_FP_LLM_REASONING_EFFORT,
                 process.env.OCR_FP_LLM_AUTH_HEADER,
                 process.env.OCR_FP_LLM_TIMEOUT,
                 process.env.OCR_FP_EFFORT,

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -179,6 +179,20 @@ The task and request timeouts are independent:
     max_tokens_budget: '10000000'
 ```
 
+### Stream live review progress
+
+By default the review runs with the machine-oriented `agent` audience and stays silent in the workflow log until it finishes; stderr is captured to a log file and uploaded as an artifact. Set `stream_progress: 'true'` to switch to the human audience and tee stderr into the workflow log, so `[ocr]` progress lines stream live while the review runs — stderr is still captured to the file for artifacts and comment posting.
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `stream_progress` | `'false'` | Stream live `[ocr]` review progress to the workflow log (human audience on stderr) instead of staying silent until the run finishes. One of `'true'` / `'false'`. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    stream_progress: 'true'
+```
+
 ### Add custom review rules
 
 ```yaml

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -165,6 +165,20 @@ The task and request timeouts are independent:
     llm_timeout: '900'
 ```
 
+### Control review effort and token budget
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `effort` | `''` | Review effort preset passed to `ocr review --effort`: `low`, `medium`, or `high` (case-insensitive). Higher effort runs more review rounds. Empty keeps the CLI default (the configured value, or medium). |
+| `max_tokens_budget` | `''` | Total token cap (input+output) passed to `ocr review --max-tokens-budget`. Empty or `'0'` means unlimited. Once the cap is exceeded, dispatch stops, skipped files are reported as failed(budget), partial results are still published, and the review exits 0. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    effort: high
+    max_tokens_budget: '10000000'
+```
+
 ### Add custom review rules
 
 ```yaml
@@ -224,7 +238,7 @@ The action posts a summary issue comment plus inline review comments. Two inputs
 | `corrupt_checkpoint` | the summary carries no readable checkpoint marker (absent, malformed, or two of them) |
 | `schema_invalid` | the marker is for another PR, another marker version, or records a run that did not complete |
 | `base_changed` | the base ref or the merge-base moved, so the diff basis is no longer the one the checkpoint was taken against |
-| `config_changed` | the model, language, `llm_extra_body`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
+| `config_changed` | the model, language, `llm_extra_body`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `effort`, `max_tokens_budget`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
 | `not_ancestor` | the checkpoint commit is in this clone but is not on the new head's history (the branch was reset to an earlier commit) |
 | `unknown_object` | the checkpoint commit is not in this clone, so ancestry could not be checked — where a force-push usually lands, since the replaced commit is no longer fetched |
 | `rule_unreadable` | a rule file was given but could not be read, so no stored fingerprint can be trusted to mean "same rules" |

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -85,7 +85,7 @@ Go to your repository's **Settings → Secrets and variables → Actions**.
 | `OCR_LLM_MODEL` | Yes | Model name |
 | `OCR_LLM_USE_ANTHROPIC` | Yes | `true` for Anthropic Claude, `false` for OpenAI-compatible |
 
-> **Note:** `GITHUB_TOKEN` is automatically provided by GitHub Actions with the required `pull-requests: write` permission. The action also sets `llm.extra_body` to disable thinking mode for compatibility with various LLM providers.
+> **Note:** `GITHUB_TOKEN` is automatically provided by GitHub Actions with the required `pull-requests: write` permission. By default the action sets `llm.extra_body` to `{"thinking": {"type": "disabled"}}`, disabling thinking mode for compatibility with various LLM providers; override it with the `llm_extra_body` input when your model needs different behavior, or use `llm_reasoning_effort` to steer reasoning depth on OpenAI-compatible protocols.
 
 ## Customization
 
@@ -179,6 +179,20 @@ The task and request timeouts are independent:
     max_tokens_budget: '10000000'
 ```
 
+### Set reasoning effort
+
+For models with steerable reasoning depth (e.g. GLM-5.x, OpenAI reasoning models), the `llm_reasoning_effort` input is merged into the request body as `reasoning_effort` via the action's existing `llm.extra_body` plumbing — no CLI support beyond the published versions is needed. OpenAI-compatible protocols only: the Anthropic API rejects unknown body fields, so the action fails fast when the input is set there — steer Anthropic thinking through an explicit `llm_extra_body` key instead. An explicit `reasoning_effort` key inside `llm_extra_body` wins over this input.
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `llm_reasoning_effort` | `''` | One of `minimal`, `low`, `medium`, `high`, `max` (case-insensitive). Empty sends nothing. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_reasoning_effort: low
+```
+
 ### Stream live review progress
 
 By default the review runs with the machine-oriented `agent` audience and stays silent in the workflow log until it finishes; stderr is captured to a log file and uploaded as an artifact. Set `stream_progress: 'true'` to switch to the human audience and tee stderr into the workflow log, so `[ocr]` progress lines stream live while the review runs — stderr is still captured to the file for artifacts and comment posting.
@@ -252,7 +266,7 @@ The action posts a summary issue comment plus inline review comments. Two inputs
 | `corrupt_checkpoint` | the summary carries no readable checkpoint marker (absent, malformed, or two of them) |
 | `schema_invalid` | the marker is for another PR, another marker version, or records a run that did not complete |
 | `base_changed` | the base ref or the merge-base moved, so the diff basis is no longer the one the checkpoint was taken against |
-| `config_changed` | the model, language, `llm_extra_body`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `effort`, `max_tokens_budget`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
+| `config_changed` | the model, language, `llm_extra_body`, `llm_reasoning_effort`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `effort`, `max_tokens_budget`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
 | `not_ancestor` | the checkpoint commit is in this clone but is not on the new head's history (the branch was reset to an earlier commit) |
 | `unknown_object` | the checkpoint commit is not in this clone, so ancestry could not be checked — where a force-push usually lands, since the replaced commit is no longer fetched |
 | `rule_unreadable` | a rule file was given but could not be read, so no stored fingerprint can be trusted to mean "same rules" |

--- a/pages/src/content/docs/en/integrations/ci.md
+++ b/pages/src/content/docs/en/integrations/ci.md
@@ -106,6 +106,38 @@ Set under **Settings → Secrets and variables → Actions**:
 > compatibility across LLM providers that don't support that field.
 > Remove the line if your provider needs thinking-mode left on.
 
+### Action inputs
+
+The upstream workflow delegates the review to the reusable composite action
+([`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml))
+via `uses: alibaba/open-code-review@main`. Beyond the credentials above,
+these inputs tune the review itself — pass them under `with:` on the action
+step:
+
+| Input | Default | Description |
+|---|---|---|
+| `effort` | `''` | Review effort preset passed to `ocr review --effort`: `low`, `medium`, or `high` (case-insensitive). Empty keeps the CLI default (the configured value, or medium). Requires OCR v1.10.0 or newer; the action fails early with a clear error on older versions. |
+| `max_tokens_budget` | `''` | Total token cap (input + output) passed to `ocr review --max-tokens-budget`. Empty or `'0'` means unlimited. Once the cap is exceeded, dispatch stops, skipped files are reported as `failed(budget)`, partial results are still published, and the review exits 0. |
+| `llm_reasoning_effort` | `''` | Reasoning depth for models with a steerable `reasoning_effort` request field (e.g. GLM-5.x, OpenAI reasoning models): `minimal`, `low`, `medium`, `high`, `max` (case-insensitive). Merged into the request body through `llm_extra_body`, so it works with every published CLI version; an explicit `reasoning_effort` key in `llm_extra_body` wins over this input. Empty (default) sends nothing. OpenAI-compatible protocols only — the Anthropic API rejects unknown body fields, so the action fails fast on that protocol; steer Anthropic thinking through an explicit `llm_extra_body` key instead. |
+| `stream_progress` | `'false'` | `'true'` streams live `[ocr]` progress lines to the workflow log (human audience on stderr) instead of staying silent until the run finishes. Display-only: stderr is still captured to a file for artifacts and comment posting. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+    effort: high
+    max_tokens_budget: '10000000'
+    llm_reasoning_effort: low
+    stream_progress: 'true'
+```
+
+See [`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)
+for the full input list — posting modes (`sticky_summary`, `incremental`),
+severity/category routing, and cross-push checkpoints included.
+
 ### Customization
 
 All of the following are edits to the workflow file you just copied

--- a/pages/src/content/docs/ja/integrations/ci.md
+++ b/pages/src/content/docs/ja/integrations/ci.md
@@ -72,6 +72,34 @@ curl -o .github/workflows/ocr-review.yml \
 > `ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'`
 > も実行され、このフィールドをサポートしない LLM プロバイダー向けに thinking-mode リクエストをオフにします。プロバイダーが thinking-mode を維持する必要がある場合は、その行を削除してください。
 
+### アクションの入力
+
+上流のワークフローは、`uses: alibaba/open-code-review@main` を通じてレビューを再利用可能なコンポジットアクション（[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)）に委譲しています。上記の認証情報に加えて、以下の入力でレビュー自体を調整できます——アクションステップの `with:` に指定してください。
+
+| 入力 | デフォルト | 説明 |
+|---|---|---|
+| `effort` | `''` | `ocr review --effort` に渡すレビュー強度プリセット：`low`、`medium`、`high`（大文字小文字を区別しません）。空の場合は CLI のデフォルト（設定済みの値、なければ medium）を使います。OCR v1.10.0 以降が必要で、それより古いバージョンではアクションが明確なエラーで早期に失敗します。 |
+| `max_tokens_budget` | `''` | `ocr review --max-tokens-budget` に渡すトークン総量（入力 + 出力）の上限。空または `'0'` は無制限です。上限を超えるとディスパッチが停止し、スキップされたファイルは `failed(budget)` として報告され、部分的な結果は引き続き公開され、レビューは 0 で終了します。 |
+| `llm_reasoning_effort` | `''` | `reasoning_effort` リクエストフィールドを調整できるモデル（GLM-5.x、OpenAI reasoning モデルなど）の推論深度：`minimal`、`low`、`medium`、`high`、`max`（大文字小文字を区別しません）。`llm_extra_body` 経由でリクエストボディにマージされるため、公開済みのすべての CLI バージョンで動作します。`llm_extra_body` 内の明示的な `reasoning_effort` キーがこの入力より優先されます。空（デフォルト）の場合は送信しません。OpenAI 互換プロトコル専用です——Anthropic API は未知のボディフィールドを拒否するため、そのプロトコルではアクションが即座に失敗します。Anthropic の thinking 制御には `llm_extra_body` の明示的なキーを使ってください。 |
+| `stream_progress` | `'false'` | `'true'` にすると、レビューが終了するまで沈黙する代わりに、`[ocr]` の進捗行をワークフローログへライブで流します（stderr の human audience）。表示のみの切り替えで、stderr は引き続きファイルにキャプチャされ、アーティファクトとコメント投稿に使われます。 |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+    effort: high
+    max_tokens_budget: '10000000'
+    llm_reasoning_effort: low
+    stream_progress: 'true'
+```
+
+入力の完全な一覧は
+[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)
+を参照してください——投稿モード（`sticky_summary`、`incremental`）、重要度/カテゴリのルーティング、プッシュをまたぐチェックポイントなどを含みます。
+
 ### カスタマイズ
 
 以下はすべて、あなたがコピーしたばかりのワークフローファイル

--- a/pages/src/content/docs/ko/integrations/ci.md
+++ b/pages/src/content/docs/ko/integrations/ci.md
@@ -97,6 +97,38 @@ curl -o .github/workflows/ocr-review.yml \
 > 요청을 끄는 설정입니다. 쓰는 프로바이더가 thinking 모드를 켠 채로 두어야 한다면
 > 이 줄을 지우세요.
 
+### 액션 입력 {#action-inputs}
+
+업스트림 워크플로는 `uses: alibaba/open-code-review@main`으로 리뷰를 재사용 가능한
+컴포짓 액션([`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml))에
+위임합니다. 위의 자격 증명 외에 다음 입력으로 리뷰 자체를 조정할 수 있습니다 —
+액션 스텝의 `with:` 아래에 지정하세요.
+
+| 입력 | 기본값 | 설명 |
+|---|---|---|
+| `effort` | `''` | `ocr review --effort`로 전달되는 리뷰 강도 프리셋: `low`, `medium`, `high`(대소문자 무시). 비워 두면 CLI 기본값(설정된 값, 없으면 medium)을 따릅니다. OCR v1.10.0 이상이 필요하며, 더 낮은 버전에서는 액션이 명확한 오류와 함께 일찍 실패합니다. |
+| `max_tokens_budget` | `''` | `ocr review --max-tokens-budget`으로 전달되는 총 토큰(입력 + 출력) 상한. 비어 있거나 `'0'`이면 무제한입니다. 상한을 넘으면 디스패치가 멈추고, 건너뛴 파일은 `failed(budget)`로 보고되며, 부분 결과는 그대로 게시되고, 리뷰는 0으로 종료합니다. |
+| `llm_reasoning_effort` | `''` | `reasoning_effort` 요청 필드를 조절할 수 있는 모델(예: GLM-5.x, OpenAI reasoning 모델)의 추론 깊이: `minimal`, `low`, `medium`, `high`, `max`(대소문자 무시). `llm_extra_body`를 통해 요청 본문에 병합되므로 이미 배포된 모든 CLI 버전에서 동작합니다. `llm_extra_body` 안의 명시적 `reasoning_effort` 키가 이 입력보다 우선합니다. 비어 있으면(기본값) 아무것도 보내지 않습니다. OpenAI 호환 프로토콜 전용입니다 — Anthropic API는 알 수 없는 본문 필드를 거부하므로 해당 프로토콜에서는 액션이 즉시 실패합니다. Anthropic의 thinking 제어는 `llm_extra_body`의 명시적 키를 사용하세요. |
+| `stream_progress` | `'false'` | `'true'`로 설정하면 실행이 끝날 때까지 조용히 기다리는 대신 `[ocr]` 진행 라인을 워크플로 로그에 실시간으로 흘려보냅니다(stderr의 human audience). 표시 전용 토글이며 stderr는 여전히 파일에 캡처되어 아티팩트와 코멘트 게시에 사용됩니다. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+    effort: high
+    max_tokens_budget: '10000000'
+    llm_reasoning_effort: low
+    stream_progress: 'true'
+```
+
+전체 입력 목록은
+[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)을
+참고하세요 — 게시 모드(`sticky_summary`, `incremental`), 심각도/카테고리 라우팅,
+푸시 간 체크포인트 등을 포함합니다.
+
 ### 커스터마이즈 {#customization}
 
 아래 내용은 모두 방금 복사한 워크플로 파일

--- a/pages/src/content/docs/ru/integrations/ci.md
+++ b/pages/src/content/docs/ru/integrations/ci.md
@@ -104,6 +104,39 @@ curl -o .github/workflows/ocr-review.yml \
 > которые не поддерживают это поле. Удалите строку, если вашему провайдеру
 > требуется включённый режим мышления.
 
+### Параметры action
+
+Исходный workflow делегирует ревью переиспользуемому составному action
+([`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml))
+через `uses: alibaba/open-code-review@main`. Помимо учётных данных выше,
+эти входные параметры настраивают само ревью — передавайте их в `with:` шага
+action:
+
+| Параметр | По умолчанию | Описание |
+|---|---|---|
+| `effort` | `''` | Пресет интенсивности ревью, передаваемый в `ocr review --effort`: `low`, `medium` или `high` (без учёта регистра). Пустое значение сохраняет значение CLI по умолчанию (настроенное значение или medium). Требуется OCR v1.10.0 или новее — на более старых версиях action завершается раньше с понятной ошибкой. |
+| `max_tokens_budget` | `''` | Общий лимит токенов (ввод + вывод), передаваемый в `ocr review --max-tokens-budget`. Пустое значение или `'0'` означает «без ограничений». После превышения лимита диспетчеризация останавливается, пропущенные файлы отмечаются как `failed(budget)`, частичные результаты по-прежнему публикуются, а ревью завершается с кодом 0. |
+| `llm_reasoning_effort` | `''` | Глубина рассуждений для моделей с управляемым полем запроса `reasoning_effort` (например, GLM-5.x, reasoning-модели OpenAI): `minimal`, `low`, `medium`, `high`, `max` (без учёта регистра). Значение вливается в тело запроса через `llm_extra_body`, поэтому работает со всеми опубликованными версиями CLI; явный ключ `reasoning_effort` в `llm_extra_body` имеет приоритет над этим параметром. Пустое значение (по умолчанию) ничего не отправляет. Только для OpenAI-совместимых протоколов — Anthropic API отклоняет неизвестные поля тела, поэтому на протоколе Anthropic action завершается сразу; управляйте режимом мышления Anthropic через явный ключ в `llm_extra_body`. |
+| `stream_progress` | `'false'` | Значение `'true'` транслирует живые строки прогресса `[ocr]` в лог workflow (human audience в stderr) вместо молчания до конца запуска. Влияет только на отображение: stderr по-прежнему записывается в файл для артефактов и публикации комментариев. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+    effort: high
+    max_tokens_budget: '10000000'
+    llm_reasoning_effort: low
+    stream_progress: 'true'
+```
+
+Полный список параметров см. в
+[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml) —
+включая режимы публикации (`sticky_summary`, `incremental`), маршрутизацию по
+важности/категориям и чекпоинты между пушами.
+
 ### Настройка
 
 Все следующие изменения вносятся в только что скопированный файл workflow

--- a/pages/src/content/docs/zh/integrations/ci.md
+++ b/pages/src/content/docs/zh/integrations/ci.md
@@ -87,6 +87,38 @@ curl -o .github/workflows/ocr-review.yml \
 > 为不支持该字段的 LLM provider 关闭 thinking-mode 请求。若你的 provider 需保留
 > thinking-mode，删除该行。
 
+### Action 参数
+
+上游工作流通过 `uses: alibaba/open-code-review@main` 把评审委托给可复用的
+composite action
+（[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)）。
+除上述凭据外，以下 input 用于调节评审本身——在 action 步骤的 `with:` 下传入：
+
+| Input | 默认值 | 说明 |
+|---|---|---|
+| `effort` | `''` | 传给 `ocr review --effort` 的评审强度预设：`low`、`medium` 或 `high`（不区分大小写）。留空则沿用 CLI 默认值（已配置的值，否则为 medium）。需要 OCR v1.10.0 或更新版本；在更旧版本上 action 会提前以明确报错失败。 |
+| `max_tokens_budget` | `''` | 传给 `ocr review --max-tokens-budget` 的 token 总量上限（输入 + 输出）。留空或 `'0'` 表示不限。超过上限后停止派发，被跳过的文件记为 `failed(budget)`，已产生的部分结果仍会发布，评审以 0 退出。 |
+| `llm_reasoning_effort` | `''` | 面向支持 `reasoning_effort` 请求字段的模型（如 GLM-5.x、OpenAI reasoning 模型）的推理深度：`minimal`、`low`、`medium`、`high`、`max`（不区分大小写）。经 `llm_extra_body` 合并进请求体，因此所有已发布的 CLI 版本均可使用；`llm_extra_body` 中显式的 `reasoning_effort` 键优先于此 input。留空（默认）则不发送。仅适用于 OpenAI 兼容协议——Anthropic API 会拒绝未知请求体字段，action 在该协议下会快速失败；Anthropic 的 thinking 控制请改用 `llm_extra_body` 中的显式键。 |
+| `stream_progress` | `'false'` | 设为 `'true'` 时，把 `[ocr]` 实时进度行流入工作流日志（stderr 上的 human audience），而不是在评审结束前保持静默。仅影响展示：stderr 仍会写入文件，供产物上传与评论张贴使用。 |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ secrets.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+    effort: high
+    max_tokens_budget: '10000000'
+    llm_reasoning_effort: low
+    stream_progress: 'true'
+```
+
+完整 input 列表见
+[`action.yml`](https://github.com/alibaba/open-code-review/blob/main/action.yml)——
+包括张贴模式（`sticky_summary`、`incremental`）、severity/类别路由与跨 push
+检查点等。
+
 ### 定制
 
 以下都是对你刚复制的工作流文件

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -570,6 +570,138 @@ function testReviewTimeoutLeadingZeroIsNormalizedAcrossSteps() {
   }
 }
 
+function testValidateInputsRejectsInvalidEffortAndBudget() {
+  const validation = validationStep();
+  assert.ok(validation, "action.yml must retain input validation");
+  const cases = [
+    [{ effort: "extreme" }, /effort must be one of/],
+    [{ effort: "max" }, /effort must be one of/],
+    [{ max_tokens_budget: "-5" }, /max_tokens_budget must be/],
+    [{ max_tokens_budget: "10.5" }, /max_tokens_budget must be/],
+    [{ max_tokens_budget: "abc" }, /max_tokens_budget must be/],
+  ];
+  for (const [overrides, pattern] of cases) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(validation, inputValues(overrides), fixture);
+      assert.notStrictEqual(
+        result.status,
+        0,
+        `inputs ${JSON.stringify(overrides)} should be rejected; ${resultDescription(result)}`
+      );
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        pattern,
+        `rejection for ${JSON.stringify(overrides)} must name the offending input; ${resultDescription(result)}`
+      );
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+}
+
+function testEffortAndBudgetNormalizeAndForwardAcrossSteps() {
+  const validation = validationStep();
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(validation, "action.yml must retain input validation");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      effort: "HIGH",
+      max_tokens_budget: "010000",
+      llm_url: "https://llm.example.invalid/v1",
+      llm_auth_token: "unused-token",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+    });
+    const validationResult = runStep(validation, values, fixture);
+    assert.strictEqual(validationResult.status, 0, `validation failed; ${resultDescription(validationResult)}`);
+    const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
+    assert.strictEqual(exported.EFFORT, "high", "validation must export lowercase effort");
+    assert.strictEqual(
+      exported.MAX_TOKENS_BUDGET,
+      "10000",
+      "validation must export normalized decimal max_tokens_budget"
+    );
+    const result = runStep(
+      run,
+      values,
+      fixture,
+      {
+        MERGE_BASE: "base-sha",
+        HEAD_SHA: "head-sha",
+        REVIEW_TASK_TIMEOUT: exported.REVIEW_TASK_TIMEOUT,
+        EFFORT: exported.EFFORT,
+        MAX_TOKENS_BUDGET: exported.MAX_TOKENS_BUDGET,
+      },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview shell block failed; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(fixture.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    const effortIndex = reviewCall.args.indexOf("--effort");
+    assert.ok(effortIndex >= 0, "Run OpenCodeReview must forward --effort");
+    assert.strictEqual(reviewCall.args[effortIndex + 1], "high");
+    const budgetIndex = reviewCall.args.indexOf("--max-tokens-budget");
+    assert.ok(budgetIndex >= 0, "Run OpenCodeReview must forward --max-tokens-budget");
+    assert.strictEqual(reviewCall.args[budgetIndex + 1], "10000");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testZeroMaxTokensBudgetNormalizesToUnlimited() {
+  const validation = validationStep();
+  assert.ok(validation, "action.yml must retain input validation");
+  const fixture = makeFixture();
+  try {
+    const result = runStep(validation, inputValues({ max_tokens_budget: "0" }), fixture);
+    assert.strictEqual(result.status, 0, `validation failed; ${resultDescription(result)}`);
+    const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
+    assert.strictEqual(exported.MAX_TOKENS_BUDGET, "", "max_tokens_budget=0 must normalize to unlimited (empty)");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testEmptyEffortAndBudgetOmitTheFlags() {
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_auth_token: "unused-token",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+    });
+    const result = runStep(
+      run,
+      values,
+      fixture,
+      {
+        MERGE_BASE: "base-sha",
+        HEAD_SHA: "head-sha",
+        REVIEW_TASK_TIMEOUT: "15",
+        EFFORT: "",
+        MAX_TOKENS_BUDGET: "",
+      },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview shell block failed; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(fixture.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    assert.ok(!reviewCall.args.includes("--effort"), "empty effort must omit --effort so the CLI default applies");
+    assert.ok(
+      !reviewCall.args.includes("--max-tokens-budget"),
+      "empty max_tokens_budget must omit --max-tokens-budget so the CLI default applies"
+    );
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
 function testConfigureBuildsCompleteLlmConfig() {
   const configure = stepNamed("Configure OCR");
   assert.ok(configure, "action.yml must retain the Configure OCR step");
@@ -889,6 +1021,39 @@ function testOfficialNpmPackageInstallIsPreserved() {
   }
 }
 
+function testInstallRejectsEffortBelowV1100() {
+  const install = installStep();
+  assert.ok(install, "action.yml must retain the Install OpenCodeReview step");
+  const cases = [
+    { output: "open-code-review 1.9.10 linux/amd64", effort: "low", valid: false },
+    { output: "open-code-review 1.10.0 linux/amd64", effort: "low", valid: true },
+    { output: "open-code-review v2.0.0 linux/amd64", effort: "high", valid: true },
+    { output: "open-code-review 1.9.10 linux/amd64", effort: "", valid: true },
+  ];
+  for (const testCase of cases) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(install, inputValues({ ocr_version: "contract-test" }), fixture, {
+        OCR_FAKE_VERSION_OUTPUT: testCase.output,
+        EFFORT: testCase.effort,
+      });
+      const message = `version ${JSON.stringify(testCase.output)} with effort=${JSON.stringify(testCase.effort)}; ${resultDescription(result)}`;
+      if (testCase.valid) {
+        assert.strictEqual(result.status, 0, `should pass: ${message}`);
+      } else {
+        assert.notStrictEqual(result.status, 0, `should fail: ${message}`);
+        assert.match(
+          `${result.stdout}\n${result.stderr}`,
+          /::error::The effort input requires OpenCodeReview v1\.10\.0 or newer/,
+          `the failure must name the effort input and the version floor; ${message}`
+        );
+      }
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+}
+
 function testInstallEnforcesAuthTokenCommandVersionFloor() {
   const install = installStep();
   assert.ok(install, "action.yml must retain the Install OpenCodeReview step");
@@ -1004,7 +1169,7 @@ function testContractHarnessFailsClosedOnUnsupportedYamlShapes() {
 
 function testRequiredStepTopologyAndEnvironmentContracts() {
   const required = {
-    "Validate review_task_timeout": ["REVIEW_TASK_TIMEOUT"],
+    "Validate inputs": ["REVIEW_TASK_TIMEOUT", "EFFORT_INPUT", "MAX_TOKENS_BUDGET_INPUT"],
     "Install OpenCodeReview": ["OCR_VERSION"],
     "Configure OCR": [
       "OCR_LLM_URL",
@@ -1097,6 +1262,10 @@ const TESTS = [
   ["default llm_timeout exports independently from review_task_timeout", testDefaultLlmTimeoutExportedSeparatelyFromReviewTimeout],
   ["empty llm_timeout normalizes before review invocation", testEmptyLlmTimeoutNormalizesBeforeReviewInvocation],
   ["review_task_timeout with a leading zero normalizes across steps", testReviewTimeoutLeadingZeroIsNormalizedAcrossSteps],
+  ["effort and max_tokens_budget reject malformed values", testValidateInputsRejectsInvalidEffortAndBudget],
+  ["effort and max_tokens_budget normalize and forward across steps", testEffortAndBudgetNormalizeAndForwardAcrossSteps],
+  ["max_tokens_budget=0 normalizes to unlimited", testZeroMaxTokensBudgetNormalizesToUnlimited],
+  ["empty effort and max_tokens_budget omit the CLI flags", testEmptyEffortAndBudgetOmitTheFlags],
   ["Configure OCR builds a complete llm config", testConfigureBuildsCompleteLlmConfig],
   ["Configure OCR never persists the token", testConfigureNeverPersistsToken],
   ["Configure OCR neutralizes stale provider and static token", testConfigureNeutralizesStaleProviderAndStaticToken],
@@ -1108,6 +1277,7 @@ const TESTS = [
   ["Run OpenCodeReview fails closed without validated task timeout", testRunFailsClosedWhenValidatedTaskTimeoutIsMissing],
   ["the official OpenCodeReview NPM install is preserved", testOfficialNpmPackageInstallIsPreserved],
   ["Install OpenCodeReview enforces the auth_token_cmd version floor", testInstallEnforcesAuthTokenCommandVersionFloor],
+  ["Install OpenCodeReview rejects the effort input below v1.10.0", testInstallRejectsEffortBelowV1100],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
   ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -702,6 +702,38 @@ function testEmptyEffortAndBudgetOmitTheFlags() {
   }
 }
 
+function testValidateInputsRejectsInvalidReasoningEffort() {
+  const validation = validationStep();
+  assert.ok(validation, "action.yml must retain input validation");
+  for (const value of ["extreme", "1", "reasoning"]) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(validation, inputValues({ llm_reasoning_effort: value }), fixture);
+      assert.notStrictEqual(
+        result.status,
+        0,
+        `llm_reasoning_effort=${JSON.stringify(value)} should be rejected; ${resultDescription(result)}`
+      );
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /llm_reasoning_effort must be one of/,
+        `rejection for llm_reasoning_effort=${JSON.stringify(value)} must name the input; ${resultDescription(result)}`
+      );
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+  const fixture = makeFixture();
+  try {
+    const result = runStep(validation, inputValues({ llm_reasoning_effort: "MAX" }), fixture);
+    assert.strictEqual(result.status, 0, `llm_reasoning_effort=MAX should be accepted; ${resultDescription(result)}`);
+    const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
+    assert.strictEqual(exported.LLM_REASONING_EFFORT, "max", "validation must export lowercase llm_reasoning_effort");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
 function testStreamProgressInputDefaultsToFalse() {
   assert.ok(INPUTS.stream_progress, "action.yml must define the stream_progress input");
   assert.strictEqual(
@@ -719,7 +751,7 @@ function testStreamProgressInputDefaultsToFalse() {
 function testValidateInputsValidatesStreamProgress() {
   const validation = validationStep();
   assert.ok(validation, "action.yml must retain input validation");
-  for (const value of ["yes", "1", "", "on"]) {
+  for (const value of ["yes", "1", "on"]) {
     const fixture = makeFixture();
     try {
       const result = runStep(validation, inputValues({ stream_progress: value }), fixture);
@@ -737,14 +769,24 @@ function testValidateInputsValidatesStreamProgress() {
       removeFixture(fixture);
     }
   }
-  const fixture = makeFixture();
-  try {
-    const result = runStep(validation, inputValues({ stream_progress: "TRUE" }), fixture);
-    assert.strictEqual(result.status, 0, `stream_progress=TRUE should be accepted; ${resultDescription(result)}`);
-    const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
-    assert.strictEqual(exported.STREAM_PROGRESS, "true", "validation must export lowercase stream_progress");
-  } finally {
-    removeFixture(fixture);
+  const acceptance = [
+    ["TRUE", "true"],
+    ["", "false"],
+  ];
+  for (const [value, expected] of acceptance) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(validation, inputValues({ stream_progress: value }), fixture);
+      assert.strictEqual(result.status, 0, `stream_progress=${JSON.stringify(value)} should be accepted; ${resultDescription(result)}`);
+      const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
+      assert.strictEqual(
+        exported.STREAM_PROGRESS,
+        expected,
+        `validation must export ${JSON.stringify(expected)} for stream_progress=${JSON.stringify(value)}`
+      );
+    } finally {
+      removeFixture(fixture);
+    }
   }
 }
 
@@ -808,6 +850,151 @@ function testRunStreamsProgressWhenOptedIn() {
     assert.ok(fs.existsSync(fixture.stderrPath), "the streaming path must still capture stderr to the log file");
   } finally {
     removeFixture(fixture);
+  }
+}
+
+function testLlmExtraBodyDefaultDisablesThinking() {
+  assert.ok(INPUTS.llm_extra_body, "action.yml must define the llm_extra_body input");
+  assert.strictEqual(
+    INPUTS.llm_extra_body.default,
+    '{"thinking": {"type": "disabled"}}',
+    "llm_extra_body default must disable thinking mode; enabling it must be an explicit opt-in"
+  );
+}
+
+function testConfigureMergesReasoningEffortIntoExtraBody() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  const baseValues = {
+    llm_url: "https://llm.example.invalid/v1",
+    llm_model: "contract-model",
+    llm_use_anthropic: "false",
+    llm_auth_token: "unused-token",
+  };
+  const cases = [
+    [
+      "the default body disables thinking when nothing is set",
+      {},
+      {},
+      { thinking: { type: "disabled" } },
+    ],
+    [
+      "the effort merges into the default body",
+      {},
+      { LLM_REASONING_EFFORT: "low" },
+      { thinking: { type: "disabled" }, reasoning_effort: "low" },
+    ],
+    [
+      "an explicitly empty extra_body still receives the effort",
+      { llm_extra_body: "" },
+      { LLM_REASONING_EFFORT: "low" },
+      { reasoning_effort: "low" },
+    ],
+    [
+      "an explicit extra_body key wins over the input",
+      { llm_extra_body: '{"reasoning_effort":"high"}' },
+      { LLM_REASONING_EFFORT: "low" },
+      { reasoning_effort: "high" },
+    ],
+    [
+      "merges alongside existing extra_body keys",
+      { llm_extra_body: '{"thinking":{"type":"enabled"}}' },
+      { LLM_REASONING_EFFORT: "max" },
+      { thinking: { type: "enabled" }, reasoning_effort: "max" },
+    ],
+  ];
+  for (const [label, overrides, extraEnv, expected] of cases) {
+    const fixture = makeFixture();
+    try {
+      const values = inputValues(Object.assign({}, baseValues, overrides));
+      const result = runStep(configure, values, fixture, extraEnv);
+      assert.strictEqual(result.status, 0, `Configure OCR failed for "${label}"; ${resultDescription(result)}`);
+      const configured = configValues(readJsonLines(fixture.configPath));
+      const body =
+        typeof configured["llm.extra_body"] === "string"
+          ? JSON.parse(configured["llm.extra_body"])
+          : configured["llm.extra_body"];
+      assert.deepStrictEqual(body, expected, `extra_body mismatch for "${label}"`);
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+}
+
+function testConfigureRejectsReasoningEffortOnAnthropic() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_model: "contract-model",
+      llm_use_anthropic: "true",
+      llm_auth_token: "unused-token",
+    });
+    const result = runStep(configure, values, fixture, { LLM_REASONING_EFFORT: "low" });
+    assert.notStrictEqual(result.status, 0, "Configure OCR must reject llm_reasoning_effort on the anthropic protocol");
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /::error::llm_reasoning_effort is supported only with OpenAI-compatible protocols/,
+      `the failure must name the llm_reasoning_effort input; ${resultDescription(result)}`
+    );
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testConfigureRejectsMalformedExtraBodyWithActionableError() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+      llm_auth_token: "unused-token",
+      llm_extra_body: "{not json",
+    });
+    const result = runStep(configure, values, fixture, { LLM_REASONING_EFFORT: "low" });
+    assert.notStrictEqual(result.status, 0, "Configure OCR must fail on malformed llm_extra_body");
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /::error::llm_extra_body is not valid JSON/,
+      `the failure must name the llm_extra_body input; ${resultDescription(result)}`
+    );
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testConfigureRejectsNonObjectExtraBody() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  for (const extraBody of ["null", "[]", "5", '"text"']) {
+    const fixture = makeFixture();
+    try {
+      const values = inputValues({
+        llm_url: "https://llm.example.invalid/v1",
+        llm_model: "contract-model",
+        llm_use_anthropic: "false",
+        llm_auth_token: "unused-token",
+        llm_extra_body: extraBody,
+      });
+      const result = runStep(configure, values, fixture, { LLM_REASONING_EFFORT: "low" });
+      assert.notStrictEqual(
+        result.status,
+        0,
+        `Configure OCR must fail on non-object llm_extra_body=${extraBody}; ${resultDescription(result)}`
+      );
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /::error::llm_extra_body must be a JSON object/,
+        `the failure must name the llm_extra_body input for ${extraBody}; ${resultDescription(result)}`
+      );
+    } finally {
+      removeFixture(fixture);
+    }
   }
 }
 
@@ -1130,6 +1317,39 @@ function testOfficialNpmPackageInstallIsPreserved() {
   }
 }
 
+function testInstallRejectsStreamProgressBelowV198() {
+  const install = installStep();
+  assert.ok(install, "action.yml must retain the Install OpenCodeReview step");
+  const cases = [
+    { output: "open-code-review 1.9.7 linux/amd64", streamProgress: "true", valid: false },
+    { output: "open-code-review 1.9.8 linux/amd64", streamProgress: "true", valid: true },
+    { output: "open-code-review v1.10.0 linux/amd64", streamProgress: "true", valid: true },
+    { output: "open-code-review 1.9.7 linux/amd64", streamProgress: "false", valid: true },
+  ];
+  for (const testCase of cases) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(install, inputValues({ ocr_version: "contract-test" }), fixture, {
+        OCR_FAKE_VERSION_OUTPUT: testCase.output,
+        STREAM_PROGRESS: testCase.streamProgress,
+      });
+      const message = `version ${JSON.stringify(testCase.output)} with stream_progress=${JSON.stringify(testCase.streamProgress)}; ${resultDescription(result)}`;
+      if (testCase.valid) {
+        assert.strictEqual(result.status, 0, `should pass: ${message}`);
+      } else {
+        assert.notStrictEqual(result.status, 0, `should fail: ${message}`);
+        assert.match(
+          `${result.stdout}\n${result.stderr}`,
+          /::error::The stream_progress input requires OpenCodeReview v1\.9\.8 or newer/,
+          `the failure must name the stream_progress input and the version floor; ${message}`
+        );
+      }
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+}
+
 function testInstallRejectsEffortBelowV1100() {
   const install = installStep();
   assert.ok(install, "action.yml must retain the Install OpenCodeReview step");
@@ -1282,6 +1502,7 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
       "REVIEW_TASK_TIMEOUT",
       "EFFORT_INPUT",
       "MAX_TOKENS_BUDGET_INPUT",
+      "LLM_REASONING_EFFORT_INPUT",
       "STREAM_PROGRESS_INPUT",
     ],
     "Install OpenCodeReview": ["OCR_VERSION"],
@@ -1380,10 +1601,16 @@ const TESTS = [
   ["effort and max_tokens_budget normalize and forward across steps", testEffortAndBudgetNormalizeAndForwardAcrossSteps],
   ["max_tokens_budget=0 normalizes to unlimited", testZeroMaxTokensBudgetNormalizesToUnlimited],
   ["empty effort and max_tokens_budget omit the CLI flags", testEmptyEffortAndBudgetOmitTheFlags],
+  ["llm_reasoning_effort rejects values outside the OpenAI/GLM vocabulary", testValidateInputsRejectsInvalidReasoningEffort],
   ["stream_progress defaults to false and describes [ocr] progress", testStreamProgressInputDefaultsToFalse],
   ["stream_progress validation accepts true/false case-insensitively", testValidateInputsValidatesStreamProgress],
   ["Run OpenCodeReview keeps --audience agent and the log file by default", testRunKeepsAgentAudienceAndLogFileByDefault],
   ["Run OpenCodeReview streams live progress when opted in", testRunStreamsProgressWhenOptedIn],
+  ["llm_extra_body defaults to disabling thinking", testLlmExtraBodyDefaultDisablesThinking],
+  ["Configure OCR merges reasoning_effort into extra_body", testConfigureMergesReasoningEffortIntoExtraBody],
+  ["Configure OCR rejects reasoning_effort on the anthropic protocol", testConfigureRejectsReasoningEffortOnAnthropic],
+  ["Configure OCR rejects malformed extra_body with an actionable error", testConfigureRejectsMalformedExtraBodyWithActionableError],
+  ["Configure OCR rejects a non-object extra_body", testConfigureRejectsNonObjectExtraBody],
   ["Configure OCR builds a complete llm config", testConfigureBuildsCompleteLlmConfig],
   ["Configure OCR never persists the token", testConfigureNeverPersistsToken],
   ["Configure OCR neutralizes stale provider and static token", testConfigureNeutralizesStaleProviderAndStaticToken],
@@ -1396,6 +1623,7 @@ const TESTS = [
   ["the official OpenCodeReview NPM install is preserved", testOfficialNpmPackageInstallIsPreserved],
   ["Install OpenCodeReview enforces the auth_token_cmd version floor", testInstallEnforcesAuthTokenCommandVersionFloor],
   ["Install OpenCodeReview rejects the effort input below v1.10.0", testInstallRejectsEffortBelowV1100],
+  ["Install OpenCodeReview rejects stream_progress below v1.9.8", testInstallRejectsStreamProgressBelowV198],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
   ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -702,6 +702,115 @@ function testEmptyEffortAndBudgetOmitTheFlags() {
   }
 }
 
+function testStreamProgressInputDefaultsToFalse() {
+  assert.ok(INPUTS.stream_progress, "action.yml must define the stream_progress input");
+  assert.strictEqual(
+    INPUTS.stream_progress.default,
+    "false",
+    "stream_progress must default to 'false' so live progress stays opt-in"
+  );
+  const inputBlock = ACTION_TEXT.match(
+    /^  stream_progress:\s*$([\s\S]*?)(?=^  [A-Za-z0-9_]+:\s*$|^outputs:|^runs:)/m
+  );
+  assert.ok(inputBlock, "action.yml must expose stream_progress metadata");
+  assert.match(inputBlock[1], /\[ocr\].*progress|progress.*\[ocr\]/i, "stream_progress must describe the [ocr] progress lines");
+}
+
+function testValidateInputsValidatesStreamProgress() {
+  const validation = validationStep();
+  assert.ok(validation, "action.yml must retain input validation");
+  for (const value of ["yes", "1", "", "on"]) {
+    const fixture = makeFixture();
+    try {
+      const result = runStep(validation, inputValues({ stream_progress: value }), fixture);
+      assert.notStrictEqual(
+        result.status,
+        0,
+        `stream_progress=${JSON.stringify(value)} should be rejected; ${resultDescription(result)}`
+      );
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        /stream_progress must be one of/,
+        `rejection for stream_progress=${JSON.stringify(value)} must name the input; ${resultDescription(result)}`
+      );
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+  const fixture = makeFixture();
+  try {
+    const result = runStep(validation, inputValues({ stream_progress: "TRUE" }), fixture);
+    assert.strictEqual(result.status, 0, `stream_progress=TRUE should be accepted; ${resultDescription(result)}`);
+    const exported = readEnvAssignments(path.join(fixture.dir, "github-env"));
+    assert.strictEqual(exported.STREAM_PROGRESS, "true", "validation must export lowercase stream_progress");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testRunKeepsAgentAudienceAndLogFileByDefault() {
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  assert.match(
+    run.run,
+    /STREAM_PROGRESS:-false\}" = "true" \]; then\s+OCR_STDERR_FIFO="\$\(mktemp -u\)"\s+mkfifo "\$OCR_STDERR_FIFO" \|\| exit 1\s+tee \/tmp\/ocr-stderr\.log < "\$OCR_STDERR_FIFO" >&2 &\s+TEE_PID=\$!\s+ocr review "\$\{ARGS\[@\]\}" > \/tmp\/ocr-result\.json 2> "\$OCR_STDERR_FIFO"\s+OCR_EXIT_CODE=\$\?\s+wait "\$TEE_PID"\s+rm -f "\$OCR_STDERR_FIFO"\s+else\s+ocr review "\$\{ARGS\[@\]\}" > \/tmp\/ocr-result\.json 2>\/tmp\/ocr-stderr\.log/,
+    "the live-tee path must be gated on stream_progress, flush the FIFO-fed tee via wait, and the default path must redirect stderr to the log file"
+  );
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_auth_token: "unused-token",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+    });
+    const result = runStep(
+      run,
+      values,
+      fixture,
+      { MERGE_BASE: "base-sha", HEAD_SHA: "head-sha", REVIEW_TASK_TIMEOUT: "15" },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview shell block failed; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(fixture.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    const audienceIndex = reviewCall.args.indexOf("--audience");
+    assert.ok(audienceIndex >= 0, "the default path must keep --audience agent");
+    assert.strictEqual(reviewCall.args[audienceIndex + 1], "agent");
+    assert.ok(fs.existsSync(fixture.stderrPath), "the default path must still capture stderr to the log file");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testRunStreamsProgressWhenOptedIn() {
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({
+      llm_url: "https://llm.example.invalid/v1",
+      llm_auth_token: "unused-token",
+      llm_model: "contract-model",
+      llm_use_anthropic: "false",
+    });
+    const result = runStep(
+      run,
+      values,
+      fixture,
+      { MERGE_BASE: "base-sha", HEAD_SHA: "head-sha", REVIEW_TASK_TIMEOUT: "15", STREAM_PROGRESS: "true" },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview shell block failed; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(fixture.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    assert.ok(!reviewCall.args.includes("--audience"), "stream_progress=true must drop --audience agent");
+    assert.ok(fs.existsSync(fixture.stderrPath), "the streaming path must still capture stderr to the log file");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
 function testConfigureBuildsCompleteLlmConfig() {
   const configure = stepNamed("Configure OCR");
   assert.ok(configure, "action.yml must retain the Configure OCR step");
@@ -1169,7 +1278,12 @@ function testContractHarnessFailsClosedOnUnsupportedYamlShapes() {
 
 function testRequiredStepTopologyAndEnvironmentContracts() {
   const required = {
-    "Validate inputs": ["REVIEW_TASK_TIMEOUT", "EFFORT_INPUT", "MAX_TOKENS_BUDGET_INPUT"],
+    "Validate inputs": [
+      "REVIEW_TASK_TIMEOUT",
+      "EFFORT_INPUT",
+      "MAX_TOKENS_BUDGET_INPUT",
+      "STREAM_PROGRESS_INPUT",
+    ],
     "Install OpenCodeReview": ["OCR_VERSION"],
     "Configure OCR": [
       "OCR_LLM_URL",
@@ -1266,6 +1380,10 @@ const TESTS = [
   ["effort and max_tokens_budget normalize and forward across steps", testEffortAndBudgetNormalizeAndForwardAcrossSteps],
   ["max_tokens_budget=0 normalizes to unlimited", testZeroMaxTokensBudgetNormalizesToUnlimited],
   ["empty effort and max_tokens_budget omit the CLI flags", testEmptyEffortAndBudgetOmitTheFlags],
+  ["stream_progress defaults to false and describes [ocr] progress", testStreamProgressInputDefaultsToFalse],
+  ["stream_progress validation accepts true/false case-insensitively", testValidateInputsValidatesStreamProgress],
+  ["Run OpenCodeReview keeps --audience agent and the log file by default", testRunKeepsAgentAudienceAndLogFileByDefault],
+  ["Run OpenCodeReview streams live progress when opted in", testRunStreamsProgressWhenOptedIn],
   ["Configure OCR builds a complete llm config", testConfigureBuildsCompleteLlmConfig],
   ["Configure OCR never persists the token", testConfigureNeverPersistsToken],
   ["Configure OCR neutralizes stale provider and static token", testConfigureNeutralizesStaleProviderAndStaticToken],

--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -224,7 +224,10 @@ async function runPostReviewComments({
     result = JSON.parse(raw);
   } catch (e) {
     log(`Failed to parse OCR output: ${e.message}`);
-    const stderr = safeRead(fs, stderrPath).trim();
+    // stream_progress streams human-audience progress into stderr, so the file
+    // can dwarf GitHub's 65536-char comment limit; keep the tail, which is
+    // where the error that killed the run was written.
+    const stderr = tailForComment(safeRead(fs, stderrPath).trim());
     if (stderr) {
       // No manifest exists on this path (the output could not be parsed), so it
       // can only ever carry the previous checkpoint forward — never advance it.
@@ -1807,6 +1810,14 @@ function fencedBlock(content, language = "") {
   return block + fence;
 }
 
+const MAX_COMMENT_STDERR_CHARS = 20000;
+
+function tailForComment(text, limit = MAX_COMMENT_STDERR_CHARS) {
+  const s = String(text || "");
+  if (s.length <= limit) return s;
+  return `[... ${s.length - limit} earlier characters truncated; see the ocr-stderr.log artifact ...]\n${s.slice(-limit)}`;
+}
+
 function safeFence(content) {
   const matches = String(content || "").match(/`+/g) || [];
   const maxTicks = matches.reduce((max, ticks) => Math.max(max, ticks.length), 0);
@@ -2613,6 +2624,8 @@ module.exports = {
   formatWarnings,
   fencedBlock,
   safeFence,
+  tailForComment,
+  MAX_COMMENT_STDERR_CHARS,
   SUMMARY_MARKER,
   NO_LINE_REASON,
   resolveBatchSize,

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -16,7 +16,7 @@
 
 const assert = require("assert");
 const path = require("path");
-const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, buildBadgeImage, SEVERITY_BADGE_COLOR, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks, SUMMARY_MARKER, buildCheckpointMarker, parseCheckpointMarker, validateCheckpointPayload, readCheckpointComment, resolveCheckpointRange, isCheckpointAuthorOurs, preserveCheckpointMarker } = require(path.join(__dirname, "post-review-comments.js"));
+const { runPostReviewComments, safeFence, fencedBlock, lineSpan, sameCommentSpan, overlapsHistory, resolveThreshold, DEFAULT_OVERLAP_THRESHOLD, newCommentId, getPostedCommentIds, computeRetryDelayMs, formatWarnings, resolveBatchSize, sortToSendDeterministically, chunkArray, buildRunTags, DEFAULT_BATCH_SIZE, buildBadge, buildBadgeImage, SEVERITY_BADGE_COLOR, sanitizeMetadata, buildPolicy, routeComment, formatComment, formatCommentMarkdown, NO_ROUTING, CATEGORIES, SEVERITIES, SEVERITY_RANK, parseDiffHunkRanges, classifyCommentAgainstDiff, describeCommentLocation, isLineResolutionFailure, getPrDiffHunks, SUMMARY_MARKER, buildCheckpointMarker, parseCheckpointMarker, validateCheckpointPayload, readCheckpointComment, resolveCheckpointRange, isCheckpointAuthorOurs, preserveCheckpointMarker, tailForComment, MAX_COMMENT_STDERR_CHARS } = require(path.join(__dirname, "post-review-comments.js"));
 
 // REVIEW_TAG as the production code builds it for this test's hardcoded run
 // identity (context.runId=undefined -> 0, runAttempt=undefined -> 1). Used as
@@ -2350,6 +2350,7 @@ async function main() {
   testActionResolveStepNeverFailsTheJob();
   testActionFingerprintsRepoLocalRuleFile();
   testActionFingerprintIncludesBackground();
+  testActionFingerprintReadsNormalizedAxes();
   testActionRangeFromIsAStepOutput();
   testActionEmitsMachineReadableRangeOutputs();
   testActionPinsGithubScriptSha();
@@ -2358,6 +2359,7 @@ async function main() {
   await testActionPinsAuthorToTheDefaultTokenApp();
   await testActionResolveStepDeclaresItsRefInputs();
   await testCheckpointMarkerMatchingIsStateless();
+  testTailForCommentKeepsTheTail();
   console.log("All post-review-comments tests passed.");
 }
 function testParseDiffHunkRanges() {
@@ -4786,6 +4788,30 @@ function testActionFingerprintIncludesBackground() {
   }
 }
 
+// The validated axes fingerprint the normalized values, not the raw inputs, so
+// spellings that mean the same thing (HIGH vs high, '0' vs '' vs '00') hash
+// identically and keep the checkpoint.
+function testActionFingerprintReadsNormalizedAxes() {
+  const block = actionStepBlock("Resolve review range");
+  const digest = fingerprintDigestSource();
+  for (const [envVar, normalized] of [
+    ["OCR_FP_EFFORT", "EFFORT"],
+    ["OCR_FP_MAX_TOKENS_BUDGET", "MAX_TOKENS_BUDGET"],
+    ["OCR_FP_LLM_REASONING_EFFORT", "LLM_REASONING_EFFORT"],
+  ]) {
+    assert.strictEqual(
+      block.includes(`${envVar}: \${{ env.${normalized} }}`),
+      true,
+      `the step must pass the normalized env.${normalized} as ${envVar}`
+    );
+    assert.strictEqual(
+      digest.includes(`process.env.${envVar},`),
+      true,
+      `${envVar} must be hashed into the fingerprint`
+    );
+  }
+}
+
 // U5. A narrowed range published through $GITHUB_ENV outlives the step: a
 // second use of this action in the same job would inherit it and skip commits
 // it was never told about. Step outputs are scoped to the step that set them.
@@ -5123,6 +5149,21 @@ async function testCheckpointMarkerMatchingIsStateless() {
   const second = await read();
   assert.strictEqual(first.raw, marker, "the carried marker is the marker itself");
   assert.deepStrictEqual(second, first, "a second read of the same body reads the same thing");
+}
+
+// The stderr dump that accompanies an unparseable result must keep the tail:
+// with stream_progress the file is mostly progress lines and the error that
+// killed the run is the last thing written.
+function testTailForCommentKeepsTheTail() {
+  assert.strictEqual(tailForComment("short"), "short", "text within the limit passes through");
+  assert.strictEqual(tailForComment("", 10), "", "empty text passes through");
+  const head = "HEAD-LINE\n" + "x".repeat(MAX_COMMENT_STDERR_CHARS);
+  const tail = "y".repeat(100) + "\nTAIL-LINE: the actual error";
+  const out = tailForComment(head + tail);
+  assert.ok(out.includes("TAIL-LINE: the actual error"), "the tail must survive truncation");
+  assert.ok(!out.includes("HEAD-LINE"), "the head must be truncated away");
+  assert.match(out, /earlier characters truncated; see the ocr-stderr\.log artifact/, "truncation must be announced");
+  assert.ok(out.length <= MAX_COMMENT_STDERR_CHARS + 200, "the result stays far below GitHub's comment limit");
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Description

This PR makes the review action tunable from workflow inputs, in three commits:

- **`effort` / `max_tokens_budget` inputs (closes #1147)** — validated and normalized in the Validate inputs step, appended as `--effort` / `--max-tokens-budget` to the review command; both join the checkpoint config fingerprint.
- **Opt-in live progress via `stream_progress` (closes #1148)** — default behavior is unchanged (`--audience agent`, stderr captured to the log file, nothing streams). Setting `stream_progress: 'true'` drops `--audience agent` so `[ocr]` progress routes to stderr while the result JSON stays on stdout; a FIFO feeds a background tee that streams progress live into the workflow log and is awaited before the log file is read, so artifacts and the posting step always see a fully flushed capture. `OCR_EXIT_CODE` handling is unaffected in either mode.
- **`llm_reasoning_effort` input (closes #1149)** — injected into the effective `llm.extra_body` via node in the Configure step (node, not jq: the Actions runtime guarantees node on PATH even inside container jobs), riding the existing extra_body merge so any published CLI supports it; an explicit `reasoning_effort` key in `llm_extra_body` wins. The `llm_extra_body` default is unchanged (`{"thinking": {"type": "disabled"}}`) — thinking stays disabled unless explicitly opted in. Malformed `llm_extra_body` JSON now fails the step with an actionable `::error::` naming the input.

## Testing

- `make check`
- `make test`
- `npm run test:github-actions` — 36/36 action contract tests pass
- End-to-end exercised through a reusable workflow consuming this fork action, with `max-tokens-budget` and `llm-reasoning-effort` wired from caller workflows

> **Upgrade note:** the three new fingerprint axes (`effort`, `max_tokens_budget`, `llm_reasoning_effort`) invalidate every existing checkpoint once on upgrade — the first run after upgrading re-reviews the full PR, then incremental resumes.