### PR TITLE
fix(mcp): bound the MCP shutdown phase

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -196,10 +196,16 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 
 	mcpClients := initMCPClients(ctx, rt.AppCfg, tools, cc.RepoDir, Version)
 	defer func() {
-		for _, mc := range mcpClients {
-			if err := mc.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to close MCP server %q: %v\n", mc.Name(), err)
-			}
+		// The close phase must stay bounded even after a cancellation (#1141):
+		// context.Background() rather than the run ctx, so a Ctrl-C that
+		// already fired does not collapse this budget to zero and orphan every
+		// subprocess. CloseAll closes concurrently and gives up after the
+		// deadline; the SDK still escalates SIGTERM to SIGKILL in the
+		// meantime, and whatever outlives the process is reclaimed by the OS.
+		closeCtx, cancel := context.WithTimeout(context.Background(), mcp.CloseTimeout)
+		defer cancel()
+		if err := mcp.CloseAll(closeCtx, mcpClients); err != nil {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %v\n", err)
 		}
 	}()
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -5,14 +5,36 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// SubprocessTerminateDuration bounds each escalation stage of the SDK's
+	// stdio subprocess shutdown: the wait after closing stdin, the wait after
+	// SIGTERM, and the wait after SIGKILL. The SDK default is 5s per stage,
+	// so one unresponsive server could hold Close for ~15s (#1141). 800ms
+	// per stage keeps a single server's worst case at ~2.4s while still
+	// giving a well-behaved server ample time to exit on its own.
+	SubprocessTerminateDuration = 800 * time.Millisecond
+
+	// CloseTimeout bounds the whole MCP close phase regardless of how many
+	// servers are configured: CloseAll stops waiting once it expires and
+	// leaves any remaining subprocess to the OS. It sits above the
+	// per-server worst case (3 stages x SubprocessTerminateDuration = 2.4s)
+	// with headroom for scheduling jitter, yet still inside the 3s shutdown
+	// budget, docker stop's 10s grace period, and the VS Code extension's 3s
+	// SIGKILL escalation.
+	CloseTimeout = 2800 * time.Millisecond
 )
 
 // Client wraps a single MCP server connection.
@@ -21,6 +43,12 @@ type Client struct {
 	session *mcp.ClientSession
 	tools   []*mcp.Tool
 }
+
+// subprocessTerminateDuration is the per-stage shutdown budget handed to every
+// CommandTransport. It defaults to SubprocessTerminateDuration and is widened
+// only by tests running under the race detector, whose re-exec'd children pay
+// ~1s of runtime overhead before noticing stdin EOF.
+var subprocessTerminateDuration = SubprocessTerminateDuration
 
 // NewClient starts an MCP server subprocess (stdio transport), initializes the
 // connection, and caches the list of available tools. The context governs the
@@ -39,7 +67,7 @@ func NewClient(ctx context.Context, name, command string, args, env []string, di
 		nil,
 	)
 
-	transport := &mcp.CommandTransport{Command: cmd}
+	transport := &mcp.CommandTransport{Command: cmd, TerminateDuration: subprocessTerminateDuration}
 	session, err := client.Connect(ctx, transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("connect to MCP server %q: %w", name, err)
@@ -175,6 +203,85 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]any)
 
 func (c *Client) Close() error {
 	return c.session.Close()
+}
+
+// CloseAll closes every client concurrently and waits for all of them, or for
+// ctx to expire, whichever comes first. Serial closing multiplied the SDK's
+// per-server shutdown bound by the number of configured servers (#1141);
+// closing in parallel keeps the whole phase at the single slowest server's
+// cost, and the ctx deadline caps even that.
+//
+// Each per-client error is wrapped with the server name, and on the happy path
+// the results are joined in configuration order, so one warning can report
+// every failed server. When ctx expires first, a final non-blocking check
+// prefers completion over a timeout report (the last Close can finish at the
+// same instant the deadline fires); on a genuine timeout the returned error
+// wraps the deadline failure, reports how many servers finished, how many of
+// those had errors, and how many were still shutting down, keeping any errors
+// already collected from servers that finished in time: their
+// Close goroutines keep running and the SDK still escalates SIGTERM to
+// SIGKILL, but if the process exits first the remaining subprocesses are left
+// to the OS.
+func CloseAll(ctx context.Context, clients []*Client) error {
+	if len(clients) == 0 {
+		return nil
+	}
+
+	errs := make([]error, len(clients))
+	remaining := len(clients)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(len(clients))
+	for i, c := range clients {
+		go func() {
+			defer wg.Done()
+			err := c.Close()
+			mu.Lock()
+			remaining--
+			if err != nil {
+				errs[i] = fmt.Errorf("close MCP server %q: %w", c.name, err)
+			}
+			mu.Unlock()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		mu.Lock()
+		defer mu.Unlock()
+		return errors.Join(errs...)
+	case <-ctx.Done():
+		// The last Close() can complete at nearly the same instant the
+		// deadline expires; with both cases ready Go picks one
+		// pseudo-randomly, so prefer completion over reporting a spurious
+		// timeout for a fully successful close (#1141 review feedback).
+		select {
+		case <-done:
+			mu.Lock()
+			defer mu.Unlock()
+			return errors.Join(errs...)
+		default:
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		errorCount := 0
+		for _, err := range errs {
+			if err != nil {
+				errorCount++
+			}
+		}
+		if joined := errors.Join(errs...); joined != nil {
+			return fmt.Errorf("%w; %d of %d server(s) closed before the deadline, %d with errors, %d still shutting down: %w",
+				ctx.Err(), len(clients)-remaining, len(clients), errorCount, remaining, joined)
+		}
+		return fmt.Errorf("timed out closing %d MCP server(s): %w; %d still shutting down, subprocesses left to the OS", len(clients), ctx.Err(), remaining)
+	}
 }
 
 func contentToText(contents []mcp.Content) string {

--- a/internal/mcp/closeall_stress_test.go
+++ b/internal/mcp/closeall_stress_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Stress coverage for issue #1141: the acceptance criterion says MCP shutdown
+// must stay bounded "regardless of how many stdio servers are configured".
+// These tests scale past the realistic fleet size (typical configs mount 1-5
+// servers) and exercise mixed-failure profiles, so the concurrency model's
+// "total cost = the slowest server" property is demonstrated rather than
+// assumed from the 2-server case.
+
+// TestCloseAll_StressManyUnresponsiveServers drives 24 hanging servers —
+// an order of magnitude past any realistic configuration — and asserts the
+// whole phase still finishes inside the 3s budget: with concurrent closing
+// the wall time is the single slowest server (~1.6s), not the sum.
+func TestCloseAll_StressManyUnresponsiveServers(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	var clients []*Client
+	for i := 0; i < 24; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("hang-%02d", i), runAsHangingServerEnv))
+	}
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	err := CloseAll(closeCtx, clients)
+	elapsed := time.Since(start)
+
+	if elapsed >= 3*time.Second {
+		t.Errorf("24 unresponsive servers took %s to close, want well inside 3s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors for the SIGKILLed servers, got nil")
+	}
+	// Every server is named in the joined error, including the last one.
+	for _, name := range []string{"hang-00", "hang-12", "hang-23"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("CloseAll error %q does not mention server %q", msg(err), name)
+		}
+	}
+}
+
+func msg(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// TestCloseAll_MixedFleetRealisticProfile models a realistic fleet: healthy
+// servers, hung servers, and servers that exit non-zero, all closing at once.
+// The total stays inside the budget, every failing server is named, and the
+// healthy ones are not reported as failures.
+func TestCloseAll_MixedFleetRealisticProfile(t *testing.T) {
+	if raceDetectorEnabled {
+		// Raced children notice stdin EOF ~1s late and, under the load of
+		// ten concurrent children, can miss even the widened 2500ms stage —
+		// healthy servers then get SIGTERM'd and pollute the error names.
+		// The production timing semantics this test asserts are only
+		// deterministic in non-race builds; CloseAll logic remains covered
+		// under -race by the pinned-budget tests.
+		t.Skip("child EOF-notice latency under -race breaks production timing; covered by non-race runs")
+	}
+	pinProductionTerminateDuration(t)
+
+	var clients []*Client
+	for i := 0; i < 4; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("normal-%d", i), runAsServerEnv))
+	}
+	for i := 0; i < 4; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("hang-%d", i), runAsHangingServerEnv))
+	}
+	for i := 0; i < 2; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("exit3-%d", i), runAsExit3ServerEnv))
+	}
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	err := CloseAll(closeCtx, clients)
+	elapsed := time.Since(start)
+
+	if elapsed >= 3*time.Second {
+		t.Errorf("mixed fleet took %s to close, want well inside 3s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors from hung and exit-3 servers, got nil")
+	}
+	msgText := err.Error()
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(msgText, fmt.Sprintf("hang-%d", i)) {
+			t.Errorf("error %q does not mention hung server hang-%d", msgText, i)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if !strings.Contains(msgText, fmt.Sprintf("exit3-%d", i)) {
+			t.Errorf("error %q does not mention exit-3 server exit3-%d", msgText, i)
+		}
+	}
+	if strings.Contains(msgText, "normal-") {
+		t.Errorf("error %q mentions healthy servers", msgText)
+	}
+}
+
+// TestCloseAll_SlowCooperativeServerIsWaitedFor covers the distinction the
+// escalation exists to make: a server that needs ~1.2s to wind down after
+// stdin closes is waited for and exits cleanly (no error, no SIGKILL), while
+// still finishing inside the budget. Only genuinely unresponsive servers
+// should be killed.
+func TestCloseAll_SlowCooperativeServerIsWaitedFor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Process.Signal(SIGTERM) is unsupported on Windows, so the SDK
+		// skips its SIGTERM wait and Kills right after the stdin-close
+		// stage: the "waited for, clean wind-down" premise is POSIX-only.
+		t.Skip("SIGTERM wind-down wait does not apply on Windows")
+	}
+	if raceDetectorEnabled {
+		// The raced child notices stdin EOF ~1s late, so its 1.2s wind-down
+		// self-exit lands after the SIGKILL escalation (1.6s) — production
+		// semantics (waited for, clean exit) are only deterministic in
+		// non-race builds.
+		t.Skip("raced child wind-down misses its self-exit window; covered by non-race runs")
+	}
+	pinProductionTerminateDuration(t)
+
+	client := startEnvServer(t, "slow-exit", runAsSlowExitServerEnv)
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	err := CloseAll(closeCtx, []*Client{client})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("CloseAll of a cooperative slow server: %v (want clean exit)", err)
+	}
+	if elapsed < time.Second {
+		t.Errorf("CloseAll returned after %s; the slow wind-down should have been awaited", elapsed)
+	}
+	if elapsed >= 3*time.Second {
+		t.Errorf("CloseAll took %s, want well inside 3s", elapsed)
+	}
+}

--- a/internal/mcp/closeall_test.go
+++ b/internal/mcp/closeall_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startEnvServer starts this test binary as the given child MCP server mode.
+func startEnvServer(t *testing.T, name, env string) *Client {
+	t.Helper()
+	requireExec(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewClient(context.Background(), name, exe, nil, []string{env + "=1"}, "", "v0.0.1")
+	if err != nil {
+		t.Fatalf("NewClient(%s): %v", name, err)
+	}
+	return c
+}
+
+// pinProductionTerminateDuration restores the production shutdown budget for
+// tests whose timing must not shift with the race detector's widened budget.
+func pinProductionTerminateDuration(t *testing.T) {
+	t.Helper()
+	old := subprocessTerminateDuration
+	subprocessTerminateDuration = SubprocessTerminateDuration
+	t.Cleanup(func() { subprocessTerminateDuration = old })
+}
+
+// TestCloseAll_UnresponsiveServersStayWithinBudget covers the issue #1141
+// acceptance criterion: total MCP shutdown stays well inside 3s no matter how
+// unresponsive the configured servers are. The hanging children ignore
+// SIGTERM, so each one exercises the full stdin-close -> SIGTERM -> SIGKILL
+// escalation of the SDK before Close returns.
+//
+// The test pins the production TerminateDuration: a SIGKILLed child dies
+// immediately even under the race detector, so the measured wall time is
+// deterministic in both build modes.
+func TestCloseAll_UnresponsiveServersStayWithinBudget(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	clients := []*Client{
+		startEnvServer(t, "hang-a", runAsHangingServerEnv),
+		startEnvServer(t, "hang-b", runAsHangingServerEnv),
+	}
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	err := CloseAll(closeCtx, clients)
+	elapsed := time.Since(start)
+
+	// POSIX: two escalation waits of 800ms each, then the SIGKILL lands.
+	// Windows: Process.Signal(SIGTERM) is unsupported (EWINDOWS), so the SDK
+	// skips its wait entirely and Kills right after the first stage — total
+	// ~800ms, below the POSIX lower bound.
+	if elapsed >= 3*time.Second {
+		t.Errorf("CloseAll took %s, want well inside 3s", elapsed)
+	}
+	if runtime.GOOS != "windows" && elapsed < 1500*time.Millisecond {
+		t.Errorf("CloseAll took %s; the SIGTERM stage should elapse before the SIGKILL", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors for the SIGKILLed servers, got nil")
+	}
+	if runtime.GOOS != "windows" && !strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("CloseAll error = %v, want it to mention the killed subprocess", err)
+	}
+}
+
+// TestCloseAll_ResponsiveServersCloseCleanly pins the unchanged behavior for
+// well-behaved servers: close is quick and error-free.
+func TestCloseAll_ResponsiveServersCloseCleanly(t *testing.T) {
+	clients := []*Client{
+		startEnvServer(t, "normal-a", runAsServerEnv),
+		startEnvServer(t, "normal-b", runAsServerEnv),
+	}
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	if err := CloseAll(closeCtx, clients); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	// Under the race detector the children need ~1s to notice stdin EOF, so
+	// the speed claim is only enforced in production builds; the error-free
+	// close is asserted everywhere.
+	if elapsed := time.Since(start); !raceDetectorEnabled && elapsed > time.Second {
+		t.Errorf("responsive servers took %s to close, want well under 1s", elapsed)
+	}
+}
+
+// TestCloseAll_JoinsPerServerErrorMessages checks the error aggregation: every
+// failing server is named, in a single joined message, and quiet servers do
+// not pollute it.
+func TestCloseAll_JoinsPerServerErrorMessages(t *testing.T) {
+	clients := []*Client{
+		startEnvServer(t, "exit3-a", runAsExit3ServerEnv),
+		startEnvServer(t, "normal", runAsServerEnv),
+		startEnvServer(t, "exit3-b", runAsExit3ServerEnv),
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), CloseTimeout)
+	defer cancel()
+	err := CloseAll(closeCtx, clients)
+	if err == nil {
+		t.Fatal("CloseAll: expected joined errors from the exit-3 servers, got nil")
+	}
+	msg := err.Error()
+	for _, name := range []string{"exit3-a", "exit3-b"} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("CloseAll error %q does not mention server %q", msg, name)
+		}
+	}
+	if !strings.Contains(msg, "exit status 3") {
+		t.Errorf("CloseAll error %q does not mention the child exit status", msg)
+	}
+	if strings.Contains(msg, `"normal"`) {
+		t.Errorf("CloseAll error %q mentions the responsive server", msg)
+	}
+}
+
+// TestCloseAll_DeadlineAbandonsTheWait checks the overall deadline: CloseAll
+// stops waiting at the ctx deadline and reports how many servers were still
+// shutting down. The abandoned Close goroutine keeps running and escalates to
+// SIGKILL ~1.6s after Close started; the remaining package runtime covers
+// that, so no shutdown sleep is needed here.
+func TestCloseAll_DeadlineAbandonsTheWait(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	clients := []*Client{startEnvServer(t, "hang", runAsHangingServerEnv)}
+
+	start := time.Now()
+	closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := CloseAll(closeCtx, clients)
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "timed out closing 1 MCP server") {
+		t.Fatalf("CloseAll error = %v, want a timeout report for 1 server", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("CloseAll returned after %s, want a prompt return at the ctx deadline", elapsed)
+	}
+}

--- a/internal/mcp/norace_test.go
+++ b/internal/mcp/norace_test.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build !race
+
+package mcp
+
+// raceDetectorEnabled reports whether this test binary was built with -race.
+const raceDetectorEnabled = false

--- a/internal/mcp/race_test.go
+++ b/internal/mcp/race_test.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build race
+
+package mcp
+
+// raceDetectorEnabled reports whether this test binary was built with -race.
+const raceDetectorEnabled = true

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -8,23 +8,47 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"os/signal"
 	"runtime"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const runAsServerEnv = "_OCR_MCP_TEST_SERVER"
+const (
+	runAsServerEnv         = "_OCR_MCP_TEST_SERVER"
+	runAsHangingServerEnv  = "_OCR_MCP_TEST_HANG_SERVER"
+	runAsExit3ServerEnv    = "_OCR_MCP_TEST_EXIT3_SERVER"
+	runAsSlowExitServerEnv = "_OCR_MCP_TEST_SLOW_EXIT_SERVER"
+)
 
 func TestMain(m *testing.M) {
-	if os.Getenv(runAsServerEnv) != "" {
-		runTestMCPServer()
-		return
+	if raceDetectorEnabled {
+		// A race-instrumented child pays ~1s of runtime overhead between
+		// seeing stdin EOF and exiting (measured: 12ms plain vs ~1s raced).
+		// Tests that need a responsive child to beat its own shutdown budget
+		// widen that budget accordingly; tests that only rely on signal death
+		// keep the production value and pin it themselves.
+		subprocessTerminateDuration = 2500 * time.Millisecond
 	}
-	os.Exit(m.Run())
+	switch {
+	case os.Getenv(runAsServerEnv) != "":
+		runTestMCPServer()
+	case os.Getenv(runAsHangingServerEnv) != "":
+		runHangingMCPServer()
+	case os.Getenv(runAsExit3ServerEnv) != "":
+		runExit3MCPServer()
+	case os.Getenv(runAsSlowExitServerEnv) != "":
+		runSlowExitMCPServer()
+	default:
+		os.Exit(m.Run())
+	}
 }
 
-func runTestMCPServer() {
+// newTestMCPServer returns a working MCP server with a single echo tool.
+func newTestMCPServer() *mcp.Server {
 	server := mcp.NewServer(
 		&mcp.Implementation{Name: "test-server", Version: "v0.0.1"},
 		nil,
@@ -52,10 +76,55 @@ func runTestMCPServer() {
 			}, nil
 		},
 	)
+	return server
+}
 
-	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+func runTestMCPServer() {
+	if err := newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		log.Fatal(err)
 	}
+	// Exit explicitly with code 0 as soon as stdin EOF ends the server loop,
+	// rather than unwinding through the test runtime, whose teardown adds a
+	// slow and variable tail under the race detector.
+	os.Exit(0)
+}
+
+// runHangingMCPServer serves MCP normally but never exits: it ignores SIGTERM
+// and blocks forever once stdin closes, so only the SDK's SIGKILL escalation
+// can reclaim it. This is the unresponsive-server case from issue #1141.
+func runHangingMCPServer() {
+	signal.Ignore(syscall.SIGTERM)
+	go func() {
+		_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	}()
+	for {
+		// Sleeping keeps a timer pending, which keeps the runtime's deadlock
+		// detector quiet after the server goroutine returns on stdin EOF.
+		time.Sleep(time.Hour)
+	}
+}
+
+// runExit3MCPServer behaves like the normal server but exits with status 3
+// once stdin closes, so Close deterministically reports a child error.
+func runExit3MCPServer() {
+	_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	os.Exit(3)
+}
+
+// runSlowExitMCPServer models a cooperative but slow server: it serves MCP
+// until stdin closes (the parent's Close), then takes a while to wind down
+// its own state before exiting cleanly. It ignores SIGTERM so its wind-down
+// completes, exiting on its own before the SDK's SIGKILL escalation.
+func runSlowExitMCPServer() {
+	signal.Ignore(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	}()
+	<-done                              // stdin EOF: the parent's Close started
+	time.Sleep(1200 * time.Millisecond) // cooperative wind-down
+	os.Exit(0)
 }
 
 func TestNewClient_Stdio(t *testing.T) {


### PR DESCRIPTION
## Description

MCP clients were closed sequentially during review shutdown. Because the MCP SDK waits up to 5 seconds at each shutdown stage, one unresponsive stdio server could delay shutdown by about 15 seconds, and multiple servers increased that delay further.

This change:

- sets `CommandTransport.TerminateDuration` to 800 ms;
- closes MCP clients concurrently through `mcp.CloseAll`;
- limits the whole MCP close phase to 2.8 seconds;
- preserves per-server errors and names in the returned error;
- prefers successful completion when the final close and deadline become ready together.

The close deadline uses a fresh background context, so a cancelled review still receives its shutdown budget.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- `internal/mcp/closeall_test.go` covers responsive servers, unresponsive servers, error aggregation, and the overall deadline. The unresponsive-server case completes in about 1.6 seconds and asserts a total below 3 seconds.
- `internal/mcp/closeall_stress_test.go` covers 24 unresponsive servers, a mixed fleet of healthy and failing servers, and a slow cooperative server.
- `internal/mcp/stdio_test.go` provides the normal, hanging, non-zero-exit, and slow-exit subprocess fixtures used by those tests.
- `internal/mcp/race_test.go` and `norace_test.go` keep subprocess timing deterministic under the race detector without changing production values.
- POSIX-only timing assertions are gated on Windows, where `Process.Signal(SIGTERM)` is unsupported and the SDK proceeds directly to `Kill`.

- [x] `make test` passes locally
- [x] Manual testing: verified the unresponsive and stress cases stay below the 3-second shutdown budget

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Related to #1141 (item 2).
