### PR TITLE
fix(llm): let --timeout raise the per-request HTTP deadline

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -149,8 +149,9 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 	}
 
 	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, llm.ResolveOptions{
-		Provider: opts.provider,
-		Model:    opts.model,
+		Provider:    opts.provider,
+		Model:       opts.model,
+		TaskTimeout: time.Duration(opts.perFileTimeout) * time.Minute,
 	})
 	if err != nil {
 		return err

--- a/cmd/opencodereview/scan_cmd.go
+++ b/cmd/opencodereview/scan_cmd.go
@@ -161,8 +161,9 @@ func executeScan(opts scanOptions) (retErr error) {
 	}
 
 	rt, err := loadLLMRuntime(cc.Template, opts.toolConfigPath, llm.ResolveOptions{
-		Provider: opts.provider,
-		Model:    opts.model,
+		Provider:    opts.provider,
+		Model:       opts.model,
+		TaskTimeout: time.Duration(opts.perFileTimeout) * time.Minute,
 	})
 	if err != nil {
 		return err

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -77,6 +77,12 @@ const (
 type ResolveOptions struct {
 	Provider string
 	Model    string
+	// TaskTimeout is the caller's concurrent-task timeout (e.g. the
+	// --timeout flag, in minutes). When set above zero it raises the
+	// per-request HTTP deadline so a slow request can use the whole task
+	// budget instead of hitting the client's independent 5-minute default.
+	// Env (OCR_LLM_TIMEOUT) and config-file timeout_sec keep precedence.
+	TaskTimeout time.Duration
 }
 
 // ResolveEndpoint resolves an endpoint without per-run overrides.
@@ -120,7 +126,7 @@ func ResolveEndpointWithOptions(configPath string, opts ResolveOptions) (Resolve
 			}
 			return ResolvedEndpoint{}, fmt.Errorf("resolve OCR config file: provider %q is not configured in %s section because the config file does not exist", opts.Provider, section)
 		}
-		return finalizeResolvedEndpoint("OCR config file", ep, env), nil
+		return finalizeResolvedEndpoint("OCR config file", ep, env, opts), nil
 	}
 
 	strategies := []struct {
@@ -142,7 +148,7 @@ func ResolveEndpointWithOptions(configPath string, opts ResolveOptions) (Resolve
 		// transport supplies both. Everything else still needs all three.
 		complete := ep.Model != "" && (ep.AmbientAuth || (ep.URL != "" && ep.Token != ""))
 		if ok && complete {
-			return finalizeResolvedEndpoint(strategy.name, ep, env), nil
+			return finalizeResolvedEndpoint(strategy.name, ep, env, opts), nil
 		}
 	}
 
@@ -176,13 +182,17 @@ func parseEnvOverrides() (envOverrides, error) {
 
 // finalizeResolvedEndpoint stamps the source label, strips the model suffix and
 // applies the global env overrides, which win over config-file values.
-func finalizeResolvedEndpoint(source string, ep ResolvedEndpoint, env envOverrides) ResolvedEndpoint {
+func finalizeResolvedEndpoint(source string, ep ResolvedEndpoint, env envOverrides, opts ResolveOptions) ResolvedEndpoint {
 	if ep.Source == "" {
 		ep.Source = source
 	}
 	ep.Model = stripModelSuffix(ep.Model)
 	if env.hasTimeout {
 		ep.Timeout = env.timeout
+	} else if ep.Timeout <= 0 && opts.TaskTimeout > 0 {
+		// No env or config-file request timeout: let the caller's task
+		// budget raise the per-request deadline above the client default.
+		ep.Timeout = opts.TaskTimeout
 	}
 	if env.headers != nil {
 		if ep.ExtraHeaders == nil {

--- a/internal/llm/resolver_test.go
+++ b/internal/llm/resolver_test.go
@@ -2622,3 +2622,62 @@ func TestResolveEndpoint_RedundantRetryCodesFiltered(t *testing.T) {
 		t.Errorf("RetryCodes = %v, want [403] (429 should be filtered)", ep.RetryCodes)
 	}
 }
+
+// Regression test for #1155: a caller's task timeout (--timeout) must raise
+// the per-request HTTP deadline above the client's 5-minute default, while
+// OCR_LLM_TIMEOUT and config-file timeout_sec keep precedence.
+func TestResolveEndpointWithOptions_TaskTimeoutRaisesRequestDeadline(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv("OCR_LLM_URL", "https://env.example.com/v1")
+	t.Setenv("OCR_LLM_TOKEN", "env-token")
+	path, _ := writeResolverConfig(t, configFile{Llm: llmFileConfig{Model: "config-model", URL: "https://config.example.com/v1", AuthToken: "config-token"}})
+
+	// Task timeout applies when no env or config-file request timeout is set.
+	ep, err := ResolveEndpointWithOptions(path, ResolveOptions{Model: "config-model", TaskTimeout: 30 * time.Minute})
+	if err != nil {
+		t.Fatalf("ResolveEndpointWithOptions: %v", err)
+	}
+	if ep.Timeout != 30*time.Minute {
+		t.Fatalf("ep.Timeout = %v, want 30m from TaskTimeout", ep.Timeout)
+	}
+
+	// Zero task timeout leaves the client default in place.
+	ep, err = ResolveEndpointWithOptions(path, ResolveOptions{})
+	if err != nil {
+		t.Fatalf("ResolveEndpointWithOptions(zero): %v", err)
+	}
+	if ep.Timeout != 0 {
+		t.Fatalf("ep.Timeout = %v, want 0 (client default)", ep.Timeout)
+	}
+}
+
+func TestResolveEndpointWithOptions_EnvTimeoutBeatsTaskTimeout(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv("OCR_LLM_URL", "https://env.example.com/v1")
+	t.Setenv("OCR_LLM_TOKEN", "env-token")
+	t.Setenv("OCR_LLM_TIMEOUT", "45")
+	path, _ := writeResolverConfig(t, configFile{Llm: llmFileConfig{Model: "config-model", URL: "https://config.example.com/v1", AuthToken: "config-token"}})
+
+	ep, err := ResolveEndpointWithOptions(path, ResolveOptions{TaskTimeout: 30 * time.Minute})
+	if err != nil {
+		t.Fatalf("ResolveEndpointWithOptions: %v", err)
+	}
+	if ep.Timeout != 45*time.Second {
+		t.Fatalf("ep.Timeout = %v, want env's 45s over TaskTimeout's 30m", ep.Timeout)
+	}
+}
+
+func TestResolveEndpointWithOptions_ConfigTimeoutBeatsTaskTimeout(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv("OCR_LLM_URL", "https://env.example.com/v1")
+	t.Setenv("OCR_LLM_TOKEN", "env-token")
+	path, _ := writeResolverConfig(t, configFile{Llm: llmFileConfig{Model: "config-model", URL: "https://config.example.com/v1", AuthToken: "config-token", TimeoutSec: 60}})
+
+	ep, err := ResolveEndpointWithOptions(path, ResolveOptions{TaskTimeout: 30 * time.Minute})
+	if err != nil {
+		t.Fatalf("ResolveEndpointWithOptions: %v", err)
+	}
+	if ep.Timeout != 60*time.Second {
+		t.Fatalf("ep.Timeout = %v, want config's 60s over TaskTimeout's 30m", ep.Timeout)
+	}
+}


### PR DESCRIPTION
## Description

`--timeout` documents a concurrent-task timeout in minutes, but the per-request HTTP deadline stayed at the client's independent 5-minute default (`cfg.Timeout = 5 * time.Minute`). A review of one slow file failed with `classification=timeout` at `duration_to_headers_ms≈300000` even when the caller granted `--timeout 30`, and no CLI setting could let the file review finish (#1155).

Per-request timeouts were already configurable through `OCR_LLM_TIMEOUT` and provider `timeout_sec`, but neither is fed by the CLI flag a caller naturally reaches for.

## Changes

- `llm.ResolveOptions` gains `TaskTimeout`: when **no** env (`OCR_LLM_TIMEOUT`) or config-file (`timeout_sec`) request timeout is set, the task budget raises the request deadline so a single request can use the whole task budget.
- Existing precedence is unchanged: env > config-file > task timeout > 5-minute client default. The default `--timeout 15` keeps today's behavior (15 min budget > 5 min request default, so nothing moves).
- `ocr review` and `ocr scan` both pass their `--timeout` value through.

## Test plan

- [x] `TestResolveEndpointWithOptions_TaskTimeoutRaisesRequestDeadline` — 30m task timeout lands on the endpoint; zero leaves the client default (0)
- [x] `TestResolveEndpointWithOptions_EnvTimeoutBeatsTaskTimeout` — `OCR_LLM_TIMEOUT=45` wins over a 30m task timeout
- [x] `TestResolveEndpointWithOptions_ConfigTimeoutBeatsTaskTimeout` — `timeout_sec: 60` wins over a 30m task timeout
- [x] Full `internal/llm` suite passes; `gofmt` clean

Fixes #1155