### PR TITLE
feat(action): expose effort and max_tokens_budget inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,22 @@ inputs:
   rule:
     description: Path to a custom rules JSON file passed to `ocr review --rule`.
     required: false
+  effort:
+    description: >-
+      Review effort preset passed to `ocr review --effort`: low, medium or
+      high, case-insensitively. It selects how many review rounds the agent
+      runs. Unset or empty appends no flag and keeps the CLI's own resolution,
+      which is the configured effort or otherwise medium.
+    required: false
+  max_tokens_budget:
+    description: >-
+      Aggregate token cap (input + output) for the whole review, passed to
+      `ocr review --max-tokens-budget`. A non-negative base-10 integer with no
+      leading zeros: dispatch stops once the budget is exceeded, the files that
+      were skipped are reported as failed(budget), and the partial result is
+      still published. 0 means unlimited, and so does leaving it unset or
+      empty, which appends no flag at all.
+    required: false
   upload_artifacts:
     description: >-
       Upload raw JSON result and stderr as workflow artifacts. Must be the
@@ -340,6 +356,42 @@ runs:
         fi
         echo "REVIEW_TASK_TIMEOUT=$REVIEW_TASK_TIMEOUT_NUMBER" >> "$GITHUB_ENV"
 
+    - name: Validate effort and max_tokens_budget
+      env:
+        OCR_EFFORT: ${{ inputs.effort }}
+        OCR_MAX_TOKENS_BUDGET: ${{ inputs.max_tokens_budget }}
+      shell: bash
+      run: |
+        # Both inputs are optional and both are forwarded verbatim, so the only
+        # thing to check is the shape of a value that was actually supplied.
+        # The CLI rejects the same values, but only after the npm install and
+        # the LLM configuration have run, and then as a generic non-zero exit
+        # buried in the stderr artifact. Checking here turns a typo into an
+        # annotated failure that costs seconds instead of a full review setup.
+        #
+        # Neither value is rewritten before it reaches the CLI. --effort needs
+        # no rewriting because `ocr review` lower-cases the preset itself. The
+        # budget is a different matter: the CLI parses integer flags with a
+        # base-0 strconv, so "010" would silently mean 8. Rather than normalize
+        # it across two steps the way review_task_timeout has to, a leading
+        # zero is simply refused - nobody writes a token budget that way, and a
+        # refusal cannot be misread.
+        if [ -n "$OCR_EFFORT" ]; then
+          case "$(printf '%s' "$OCR_EFFORT" | tr '[:upper:]' '[:lower:]')" in
+            low|medium|high) ;;
+            *)
+              echo "::error::effort must be one of low, medium or high (got '${OCR_EFFORT}')"
+              exit 1
+              ;;
+          esac
+        fi
+        if [ -n "$OCR_MAX_TOKENS_BUDGET" ]; then
+          if [[ ! "$OCR_MAX_TOKENS_BUDGET" =~ ^(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::max_tokens_budget must be a non-negative base-10 integer without leading zeros, where 0 means unlimited (got '${OCR_MAX_TOKENS_BUDGET}')"
+            exit 1
+          fi
+        fi
+
     - name: Install OpenCodeReview
       shell: bash
       env:
@@ -461,6 +513,21 @@ runs:
         OCR_FP_ROUTE_SEVERITY_BELOW: ${{ inputs.route_severity_below }}
         OCR_FP_ROUTE_CATEGORIES: ${{ inputs.route_categories }}
         OCR_FP_BACKGROUND: ${{ inputs.background }}
+        # The effort preset picks how many review rounds run, so a checkpoint
+        # recorded by a `low` run must not let a later `high` run skip the
+        # commits it covered less thoroughly.
+        #
+        # `max_tokens_budget` deliberately stays out, even though issue #1147
+        # proposed it alongside effort. The budget has exactly one entry
+        # point: the dispatch look-ahead in internal/agent/agent.go, the only
+        # writer of budgetExceeded, which always leaves at least one group
+        # undispatched and records a pending failed(budget) cause. That makes
+        # the manifest partial, and only a complete manifest ever advances a
+        # checkpoint - including for the round-skipping path, which is gated
+        # on the same flag. So a budget cannot record a checkpoint over a
+        # range it reviewed less than fully, and fingerprinting it would only
+        # force needless full reviews whenever the budget is retuned.
+        OCR_FP_EFFORT: ${{ inputs.effort }}
         OCR_RULE_PATH: ${{ inputs.rule }}
         # `github.token` is always the "github-actions" app, so when the caller
         # did not override the token we know exactly which app wrote our summary
@@ -584,6 +651,7 @@ runs:
                 process.env.OCR_FP_ROUTE_SEVERITY_BELOW,
                 process.env.OCR_FP_ROUTE_CATEGORIES,
                 process.env.OCR_FP_BACKGROUND,
+                process.env.OCR_FP_EFFORT,
                 versionActual,
                 ruleDigest,
                 localRuleDigest,
@@ -654,6 +722,8 @@ runs:
         OCR_REVIEW_CONCURRENCY: ${{ inputs.review_concurrency }}
         OCR_BACKGROUND: ${{ inputs.background }}
         OCR_RULE: ${{ inputs.rule }}
+        OCR_EFFORT: ${{ inputs.effort }}
+        OCR_MAX_TOKENS_BUDGET: ${{ inputs.max_tokens_budget }}
         # Step output, not job env: empty when the resolve step was skipped or
         # chose the full range, and never inherited from an earlier use of this
         # action in the same job.
@@ -669,6 +739,12 @@ runs:
         [ -n "$OCR_REVIEW_CONCURRENCY" ] && ARGS+=(--concurrency "$OCR_REVIEW_CONCURRENCY")
         [ -n "$OCR_BACKGROUND" ] && ARGS+=(--background "$OCR_BACKGROUND")
         [ -n "$OCR_RULE" ] && ARGS+=(--rule "$OCR_RULE")
+        # Empty means "no flag": the CLI then applies its own default, which is
+        # the configured effort (otherwise medium) and an unlimited budget. An
+        # explicit 0 budget is forwarded and means unlimited too, matching
+        # --max-tokens-budget's own documented semantics.
+        [ -n "$OCR_EFFORT" ] && ARGS+=(--effort "$OCR_EFFORT")
+        [ -n "$OCR_MAX_TOKENS_BUDGET" ] && ARGS+=(--max-tokens-budget "$OCR_MAX_TOKENS_BUDGET")
         set +e
         ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log
         OCR_EXIT_CODE=$?

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -165,6 +165,28 @@ The task and request timeouts are independent:
     llm_timeout: '900'
 ```
 
+### Tune review depth and the token budget
+
+Both inputs are optional. Leaving one empty appends no flag, so the CLI default stands:
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `effort` | none | Review effort preset passed to `ocr review --effort`: `low`, `medium` or `high` (case-insensitive), which selects how many review rounds the agent runs. Unset leaves the CLI's own resolution, i.e. `medium`. |
+| `max_tokens_budget` | none | Aggregate token cap (input + output) passed to `ocr review --max-tokens-budget`. A non-negative integer without leading zeros; `0` means unlimited, and so does leaving it unset. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    effort: 'high'
+    max_tokens_budget: '250000'
+```
+
+The budget is the only cap on a review's total spend: dispatch stops once it is exceeded, the files that were never reached are reported as `failed(budget)`, and the partial result is still posted (the job does not fail unless every selected item failed).
+
+> A leading zero is rejected rather than normalized, because the CLI parses integer flags with a base-0 conversion where `010` would quietly mean 8.
+
+> Changing `effort` invalidates any stored checkpoint (see [Review only what changed since the last run](#review-only-what-changed-since-the-last-run-checkpoints)), so the next run re-reviews the whole `merge-base..head` range at the new depth. `max_tokens_budget` does not: a run that hits its budget is partial, and only a complete run ever records a checkpoint.
+
 ### Add custom review rules
 
 ```yaml

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -872,6 +872,200 @@ function testRunFailsClosedWhenValidatedTaskTimeoutIsMissing() {
   }
 }
 
+// --- effort / max_tokens_budget ---
+//
+// Both are optional passthroughs to `ocr review`. "Unset" has to stay
+// distinguishable from "set to something": appending the flag with an empty
+// value would not restore the CLI default, it would hand the CLI an empty
+// argument.
+
+function effortAndBudgetValidationStep() {
+  return stepNamed("Validate effort and max_tokens_budget");
+}
+
+// The Run step needs a validated timeout and a merge base in the environment;
+// these tests care only about the argv it builds from there.
+function reviewCallWith(overrides) {
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  const fixture = makeFixture();
+  try {
+    const values = inputValues(
+      Object.assign(
+        {
+          review_task_timeout: "10",
+          llm_url: "https://llm.example.invalid/v1",
+          llm_auth_token: "unused-token",
+          llm_model: "contract-model",
+          llm_use_anthropic: "false",
+        },
+        overrides
+      )
+    );
+    const result = runStep(
+      run,
+      values,
+      fixture,
+      { MERGE_BASE: "base-sha", HEAD_SHA: "head-sha", REVIEW_TASK_TIMEOUT: values.review_task_timeout },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview shell block failed; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(fixture.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    return reviewCall;
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+// Every value forwarded for `flag`, so a test can tell "absent" from "present
+// once" from "duplicated" instead of only asserting inclusion.
+function flagValues(args, flag) {
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === flag) values.push(args[index + 1]);
+  }
+  return values;
+}
+
+function assertTuningValidation(overrides, expectedValid, expectedMessage) {
+  const step = effortAndBudgetValidationStep();
+  assert.ok(step, "action.yml must validate effort and max_tokens_budget in a dedicated step");
+  const fixture = makeFixture();
+  try {
+    const result = runStep(step, inputValues(overrides), fixture);
+    const description = `${JSON.stringify(overrides)}; ${resultDescription(result)}`;
+    if (expectedValid) {
+      assert.strictEqual(result.status, 0, `value should be accepted; ${description}`);
+    } else {
+      assert.notStrictEqual(result.status, 0, `value should be rejected; ${description}`);
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        expectedMessage,
+        `the rejection must name the input and its accepted values; ${description}`
+      );
+    }
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+function testEffortAndBudgetInputsAreOptional() {
+  for (const name of ["effort", "max_tokens_budget"]) {
+    assert.ok(INPUTS[name], `action.yml must define the ${name} input`);
+    assert.strictEqual(
+      INPUTS[name].default,
+      undefined,
+      `${name} must carry no default, so leaving it unset keeps the CLI's own default`
+    );
+  }
+}
+
+function testUnsetEffortAndBudgetAppendNoFlags() {
+  const reviewCall = reviewCallWith({});
+  for (const flag of ["--effort", "--max-tokens-budget"]) {
+    assert.deepStrictEqual(
+      flagValues(reviewCall.args, flag),
+      [],
+      `an unset input must not append ${flag}; args=${JSON.stringify(reviewCall.args)}`
+    );
+  }
+}
+
+function testEffortAndBudgetForwardedToReviewCommand() {
+  const reviewCall = reviewCallWith({ effort: "high", max_tokens_budget: "120000" });
+  assert.deepStrictEqual(
+    flagValues(reviewCall.args, "--effort"),
+    ["high"],
+    `effort must be forwarded once as --effort; args=${JSON.stringify(reviewCall.args)}`
+  );
+  assert.deepStrictEqual(
+    flagValues(reviewCall.args, "--max-tokens-budget"),
+    ["120000"],
+    `max_tokens_budget must be forwarded once as --max-tokens-budget; args=${JSON.stringify(reviewCall.args)}`
+  );
+}
+
+// 0 is a real value, not a synonym for unset: the CLI documents it as
+// "unlimited", so it is forwarded rather than dropped, and the two paths agree
+// on what the review does.
+function testZeroBudgetIsForwardedVerbatim() {
+  const reviewCall = reviewCallWith({ max_tokens_budget: "0" });
+  assert.deepStrictEqual(
+    flagValues(reviewCall.args, "--max-tokens-budget"),
+    ["0"],
+    `an explicit 0 budget must reach the CLI; args=${JSON.stringify(reviewCall.args)}`
+  );
+}
+
+function testEffortValidationAcceptsThePresets() {
+  // Upper case included: `ocr review` lower-cases the preset itself, so the
+  // action must not be stricter than the flag it forwards to.
+  for (const value of ["", "low", "medium", "high", "HIGH", "Medium"]) {
+    assertTuningValidation({ effort: value }, true);
+  }
+}
+
+function testEffortValidationRejectsUnknownPresets() {
+  for (const value of ["extreme", "lowest", "low medium", " low", "2"]) {
+    assertTuningValidation({ effort: value }, false, /effort must be one of low, medium or high/);
+  }
+}
+
+function testBudgetValidationAcceptsNonNegativeIntegers() {
+  for (const value of ["", "0", "1", "120000"]) {
+    assertTuningValidation({ max_tokens_budget: value }, true);
+  }
+}
+
+function testBudgetValidationRejectsMalformedValues() {
+  // "010" is not a typo in this list: the CLI parses integer flags with a
+  // base-0 strconv, so a leading zero would silently mean octal 8.
+  for (const value of ["-1", "-120000", "1.5", "1e6", "+10", "abc", "12 000", "010"]) {
+    assertTuningValidation(
+      { max_tokens_budget: value },
+      false,
+      /max_tokens_budget must be a non-negative base-10 integer/
+    );
+  }
+}
+
+function testEffortAndBudgetValidationPrecedesNpmInstall() {
+  const validation = effortAndBudgetValidationStep();
+  const install = installStep();
+  assert.ok(validation, "action.yml must validate effort and max_tokens_budget before installation");
+  assert.ok(install, "action.yml must retain an OpenCodeReview installation step");
+  assert.ok(validation.index < install.index, "effort/max_tokens_budget validation must occur before NPM install");
+
+  const fixture = makeFixture();
+  try {
+    const values = inputValues({ effort: "extreme", ocr_version: "contract-test" });
+    const script = `${renderedRun(validation, values)}\n${renderedRun(install, values)}`;
+    const env = Object.assign({}, renderedEnv(validation, values), renderedEnv(install, values));
+    const result = runShell(script, env, fixture);
+    assert.notStrictEqual(result.status, 0, `an invalid effort must stop the action; ${resultDescription(result)}`);
+    assert.deepStrictEqual(readJsonLines(fixture.npmCallsPath), [], "NPM must not run after effort validation fails");
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
+// The effort preset changes how many review rounds run, so a checkpoint
+// recorded by a shallower run must not narrow a later, deeper one.
+function testEffortParticipatesInTheCheckpointFingerprint() {
+  const resolve = stepNamed("Resolve review range");
+  assert.ok(resolve, "action.yml must retain the Resolve review range step");
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(resolve.env, "OCR_FP_EFFORT"),
+    "Resolve review range must feed effort into the configuration fingerprint"
+  );
+  assert.match(
+    ACTION_TEXT,
+    /process\.env\.OCR_FP_EFFORT,/,
+    "the fingerprint digest must actually read OCR_FP_EFFORT"
+  );
+}
+
 function testOfficialNpmPackageInstallIsPreserved() {
   const install = installStep();
   assert.ok(install, "action.yml must retain the Install OpenCodeReview step");
@@ -1014,6 +1208,7 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
       "OCR_EXTRA_BODY",
       "OCR_LANGUAGE",
     ],
+    "Validate effort and max_tokens_budget": ["OCR_EFFORT", "OCR_MAX_TOKENS_BUDGET"],
     "Run OpenCodeReview": [
       "OCR_LLM_URL",
       "OCR_LLM_TOKEN",
@@ -1025,6 +1220,8 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
       "OCR_REVIEW_CONCURRENCY",
       "OCR_BACKGROUND",
       "OCR_RULE",
+      "OCR_EFFORT",
+      "OCR_MAX_TOKENS_BUDGET",
     ],
   };
   for (const [name, envNames] of Object.entries(required)) {
@@ -1087,6 +1284,19 @@ function testExampleReadmeDocumentsTimeoutAndVersionContracts() {
   );
 }
 
+function testExampleReadmeDocumentsEffortAndBudget() {
+  assert.match(
+    EXAMPLE_README_TEXT,
+    /\| `effort` \|[^\n]*low[^\n]*medium[^\n]*high[^\n]*\|/i,
+    "GitHub Actions README must document the effort presets"
+  );
+  assert.match(
+    EXAMPLE_README_TEXT,
+    /\| `max_tokens_budget` \|[^\n]*0[^\n]*unlimited[^\n]*\|/i,
+    "GitHub Actions README must document that a 0 budget means unlimited"
+  );
+}
+
 const TESTS = [
   ["review_task_timeout names and describes the CLI task deadline", testReviewTaskTimeoutInputNameAndScope],
   ["llm_timeout defaults to the CLI's 5-minute timeout", testLlmTimeoutInputDefault],
@@ -1106,12 +1316,23 @@ const TESTS = [
   ["Configure OCR clears stale persisted retry codes", testConfigureClearsStaleRetryCodesBeforeEndpointConfig],
   ["Run OpenCodeReview retains the extra-headers env override", testRunRetainsExtraHeadersEnvironmentOverride],
   ["Run OpenCodeReview fails closed without validated task timeout", testRunFailsClosedWhenValidatedTaskTimeoutIsMissing],
+  ["effort and max_tokens_budget are optional and undefaulted", testEffortAndBudgetInputsAreOptional],
+  ["unset effort and max_tokens_budget append no review flags", testUnsetEffortAndBudgetAppendNoFlags],
+  ["effort and max_tokens_budget reach ocr review once each", testEffortAndBudgetForwardedToReviewCommand],
+  ["an explicit 0 token budget is forwarded verbatim", testZeroBudgetIsForwardedVerbatim],
+  ["effort accepts the CLI presets in any case", testEffortValidationAcceptsThePresets],
+  ["effort rejects values the CLI would not accept", testEffortValidationRejectsUnknownPresets],
+  ["max_tokens_budget accepts non-negative integers", testBudgetValidationAcceptsNonNegativeIntegers],
+  ["max_tokens_budget rejects malformed values", testBudgetValidationRejectsMalformedValues],
+  ["effort/max_tokens_budget validation runs before NPM install", testEffortAndBudgetValidationPrecedesNpmInstall],
+  ["effort participates in the checkpoint fingerprint", testEffortParticipatesInTheCheckpointFingerprint],
   ["the official OpenCodeReview NPM install is preserved", testOfficialNpmPackageInstallIsPreserved],
   ["Install OpenCodeReview enforces the auth_token_cmd version floor", testInstallEnforcesAuthTokenCommandVersionFloor],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
   ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],
   ["GitHub Actions README documents timeout and version contracts", testExampleReadmeDocumentsTimeoutAndVersionContracts],
+  ["GitHub Actions README documents effort and max_tokens_budget", testExampleReadmeDocumentsEffortAndBudget],
 ];
 
 function main() {

--- a/scripts/github-actions/post-review-comments.test.js
+++ b/scripts/github-actions/post-review-comments.test.js
@@ -4316,6 +4316,12 @@ async function testActionScriptFingerprintCoversRepoLocalRules() {
   assert.notStrictEqual(shifted, shiftedBack, "no input value may shift a fingerprint field boundary");
   const otherVersion = await fingerprint({ OCR_VERSION_ACTUAL: "1.2.4" });
   assert.notStrictEqual(otherVersion, edited, "a changed OCR version must invalidate the checkpoint");
+
+  // The effort preset decides how many review rounds run, so a checkpoint a
+  // `low` run recorded must not let a later `high` run skip the commits it
+  // covered less thoroughly.
+  const otherEffort = await fingerprint({ OCR_FP_EFFORT: "high" });
+  assert.notStrictEqual(otherEffort, edited, "a changed effort preset must invalidate the checkpoint");
 }
 
 // U1. GET /user is 403 ("Resource not accessible by integration") for the


### PR DESCRIPTION
## Description

The composite action builds the `ocr review` command itself and exposes only `--concurrency`, `--timeout`, `--background` and `--rule`, so two flags were unreachable from a workflow: `--effort`, which picks the review-round preset, and `--max-tokens-budget`, the only aggregate cap on a review's token spend (`review_cmd.go` gives it no config or environment fallback).

This adds both as optional inputs, appended to the review args only when non-empty, so an unset input keeps the CLI default: the configured effort (otherwise medium) and an unlimited budget. An explicit `0` budget is forwarded rather than dropped and means unlimited, matching the flag's own documentation.

Both are validated before the npm install, so a typo fails with an annotation in seconds instead of after the whole review setup. `effort` accepts low/medium/high in any case, because `ocr review` lower-cases the preset itself; the budget must be a non-negative integer without leading zeros, because the CLI parses integer flags with base-0 `strconv`, where `010` would silently mean 8.

`effort` also joins the checkpoint fingerprint: a checkpoint recorded by a low-effort run must not narrow a later high-effort one. `max_tokens_budget` deliberately stays out of it, since a run that hits its budget is partial and only a complete run should advance a checkpoint.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

- `npm run test:github-actions`: action-contract cases for both inputs (unset, set, `0` budget, invalid values, case handling of `effort`) and the fingerprint change in `post-review-comments.test.js`.
- `make test` on this branch (Go packages plus the node script tests).
- Only `action.yml`, the scripts under `scripts/github-actions/` and `examples/github_actions/README.md` change; there is no Go change.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [ ] I have signed the CLA

## Related Issues

Closes #1147
