### PR TITLE
feat(action): add optional pr_number input and workflow_run fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,6 +195,16 @@ inputs:
   head_sha:
     description: Override the head commit SHA (use with base_ref for comment triggers).
     required: false
+  pr_number:
+    description: >-
+      Override the pull request number the run fetches and posts to. Defaults to
+      the number in the event payload (pull_request / pull_request_target /
+      issue_comment), then to github.event.workflow_run.pull_requests[0].number.
+      Provide it for a trigger that carries no pull request of its own, or when a
+      workflow_run payload lists more than one; the action fails before any
+      review work when no number resolves.
+    required: false
+    default: ''
   node_version:
     description: Node.js version for actions/setup-node.
     required: false
@@ -320,15 +330,38 @@ runs:
       env:
         INPUT_BASE_REF: ${{ inputs.base_ref }}
         INPUT_HEAD_SHA: ${{ inputs.head_sha }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
         EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        # workflow_run carries no pull request of its own, so the run that
+        # triggered it is reachable only through this array. GitHub fills it in
+        # only for head branches that live in this repository, and it can list
+        # more than one PR when several share a head; either case is what
+        # pr_number is for.
+        WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       run: |
         BASE_REF="${INPUT_BASE_REF:-$EVENT_BASE_REF}"
         HEAD_SHA="${INPUT_HEAD_SHA:-$EVENT_HEAD_SHA}"
+        PR_NUMBER="${INPUT_PR_NUMBER:-${EVENT_PR_NUMBER:-$WORKFLOW_RUN_PR_NUMBER}}"
+        # Fail here rather than after the review: everything downstream posts to
+        # this number, and an empty one used to reach GitHub as
+        # /repos/OWNER/REPO/issues//comments — a 404 that discarded a completed
+        # review's findings.
+        if [ -z "$PR_NUMBER" ]; then
+          echo "::error::No pull request number: the '${GITHUB_EVENT_NAME:-unknown}' event payload carries none. Pass the pr_number input; a workflow_run payload names the PR under workflow_run.pull_requests[0].number."
+          exit 1
+        fi
+        if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::Resolved pull request number '${PR_NUMBER}' is not a positive integer; pr_number must be the PR's number alone."
+          exit 1
+        fi
         echo "BASE_REF=$BASE_REF" >> "$GITHUB_ENV"
         echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+        echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
         echo "PR base ref: $BASE_REF"
         echo "PR head sha: $HEAD_SHA"
+        echo "PR number: $PR_NUMBER"
 
     - name: Checkout base
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -343,7 +376,7 @@ runs:
       if: env.HEAD_SHA != ''
       shell: bash
       env:
-        PR_NUM: ${{ github.event.pull_request.number || github.event.issue.number }}
+        PR_NUM: ${{ env.PR_NUMBER }}
       run: |
         if [ -n "$PR_NUM" ]; then
           git fetch origin "pull/${PR_NUM}/head"
@@ -591,6 +624,10 @@ runs:
         OCR_HEAD_SHA: ${{ env.HEAD_SHA }}
         OCR_BASE_REF: ${{ env.BASE_REF }}
         OCR_MERGE_BASE: ${{ env.MERGE_BASE }}
+        # Same origin, but this one cannot arrive empty: "Resolve PR refs" fails
+        # the job when no PR number resolves, so a checkpoint is always read for
+        # a known PR rather than for issue //comments.
+        OCR_PR_NUMBER: ${{ env.PR_NUMBER }}
         # Everything that changes what a review would say. Any difference
         # invalidates the checkpoint, because findings from the previous run are
         # no longer comparable to what this configuration would produce.
@@ -777,7 +814,7 @@ runs:
               github,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              prNumber: context.issue.number,
+              prNumber: Number(process.env.OCR_PR_NUMBER),
               // Non-empty only when the token is the default one, whose app
               // identity is known; empty keeps the wider bot check.
               appSlug: process.env.OCR_CHECKPOINT_APP_SLUG || '',
@@ -914,6 +951,9 @@ runs:
         OCR_RANGE_REASON: ${{ steps.range.outputs.range_reason }}
         OCR_BASE_REF: ${{ env.BASE_REF }}
         OCR_MERGE_BASE: ${{ env.MERGE_BASE }}
+        # Resolved by "Resolve PR refs", which fails the job when no number is
+        # available; context.issue.number resolves nothing on a workflow_run.
+        OCR_PR_NUMBER: ${{ env.PR_NUMBER }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -936,6 +976,7 @@ runs:
             context,
             core,
             fs,
+            prNumber: Number(process.env.OCR_PR_NUMBER),
             resultPath: '/tmp/ocr-result.json',
             stderrPath: '/tmp/ocr-stderr.log',
             stickySummary: ${{ inputs.sticky_summary == 'true' }},

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -103,6 +103,50 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 ```
 
+### Review from a trigger that carries no pull request
+
+The action needs a PR number to fetch the head and to post to. It resolves one in this order:
+
+| Source | When it applies |
+|--------|-----------------|
+| `pr_number` input | Whenever you set it. Overrides everything below. |
+| `github.event.pull_request.number`, then `github.event.issue.number` | `pull_request`, `pull_request_target`, `issue_comment`. |
+| `github.event.workflow_run.pull_requests[0].number` | `workflow_run`, when GitHub populated the array. |
+
+When none of them resolves, the action stops before installing OCR or spending any LLM quota, instead of reviewing and then failing to post.
+
+`workflow_run` is the trigger for "review the head CI already passed", and its payload names the PR only through that array — which GitHub fills in only for head branches that live in this repository, and which can list more than one PR when several share a head. Pass `pr_number` explicitly whenever you need a specific one:
+
+```yaml
+on:
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alibaba/open-code-review@main
+        with:
+          llm_url: ${{ secrets.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: ${{ vars.OCR_LLM_MODEL }}
+          llm_use_anthropic: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          base_ref: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+          head_sha: ${{ github.event.workflow_run.head_sha }}
+```
+
+`pr_number` is the third member of the `base_ref` / `head_sha` set: each one lets the caller supply what its event cannot.
+
+> `workflow_run` runs the default branch's copy of the workflow with a write-scoped token, so gate the job on the upstream conclusion and leave the checkout to the action: it checks out the trusted base and fetches only the head's blobs, exactly as it does under `pull_request_target`.
+
 ### Customize comment trigger keywords
 
 By default the workflow also re-reviews on demand when a PR comment starts with `/open-code-review` or `@open-code-review`. The `if` condition is more defensive than a bare keyword check — it gates comment triggers so only authorized humans can spend LLM quota:

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -361,6 +361,226 @@ function assertValidation(value, expectedValid) {
   }
 }
 
+function prRefsStep() {
+  const step = stepNamed("Resolve PR refs");
+  assert.ok(step, "action.yml must retain the Resolve PR refs step");
+  return step;
+}
+
+// The step reads its candidate PR numbers from `github.*` expressions, which the
+// harness deliberately refuses to resolve. So the sources are supplied here the
+// way the runner would have rendered them for a given event, and the precedence
+// between them — the part that is actually under test — runs as written.
+function runPrRefs(sources) {
+  const fixture = makeFixture();
+  try {
+    const env = Object.assign(
+      {
+        INPUT_BASE_REF: "",
+        INPUT_HEAD_SHA: "",
+        INPUT_PR_NUMBER: "",
+        EVENT_BASE_REF: "main",
+        EVENT_HEAD_SHA: "a".repeat(40),
+        EVENT_PR_NUMBER: "",
+        WORKFLOW_RUN_PR_NUMBER: "",
+        GITHUB_EVENT_NAME: "workflow_run",
+      },
+      sources
+    );
+    const result = runShell(renderedRun(prRefsStep(), inputValues()), env, fixture);
+    return { result, exported: readEnvAssignments(path.join(fixture.dir, "github-env")) };
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testPrNumberInputIsOptionalAndDocumented() {
+  assert.ok(INPUTS.pr_number, "action.yml must define the pr_number input");
+  assert.strictEqual(
+    INPUTS.pr_number.default,
+    "",
+    "pr_number must default to empty so every current trigger keeps today's resolution"
+  );
+  const inputBlock = ACTION_TEXT.match(
+    /^  pr_number:\s*$([\s\S]*?)(?=^  [A-Za-z0-9_]+:\s*$|^outputs:|^runs:)/m
+  );
+  assert.ok(inputBlock, "action.yml must expose pr_number metadata");
+  assert.match(inputBlock[1], /required:\s*false/, "pr_number must stay optional");
+  assert.match(
+    inputBlock[1],
+    /workflow_run/,
+    "pr_number must document the trigger it exists for"
+  );
+}
+
+function testPrNumberResolutionOrder() {
+  const cases = [
+    [
+      "the explicit input outranks every payload field",
+      { INPUT_PR_NUMBER: "4242", EVENT_PR_NUMBER: "7", WORKFLOW_RUN_PR_NUMBER: "9" },
+      "4242",
+    ],
+    [
+      "pull_request / issue_comment payloads are used when no input is given",
+      { EVENT_PR_NUMBER: "7", WORKFLOW_RUN_PR_NUMBER: "9" },
+      "7",
+    ],
+    [
+      "workflow_run.pull_requests[0] is the last resort",
+      { WORKFLOW_RUN_PR_NUMBER: "9" },
+      "9",
+    ],
+  ];
+  for (const [label, sources, expected] of cases) {
+    const { result, exported } = runPrRefs(sources);
+    assert.strictEqual(result.status, 0, `${label}; ${resultDescription(result)}`);
+    assert.strictEqual(exported.PR_NUMBER, expected, label);
+    assert.strictEqual(exported.BASE_REF, "main", `${label}; the ref resolution is unchanged`);
+    assert.strictEqual(exported.HEAD_SHA, "a".repeat(40), `${label}; the head resolution is unchanged`);
+  }
+}
+
+function testPrNumberFailsBeforeAnyReviewWork() {
+  const { result, exported } = runPrRefs({});
+  assert.notStrictEqual(
+    result.status,
+    0,
+    `an unresolvable PR number must stop the run; ${resultDescription(result)}`
+  );
+  const output = `${result.stdout}${result.stderr}`;
+  assert.match(output, /::error::/, "the failure must be annotated for the run summary");
+  assert.match(output, /pr_number/, "…and must name the input that fixes it");
+  assert.match(output, /workflow_run\.pull_requests\[0\]\.number/, "…and where that payload keeps it");
+  assert.strictEqual(exported.PR_NUMBER, undefined, "nothing is exported when no number is known");
+
+  // The point of failing here is that it costs nothing: no install, no LLM
+  // quota, no half-finished review whose findings have nowhere to go.
+  const refs = prRefsStep();
+  for (const later of ["Install OpenCodeReview", "Run OpenCodeReview", "Post review comments"]) {
+    const step = stepNamed(later);
+    assert.ok(step, `action.yml must retain the ${later} step`);
+    assert.ok(refs.index < step.index, `PR number resolution must precede ${later}`);
+  }
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({ ocr_version: "contract-test" });
+    const install = installStep();
+    const script = `${renderedRun(refs, values)}\n${renderedRun(install, values)}`;
+    const env = Object.assign(
+      {
+        INPUT_BASE_REF: "",
+        INPUT_HEAD_SHA: "",
+        INPUT_PR_NUMBER: "",
+        EVENT_BASE_REF: "main",
+        EVENT_HEAD_SHA: "a".repeat(40),
+        EVENT_PR_NUMBER: "",
+        WORKFLOW_RUN_PR_NUMBER: "",
+        GITHUB_EVENT_NAME: "workflow_run",
+      },
+      renderedEnv(install, values)
+    );
+    const combined = runShell(script, env, fixture);
+    assert.notStrictEqual(combined.status, 0, `the run must stop; ${resultDescription(combined)}`);
+    assert.deepStrictEqual(
+      readJsonLines(fixture.npmCallsPath),
+      [],
+      "NPM must not run after PR-number resolution fails"
+    );
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testPrNumberRejectsValuesThatAreNotAPrNumber() {
+  for (const value of ["#123", "123abc", "0", "-1", "12.0", " ", "pull/123"]) {
+    const { result, exported } = runPrRefs({ INPUT_PR_NUMBER: value });
+    assert.notStrictEqual(
+      result.status,
+      0,
+      `pr_number=${JSON.stringify(value)} must be rejected; ${resultDescription(result)}`
+    );
+    assert.strictEqual(exported.PR_NUMBER, undefined, "a rejected value is never exported");
+  }
+  for (const value of ["1", "4242"]) {
+    const { result, exported } = runPrRefs({ INPUT_PR_NUMBER: value });
+    assert.strictEqual(
+      result.status,
+      0,
+      `pr_number=${JSON.stringify(value)} must be accepted; ${resultDescription(result)}`
+    );
+    assert.strictEqual(exported.PR_NUMBER, value);
+  }
+}
+
+function testResolvedPrNumberReachesTheHeadFetch() {
+  const step = stepNamed("Fetch PR head (fork-safe)");
+  assert.ok(step, "action.yml must retain the fork-safe head fetch");
+  assert.strictEqual(
+    step.env.PR_NUM,
+    "${{ env.PR_NUMBER }}",
+    "the fetch must use the resolved number rather than re-reading the payload"
+  );
+  const fixture = makeFixture();
+  try {
+    const gitCalls = path.join(fixture.dir, "git-calls.jsonl");
+    fs.writeFileSync(
+      path.join(fixture.bin, "git"),
+      `#!/usr/bin/env node
+require("fs").appendFileSync(process.env.OCR_GIT_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");
+`,
+      { mode: 0o755 }
+    );
+    const result = runShell(
+      renderedRun(step, inputValues()),
+      { PR_NUM: "4242", OCR_GIT_CALLS: gitCalls },
+      fixture
+    );
+    assert.strictEqual(result.status, 0, resultDescription(result));
+    assert.deepStrictEqual(
+      readJsonLines(gitCalls),
+      [["fetch", "origin", "pull/4242/head"]],
+      "the head fetch must name the resolved PR"
+    );
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testPrNumberWiredIntoBothGithubScriptSteps() {
+  for (const name of ["Resolve review range", "Post review comments"]) {
+    const step = stepNamed(name);
+    assert.ok(step, `action.yml must retain the ${name} step`);
+    assert.strictEqual(
+      step.env.OCR_PR_NUMBER,
+      "${{ env.PR_NUMBER }}",
+      `${name} must read the resolved PR number`
+    );
+  }
+  assert.doesNotMatch(
+    ACTION_TEXT,
+    /prNumber:\s*context\.issue\.number/,
+    "no step may fall back to context.issue.number, which resolves nothing on workflow_run"
+  );
+  assert.strictEqual(
+    (ACTION_TEXT.match(/prNumber: Number\(process\.env\.OCR_PR_NUMBER\)/g) || []).length,
+    2,
+    "both github-script steps must pass the resolved number"
+  );
+}
+
+function testExampleReadmeDocumentsPrNumberResolution() {
+  assert.match(
+    EXAMPLE_README_TEXT,
+    /\| `pr_number` input \|/,
+    "GitHub Actions README must document pr_number as the first resolution source"
+  );
+  assert.match(
+    EXAMPLE_README_TEXT,
+    /pr_number: \$\{\{ github\.event\.workflow_run\.pull_requests\[0\]\.number \}\}/,
+    "GitHub Actions README must show the workflow_run wiring it exists for"
+  );
+}
+
 function testReviewTaskTimeoutInputNameAndScope() {
   assert.ok(INPUTS.review_task_timeout, "action.yml must define the review_task_timeout input");
   assert.ok(!INPUTS.review_timeout, "the not-yet-released review_timeout input must be renamed");
@@ -1628,6 +1848,13 @@ const TESTS = [
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
   ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],
   ["GitHub Actions README documents timeout and version contracts", testExampleReadmeDocumentsTimeoutAndVersionContracts],
+  ["pr_number is an optional, documented input", testPrNumberInputIsOptionalAndDocumented],
+  ["the PR number resolves input, then payload, then workflow_run", testPrNumberResolutionOrder],
+  ["an unresolvable PR number fails before any review work", testPrNumberFailsBeforeAnyReviewWork],
+  ["pr_number rejects values that are not a PR number", testPrNumberRejectsValuesThatAreNotAPrNumber],
+  ["the resolved PR number reaches the fork-safe head fetch", testResolvedPrNumberReachesTheHeadFetch],
+  ["both github-script steps read the resolved PR number", testPrNumberWiredIntoBothGithubScriptSteps],
+  ["GitHub Actions README documents PR number resolution", testExampleReadmeDocumentsPrNumberResolution],
 ];
 
 function main() {

--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -71,6 +71,11 @@ async function runPostReviewComments({
   context,
   core,
   fs,
+  // The pull request everything below posts to. action.yml resolves it before
+  // the review runs (pr_number input, then the event payload, then
+  // workflow_run.pull_requests[0]) because context.issue.number resolves
+  // nothing on a workflow_run. Omitting it keeps the event-derived number.
+  prNumber: prNumberOverride,
   resultPath = "/tmp/ocr-result.json",
   stderrPath = "/tmp/ocr-stderr.log",
   stickySummary = true,
@@ -113,7 +118,7 @@ async function runPostReviewComments({
 
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const prNumber = context.issue.number;
+  const prNumber = prNumberOverride != null ? prNumberOverride : context.issue.number;
 
   // Per-run idempotency tags. context.runId / context.runAttempt come from
   // @actions/github's Context (parsed from GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT).

--- a/scripts/github-actions/post-review-comments.js
+++ b/scripts/github-actions/post-review-comments.js
@@ -118,7 +118,8 @@ async function runPostReviewComments({
 
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const prNumber = prNumberOverride != null ? prNumberOverride : context.issue.number;
+  const prNumber =
+    prNumberOverride !== null && prNumberOverride !== undefined ? prNumberOverride : context.issue.number;
 
   // Per-run idempotency tags. context.runId / context.runAttempt come from
   // @actions/github's Context (parsed from GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT).

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -2360,6 +2360,8 @@ async function main() {
   await testActionResolveStepDeclaresItsRefInputs();
   await testCheckpointMarkerMatchingIsStateless();
   testTailForCommentKeepsTheTail();
+  // Optional pr_number (#1150)
+  await testPrNumberOverrideAddressesEveryCall();
   console.log("All post-review-comments tests passed.");
 }
 function testParseDiffHunkRanges() {
@@ -4187,6 +4189,9 @@ function resolveEnv(over = {}) {
       OCR_HEAD_SHA: CK_NEW,
       OCR_BASE_REF: "main",
       OCR_MERGE_BASE: CK_MB,
+      // Written by "Resolve PR refs", which fails the job rather than leaving
+      // it empty; ckPayload records the same PR, so the checkpoint matches.
+      OCR_PR_NUMBER: "123",
       OCR_STICKY_SUMMARY: "true",
       OCR_FULL_REVIEW: "false",
       OCR_EVENT_ACTION: "synchronize",
@@ -4268,6 +4273,7 @@ async function testActionScriptFingerprintCoversRepoLocalRules() {
           OCR_HEAD_SHA: CK_NEW,
           OCR_BASE_REF: "main",
           OCR_MERGE_BASE: CK_MB,
+          OCR_PR_NUMBER: "123",
           OCR_STICKY_SUMMARY: "true",
           OCR_FULL_REVIEW: "false",
           OCR_EVENT_ACTION: "synchronize",
@@ -5078,17 +5084,18 @@ async function testCheckpointReasonsMatchTheDocs() {
   assert.strictEqual(/force-push/.test(forcePush[1]), true, "unknown_object is where a force-push actually lands");
 }
 
-// The resolve step's git refs come from $GITHUB_ENV, written by two earlier
-// steps. Reading them straight off the ambient job env made that dependency
-// invisible: nothing in the step said it needed those steps to have run. Pin
-// both halves — the declaration, and what happens when the declaration is empty
-// because an upstream step was skipped.
+// The resolve step's git refs and PR number come from $GITHUB_ENV, written by
+// two earlier steps. Reading them straight off the ambient job env made that
+// dependency invisible: nothing in the step said it needed those steps to have
+// run. Pin both halves — the declaration, and what happens when the declaration
+// is empty because an upstream step was skipped.
 async function testActionResolveStepDeclaresItsRefInputs() {
   const block = actionStepBlock("Resolve review range");
   for (const [envVar, source] of [
     ["OCR_HEAD_SHA", "env.HEAD_SHA"],
     ["OCR_BASE_REF", "env.BASE_REF"],
     ["OCR_MERGE_BASE", "env.MERGE_BASE"],
+    ["OCR_PR_NUMBER", "env.PR_NUMBER"],
   ]) {
     assert.strictEqual(
       block.includes(`${envVar}: \${{ ${source} }}`),
@@ -5097,7 +5104,7 @@ async function testActionResolveStepDeclaresItsRefInputs() {
     );
     assert.strictEqual(block.includes(`process.env.${envVar}`), true, `…and read it as ${envVar}`);
   }
-  for (const bare of ["process.env.HEAD_SHA", "process.env.BASE_REF", "process.env.MERGE_BASE"]) {
+  for (const bare of ["process.env.HEAD_SHA", "process.env.BASE_REF", "process.env.MERGE_BASE", "process.env.PR_NUMBER"]) {
     assert.strictEqual(block.includes(bare), false, `no undeclared ${bare} may remain`);
   }
 
@@ -5114,6 +5121,74 @@ async function testActionResolveStepDeclaresItsRefInputs() {
   assert.strictEqual(core.outputs.range_reason, "base_changed", "…because the stored base cannot match an empty one");
   assert.strictEqual(core.outputs.range_from, "", "empty range_from means ${RANGE_FROM:-$MERGE_BASE}");
   assert.strictEqual(core.warnings.length, 0, "and it is a decision, not a crash");
+}
+
+// ---------------------------------------------------------------------------
+// Optional pr_number (#1150)
+// ---------------------------------------------------------------------------
+
+// Everything this module writes is addressed by one number. On a workflow_run
+// the event payload holds no issue and no pull request, so context.issue.number
+// is undefined and every call used to be addressed to /issues//… — a 404 after
+// a completed review. The caller now resolves the number and passes it in.
+async function testPrNumberOverrideAddressesEveryCall() {
+  const findings = {
+    comments: [{ path: "src/a.js", content: "finding", start_line: 3, end_line: 3 }],
+    warnings: [],
+  };
+  const workflowRunContext = {
+    repo: { owner: "owner", repo: "repo" },
+    // What @actions/github's Context yields for a workflow_run payload.
+    issue: { number: undefined },
+    eventName: "workflow_run",
+    payload: { workflow_run: { pull_requests: [{ number: 4242 }] } },
+  };
+
+  const github = makeGithub({
+    files: [{ filename: "src/a.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c" }],
+  });
+  await runPostReviewComments({
+    github,
+    context: workflowRunContext,
+    core: mockCore(),
+    fs: mockFs(JSON.stringify(findings), ""),
+    prNumber: 4242,
+    stickySummary: true,
+  });
+
+  // Every read and write, not just the summary: the head lookup, the diff
+  // inventory, the review itself and the summary comment all address the PR the
+  // caller resolved.
+  const addressed = [
+    ...github.getPullCalls.map((c) => c.pull_number),
+    ...github.listFilesCalls.map((c) => c.pull_number),
+    ...github.createReviewCalls.map((c) => c.pull_number),
+    ...github.listCommentsCalls.map((c) => c.issue_number),
+    ...github.issueComments.map((c) => c.issue_number),
+  ];
+  assert.ok(github.createReviewCalls.length > 0, "the review must be posted");
+  assert.ok(github.issueComments.length > 0, "the summary must be posted");
+  assert.deepStrictEqual(
+    [...new Set(addressed)],
+    [4242],
+    "every call must address the resolved PR, and none of them undefined"
+  );
+
+  // Omitting the option keeps the event-derived number, so callers that never
+  // pass one (and every trigger that carries a PR) are unaffected.
+  const legacy = makeGithub({ files: [{ filename: "src/a.js", patch: "@@ -1,3 +1,3 @@\n a\n b\n c" }] });
+  await runPostReviewComments({
+    github: legacy,
+    context,
+    core: mockCore(),
+    fs: mockFs(JSON.stringify(findings), ""),
+    stickySummary: true,
+  });
+  assert.deepStrictEqual(
+    [...new Set(legacy.createReviewCalls.map((c) => c.pull_number))],
+    [context.issue.number],
+    "without the option the event's own number is still used"
+  );
 }
 
 // The flagless marker RegExp is shared across calls now. That is only safe


### PR DESCRIPTION
## Description

On `workflow_run` the action found no pull request number. The fetch step read `github.event.pull_request.number || github.event.issue.number` and the range and posting steps read `context.issue.number`; none of them resolve for that event, whose payload names the pull request only under `workflow_run.pull_requests[0]`. The review ran to completion, the posting step requested `/repos/OWNER/REPO/issues//comments`, got a 404, and the findings were lost.

A new "Resolve PR refs" step resolves the number once, in this order: the new optional `pr_number` input, then the event payload, then `workflow_run.pull_requests[0].number`. It publishes the value as `$PR_NUMBER` and fails right there, before OCR is installed or any LLM quota is spent, when nothing resolves or the value is not a PR number. The head fetch, the checkpoint resolver and the posting step all read that one value; `runPostReviewComments` takes it as an option and still falls back to `context.issue.number` when a caller omits it.

`pull_request`, `pull_request_target` and `issue_comment` behave as before: an unset input falls through to the existing resolution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

- `npm run test:github-actions`: new action-contract cases cover the resolution order, the `workflow_run` fallback, the early failure on a missing or non-numeric value, and the `prNumber` option of `runPostReviewComments` together with its existing `context.issue.number` fallback.
- `make test` on this branch (Go packages plus the node script tests).
- Only `action.yml`, the scripts under `scripts/github-actions/` and `examples/github_actions/README.md` change; there is no Go change.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #1150
