### PR TITLE
fix(llmloop): bound memory-compression request to a safe token ceiling

### DIFF
--- a/internal/llmloop/compression.go
+++ b/internal/llmloop/compression.go
@@ -216,6 +216,43 @@ func copyMessages(msgs []llm.Message) []llm.Message {
 	return out
 }
 
+// maxCompressionContextTokens bounds how much conversation content a single
+// memory-compression call may attempt to summarize. The compress zone's size
+// is otherwise unbounded: it is whatever accumulated between the frozen and
+// active zones, which can include many rounds of tool-call output (e.g. broad
+// code_search/file_read results). Without this cap, a single compression
+// request can end up needing far more tokens than the model's real context
+// window, so the LLM call itself fails and the whole review aborts (see
+// alibaba/open-code-review#838 — three-zone compression can let live/compress
+// content overfill past its intended threshold). This is independent of the
+// per-file MaxTokens template setting: it is a hard backstop sized well under
+// real-world model context windows (even the smallest current-generation
+// models offer >= 128K tokens), so it only engages in pathological cases.
+const maxCompressionContextTokens = 200_000
+
+// boundCompressZoneStart returns the start index of the largest trailing
+// slice of msgs[frozenEnd:compressEnd] whose combined token count fits within
+// limit. The compress zone summarizes its oldest content first (closest to
+// the frozen zone) and its newest content last (closest to the active zone
+// it hands off to), so trimming from the old end discards the least
+// contextually relevant material when a single call cannot fit everything.
+// Always includes at least the single newest message in the zone, even if
+// that message alone exceeds limit, so the caller never ends up with an
+// empty range to summarize.
+func boundCompressZoneStart(msgs []llm.Message, frozenEnd, compressEnd, limit int) int {
+	tokens := 0
+	i := compressEnd
+	for i > frozenEnd {
+		t := messageTokens(msgs[i-1])
+		if i < compressEnd && tokens+t > limit {
+			break
+		}
+		tokens += t
+		i--
+	}
+	return i
+}
+
 // runCompression performs three-zone memory compression on the given
 // messages, summarizing the compress zone while preserving the active zone
 // intact. Returns rebuilt as [frozen] + [compressed_summary appended to
@@ -230,7 +267,13 @@ func (r *Runner) runCompression(ctx context.Context, msgs []llm.Message, filePat
 		return msgs, nil
 	}
 
-	contextXML := buildMessageXML(msgs[part.frozenEnd:part.compressEnd])
+	compressStart := boundCompressZoneStart(msgs, part.frozenEnd, part.compressEnd, maxCompressionContextTokens)
+	contextXML := buildMessageXML(msgs[compressStart:part.compressEnd])
+	if compressStart > part.frozenEnd {
+		contextXML = fmt.Sprintf(
+			"<truncation_notice>%d earlier message(s) omitted: accumulated conversation history exceeded the %d-token compression size limit and could not be summarized in a single request.</truncation_notice>\n%s",
+			compressStart-part.frozenEnd, maxCompressionContextTokens, contextXML)
+	}
 
 	compressionMsgs := make([]llm.Message, 0, len(r.deps.Template.MemoryCompressionTask.Messages))
 	for _, m := range r.deps.Template.MemoryCompressionTask.Messages {

--- a/internal/llmloop/compression_test.go
+++ b/internal/llmloop/compression_test.go
@@ -131,6 +131,67 @@ func TestPartitionMessages_EverythingFits(t *testing.T) {
 	}
 }
 
+// TestBoundCompressZoneStart_EverythingFits guards the common case: when the
+// whole compress zone fits within limit, nothing should be trimmed.
+func TestBoundCompressZoneStart_EverythingFits(t *testing.T) {
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "short reply one"),
+		msg("tool", "ok one"),
+		msg("assistant", "short reply two"),
+		msg("tool", "ok two"),
+	}
+	got := boundCompressZoneStart(messages, 2, len(messages), 100000)
+	if got != 2 {
+		t.Errorf("boundCompressZoneStart = %d, want 2 (nothing trimmed)", got)
+	}
+}
+
+// TestBoundCompressZoneStart_TrimsOldestFirst is the regression test for the
+// bug reported against production: a compress zone whose accumulated content
+// (e.g. many rounds of large tool-call output) exceeds even a generous
+// compression budget must be trimmed from its OLDEST end, never sent to the
+// LLM whole. Before this fix, runCompression sent the entire compress zone
+// unconditionally, which could make a single compression request larger than
+// the model's real context window (see alibaba/open-code-review#838).
+func TestBoundCompressZoneStart_TrimsOldestFirst(t *testing.T) {
+	big := strings.Repeat("x ", 5000) // large tool result, several thousand tokens
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "call 1"),
+		msg("tool", big), // oldest round — should be dropped
+		msg("assistant", "call 2"),
+		msg("tool", big), // newest round — should be kept
+	}
+	roundTokens := messageTokens(messages[4]) + messageTokens(messages[5])
+	// A limit that fits exactly one round but not both.
+	limit := roundTokens + 10
+
+	got := boundCompressZoneStart(messages, 2, len(messages), limit)
+	if got != 4 {
+		t.Errorf("boundCompressZoneStart = %d, want 4 (only the newest round kept)", got)
+	}
+}
+
+// TestBoundCompressZoneStart_SingleMessageExceedsLimit guards against ever
+// returning an empty range: even when the single newest message alone
+// exceeds limit, it must still be included so runCompression always has
+// something to summarize.
+func TestBoundCompressZoneStart_SingleMessageExceedsLimit(t *testing.T) {
+	messages := []llm.Message{
+		msg("system", "sys"),
+		msg("user", "prompt"),
+		msg("assistant", "call"),
+		msg("tool", strings.Repeat("x ", 100000)), // far larger than limit alone
+	}
+	got := boundCompressZoneStart(messages, 2, len(messages), 10)
+	if got != len(messages)-1 {
+		t.Errorf("boundCompressZoneStart = %d, want %d (still includes the one oversized message)", got, len(messages)-1)
+	}
+}
+
 func TestStripMarkdownFences(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

`runCompression` builds its summarization prompt from the entire compress zone (`msgs[frozenEnd:compressEnd]`) with no upper bound on size. That zone is otherwise unconstrained — it holds whatever accumulated between the frozen and active zones, which can include many rounds of tool-call output (e.g. broad `code_search`/`file_read` results across a large repository). When that content grows large enough, the resulting compression request can itself exceed the model's real context window, so the LLM call fails outright and the whole review aborts instead of compressing.

**Reproduced against a real Azure-hosted DeepSeek deployment:** a single compression request grew to ~1.26M tokens against a 1,048,576-token model context limit. Azure rejected it with a deterministic `"input longer than context length"` 400, which `open-code-review` then surfaces as an opaque `"Context compression exceeded threshold, stopping"` and fails every file in the review.

This is a real-world production failure I hit and traced end-to-end (proxied/captured the actual outgoing request and Azure's response to confirm the exact byte size and error).

## Fix

Adds `boundCompressZoneStart`, which trims the compress zone from its **oldest** end until it fits a fixed `maxCompressionContextTokens` ceiling (200K — independent of the per-file `MaxTokens` template setting, and sized well under real-world model context windows), always keeping at least the single newest message so the summarization call never ends up with an empty range. A `<truncation_notice>` is prepended when trimming occurs, so the summary's consumer knows some history was dropped rather than summarized.

## Relation to #838

This addresses the unbounded-compress-zone-size symptom described in #838 — an oversized compression request can be produced when the compress zone's own accounting lets it grow past any sane threshold. I have **not** independently verified the "everything fits but still gets marked for compression" or "template-less truncation" cases also described in that issue, so I'm not claiming this closes #838 outright — it's a defensively-scoped fix for the specific failure mode above.

## Testing

- Existing `internal/llmloop` test suite passes unchanged.
- Added `TestBoundCompressZoneStart_EverythingFits`, `TestBoundCompressZoneStart_TrimsOldestFirst`, `TestBoundCompressZoneStart_SingleMessageExceedsLimit`.
- Full `go build ./...` is clean.
- Re-ran my original failing reproduction (previously a guaranteed 400 on the first or second compression attempt) against the patched binary: every compression call across multiple runs succeeded, with the new truncation path visibly engaging on requests that would otherwise have overflowed the model's context window.

---

