### PR TITLE
fix(rules): route Objective-C++ files to Objective-C rules

### DIFF
--- a/internal/config/rules/sniffer.go
+++ b/internal/config/rules/sniffer.go
@@ -73,8 +73,7 @@ func (s *sniffer) resolveDetail(path string) RuleDetail {
 }
 
 // CanonicalConfig forwards the wrapped layer's fields and appends the objc
-// rule text, so editing objc.md changes the run manifest's
-// rule_config_sha256 exactly as editing any other rule doc does.
+// rule text, so editing objc.md changes the run manifest's rule_config_sha256.
 func (s *sniffer) CanonicalConfig() []string {
 	fields := s.inner.CanonicalConfig()
 	if s.objcRule != "" {

--- a/internal/config/rules/system_rules.go
+++ b/internal/config/rules/system_rules.go
@@ -115,8 +115,7 @@ func LoadDefault() (*SystemRule, error) {
 }
 
 // loadObjCRule reads the embedded Objective-C rule doc used by the ".m"
-// content sniff. It is not referenced from system_rules.json's path_rule_map,
-// so it is loaded explicitly rather than through the PathRules loop.
+// content sniff.
 func loadObjCRule() (string, error) {
 	content, err := rulesFS.ReadFile("rule_docs/objc.md")
 	if err != nil {

--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -47,6 +47,7 @@
     "**/*.{v,sv,vh}": "verilog.md",
     "**/*.{vhd,vhdl}": "vhdl.md",
     "**/*.m": "matlab.md",
+    "**/*.mm": "objc.md",
     "**/*.sol": "solidity.md",
     "**/*.vy": "vyper.md"
   }

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -152,6 +152,8 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"rtl/fifo.vhd", "numeric_std"},
 		{"rtl/fifo.vhdl", "numeric_std"},
 		{"Models/main.m", "Indexing, Shapes, and Implicit Expansion"},
+		{"ios/ViewController.mm", "ARC and Object Ownership"},
+		{"ios/ViewController.MM", "ARC and Object Ownership"},
 		{"src/Counter.sol", "Checks-Effects-Interactions"},
 		{"contracts/Vault.sol", "Delegatecall and Proxy Upgradeability"},
 		{"contracts/token.vy", "Language Restrictions"},
@@ -179,9 +181,6 @@ func TestResolve_FallbackToDefault(t *testing.T) {
 		"readme.md",
 		"docs/architecture.txt",
 		"Makefile",
-		// Note: .m now matches matlab.md, so it's no longer a "no rule
-		// matches" example; .mm remains one.
-		"ios/ViewController.mm",
 	}
 
 	for _, path := range paths {

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -186,6 +186,7 @@ matching order:
 | `**/*.{v,sv,vh}` | `verilog.md` — Verilog and SystemVerilog RTL. |
 | `**/*.{vhd,vhdl}` | `vhdl.md` — VHDL RTL. |
 | `**/*.m` | `matlab.md` (or `objc.md` via [content sniffing](#content-sniffing-for-m-files)) |
+| `**/*.mm` | `objc.md` — Objective-C++ source. |
 | `**/*.sol` | `solidity.md` — Solidity smart contracts. |
 | `**/*.vy` | `vyper.md` — Vyper smart contracts. |
 | *(fallback)* | `default.md` |

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -148,6 +148,7 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{v,sv,vh}` | `verilog.md`: Verilog および SystemVerilog の RTL。 |
 | `**/*.{vhd,vhdl}` | `vhdl.md`: VHDL の RTL。 |
 | `**/*.m` | `matlab.md`（または[コンテンツスニッフィング](#content-sniffing-for-m-files)により `objc.md`） |
+| `**/*.mm` | `objc.md`: Objective-C++ ソースコード。 |
 | `**/*.sol` | `solidity.md`: Solidity スマートコントラクト。 |
 | `**/*.vy` | `vyper.md`: Vyper スマートコントラクト。 |
 | *(fallback)* | `default.md` |

--- a/pages/src/content/docs/ko/review-rules.md
+++ b/pages/src/content/docs/ko/review-rules.md
@@ -177,6 +177,7 @@ diff 단계에서 일어납니다.
 | `**/*.{v,sv,vh}` | `verilog.md` — Verilog 및 SystemVerilog RTL. |
 | `**/*.{vhd,vhdl}` | `vhdl.md` — VHDL RTL. |
 | `**/*.m` | `matlab.md`(또는 [내용 탐지](#content-sniffing-for-m-files)로 `objc.md`) |
+| `**/*.mm` | `objc.md` — Objective-C++ 소스. |
 | `**/*.sol` | `solidity.md` — Solidity 스마트 컨트랙트. |
 | `**/*.vy` | `vyper.md` — Vyper 스마트 컨트랙트. |
 | *(대체값)* | `default.md` |

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -188,6 +188,7 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.{v,sv,vh}` | `verilog.md` — RTL на Verilog и SystemVerilog. |
 | `**/*.{vhd,vhdl}` | `vhdl.md` — RTL на VHDL. |
 | `**/*.m` | `matlab.md` (или `objc.md` через [определение содержимого](#content-sniffing-for-m-files)) |
+| `**/*.mm` | `objc.md` — исходный код Objective-C++. |
 | `**/*.sol` | `solidity.md` — смарт-контракты Solidity. |
 | `**/*.vy` | `vyper.md` — смарт-контракты Vyper. |
 | *(fallback)* | `default.md` |

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -169,6 +169,7 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.{v,sv,vh}` | `verilog.md`——Verilog 与 SystemVerilog RTL。 |
 | `**/*.{vhd,vhdl}` | `vhdl.md`——VHDL RTL。 |
 | `**/*.m` | `matlab.md`（或通过[内容嗅探](#针对-m-文件的内容嗅探)使用 `objc.md`） |
+| `**/*.mm` | `objc.md`——Objective-C++ 源代码。 |
 | `**/*.sol` | `solidity.md`——Solidity 智能合约。 |
 | `**/*.vy` | `vyper.md`——Vyper 智能合约。 |
 | *(fallback)* | `default.md` |


### PR DESCRIPTION
## Description

Maps Objective-C++ `.mm` files to the existing `objc.md` review rules instead of `default.md`.

Adds `.mm` and `.MM` test coverage and updates the rule tables in all five documentation languages. Existing `.m` handling remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing

Also verified with:

- `make check`
- `make coverage`
- `./dist/opencodereview rules check ios/ViewController.mm`
- `./dist/opencodereview rules check ios/ViewController.MM`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation accordingly
- [x] I have signed the CLA

## Related Issues

Closes #1165