### PR TITLE
feat(rules): merge multiple rule files per path

### DIFF
--- a/cmd/opencodereview/rules_check_test.go
+++ b/cmd/opencodereview/rules_check_test.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +34,160 @@ func TestRunRulesCheck(t *testing.T) {
 		defer func() { rulesCheckRepoDir = dir }()
 		if err := runRulesCheck("x.go"); err == nil {
 			t.Fatal("expected error for non-git repo dir")
+		}
+	})
+}
+
+// TestRunRulesCheck_RuleFilesOutput verifies `ocr rules check` prints a
+// "Rule Files:" line for both array rules and single-file rules.
+func TestRunRulesCheck_RuleFilesOutput(t *testing.T) {
+	t.Run("array rule lists each file", func(t *testing.T) {
+		setTestHome(t, t.TempDir()) // isolate from real ~/.opencodereview
+		dir := initTestGitRepo(t)
+		if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("General review guidance.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "b.md"), []byte("Kotlin-specific guidance.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfgDir := filepath.Join(dir, ".opencodereview")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"),
+			[]byte(`{"rules":[{"path":"**/*.kt","rule":["a.md","b.md"]}]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		setRulesCheckRepo(t, dir)
+
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runRulesCheck("src/Foo.kt")
+		})
+		if runErr != nil {
+			t.Fatalf("runRulesCheck error: %v", runErr)
+		}
+		if !strings.Contains(out, "Rule Files: a.md, b.md") {
+			t.Errorf("expected 'Rule Files: a.md, b.md' line, got:\n%s", out)
+		}
+	})
+
+	t.Run("single file rule prints one file", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		dir := initTestGitRepo(t)
+		if err := os.WriteFile(filepath.Join(dir, "kotlin.md"), []byte("Kotlin rules\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfgDir := filepath.Join(dir, ".opencodereview")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"),
+			[]byte(`{"rules":[{"path":"**/*.kt","rule":"kotlin.md"}]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		setRulesCheckRepo(t, dir)
+
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runRulesCheck("src/Foo.kt")
+		})
+		if runErr != nil {
+			t.Fatalf("runRulesCheck error: %v", runErr)
+		}
+		if !strings.Contains(out, "Rule Files: kotlin.md") {
+			t.Errorf("expected 'Rule Files: kotlin.md' line, got:\n%s", out)
+		}
+	})
+
+	t.Run("missing single file prints no Rule Files line", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		dir := initTestGitRepo(t)
+		cfgDir := filepath.Join(dir, ".opencodereview")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Referencing a single .md file that does not exist yields no "Rule
+		// Files:" line: the entry resolves to no rule body of its own and
+		// falls back to the system built-in rule, which has no rule files to
+		// report.
+		if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"),
+			[]byte(`{"rules":[{"path":"**/*.kt","rule":"missing.md"}]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		setRulesCheckRepo(t, dir)
+
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runRulesCheck("src/Foo.kt")
+		})
+		if runErr != nil {
+			t.Fatalf("runRulesCheck error: %v", runErr)
+		}
+		if strings.Contains(out, "Rule Files:") {
+			t.Errorf("missing single file must not print a Rule Files line, got:\n%s", out)
+		}
+	})
+
+	t.Run("empty single element array with merge_system_rule prints no Rule Files line", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		dir := initTestGitRepo(t)
+		cfgDir := filepath.Join(dir, ".opencodereview")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// rule:[""] with merge_system_rule:true merges with the system
+		// rule. The empty element contributes neither a rule file nor an
+		// inline body, so no "Rule Files:" line appears — and not a spurious
+		// "<inline>" label.
+		if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"),
+			[]byte(`{"rules":[{"path":"**/*.kt","merge_system_rule":true,"rule":[""]}]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		setRulesCheckRepo(t, dir)
+
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runRulesCheck("src/Foo.kt")
+		})
+		if runErr != nil {
+			t.Fatalf("runRulesCheck error: %v", runErr)
+		}
+		if strings.Contains(out, "Rule Files:") {
+			t.Errorf("empty [\"\"] must not print a Rule Files line, got:\n%s", out)
+		}
+	})
+
+	t.Run("whitespace single value prints Rule Files inline", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		dir := initTestGitRepo(t)
+		cfgDir := filepath.Join(dir, ".opencodereview")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// A whitespace-only single-value rule is treated as an inline rule
+		// regardless of its content, so it is labeled "<inline>" — uniform
+		// with any other inline rule, not suppressed.
+		if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"),
+			[]byte(`{"rules":[{"path":"**/*.kt","rule":"  "}]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		setRulesCheckRepo(t, dir)
+
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runRulesCheck("src/Foo.kt")
+		})
+		if runErr != nil {
+			t.Fatalf("runRulesCheck error: %v", runErr)
+		}
+		if !strings.Contains(out, "Rule Files: <inline>") {
+			t.Errorf("whitespace inline rule should print 'Rule Files: <inline>', got:\n%s", out)
 		}
 	})
 }

--- a/cmd/opencodereview/rules_cmd.go
+++ b/cmd/opencodereview/rules_cmd.go
@@ -70,6 +70,9 @@ func runRulesCheck(filePath string) error {
 	fmt.Printf("File: %s\n", filePath)
 	fmt.Printf("Source: %s\n", sourceLabel[detail.Source])
 	fmt.Printf("Pattern: %s\n", detail.Pattern)
+	if len(detail.RuleFiles) > 0 {
+		fmt.Printf("Rule Files: %s\n", strings.Join(detail.RuleFiles, ", "))
+	}
 	if detail.SniffedAs != "" {
 		fmt.Printf("Note:    rule selected by file content (%s), not by path alone\n", detail.SniffedAs)
 	}

--- a/internal/config/rules/multi_rule_test.go
+++ b/internal/config/rules/multi_rule_test.go
@@ -1,0 +1,1776 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package rules
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// unmarshalEntry builds a single ProjectRuleEntry from a JSON object so the
+// unexported ruleInputs is populated via the real UnmarshalJSON path.
+func unmarshalEntry(t *testing.T, j string) ProjectRuleEntry {
+	t.Helper()
+	var e ProjectRuleEntry
+	if err := json.Unmarshal([]byte(j), &e); err != nil {
+		t.Fatalf("unmarshal entry %q: %v", j, err)
+	}
+	return e
+}
+
+// unmarshalEntries builds a []ProjectRuleEntry from a JSON array of objects.
+func unmarshalEntries(t *testing.T, j string) []ProjectRuleEntry {
+	t.Helper()
+	var es []ProjectRuleEntry
+	if err := json.Unmarshal([]byte(j), &es); err != nil {
+		t.Fatalf("unmarshal entries %q: %v", j, err)
+	}
+	return es
+}
+
+// writeProjectRule writes a .opencodereview/rule.json into repoDir.
+func writeProjectRule(t *testing.T, repoDir, content string) {
+	t.Helper()
+	cfgDir := filepath.Join(repoDir, ".opencodereview")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "rule.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeRuleMD writes a rule markdown file into repoDir under name.
+func writeRuleMD(t *testing.T, repoDir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoDir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// newResolverAt builds a resolver rooted at repoDir with an isolated home so
+// the developer's real ~/.opencodereview/rule.json never leaks in.
+func newResolverAt(t *testing.T, repoDir string) Resolver {
+	t.Helper()
+	setTestHome(t, t.TempDir())
+	r, _, err := NewResolver(repoDir, "", ResolverOptions{})
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	return r
+}
+
+// captureStderr captures everything written to os.Stderr during fn by swapping
+// the file and draining the pipe concurrently (an undrained pipe deadlocks
+// once output exceeds the OS pipe buffer). The drain waits for fn to finish
+// inside a deferred cleanup so os.Stderr is restored and the reader goroutine
+// is unblocked even if fn calls t.Fatalf (runtime.Goexit) or panics.
+//
+// captureStderr swaps the process-global os.Stderr, so it must NOT be called
+// from a test that also calls t.Parallel(): concurrent tests would race on
+// os.Stderr and interleave or lose output. All current callers run serially.
+func captureStderr(t *testing.T, fn func()) (out string) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = buf.ReadFrom(r)
+	}()
+	// Register cleanup before fn() so it runs under Goexit/panic: close the
+	// writer (signals EOF to the reader), restore stderr, wait for the reader
+	// to finish draining, then publish the captured output to the named
+	// return. The drain must complete before out is read by the caller, so it
+	// happens here in defer — not at the return expression.
+	defer func() {
+		_ = w.Close()
+		os.Stderr = old
+		<-done
+		_ = r.Close()
+		out = buf.String()
+	}()
+	fn()
+	return
+}
+
+// --- ProjectRuleEntry.UnmarshalJSON (multi-rule merge) ---
+
+func TestProjectRuleEntry_UnmarshalJSON_String(t *testing.T) {
+	e := unmarshalEntry(t, `{"path":"**/*.kt","rule":"rules/kotlin.md"}`)
+	if e.Rule != "rules/kotlin.md" {
+		t.Errorf("Rule: want %q, got %q", "rules/kotlin.md", e.Rule)
+	}
+	if !reflect.DeepEqual(e.ruleInputs, []string{"rules/kotlin.md"}) {
+		t.Errorf("ruleInputs: want [rules/kotlin.md], got %v", e.ruleInputs)
+	}
+}
+
+func TestProjectRuleEntry_UnmarshalJSON_Array(t *testing.T) {
+	e := unmarshalEntry(t, `{"path":"**/*.kt","rule":["a.md","b.md"]}`)
+	if e.Rule != "" {
+		t.Errorf("Rule: want empty (resolved later), got %q", e.Rule)
+	}
+	if !reflect.DeepEqual(e.ruleInputs, []string{"a.md", "b.md"}) {
+		t.Errorf("ruleInputs: want [a.md b.md], got %v", e.ruleInputs)
+	}
+}
+
+func TestProjectRuleEntry_UnmarshalJSON_SingleElementArray(t *testing.T) {
+	e := unmarshalEntry(t, `{"path":"**/*.kt","rule":["a.md"]}`)
+	// Single-element array degrades to the single-value path: Rule is set so it
+	// is byte-identical to the string form.
+	if e.Rule != "a.md" {
+		t.Errorf("Rule: want %q, got %q", "a.md", e.Rule)
+	}
+	if !reflect.DeepEqual(e.ruleInputs, []string{"a.md"}) {
+		t.Errorf("ruleInputs: want [a.md], got %v", e.ruleInputs)
+	}
+}
+
+func TestProjectRuleEntry_UnmarshalJSON_Empty(t *testing.T) {
+	// All of these are equivalent — an empty rule contributes nothing — so
+	// each must leave Rule="" and ruleInputs=nil. The single-element array
+	// [""] must match the string form "" (not keep a [""] slice, which would
+	// make classifyRuleFiles emit a spurious "<inline>" RuleFiles entry).
+	for _, j := range []string{
+		`{"path":"**/*.kt","rule":""}`,
+		`{"path":"**/*.kt"}`,
+		`{"path":"**/*.kt","rule":null}`,
+		`{"path":"**/*.kt","rule":[""]}`,
+	} {
+		e := unmarshalEntry(t, j)
+		if e.Rule != "" {
+			t.Errorf("%s: Rule want empty, got %q", j, e.Rule)
+		}
+		if e.ruleInputs != nil {
+			t.Errorf("%s: ruleInputs want nil, got %v", j, e.ruleInputs)
+		}
+	}
+}
+
+func TestProjectRuleEntry_UnmarshalJSON_Invalid(t *testing.T) {
+	for _, j := range []string{`{"path":"**/*.kt","rule":123}`, `{"path":"**/*.kt","rule":["a",1]}`, `{"path":"**/*.kt","rule":{}}`} {
+		var e ProjectRuleEntry
+		err := json.Unmarshal([]byte(j), &e)
+		if err == nil {
+			t.Errorf("%s: expected error, got nil (entry=%+v)", j, e)
+			continue
+		}
+		// The error carries the generic prefix; the wrapped cause (checked in
+		// TestProjectRuleEntry_UnmarshalJSON_MixedArrayErrorPinpointsElement)
+		// adds the underlying decode detail for diagnosis.
+		if !strings.Contains(err.Error(), "must be a string or array of strings") {
+			t.Errorf("%s: error missing generic prefix, got %v", j, err)
+		}
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_MixedArrayErrorPinpointsElement
+// verifies a mixed-type array reports the offending element via the wrapped
+// json error, not just the generic message.
+func TestProjectRuleEntry_UnmarshalJSON_MixedArrayErrorPinpointsElement(t *testing.T) {
+	var e ProjectRuleEntry
+	err := json.Unmarshal([]byte(`{"path":"**/*.kt","rule":["a.md",42]}`), &e)
+	if err == nil {
+		t.Fatal("expected error for mixed-type array, got nil")
+	}
+	// The wrapped cause comes from the array decode, which references the
+	// non-string element (the number 42) so the user can locate it.
+	cause := errors.Unwrap(err)
+	if cause == nil {
+		t.Fatalf("error does not wrap a cause: %v", err)
+	}
+	if !strings.Contains(cause.Error(), "string") {
+		t.Errorf("cause should mention the string type mismatch, got %q", cause.Error())
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_NonArrayErrorNamesOffendingType verifies
+// that for a non-array invalid rule (e.g. a number), the wrapped cause is the
+// string decode error — which names the actual offending type ("number") —
+// rather than the array decode error that references the []string target the
+// user never wrote. The generic prefix still states both accepted types.
+func TestProjectRuleEntry_UnmarshalJSON_NonArrayErrorNamesOffendingType(t *testing.T) {
+	for _, j := range []string{
+		`{"path":"**/*.kt","rule":123}`,
+		`{"path":"**/*.kt","rule":true}`,
+		`{"path":"**/*.kt","rule":{}}`,
+	} {
+		var e ProjectRuleEntry
+		err := json.Unmarshal([]byte(j), &e)
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", j)
+		}
+		if !strings.Contains(err.Error(), "must be a string or array of strings") {
+			t.Errorf("%s: missing generic prefix, got %v", j, err)
+		}
+		cause := errors.Unwrap(err)
+		if cause == nil {
+			t.Fatalf("%s: error does not wrap a cause: %v", j, err)
+		}
+		// The cause must not reference the []string target for a non-array
+		// input; the string decode error names the actual value type instead.
+		if strings.Contains(cause.Error(), "[]string") {
+			t.Errorf("%s: cause should not mention []string for a non-array input, got %q", j, cause.Error())
+		}
+	}
+	// Spot-check: a number reports the number type via the string decode error.
+	var e ProjectRuleEntry
+	err := json.Unmarshal([]byte(`{"path":"**/*.kt","rule":123}`), &e)
+	if err == nil {
+		t.Fatal("expected error for rule:123, got nil")
+	}
+	cause := errors.Unwrap(err)
+	if cause == nil {
+		t.Fatalf("error does not wrap a cause: %v", err)
+	}
+	// "number" comes from encoding/json's error wording
+	// ("cannot unmarshal number into Go value of type string"). This is a stdlib
+	// implementation detail, stable since Go 1.0 but not part of any API
+	// contract; if a future Go version changes the wording, update this
+	// substring. We keep the assertion (rather than only checking cause != nil)
+	// because this test's purpose is to verify the offending type is named.
+	if !strings.Contains(cause.Error(), "number") {
+		t.Errorf("number rule: cause should name the number type, got %q", cause.Error())
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_RoundTripAllFields guards the shadow
+// struct in UnmarshalJSON (raw): it mirrors ProjectRuleEntry's exported JSON
+// fields, and a field added to the entry but forgotten in raw would be
+// silently dropped on decode. This marshals a fully-populated entry and
+// asserts every JSON-tagged field survives a round-trip through the custom
+// UnmarshalJSON. A future JSON field must be populated+asserted here, which
+// then fails until the field is also added to raw — turning the sync
+// requirement into a test-time enforcement rather than just a comment.
+func TestProjectRuleEntry_UnmarshalJSON_RoundTripAllFields(t *testing.T) {
+	orig := ProjectRuleEntry{
+		Path:            "**/*.kt",
+		Rule:            "check for null safety",
+		MergeSystemRule: true,
+	}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ProjectRuleEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", data, err)
+	}
+	if got.Path != orig.Path {
+		t.Errorf("Path not preserved: want %q, got %q", orig.Path, got.Path)
+	}
+	if got.Rule != orig.Rule {
+		t.Errorf("Rule not preserved: want %q, got %q", orig.Rule, got.Rule)
+	}
+	if got.MergeSystemRule != orig.MergeSystemRule {
+		t.Errorf("MergeSystemRule not preserved: want %v, got %v",
+			orig.MergeSystemRule, got.MergeSystemRule)
+	}
+	// The custom UnmarshalJSON back-fills ruleInputs for traceability.
+	if !reflect.DeepEqual(got.ruleInputs, []string{orig.Rule}) {
+		t.Errorf("ruleInputs not back-filled: want [%q], got %v", orig.Rule, got.ruleInputs)
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_InvalidTypeClearsStale verifies that
+// decoding an invalid "rule" type (e.g. a number) into an already-populated
+// entry returns an error AND clears every stale field the success path sets
+// (Path, MergeSystemRule, Rule, ruleInputs), matching the contract honored by
+// the shadow-decode-error branch and the absent/null/empty branches above.
+// The re-decode deliberately sets merge_system_rule:true so the test would
+// catch a half-cleared state: if MergeSystemRule survived, an entry with
+// Rule="" and MergeSystemRule=true would NOT be skipped downstream
+// (entry.Rule=="" && !entry.MergeSystemRule is false), causing an empty
+// user rule to merge with the system rule — the exact hazard the full clear
+// guards against should a future caller ignore the returned error.
+func TestProjectRuleEntry_UnmarshalJSON_InvalidTypeClearsStale(t *testing.T) {
+	// Seed with a string rule (Path/MergeSystemRule/Rule/ruleInputs all set).
+	e := unmarshalEntry(t, `{"path":"**/*.kt","merge_system_rule":true,"rule":"stale.md"}`)
+	if e.Rule != "stale.md" || len(e.ruleInputs) != 1 || !e.MergeSystemRule || e.Path != "**/*.kt" {
+		t.Fatalf("seed not populated as expected: Path=%q MergeSystemRule=%v Rule=%q ruleInputs=%v",
+			e.Path, e.MergeSystemRule, e.Rule, e.ruleInputs)
+	}
+	// Re-decode with an invalid rule type into the same populated entry.
+	// The new JSON also sets merge_system_rule:true so a half-clear that left
+	// MergeSystemRule set would be observable (not masked by a false default).
+	err := json.Unmarshal([]byte(`{"path":"**/*.kt","merge_system_rule":true,"rule":123}`), &e)
+	if err == nil {
+		t.Fatal("expected error for invalid rule type 123, got nil")
+	}
+	if e.Path != "" {
+		t.Errorf("stale Path leaked after invalid-type re-decode: %q", e.Path)
+	}
+	if e.MergeSystemRule {
+		t.Errorf("stale MergeSystemRule leaked after invalid-type re-decode: %v", e.MergeSystemRule)
+	}
+	if e.Rule != "" {
+		t.Errorf("stale Rule leaked after invalid-type re-decode: %q", e.Rule)
+	}
+	if e.ruleInputs != nil {
+		t.Errorf("stale ruleInputs leaked after invalid-type re-decode: %v", e.ruleInputs)
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_ShadowDecodeErrorClearsStale verifies that
+// a shadow-struct decode failure — the initial json.Unmarshal(data, &raw) in
+// UnmarshalJSON, triggered by a field type mismatch such as "path":123 —
+// returns an error AND clears every stale field the success path sets (Path,
+// MergeSystemRule, Rule, ruleInputs), matching the contract honored by every
+// other non-productive branch. The stdlib validates JSON syntax before
+// dispatching to UnmarshalJSON, so a field type mismatch (not syntactically
+// malformed JSON) is the realistic way this initial decode fails.
+func TestProjectRuleEntry_UnmarshalJSON_ShadowDecodeErrorClearsStale(t *testing.T) {
+	// Seed with a string rule plus a path and merge_system_rule so all four
+	// fields are populated.
+	e := unmarshalEntry(t, `{"path":"**/*.kt","rule":"stale.md","merge_system_rule":true}`)
+	if e.Path != "**/*.kt" || e.Rule != "stale.md" || !e.MergeSystemRule || len(e.ruleInputs) != 1 {
+		t.Fatalf("seed not populated as expected: Path=%q Rule=%q MergeSystemRule=%v ruleInputs=%v",
+			e.Path, e.Rule, e.MergeSystemRule, e.ruleInputs)
+	}
+	// Re-decode with a "path" type mismatch into the same populated entry.
+	// The shadow struct's Path is a string, so a number fails the initial
+	// json.Unmarshal(data, &raw) before any field is read.
+	err := json.Unmarshal([]byte(`{"path":123}`), &e)
+	if err == nil {
+		t.Fatal("expected error for path type mismatch, got nil")
+	}
+	if e.Path != "" {
+		t.Errorf("stale Path leaked after shadow-decode-error re-decode: %q", e.Path)
+	}
+	if e.MergeSystemRule {
+		t.Errorf("stale MergeSystemRule leaked after shadow-decode-error re-decode: %v", e.MergeSystemRule)
+	}
+	if e.Rule != "" {
+		t.Errorf("stale Rule leaked after shadow-decode-error re-decode: %q", e.Rule)
+	}
+	if e.ruleInputs != nil {
+		t.Errorf("stale ruleInputs leaked after shadow-decode-error re-decode: %v", e.ruleInputs)
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_ResetsStaleValues verifies that decoding a
+// rule object without a "rule" field into an already-populated entry clears
+// stale Rule/ruleInputs. encoding/json does not zero the receiver before
+// calling UnmarshalJSON, so a conformant unmarshaler must self-initialize.
+// It covers every non-productive branch: absent, null, empty string, empty
+// array — each must clear stale values from a prior decode.
+func TestProjectRuleEntry_UnmarshalJSON_ResetsStaleValues(t *testing.T) {
+	// Seed an entry with a multi-element array (Rule="", ruleInputs populated).
+	seed := func(t *testing.T) ProjectRuleEntry {
+		e := unmarshalEntry(t, `{"path":"**/*.kt","rule":["a.md","b.md"]}`)
+		if e.Rule != "" || len(e.ruleInputs) != 2 {
+			t.Fatalf("seed entry not populated as expected: Rule=%q ruleInputs=%v", e.Rule, e.ruleInputs)
+		}
+		return e
+	}
+	// Also seed with a string rule (Rule set) to catch stale Rule leakage.
+	seedString := func(t *testing.T) ProjectRuleEntry {
+		e := unmarshalEntry(t, `{"path":"**/*.kt","rule":"stale.md"}`)
+		if e.Rule != "stale.md" || len(e.ruleInputs) != 1 {
+			t.Fatalf("seed string entry not populated as expected: Rule=%q ruleInputs=%v", e.Rule, e.ruleInputs)
+		}
+		return e
+	}
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"absent", `{"path":"**/*.kt"}`},
+		{"null", `{"path":"**/*.kt","rule":null}`},
+		{"empty string", `{"path":"**/*.kt","rule":""}`},
+		{"empty array", `{"path":"**/*.kt","rule":[]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// From an array-seeded entry: stale ruleInputs must be cleared.
+			e := seed(t)
+			if err := json.Unmarshal([]byte(c.json), &e); err != nil {
+				t.Fatalf("re-decode %s: %v", c.name, err)
+			}
+			if e.Rule != "" {
+				t.Errorf("%s: stale Rule leaked: %q", c.name, e.Rule)
+			}
+			if e.ruleInputs != nil {
+				t.Errorf("%s: stale ruleInputs leaked: %v", c.name, e.ruleInputs)
+			}
+			// From a string-seeded entry: stale Rule must be cleared.
+			e2 := seedString(t)
+			if err := json.Unmarshal([]byte(c.json), &e2); err != nil {
+				t.Fatalf("re-decode %s (string seed): %v", c.name, err)
+			}
+			if e2.Rule != "" {
+				t.Errorf("%s: stale Rule leaked from string seed: %q", c.name, e2.Rule)
+			}
+			if e2.ruleInputs != nil {
+				t.Errorf("%s: stale ruleInputs leaked from string seed: %v", c.name, e2.ruleInputs)
+			}
+		})
+	}
+}
+
+// --- resolveRuleEntries merge path ---
+
+func TestResolveRuleEntries_MultiFileMerge(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, dir, "b.md", "Kotlin-specific guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","b.md"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	want := "General review guidance.\n\n---\n\nKotlin-specific guidance."
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+}
+
+func TestResolveRuleEntries_SingleElementNoSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	// Single-element array degrades to the single-value path: no heading, no
+	// separator, byte-identical to "rule":"a.md".
+	if entries[0].Rule != "General review guidance." {
+		t.Errorf("Rule: want %q, got %q", "General review guidance.", entries[0].Rule)
+	}
+}
+
+// TestResolveRuleEntries_SubdirPathResolves verifies that a relative
+// subdirectory path in the rule array (e.g. "rules/kotlin.md") resolves
+// correctly against the repo root and its content merges with the other
+// segments, separated by "---" with no per-file headings.
+func TestResolveRuleEntries_SubdirPathResolves(t *testing.T) {
+	dir := t.TempDir()
+	// general.md at repo root, kotlin.md under rules/
+	if err := os.MkdirAll(filepath.Join(dir, "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRuleMD(t, dir, "general.md", "General review guidance.\n")
+	writeRuleMD(t, dir, filepath.Join("rules", "kotlin.md"), "Kotlin-specific guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["general.md","rules/kotlin.md"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	want := "General review guidance.\n\n---\n\nKotlin-specific guidance."
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+}
+
+func TestResolveRuleEntries_MixedInlineAndFile(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","extra: check null safety"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	want := "General review guidance.\n\n---\n\nextra: check null safety"
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+}
+
+func TestResolveRuleEntries_AllInline(t *testing.T) {
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["first inline rule","second inline rule"]}]`)
+	resolveRuleEntries(entries, t.TempDir(), "")
+
+	want := "first inline rule\n\n---\n\nsecond inline rule"
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+}
+
+// TestResolveRuleEntries_EmptyElementWarned verifies an empty/whitespace array
+// element (e.g. from a trailing comma) is skipped but warned about, so a
+// merge with fewer segments than expected stays diagnosable.
+func TestResolveRuleEntries_EmptyElementWarned(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, dir, "b.md", "Kotlin-specific guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","","  ","b.md"]}]`)
+
+	out := captureStderr(t, func() {
+		resolveRuleEntries(entries, dir, "")
+	})
+	// Two empty elements ("" at index 1, "  " at index 2) => two warnings,
+	// each carrying the element index and the owning entry's path so the
+	// user can locate which rule entry the skipped element belongs to.
+	if c := strings.Count(out, "empty rule input skipped in array"); c != 2 {
+		t.Errorf("empty-input warnings: want 2, got %d (stderr=%q)", c, out)
+	}
+	if !strings.Contains(out, "at index 1 (path: **/*.kt)") {
+		t.Errorf("warning missing index 1 / path context, got:\n%s", out)
+	}
+	if !strings.Contains(out, "at index 2 (path: **/*.kt)") {
+		t.Errorf("warning missing index 2 / path context, got:\n%s", out)
+	}
+	// The two empty elements are skipped; a.md and b.md still merge.
+	want := "General review guidance.\n\n---\n\nKotlin-specific guidance."
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+}
+
+// TestResolveRuleEntries_EmptyPathWarningOmitsPathSuffix verifies that when a
+// rule entry omits the "path" field (or carries a whitespace-only one —
+// UnmarshalJSON stores path verbatim without trimming), none of the resolve
+// warnings emit a confusing "(path: )" / "(path:   )" suffix. tryReadRuleFile
+// already appends the entry path conditionally; the cap/empty-element/empty-file
+// warnings now share that conditional, TrimSpace-guarded form so an empty or
+// whitespace path produces a clean message with no dangling suffix. (A missing
+// "path" is unusual but valid: the entry still matches by pattern defaults
+// downstream.)
+func TestResolveRuleEntries_EmptyPathWarningOmitsPathSuffix(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+
+	t.Run("empty path empty-element warning", func(t *testing.T) {
+		// No "path" field => entryPath == "" during resolution. Only 3 inputs,
+		// well under the count cap, so only the empty-element warning fires.
+		entries := unmarshalEntries(t, `[{"rule":["a.md","","  "]}]`)
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, dir, "")
+		})
+		if !strings.Contains(out, "empty rule input skipped in array at index 1") {
+			t.Errorf("missing empty-input warning for index 1, got:\n%s", out)
+		}
+		if strings.Contains(out, "(path: )") {
+			t.Errorf("warning leaked a confusing \"(path: )\" suffix for an entry with no path, got:\n%s", out)
+		}
+	})
+
+	t.Run("empty path count-cap warning", func(t *testing.T) {
+		// No "path" field => entryPath == "". Exceed maxRuleInputs so the
+		// count-cap warning fires; it must NOT leak "(path: )".
+		n := maxRuleInputs + 1
+		inputs := make([]string, n)
+		for i := range inputs {
+			inputs[i] = fmt.Sprintf("inline rule %04d", i+1)
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		entries := unmarshalEntries(t, fmt.Sprintf(`[{"rule":%s}]`, ruleJSON))
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		if !strings.Contains(out, "only the first") {
+			t.Errorf("missing count-cap warning, got:\n%s", out)
+		}
+		if strings.Contains(out, "(path: )") {
+			t.Errorf("count-cap warning leaked \"(path: )\" for an entry with no path, got:\n%s", out)
+		}
+	})
+
+	t.Run("whitespace path no suffix on any warning", func(t *testing.T) {
+		// A whitespace-only "path" => entryPath == "  ". UnmarshalJSON does
+		// not trim it, so the TrimSpace guard (not a bare != "" check) is
+		// what prevents a "(path:   )" suffix. Trigger the empty-element
+		// warning and the count-cap warning together.
+		n := maxRuleInputs + 1
+		inputs := make([]string, n)
+		inputs[0] = "" // empty element fires the empty-element warning
+		for i := 1; i < n; i++ {
+			inputs[i] = fmt.Sprintf("inline rule %04d", i)
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		entries := unmarshalEntries(t, fmt.Sprintf(`[{"path":"  ","rule":%s}]`, ruleJSON))
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		if !strings.Contains(out, "empty rule input skipped in array at index 0") {
+			t.Errorf("missing empty-input warning for index 0, got:\n%s", out)
+		}
+		if !strings.Contains(out, "only the first") {
+			t.Errorf("missing count-cap warning, got:\n%s", out)
+		}
+		if strings.Contains(out, "(path:   )") || strings.Contains(out, "(path: )") {
+			t.Errorf("warning leaked a whitespace/empty path suffix, got:\n%s", out)
+		}
+	})
+}
+
+// TestResolveRuleEntries_TotalSizeCap verifies resolveMultiRuleParts bounds the
+// merged body to maxRuleBodySize (the same 512 KB budget as a single rule file)
+// rather than relying on the input count alone. The count is first capped to
+// maxRuleInputs by the caller; within the survivors, once the running total of
+// segment content plus "\n\n---\n\n" separators would exceed the budget, the
+// overflowing input is skipped from the Rule body with a warning (the running
+// total is unchanged, so a later smaller input may still fit the budget and
+// contribute), but ruleInputs is left as the (already count-capped) survivors
+// so "Rule Files:" reports what was processed. Each part is kept whole — never
+// mid-file/mid-string truncated.
+func TestResolveRuleEntries_TotalSizeCap(t *testing.T) {
+	t.Run("under budget merges all without warning", func(t *testing.T) {
+		// A few small inline inputs (well under maxRuleInputs and well under
+		// 512 KB) all merge with no cap or size warning.
+		n := 10
+		inputs := make([]string, n)
+		for i := range inputs {
+			inputs[i] = fmt.Sprintf("inline rule %04d", i+1)
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		if strings.Contains(out, "merged rule body exceeds") {
+			t.Errorf("no size warning expected under budget, got:\n%s", out)
+		}
+		if strings.Contains(out, "only the first") {
+			t.Errorf("no count-cap warning expected under maxRuleInputs, got:\n%s", out)
+		}
+		if !strings.Contains(entries[0].Rule, fmt.Sprintf("inline rule %04d", n)) {
+			t.Errorf("expected last element %d in Rule, got:\n%s", n, entries[0].Rule)
+		}
+		// ruleInputs keeps all inputs (under the count cap, none dropped).
+		if got := len(entries[0].ruleInputs); got != n {
+			t.Errorf("ruleInputs want %d, got %d", n, got)
+		}
+		files := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule)
+		if got := len(files); got != n {
+			t.Errorf("classifyRuleFiles want %d labels, got %d", n, got)
+		}
+	})
+
+	t.Run("over budget skips overflowing input with warning", func(t *testing.T) {
+		// Three 200000-byte inline inputs. part1=200000 (total 200000),
+		// part2=200000+7 (total 400007), part3 delta=200007 -> 600014 >
+		// 524288: part3 is skipped (the running total is unchanged by the
+		// skip), and there is nothing after it, so body = parts 1+2. 3 inputs
+		// is under maxRuleInputs, so no count cap fires; the size cap skips
+		// part3 only.
+		big := strings.Repeat("a", 200000)
+		inputs := []string{big, big, big}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		wantWarn := fmt.Sprintf("merged rule body exceeds %d bytes at input index 2; this input skipped (path: **/*.kt)", maxRuleBodySize)
+		if !strings.Contains(out, wantWarn) {
+			t.Errorf("size warning missing, got:\n%s", out)
+		}
+		// Body holds parts 1 and 2 only: 200000 + len(rulePartSep) + 200000 bytes.
+		// Use len(rulePartSep) — not the literal 7 — so this assertion tracks the
+		// shared separator constant rather than hardcoding its current length.
+		rule := entries[0].Rule
+		if got, want := len(rule), 200000+len(rulePartSep)+200000; got != want {
+			t.Errorf("Rule body length want %d, got %d", want, got)
+		}
+		// ruleInputs keeps all 3 (under the count cap; the size cap skips from
+		// the body only, not ruleInputs).
+		if got := len(entries[0].ruleInputs); got != 3 {
+			t.Errorf("ruleInputs want 3, got %d", got)
+		}
+		files := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule)
+		if got := len(files); got != 3 {
+			t.Errorf("classifyRuleFiles want 3 labels, got %d", got)
+		}
+	})
+
+	t.Run("huge inline element skipped, later smaller input kept", func(t *testing.T) {
+		// 2-element array where the first element alone exceeds the budget:
+		// it is skipped whole (no truncation, total unchanged), so the second
+		// (small) input still fits the budget and is kept. ruleInputs lists
+		// both (under the count cap).
+		huge := strings.Repeat("b", maxRuleBodySize+1)
+		inputs := []string{huge, "second"}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		wantWarn := fmt.Sprintf("merged rule body exceeds %d bytes at input index 0; this input skipped (path: **/*.kt)", maxRuleBodySize)
+		if !strings.Contains(out, wantWarn) {
+			t.Errorf("size warning missing, got:\n%s", out)
+		}
+		if entries[0].Rule != "second" {
+			t.Errorf("overflowing first part should be skipped, keeping the second; got %q", entries[0].Rule)
+		}
+		if got := len(entries[0].ruleInputs); got != 2 {
+			t.Errorf("ruleInputs want 2, got %d", got)
+		}
+	})
+
+	t.Run("huge first input skipped, later small inputs still fit", func(t *testing.T) {
+		// The motivating scenario for `continue` over `break`: a huge first
+		// input would cause a `break` to drop everything after it, but with
+		// `continue` the huge part is skipped (total unchanged) and the two
+		// small inputs that follow still fit the budget and are kept.
+		// 2 inputs is under maxRuleInputs, so no count cap fires.
+		huge := strings.Repeat("c", maxRuleBodySize+1)
+		small := strings.Repeat("d", 10000) // 10 KB
+		inputs := []string{huge, small, small}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		out := captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+		// Only the huge input overflows; it is skipped at index 0. The two
+		// small inputs fit (0+10000, then 10000+10007), so no further warning.
+		wantWarn := fmt.Sprintf("merged rule body exceeds %d bytes at input index 0; this input skipped (path: **/*.kt)", maxRuleBodySize)
+		if !strings.Contains(out, wantWarn) {
+			t.Errorf("size warning for index 0 missing, got:\n%s", out)
+		}
+		// Body holds the two small inputs joined by one separator.
+		rule := entries[0].Rule
+		if got, want := len(rule), 10000+len(rulePartSep)+10000; got != want {
+			t.Errorf("Rule body length want %d, got %d", want, got)
+		}
+		// ruleInputs keeps all 3 (under the count cap; the size cap skips from
+		// the body only, not ruleInputs).
+		if got := len(entries[0].ruleInputs); got != 3 {
+			t.Errorf("ruleInputs want 3, got %d", got)
+		}
+		files := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule)
+		if got := len(files); got != 3 {
+			t.Errorf("classifyRuleFiles want 3 labels, got %d", got)
+		}
+	})
+}
+
+// TestResolveRuleEntries_InputCountCap verifies the maxRuleInputs count cap:
+// resolveRuleEntries caps a multi-input array's inputs to maxRuleInputs BEFORE
+// any file I/O, so at most maxRuleInputs files are read per entry and ruleInputs
+// retains at most maxRuleInputs elements. Every input — valid file, inline text,
+// or an empty "" element — counts toward the limit. Inputs beyond the cap are
+// dropped from both the resolved Rule body and ruleInputs (with a warning naming
+// the first dropped index), so they cost no I/O and do not appear in "Rule Files:".
+// This bounds both the file-read I/O and the retained ruleInputs memory that the
+// byte cap maxRuleBodySize alone cannot reach (empty/missing/empty-file inputs are
+// skipped without growing the running total).
+func TestResolveRuleEntries_InputCountCap(t *testing.T) {
+	t.Run("inputs beyond cap are dropped before I/O", func(t *testing.T) {
+		// maxRuleInputs+20 real files. Only the first maxRuleInputs are read;
+		// the rest are dropped before any file I/O, with a single warning
+		// naming the first dropped index (maxRuleInputs). ruleInputs is capped
+		// to maxRuleInputs, so "Rule Files:" lists only the resolved files.
+		dir := t.TempDir()
+		n := maxRuleInputs + 20
+		inputs := make([]string, n)
+		for i := range inputs {
+			name := fmt.Sprintf("rule%04d.md", i)
+			writeRuleMD(t, dir, name, fmt.Sprintf("guidance %d\n", i))
+			inputs[i] = name
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		warned := captureStderr(t, func() {
+			resolveRuleEntries(entries, dir, "")
+		})
+		// The count-cap warning names the first dropped index (maxRuleInputs)
+		// and the total/original count.
+		wantWarn := fmt.Sprintf("rule array has %d inputs; only the first %d are resolved, the rest (from index %d) are dropped (path: **/*.kt)", n, maxRuleInputs, maxRuleInputs)
+		if !strings.Contains(warned, wantWarn) {
+			t.Errorf("count-cap warning missing, want:\n%s\ngot:\n%s", wantWarn, warned)
+		}
+		// ruleInputs is capped to maxRuleInputs.
+		if got := len(entries[0].ruleInputs); got != maxRuleInputs {
+			t.Errorf("ruleInputs want %d (capped), got %d", maxRuleInputs, got)
+		}
+		// The last retained file (index maxRuleInputs-1) is in the body; the
+		// first dropped file (index maxRuleInputs) is not.
+		if !strings.Contains(entries[0].Rule, fmt.Sprintf("guidance %d", maxRuleInputs-1)) {
+			t.Errorf("expected last retained file guidance %d in Rule", maxRuleInputs-1)
+		}
+		if strings.Contains(entries[0].Rule, fmt.Sprintf("guidance %d", maxRuleInputs)) {
+			t.Errorf("first dropped file guidance %d should not be in Rule", maxRuleInputs)
+		}
+		// classifyRuleFiles reflects the capped ruleInputs.
+		files := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule)
+		if got := len(files); got != maxRuleInputs {
+			t.Errorf("classifyRuleFiles want %d labels, got %d", maxRuleInputs, got)
+		}
+	})
+
+	t.Run("empty elements count toward the cap", func(t *testing.T) {
+		// 31 empty "" elements followed by 32 real files (63 total). Empty
+		// elements count toward maxRuleInputs (32) but contribute nothing to
+		// the body, so only the inputs within the first 32 are processed: the
+		// 31 empties plus the 1st real file. The 1st real file is the only one
+		// read; the other 31 real files (indices 32-62) are dropped by the cap
+		// before any I/O. This is the user's own misconfiguration (padding with
+		// junk starves their own budget), so it is left to them to fix.
+		dir := t.TempDir()
+		var inputs []string
+		for i := 0; i < 31; i++ {
+			inputs = append(inputs, "")
+		}
+		for i := 0; i < 32; i++ {
+			name := fmt.Sprintf("real%04d.md", i)
+			writeRuleMD(t, dir, name, fmt.Sprintf("real guidance %d\n", i))
+			inputs = append(inputs, name)
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		warned := captureStderr(t, func() {
+			resolveRuleEntries(entries, dir, "")
+		})
+		// The count cap fires at index maxRuleInputs (32), dropping inputs
+		// 32-62. ruleInputs is capped to 32 (31 empties + real0000.md).
+		wantWarn := fmt.Sprintf("rule array has %d inputs; only the first %d are resolved, the rest (from index %d) are dropped (path: **/*.kt)", len(inputs), maxRuleInputs, maxRuleInputs)
+		if !strings.Contains(warned, wantWarn) {
+			t.Errorf("count-cap warning missing, want:\n%s\ngot:\n%s", wantWarn, warned)
+		}
+		if got := len(entries[0].ruleInputs); got != maxRuleInputs {
+			t.Errorf("ruleInputs want %d (capped), got %d", maxRuleInputs, got)
+		}
+		// Only real0000.md was read (the one real file within the first 32);
+		// its content is the body. The 31 empties contributed nothing.
+		if !strings.Contains(entries[0].Rule, "real guidance 0") {
+			t.Errorf("expected real0000.md content in Rule, got:\n%s", entries[0].Rule)
+		}
+		if strings.Contains(entries[0].Rule, "real guidance 1") {
+			t.Errorf("real0001.md (index 32, beyond cap) should not be in Rule")
+		}
+		// classifyRuleFiles omits the empty elements, so only real0000.md
+		// appears in "Rule Files:" (the empties are skipped from the display).
+		files := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule)
+		if got, want := files, []string{"real0000.md"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("classifyRuleFiles want %v (empties omitted), got %v", want, got)
+		}
+	})
+
+	// cappedRuleInputsCopies verifies the count cap copies survivors into a
+	// fresh slice rather than subslicing the original. A plain subslice
+	// aliases the backing array populated by UnmarshalJSON, so the dropped
+	// inputs' strings stay alive (Go retains the whole backing array); copying
+	// lets the GC reclaim them. We assert the survivors live in an independent
+	// backing array from the original ruleInputs.
+	t.Run("cappedRuleInputsCopies", func(t *testing.T) {
+		// maxRuleInputs+5 distinct inline inputs. inline (not files) so the
+		// retained memory is the string data itself — exactly the surface the
+		// copy must release.
+		n := maxRuleInputs + 5
+		inputs := make([]string, n)
+		for i := range inputs {
+			inputs[i] = fmt.Sprintf("inline-input-%04d", i)
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+		// Capture the original backing array before the cap copies away.
+		original := entries[0].ruleInputs
+
+		_ = captureStderr(t, func() {
+			resolveRuleEntries(entries, t.TempDir(), "")
+		})
+
+		capped := entries[0].ruleInputs
+		if got := len(capped); got != maxRuleInputs {
+			t.Fatalf("ruleInputs want %d (capped), got %d", maxRuleInputs, got)
+		}
+		// The capped slice must have an independent backing array: mutating
+		// the original must not affect the capped copy. If they shared the
+		// backing array (a plain subslice, the bug this copy fixes), the
+		// mutation would leak through. This avoids uintptr(unsafe.Pointer)
+		// address comparison, which is outside the sanctioned unsafe patterns
+		// and could go stale under a future moving GC.
+		if len(original) > 0 && len(capped) > 0 {
+			original[0] = ""
+			if capped[0] == "" {
+				t.Errorf("capped ruleInputs aliases the original backing array; survivors must be copied to a fresh slice so dropped inputs can be GC'd")
+			}
+		}
+		// Survivor content is the first maxRuleInputs inputs, unchanged.
+		for i := 0; i < maxRuleInputs; i++ {
+			if capped[i] != inputs[i] {
+				t.Errorf("survivor[%d]: want %q, got %q", i, inputs[i], capped[i])
+			}
+		}
+	})
+
+	t.Run("exactly at cap is not capped", func(t *testing.T) {
+		// Exactly maxRuleInputs real files: no count-cap warning, all retained
+		// and resolved.
+		dir := t.TempDir()
+		n := maxRuleInputs
+		inputs := make([]string, n)
+		for i := range inputs {
+			name := fmt.Sprintf("rule%04d.md", i)
+			writeRuleMD(t, dir, name, fmt.Sprintf("guidance %d\n", i))
+			inputs[i] = name
+		}
+		ruleJSON, err := json.Marshal(inputs)
+		if err != nil {
+			t.Fatalf("marshal inputs: %v", err)
+		}
+		j := fmt.Sprintf(`[{"path":"**/*.kt","rule":%s}]`, ruleJSON)
+		entries := unmarshalEntries(t, j)
+
+		warned := captureStderr(t, func() {
+			resolveRuleEntries(entries, dir, "")
+		})
+		if strings.Contains(warned, "only the first") {
+			t.Errorf("no count-cap warning expected at exactly maxRuleInputs, got:\n%s", warned)
+		}
+		if got := len(entries[0].ruleInputs); got != n {
+			t.Errorf("ruleInputs want %d, got %d", n, got)
+		}
+	})
+}
+
+func TestResolveRuleEntries_PartialMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, dir, "c.md", "Android domain guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","missing.md","c.md"]}]`)
+
+	warned := captureStderr(t, func() {
+		resolveRuleEntries(entries, dir, "")
+	})
+
+	// missing.md is skipped; a and c remain, joined by a separator (no headings).
+	want := "General review guidance.\n\n---\n\nAndroid domain guidance."
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+	// ruleInputs keep the user's original inputs verbatim (resolveRuleEntries
+	// preserves them except when the maxRuleInputs cap trims to survivors):
+	// missing.md is NOT dropped, so the "Rule Files:" display reports what
+	// the user wrote even though missing.md contributed nothing to Rule.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"a.md", "missing.md", "c.md"}) {
+		t.Errorf("ruleInputs: want [a.md missing.md c.md], got %v", entries[0].ruleInputs)
+	}
+	// The missing-file warning carries the owning entry's path, consistent
+	// with the empty-element and empty-file warnings in the same function.
+	if !strings.Contains(warned, "rule file not found: missing.md (path: **/*.kt)") {
+		t.Errorf("missing-file warning lacks entry path, got:\n%s", warned)
+	}
+}
+
+// TestResolveRuleEntries_EmptyFileSkipped verifies that an existing but
+// empty rule file (zero bytes, or only newlines) is skipped in the multi-input
+// merge path — parallel to a missing file. Without this, the empty file would
+// add an empty segment to the merged parts, producing a blank between
+// separators in the merged output. The file still appears in ruleInputs (and
+// thus "Rule Files:") because ruleInputs keeps the user's original inputs
+// verbatim; it just contributes no text to Rule.
+func TestResolveRuleEntries_EmptyFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, dir, "empty.md", "")       // zero-byte file
+	writeRuleMD(t, dir, "nl.md", "\n\n\n")    // only newlines → trims to ""
+	writeRuleMD(t, dir, "ws.md", "   \t  \n") // only spaces/tabs → TrimSpace ""
+	writeRuleMD(t, dir, "c.md", "Android domain guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","empty.md","nl.md","ws.md","c.md"]}]`)
+
+	warned := captureStderr(t, func() {
+		resolveRuleEntries(entries, dir, "")
+	})
+
+	// The three empty/whitespace files (empty.md, nl.md, ws.md) are skipped;
+	// a and c remain, joined by a separator (no headings) — identical to the
+	// partial-missing case.
+	want := "General review guidance.\n\n---\n\nAndroid domain guidance."
+	if entries[0].Rule != want {
+		t.Errorf("Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+	// No per-file heading for the empty files (nor for any file — the body
+	// is heading-free; traceability lives in the "Rule Files:" line).
+	if strings.Contains(entries[0].Rule, "## Rule: empty.md") {
+		t.Errorf("Rule has dangling heading for empty.md: %q", entries[0].Rule)
+	}
+	if strings.Contains(entries[0].Rule, "## Rule: nl.md") {
+		t.Errorf("Rule has dangling heading for nl.md: %q", entries[0].Rule)
+	}
+	if strings.Contains(entries[0].Rule, "## Rule: ws.md") {
+		t.Errorf("Rule has dangling heading for ws.md: %q", entries[0].Rule)
+	}
+	// ruleInputs keep the user's original inputs verbatim: the
+	// empty/whitespace files are NOT dropped, so "Rule Files:" reports what
+	// the user wrote even though those files contributed nothing to Rule.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"a.md", "empty.md", "nl.md", "ws.md", "c.md"}) {
+		t.Errorf("ruleInputs: want [a.md empty.md nl.md ws.md c.md], got %v", entries[0].ruleInputs)
+	}
+	// All three empty/whitespace files are warned with the owning entry's
+	// path, parallel to the missing-file warning and the empty-element warning.
+	for _, name := range []string{"empty.md", "nl.md", "ws.md"} {
+		want := "rule file is empty: " + name + " (path: **/*.kt)"
+		if !strings.Contains(warned, want) {
+			t.Errorf("missing %q warning, got:\n%s", want, warned)
+		}
+	}
+}
+
+func TestResolveRuleEntries_AllMissing(t *testing.T) {
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["x.md","y.md"]}]`)
+	resolveRuleEntries(entries, t.TempDir(), "")
+
+	if entries[0].Rule != "" {
+		t.Errorf("all-missing array: Rule want empty (entry skipped), got %q", entries[0].Rule)
+	}
+	// ruleInputs keep the user's original inputs verbatim: even though
+	// all files are missing and Rule is empty, the inputs are not cleared,
+	// so "Rule Files:" still reports what the user wrote.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"x.md", "y.md"}) {
+		t.Errorf("ruleInputs: want [x.md y.md], got %v", entries[0].ruleInputs)
+	}
+}
+
+// TestResolveRuleEntries_IdempotentOnReResolve verifies that calling
+// resolveRuleEntries twice on the same entries leaves the merged Rule
+// unchanged. Because resolveRuleEntries keeps the user's original inputs
+// verbatim (except when the maxRuleInputs cap trims to survivors), a
+// second call re-reads the same inputs and rebuilds the same Rule — the
+// function is naturally idempotent, with no resolved flag needed.
+func TestResolveRuleEntries_IdempotentOnReResolve(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "General review guidance.\n")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","inline rule text"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	want := entries[0].Rule
+	if want == "" {
+		t.Fatal("first resolve produced empty Rule")
+	}
+	// A second call must reproduce the same Rule. Because resolveRuleEntries
+	// keeps the user's original inputs verbatim, a repeat call re-reads
+	// the same inputs and rebuilds the same Rule — the function is naturally
+	// idempotent, with no resolved flag needed.
+	resolveRuleEntries(entries, dir, "")
+	if entries[0].Rule != want {
+		t.Errorf("re-resolve corrupted Rule:\n want %q\n got  %q", want, entries[0].Rule)
+	}
+	if strings.Contains(entries[0].Rule, "<inline>") {
+		t.Errorf("re-resolve leaked the <inline> sentinel into Rule: %q", entries[0].Rule)
+	}
+}
+
+// TestResolveRuleEntries_IdempotentWhenReducedToOnePart covers the edge case
+// where the multi-input merge path reduces to a single contributing part
+// (all other inputs missing). Because resolveRuleEntries keeps ruleInputs
+// verbatim, it stays at the user's original inputs ([a.md, missing.md],
+// still len >= 2), so a repeat call re-enters the multi-input path and
+// rebuilds the same Rule from the same original inputs — naturally
+// idempotent, with no resolved flag. The lone file's content here
+// ("looks-like-a-path.md") happens to look like a file path; under the old
+// resolved-flag design the reduction made ruleInputs len 1 and a re-resolve
+// fell through to the single-value path, which would re-read/clear it.
+// Keeping ruleInputs verbatim avoids that fall-through entirely because
+// ruleInputs is never reduced.
+func TestResolveRuleEntries_IdempotentWhenReducedToOnePart(t *testing.T) {
+	dir := t.TempDir()
+	// a.md's content is a single .md-looking line with no spaces, so
+	// looksLikeFilePath treats it as a file path. It is NOT a real file in
+	// dir, so if the single-value path ever ran on it, tryReadRuleFile would
+	// return nil and clear Rule to "".
+	writeRuleMD(t, dir, "a.md", "looks-like-a-path.md")
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","missing.md"]}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	want := "looks-like-a-path.md"
+	if entries[0].Rule != want {
+		t.Fatalf("first resolve: Rule want %q, got %q", want, entries[0].Rule)
+	}
+	// ruleInputs keeps the original inputs verbatim (missing.md is not
+	// dropped), so the entry stays on the multi-input path on re-resolve.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"a.md", "missing.md"}) {
+		t.Fatalf("first resolve: ruleInputs want [a.md missing.md], got %v", entries[0].ruleInputs)
+	}
+
+	// Re-resolve: ruleInputs is unchanged, so the multi-input path runs
+	// again and rebuilds the same Rule — the path-looking content is never
+	// fed to the single-value path.
+	resolveRuleEntries(entries, dir, "")
+	if entries[0].Rule != want {
+		t.Errorf("re-resolve corrupted Rule: want %q, got %q", want, entries[0].Rule)
+	}
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"a.md", "missing.md"}) {
+		t.Errorf("re-resolve corrupted ruleInputs: want [a.md missing.md], got %v", entries[0].ruleInputs)
+	}
+}
+
+// TestProjectRuleEntry_UnmarshalJSON_ReDecodeReResolvesNewArray verifies that
+// re-decoding an already-resolved entry (in place) as a different multi-element
+// array discards the prior resolution and re-resolves the new inputs.
+// encoding/json does not zero the receiver before UnmarshalJSON, so
+// UnmarshalJSON must clear the stale Rule/ruleInputs itself; otherwise the
+// old merged Rule would survive the re-decode and the new inputs would never
+// be read. (The earlier resolved-flag variant of this test is obsolete now
+// that there is no resolved flag — the re-decode simply repopulates
+// ruleInputs with the new array and resolveRuleEntries rebuilds Rule from it.)
+func TestProjectRuleEntry_UnmarshalJSON_ReDecodeReResolvesNewArray(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "a.md", "first file body\n")
+	writeRuleMD(t, dir, "b.md", "second file body\n")
+	writeRuleMD(t, dir, "c.md", "third file body\n")
+	writeRuleMD(t, dir, "d.md", "fourth file body\n")
+
+	// 1. Decode + resolve a multi-element array entry.
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["a.md","b.md"]}]`)
+	resolveRuleEntries(entries, dir, "")
+	first := entries[0].Rule
+	if first == "" {
+		t.Fatal("first resolve produced empty Rule")
+	}
+	if !strings.Contains(first, "first file body") {
+		t.Fatalf("first resolve missing a.md content: %q", first)
+	}
+
+	// 2. Re-decode the SAME entry (in place) as a different multi-element
+	//    array. UnmarshalJSON must clear the stale Rule/ruleInputs so the
+	//    prior resolution is discarded.
+	if err := json.Unmarshal(
+		[]byte(`[{"path":"**/*.kt","rule":["c.md","d.md"]}]`), &entries); err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	if entries[0].Rule != "" {
+		t.Errorf("re-decode should clear stale Rule, got %q", entries[0].Rule)
+	}
+
+	// 3. Re-resolve: must produce the NEW merge (c.md + d.md), not reuse the
+	//    stale Rule left from a.md/b.md.
+	resolveRuleEntries(entries, dir, "")
+	got := entries[0].Rule
+	if got == "" {
+		t.Fatal("re-resolve after re-decode produced empty Rule")
+	}
+	if strings.Contains(got, "first file body") || strings.Contains(got, "second file body") {
+		t.Errorf("re-resolve used stale a.md/b.md content: %q", got)
+	}
+	if !strings.Contains(got, "third file body") || !strings.Contains(got, "fourth file body") {
+		t.Errorf("re-resolve missing c.md/d.md content: %q", got)
+	}
+}
+
+// TestResolveRuleEntries_SingleMissingKeepsRuleInputs verifies the single-value
+// path keeps ruleInputs at the user's original input when its file is missing.
+// Rule is cleared (legacy: the entry is skipped and falls through), but
+// ruleInputs is not cleared, so "Rule Files:" still reports the missing file
+// the user wrote — consistent with the multi-file path.
+func TestResolveRuleEntries_SingleMissingKeepsRuleInputs(t *testing.T) {
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":"missing.md"}]`)
+	resolveRuleEntries(entries, t.TempDir(), "")
+
+	if entries[0].Rule != "" {
+		t.Errorf("single-missing: Rule want empty, got %q", entries[0].Rule)
+	}
+	// ruleInputs keeps the original input: the missing file is reported
+	// in "Rule Files:" even though it contributed nothing to Rule.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"missing.md"}) {
+		t.Errorf("single-missing: ruleInputs want [missing.md], got %v", entries[0].ruleInputs)
+	}
+	if got := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule); !reflect.DeepEqual(got, []string{"missing.md"}) {
+		t.Errorf("single-missing: classifyRuleFiles want [missing.md], got %v", got)
+	}
+}
+
+// TestResolveRuleEntries_SingleEmptyFileKeepsRuleInputs is the empty/whitespace
+// counterpart of TestResolveRuleEntries_SingleMissingKeepsRuleInputs. A rule
+// file that exists but is empty (or whitespace-only) contributes no rule text;
+// ruleInputs still keeps the user's original input, so "Rule Files:"
+// reports the file even though it contributed nothing. Rule resolution stays
+// byte-identical to legacy: an empty file resolves to "" and a whitespace-only
+// file still wins its layer (e.Rule keeps the content verbatim).
+func TestResolveRuleEntries_SingleEmptyFileKeepsRuleInputs(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "empty.md", "")       // zero-byte
+	writeRuleMD(t, dir, "ws.md", "   \t  \n") // whitespace-only → TrimSpace ""
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":"empty.md"},{"path":"**/*.java","rule":"ws.md"}]`)
+	resolveRuleEntries(entries, dir, "")
+
+	// empty.md: Rule="" (legacy — entry skipped unless MergeSystemRule).
+	if entries[0].Rule != "" {
+		t.Errorf("empty file: Rule want %q, got %q", "", entries[0].Rule)
+	}
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"empty.md"}) {
+		t.Errorf("empty file: ruleInputs want [empty.md], got %v", entries[0].ruleInputs)
+	}
+	if got := classifyRuleFiles(entries[0].ruleInputs, entries[0].Rule); !reflect.DeepEqual(got, []string{"empty.md"}) {
+		t.Errorf("empty file: classifyRuleFiles want [empty.md], got %v", got)
+	}
+
+	// ws.md: Rule keeps the whitespace content (legacy — entry still wins).
+	if strings.TrimSpace(entries[1].Rule) != "" {
+		t.Errorf("ws file: Rule want whitespace-only, got %q", entries[1].Rule)
+	}
+	if !reflect.DeepEqual(entries[1].ruleInputs, []string{"ws.md"}) {
+		t.Errorf("ws file: ruleInputs want [ws.md], got %v", entries[1].ruleInputs)
+	}
+	// ruleInputs keeps the original input: classifyRuleFiles reports the
+	// file the user wrote, even though it contributed only whitespace.
+	if got := classifyRuleFiles(entries[1].ruleInputs, entries[1].Rule); !reflect.DeepEqual(got, []string{"ws.md"}) {
+		t.Errorf("ws file: classifyRuleFiles want [ws.md], got %v", got)
+	}
+}
+
+func TestResolveRuleEntries_MultiFileConfinedToRepo(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "inside.md", "inside\n")
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(outside, []byte("OUTSIDE SECRET\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Array referencing an in-repo file plus an absolute path outside the repo.
+	// json.Marshal the absolute path so backslashes (Windows t.TempDir paths)
+	// are properly escaped into a valid JSON string, not raw-embedded.
+	outsideJSON, err := json.Marshal(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := unmarshalEntries(t, `[{"path":"**/*.kt","rule":["inside.md",`+string(outsideJSON)+`]}]`)
+	resolveRuleEntries(entries, repoDir, canonicalRoot(t, repoDir))
+
+	// Only the in-repo file survives; the outside path is rejected by #1100.
+	if entries[0].Rule != "inside" {
+		t.Errorf("Rule: want %q, got %q", "inside", entries[0].Rule)
+	}
+	if strings.Contains(entries[0].Rule, "OUTSIDE SECRET") {
+		t.Errorf("outside secret leaked into rule: %q", entries[0].Rule)
+	}
+	// ruleInputs keeps the user's original input: the rejected outside
+	// path is still reported in "Rule Files:" even though #1100 dropped it
+	// from Rule. The secret never leaks because the file was never read.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"inside.md", outside}) {
+		t.Errorf("ruleInputs: want [inside.md <outside>], got %v", entries[0].ruleInputs)
+	}
+}
+
+func TestResolveRuleEntries_GoLiteralStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleMD(t, dir, "foo.md", "General review guidance.\n")
+	// Go-literal-constructed entry: ruleInputs is nil, takes the legacy path.
+	entries := []ProjectRuleEntry{{Path: "**/*.kt", Rule: "foo.md"}}
+	resolveRuleEntries(entries, dir, "")
+
+	if entries[0].Rule != "General review guidance." {
+		t.Errorf("Rule: want %q, got %q", "General review guidance.", entries[0].Rule)
+	}
+	// ruleInputs is back-filled so RuleFiles can still trace the file.
+	if !reflect.DeepEqual(entries[0].ruleInputs, []string{"foo.md"}) {
+		t.Errorf("ruleInputs: want [foo.md], got %v", entries[0].ruleInputs)
+	}
+}
+
+// --- Resolve: merge_system_rule + first-match-wins ---
+
+func TestResolve_MergeSystemRuleWithArray(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "User rule A.\n")
+	writeRuleMD(t, repoDir, "b.md", "User rule B.\n")
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.go","merge_system_rule":true,"rule":["a.md","b.md"]}]}`)
+	r := newResolverAt(t, repoDir)
+
+	got := r.Resolve("src/foo.go")
+	if !strings.Contains(got, "## System-Specific Rules") {
+		t.Errorf("merged rule missing system section: %q", truncate(got, 120))
+	}
+	if !strings.Contains(got, "User rule A.") || !strings.Contains(got, "User rule B.") {
+		t.Errorf("merged rule missing user content: %q", truncate(got, 200))
+	}
+}
+
+func TestResolve_FirstMatchWinsUnchangedWithArray(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, repoDir, "b.md", "Kotlin-specific guidance.\n")
+	writeRuleMD(t, repoDir, "other.md", "OTHER\n")
+	// First entry is an array that matches; second entry also matches but must
+	// not participate (first-match-wins is unchanged).
+	writeProjectRule(t, repoDir, `{"rules":[
+		{"path":"**/*.go","rule":["a.md","b.md"]},
+		{"path":"**/*.go","rule":"other.md"}
+	]}`)
+	r := newResolverAt(t, repoDir)
+
+	got := r.Resolve("src/foo.go")
+	if !strings.Contains(got, "General review guidance.") || !strings.Contains(got, "Kotlin-specific guidance.") {
+		t.Errorf("expected merged a.md+b.md, got %q", truncate(got, 120))
+	}
+	if strings.Contains(got, "OTHER") {
+		t.Errorf("second entry must not win under first-match-wins, got %q", truncate(got, 120))
+	}
+}
+
+// TestResolve_CustomArrayOverridesProject is the multi-md dual of
+// TestNewResolver_CustomOverridesProject: a custom-layer array entry must win
+// over a project-layer single-value entry for the same path, and Resolve must
+// return the merged multi-file body (not the project single value). This
+// guards that an array entry is a first-class participant in inter-layer
+// priority and that the winner's merged body is what reaches the caller.
+func TestResolve_CustomArrayOverridesProject(t *testing.T) {
+	repoDir := t.TempDir()
+	// Project layer: single-value rule that would win if custom were absent.
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.java","rule":"project-java-rule"}]}`)
+
+	// Custom layer (--rule): array of two files, same path pattern.
+	customDir := t.TempDir()
+	writeRuleMD(t, customDir, "cust-a.md", "Custom rule A.\n")
+	writeRuleMD(t, customDir, "cust-b.md", "Custom rule B.\n")
+	customPath := filepath.Join(customDir, "custom_rules.json")
+	customJSON := `{"rules":[{"path":"**/*.java","rule":["cust-a.md","cust-b.md"]}]}`
+	if err := os.WriteFile(customPath, []byte(customJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestHome(t, t.TempDir()) // isolate global layer
+	r, _, err := NewResolver(repoDir, customPath, ResolverOptions{})
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	got := r.Resolve("src/Foo.java")
+	if !strings.Contains(got, "Custom rule A.") || !strings.Contains(got, "Custom rule B.") {
+		t.Errorf("expected merged cust-a.md+cust-b.md, got %q", truncate(got, 160))
+	}
+	if !strings.Contains(got, "\n\n---\n\n") {
+		t.Errorf("expected segment separator in merged body, got %q", truncate(got, 160))
+	}
+	if strings.Contains(got, "project-java-rule") {
+		t.Errorf("custom array must override project, got project rule: %q", truncate(got, 160))
+	}
+}
+
+// TestResolve_ProjectArrayOverridesSystem is the multi-md dual of
+// TestNewResolver_ProjectRuleReplacesSystemRuleByDefault: a project-layer
+// array entry (without merge_system_rule) must replace the system rule, and
+// Resolve must return the merged multi-file body rather than the system rule.
+// Guards that an array entry wins the layer and its merged body replaces
+// (does not merge with) the system default.
+func TestResolve_ProjectArrayOverridesSystem(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "proj-a.md", "Project rule A.\n")
+	writeRuleMD(t, repoDir, "proj-b.md", "Project rule B.\n")
+	// No merge_system_rule: a winning project entry replaces the system rule.
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.go","rule":["proj-a.md","proj-b.md"]}]}`)
+	r := newResolverAt(t, repoDir)
+
+	got := r.Resolve("main.go")
+	if !strings.Contains(got, "Project rule A.") || !strings.Contains(got, "Project rule B.") {
+		t.Errorf("expected merged proj-a.md+proj-b.md, got %q", truncate(got, 160))
+	}
+	if strings.Contains(got, "## System-Specific Rules") {
+		t.Errorf("project array without merge must replace system, got system section: %q", truncate(got, 160))
+	}
+}
+
+// TestResolve_ArrayAllMissingWithMergeReturnsSystemOnly is the multi-md dual
+// of TestNewResolver_EmptyRuleMergeSystemRuleReturnsSystemOnly: when every
+// array element fails to resolve (all missing), the merged Rule is empty, but
+// because merge_system_rule is set the entry is NOT skipped (the skip guard
+// is `Rule == "" && !MergeSystemRule`) — Resolve must return the system rule
+// only, with no User-Specific Rules section. This counter-intuitive boundary
+// (merge bypasses the empty-rule skip) is the point most easily broken by a
+// naive "drop empty array entries" refactor, so it is pinned explicitly.
+func TestResolve_ArrayAllMissingWithMergeReturnsSystemOnly(t *testing.T) {
+	repoDir := t.TempDir()
+	// Both referenced files are intentionally absent; merge_system_rule is set
+	// so the empty merged Rule still triggers mergeWithSystemRule.
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.go","merge_system_rule":true,"rule":["missing-a.md","missing-b.md"]}]}`)
+	r := newResolverAt(t, repoDir)
+
+	systemRule, err := LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault: %v", err)
+	}
+	want := systemRule.Resolve("main.go")
+
+	got := r.Resolve("main.go")
+	if got != want {
+		t.Fatalf("all-missing array + merge: want system rule only, got %q", truncate(got, 160))
+	}
+	if strings.Contains(got, "User-Specific Rules") {
+		t.Fatalf("all-missing array + merge: must not contain User-Specific Rules, got %q", truncate(got, 160))
+	}
+}
+
+// TestResolveDetail_CustomArrayOverridesAll is the multi-md dual of
+// TestResolveDetail_CustomOverridesAll: a custom-layer array entry must win
+// via the ResolveDetail path, report Source "custom", carry the merged
+// multi-file body in Rule, and list both files in RuleFiles. Guards that the
+// detail-resolution chain (matchProjectRuleDetail -> matchProjectRuleEntry,
+// unchanged by the feature) treats an array entry identically to a
+// single-value entry at the selection layer, and that RuleFiles traceability
+// survives an inter-layer win.
+func TestResolveDetail_CustomArrayOverridesAll(t *testing.T) {
+	repoDir := t.TempDir()
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.java","rule":"project-java-rule"}]}`)
+
+	customDir := t.TempDir()
+	writeRuleMD(t, customDir, "cust-a.md", "Custom rule A.\n")
+	writeRuleMD(t, customDir, "cust-b.md", "Custom rule B.\n")
+	customPath := filepath.Join(customDir, "custom_rules.json")
+	customJSON := `{"rules":[{"path":"**/*.java","rule":["cust-a.md","cust-b.md"]}]}`
+	if err := os.WriteFile(customPath, []byte(customJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestHome(t, t.TempDir())
+	r, _, err := NewResolver(repoDir, customPath, ResolverOptions{})
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	dr := r.(DetailResolver)
+
+	d := dr.ResolveDetail("src/foo.java")
+	if d.Source != "custom" {
+		t.Errorf("expected source 'custom', got %q", d.Source)
+	}
+	if !strings.Contains(d.Rule, "Custom rule A.") || !strings.Contains(d.Rule, "Custom rule B.") {
+		t.Errorf("expected merged custom body, got %q", truncate(d.Rule, 160))
+	}
+	if !reflect.DeepEqual(d.RuleFiles, []string{"cust-a.md", "cust-b.md"}) {
+		t.Errorf("RuleFiles: want [cust-a.md cust-b.md], got %v", d.RuleFiles)
+	}
+	if strings.Contains(d.Rule, "project-java-rule") {
+		t.Errorf("custom array must override project in detail path, got project rule: %q", truncate(d.Rule, 160))
+	}
+}
+
+func TestCanonicalConfig_StableForMerged(t *testing.T) {
+	build := func(t *testing.T, repoDir string) []string {
+		r := newResolverAt(t, repoDir).(*composedResolver)
+		return r.CanonicalConfig()
+	}
+
+	withFiles := func(t *testing.T) string {
+		repoDir := t.TempDir()
+		writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+		writeRuleMD(t, repoDir, "b.md", "Kotlin-specific guidance.\n")
+		writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.go","rule":["a.md","b.md"]}]}`)
+		return repoDir
+	}
+
+	// Same merged content => identical canonical config.
+	c1 := build(t, withFiles(t))
+	c2 := build(t, withFiles(t))
+	if !reflect.DeepEqual(c1, c2) {
+		t.Errorf("same merged config must be stable:\n c1=%v\n c2=%v", c1, c2)
+	}
+
+	// Different merged content => different canonical config.
+	repoDir2 := t.TempDir()
+	writeRuleMD(t, repoDir2, "a.md", "DIFFERENT\n")
+	writeRuleMD(t, repoDir2, "b.md", "Kotlin-specific guidance.\n")
+	writeProjectRule(t, repoDir2, `{"rules":[{"path":"**/*.go","rule":["a.md","b.md"]}]}`)
+	c3 := build(t, repoDir2)
+	if reflect.DeepEqual(c1, c3) {
+		t.Errorf("different merged content must yield different config:\n c1=%v\n c3=%v", c1, c3)
+	}
+}
+
+// --- ResolveDetail.RuleFiles ---
+
+func TestResolveDetail_RuleFilesPopulated_Array(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, repoDir, "b.md", "Kotlin-specific guidance.\n")
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":["a.md","b.md"]}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	if !reflect.DeepEqual(d.RuleFiles, []string{"a.md", "b.md"}) {
+		t.Errorf("RuleFiles: want [a.md b.md], got %v", d.RuleFiles)
+	}
+}
+
+func TestResolveDetail_RuleFilesPopulated_SingleFile(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "kotlin.md", "Kotlin review guidance.\n")
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":"kotlin.md"}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	if !reflect.DeepEqual(d.RuleFiles, []string{"kotlin.md"}) {
+		t.Errorf("RuleFiles: want [kotlin.md], got %v", d.RuleFiles)
+	}
+}
+
+func TestResolveDetail_RuleFilesPopulated_Inline(t *testing.T) {
+	repoDir := t.TempDir()
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":"watch for null safety"}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	if !reflect.DeepEqual(d.RuleFiles, []string{"<inline>"}) {
+		t.Errorf("RuleFiles: want [<inline>], got %v", d.RuleFiles)
+	}
+}
+
+// TestResolveDetail_RuleFiles_SingleEmptyFileShownAsWritten verifies the
+// scenario from the review: a single-value rule pointing at an empty (or
+// whitespace-only) file lists that file in "Rule Files:" as the user wrote it
+// (ruleInputs keeps the original input). The file contributed nothing to
+// Rule, but it is still the source the user named, so it is reported honestly.
+// When merge_system_rule keeps the empty entry as the winner, the file is
+// shown; when a whitespace-only file wins under legacy resolution, it is shown
+// too. The Rule body itself stays byte-identical to legacy.
+func TestResolveDetail_RuleFiles_SingleEmptyFileShownAsWritten(t *testing.T) {
+	t.Run("empty file with merge_system_rule", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeRuleMD(t, repoDir, "empty.md", "")
+		writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":"empty.md","merge_system_rule":true}]}`)
+		dr := newResolverAt(t, repoDir).(DetailResolver)
+
+		d := dr.ResolveDetail("src/Foo.kt")
+		if d.Source != "project" {
+			t.Fatalf("expected the project entry to win (merge_system_rule), got Source=%q", d.Source)
+		}
+		if !reflect.DeepEqual(d.RuleFiles, []string{"empty.md"}) {
+			t.Errorf("empty file: RuleFiles want [empty.md], got %v", d.RuleFiles)
+		}
+	})
+	t.Run("whitespace-only file shown as written", func(t *testing.T) {
+		repoDir := t.TempDir()
+		writeRuleMD(t, repoDir, "ws.md", "   \t  \n")
+		writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":"ws.md"}]}`)
+		dr := newResolverAt(t, repoDir).(DetailResolver)
+
+		d := dr.ResolveDetail("src/Foo.kt")
+		if d.Source != "project" {
+			t.Fatalf("expected the whitespace-file entry to win (legacy), got Source=%q", d.Source)
+		}
+		// The whitespace-only file contributed no real content to Rule, but
+		// ruleInputs keeps the user's input, so "Rule Files:" reports the
+		// file by name — neither nil (hiding the source) nor "<inline>"
+		// (mislabeling a file as inline).
+		if !reflect.DeepEqual(d.RuleFiles, []string{"ws.md"}) {
+			t.Errorf("whitespace file: RuleFiles want [ws.md], got %v", d.RuleFiles)
+		}
+	})
+}
+
+// TestClassifyRuleFiles_PreservesFullInput verifies that the "Rule Files:"
+// display label keeps each input verbatim — the full path as the user wrote
+// it in the rule array (e.g. "rules/kotlin.md"), not a basename, so same-named
+// files in different directories stay distinguishable. This is local
+// ocr-rules-check output only (RuleFiles has json:"-" and never reaches the
+// LLM/delegate); path-traversal safety is already enforced by #1100's
+// confineRoot on the untrusted project layer, so no extra sanitization is
+// applied and the input is preserved as-is. Inline inputs become "<inline>".
+func TestClassifyRuleFiles_PreservesFullInput(t *testing.T) {
+	// Relative file path kept verbatim (full path, not basename).
+	got := classifyRuleFiles([]string{"rules/kotlin.md"}, "x")
+	if !reflect.DeepEqual(got, []string{"rules/kotlin.md"}) {
+		t.Errorf("relative input: want [rules/kotlin.md], got %v", got)
+	}
+	// A bare basename is kept verbatim too.
+	got = classifyRuleFiles([]string{"a.md"}, "x")
+	if !reflect.DeepEqual(got, []string{"a.md"}) {
+		t.Errorf("basename input: want [a.md], got %v", got)
+	}
+	// Mixed file + inline inputs labeled per-element.
+	got = classifyRuleFiles([]string{"rules/kotlin.md", "watch for null safety"}, "x")
+	if !reflect.DeepEqual(got, []string{"rules/kotlin.md", "<inline>"}) {
+		t.Errorf("mixed input: want [rules/kotlin.md <inline>], got %v", got)
+	}
+	// An empty/whitespace array element is skipped from the Rule body by
+	// resolveMultiRuleParts (warned, contributes nothing), so it is omitted
+	// from the "Rule Files:" display entirely — it is not a file and carries
+	// no inline text, so a label would be misleading.
+	got = classifyRuleFiles([]string{"a.md", "", "b.md"}, "x")
+	if !reflect.DeepEqual(got, []string{"a.md", "b.md"}) {
+		t.Errorf("empty element omitted: want [a.md b.md], got %v", got)
+	}
+	got = classifyRuleFiles([]string{"a.md", "  ", "b.md"}, "x")
+	if !reflect.DeepEqual(got, []string{"a.md", "b.md"}) {
+		t.Errorf("whitespace element omitted: want [a.md b.md], got %v", got)
+	}
+	// Fallback (Go-literal, ruleInputs nil) infers from the resolved Rule.
+	got = classifyRuleFiles(nil, "rules/kotlin.md")
+	if !reflect.DeepEqual(got, []string{"rules/kotlin.md"}) {
+		t.Errorf("relative fallback: want [rules/kotlin.md], got %v", got)
+	}
+	got = classifyRuleFiles(nil, "inline rule text")
+	if !reflect.DeepEqual(got, []string{"<inline>"}) {
+		t.Errorf("inline fallback: want [<inline>], got %v", got)
+	}
+	// Fallback with an empty resolved Rule yields nil (no file, no text).
+	got = classifyRuleFiles(nil, "")
+	if got != nil {
+		t.Errorf("empty fallback: want nil, got %v", got)
+	}
+	got = classifyRuleFiles(nil, "  ")
+	if got != nil {
+		t.Errorf("whitespace fallback: want nil, got %v", got)
+	}
+}
+
+// TestClassifyRuleFiles_AllEmptyReturnsNil verifies that when every element of
+// a multi-element array is an empty/whitespace element (all omitted from the
+// "Rule Files:" display), the inputs branch returns nil — the same "no rule
+// files" representation the fallback path uses for an empty/whitespace Rule —
+// so the two paths never diverge (a caller comparing != nil sees the same
+// result either way). The production caller uses len()>0, which already
+// handles both nil and a non-nil empty slice identically, but aligning on nil
+// keeps the convention consistent for any future != nil check.
+func TestClassifyRuleFiles_AllEmptyReturnsNil(t *testing.T) {
+	if got := classifyRuleFiles([]string{"", ""}, "x"); got != nil {
+		t.Errorf("all empty: want nil, got %v", got)
+	}
+	if got := classifyRuleFiles([]string{"  ", "\t"}, "x"); got != nil {
+		t.Errorf("all whitespace: want nil, got %v", got)
+	}
+	if got := classifyRuleFiles([]string{"", "  ", ""}, ""); got != nil {
+		t.Errorf("mixed empty/whitespace: want nil, got %v", got)
+	}
+	// A single (non-multi) whitespace input is the whole rule and wins its
+	// layer (legacy), so it stays "<inline>", NOT nil — only multi-element
+	// arrays omit empty elements. This guards against the fix over-reaching.
+	if got := classifyRuleFiles([]string{"  "}, "x"); !reflect.DeepEqual(got, []string{"<inline>"}) {
+		t.Errorf("single whitespace input: want [<inline>], got %v", got)
+	}
+}
+
+func TestResolveDetail_RuleFiles_GoLiteral(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+	// Construct a project rule by Go literal (no UnmarshalJSON => ruleInputs nil),
+	// resolve, then match via a composedResolver.
+	pr := &ProjectRule{Rules: []ProjectRuleEntry{{Path: "**/*.kt", Rule: "a.md"}}}
+	resolveRuleEntries(pr.Rules, repoDir, "")
+	c := &composedResolver{project: pr}
+
+	d := c.matchProjectRuleDetail(pr, "src/Foo.kt", "project")
+	if d == nil {
+		t.Fatal("expected a match")
+	}
+	if !reflect.DeepEqual(d.RuleFiles, []string{"a.md"}) {
+		t.Errorf("RuleFiles (Go literal): want [a.md], got %v", d.RuleFiles)
+	}
+}
+
+// TestResolveDetail_RuleFiles_MixedInlineAndFileLabels verifies that a
+// multi-element array mixing file and inline inputs labels each correctly:
+// files keep their path, inline parts become "<inline>". ruleInputs keeps the
+// user's original inputs verbatim, and classifyRuleFiles labels each
+// element from those original inputs.
+func TestResolveDetail_RuleFiles_MixedInlineAndFileLabels(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":["a.md","watch for null safety"]}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	if !reflect.DeepEqual(d.RuleFiles, []string{"a.md", "<inline>"}) {
+		t.Errorf("RuleFiles: want [a.md <inline>], got %v", d.RuleFiles)
+	}
+}
+
+// TestResolveDetail_RuleFiles_EmptyElementOmitted verifies that an empty
+// (or whitespace-only) array element — e.g. a trailing comma producing "" —
+// is skipped from the Rule body by resolveMultiRuleParts (warned, contributes
+// nothing) and omitted from "Rule Files:" by classifyRuleFiles. The empty
+// element is not a file and carries no inline text, so a label would be
+// misleading; the display reports only the inputs that are files or inline
+// text. The merged Rule body omits the empty element (no dangling separator).
+func TestResolveDetail_RuleFiles_EmptyElementOmitted(t *testing.T) {
+	repoDir := t.TempDir()
+	writeRuleMD(t, repoDir, "a.md", "General review guidance.\n")
+	writeRuleMD(t, repoDir, "b.md", "Kotlin-specific guidance.\n")
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":["a.md","","b.md"]}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	// The empty element is omitted from RuleFiles (it is neither a file nor
+	// inline text); only a.md and b.md are reported.
+	if !reflect.DeepEqual(d.RuleFiles, []string{"a.md", "b.md"}) {
+		t.Errorf("RuleFiles: want [a.md b.md] (empty omitted), got %v", d.RuleFiles)
+	}
+	// The empty element contributes nothing to the Rule body: a.md and b.md
+	// merge with a single separator, no dangling heading for the empty slot.
+	want := "General review guidance.\n\n---\n\nKotlin-specific guidance."
+	if d.Rule != want {
+		t.Errorf("Rule body:\n want %q\n got  %q", want, d.Rule)
+	}
+}
+
+// TestResolveDetail_RuleFiles_WhitespaceIsInline verifies that a
+// whitespace-only single-value rule (legacy: it wins first-match-wins and its
+// Rule is left byte-identical by resolveRuleEntries) is labeled "<inline>":
+// an inline rule is inline regardless of its content, so whitespace content
+// is still an inline (non-file) source. Rule stays "  " (byte-identical
+// legacy); RuleFiles reports [<inline>].
+func TestResolveDetail_RuleFiles_WhitespaceIsInline(t *testing.T) {
+	repoDir := t.TempDir()
+	writeProjectRule(t, repoDir, `{"rules":[{"path":"**/*.kt","rule":"  "}]}`)
+	dr := newResolverAt(t, repoDir).(DetailResolver)
+
+	d := dr.ResolveDetail("src/Foo.kt")
+	if d.Rule != "  " {
+		t.Errorf("Rule: want \"  \" (byte-identical legacy, whitespace wins first-match-wins), got %q", d.Rule)
+	}
+	if !reflect.DeepEqual(d.RuleFiles, []string{"<inline>"}) {
+		t.Errorf("RuleFiles: want [<inline>] for whitespace inline rule, got %v", d.RuleFiles)
+	}
+}
+
+// TestResolveDetail_RuleFiles_WhitespaceGoLiteralIsNil verifies the
+// ruleInputs-nil (Go-literal) fallback path: a whitespace-only Rule yields
+// nil, not ["<inline>"]. classifyRuleFiles cannot tell a Go-literal inline
+// whitespace rule from a file that resolved to whitespace (both have
+// ruleInputs nil and a whitespace Rule); since whitespace contributes no
+// meaningful source either way, the fallback reports nothing. (A JSON
+// inline whitespace rule like `rule: "  "` still goes through the inputs
+// branch with ruleInputs=["  "] and is labeled "<inline>" — see
+// TestResolveDetail_RuleFiles_WhitespaceIsInline.) Rule stays "  "
+// (byte-identical legacy: the entry still wins first-match-wins).
+func TestResolveDetail_RuleFiles_WhitespaceGoLiteralIsNil(t *testing.T) {
+	pr := &ProjectRule{Rules: []ProjectRuleEntry{{Path: "**/*.kt", Rule: "  "}}}
+	resolveRuleEntries(pr.Rules, t.TempDir(), "")
+	c := &composedResolver{project: pr}
+
+	d := c.matchProjectRuleDetail(pr, "src/Foo.kt", "project")
+	if d == nil {
+		t.Fatal("expected a match")
+	}
+	if d.Rule != "  " {
+		t.Errorf("Rule: want \"  \" (byte-identical legacy), got %q", d.Rule)
+	}
+	if d.RuleFiles != nil {
+		t.Errorf("RuleFiles: want nil for whitespace Go-literal rule, got %v", d.RuleFiles)
+	}
+}

--- a/internal/config/rules/system_rules.go
+++ b/internal/config/rules/system_rules.go
@@ -129,6 +129,10 @@ type RuleDetail struct {
 	Rule    string // rule text
 	Source  string // "custom" | "project" | "global" | "system"
 	Pattern string // glob pattern that matched, or "default" for fallback — always a plain glob, never annotated
+	// RuleFiles lists the source rule files (or "<inline>") that produced Rule,
+	// for ocr-rules-check traceability. Empty for the system layer. It is a
+	// debugging aid only: it never enters the LLM prompt or delegate JSON.
+	RuleFiles []string `json:"-"`
 	// SniffedAs is "" for a plain path match, or the sniffed language (e.g.
 	// "objc") when content sniffing overrode the path-based rule. Internal
 	// only: callers that serialize RuleDetail (e.g. delegateRuleGroupJSON)
@@ -207,6 +211,155 @@ type ProjectRuleEntry struct {
 	Path            string `json:"path"`
 	Rule            string `json:"rule"`
 	MergeSystemRule bool   `json:"merge_system_rule,omitempty"`
+
+	// ruleInputs records the raw "rule" inputs (file paths or inline text) as
+	// written by the user, before resolveRuleEntries reads/merges them into
+	// Rule. It drives the multi-file merge path (len >= 2) and preserves the
+	// original source for ocr-rules-check traceability after Rule becomes file
+	// content. resolveRuleEntries keeps the user's original inputs verbatim
+	// (including files that failed to read or were rejected by #1100), so the
+	// "Rule Files:" display reports what the user wrote, while Rule contains
+	// only the inputs that actually contributed — with one exception: when an
+	// array exceeds maxRuleInputs, resolveRuleEntries truncates ruleInputs to
+	// the first maxRuleInputs survivors (before any file I/O), so the display
+	// then reports only those survivors, not the dropped trailing inputs.
+	// This makes the multi-input path naturally idempotent: a repeat call
+	// re-reads the same surviving inputs and produces the same Rule. The
+	// single-value path reads e.Rule like the legacy code (not idempotent,
+	// but every caller invokes it exactly once per load).
+	// Unexported: it never serializes. nil for Go-literal-constructed entries
+	// (no UnmarshalJSON), which take the single-value path and get back-filled
+	// here so RuleFiles can still report their source.
+	ruleInputs []string
+}
+
+// UnmarshalJSON accepts "rule" as either a string (legacy, byte-identical) or
+// an array of strings (multi-file merge). A single-element array degrades
+// to the single-value path so its output is byte-identical to the string form.
+func (e *ProjectRuleEntry) UnmarshalJSON(data []byte) error {
+	// raw mirrors ProjectRuleEntry's exported JSON fields, keeping Rule as a
+	// RawMessage so it can be decoded polymorphically (string or array) below.
+	// Decoding into e directly would recurse into this method, so a shadow
+	// struct is the idiomatic way. Keep these fields in sync with
+	// ProjectRuleEntry's json tags: a new JSON field added to the entry must
+	// be added here too, or it is silently dropped during decoding.
+	var raw struct {
+		Path            string          `json:"path"`
+		Rule            json.RawMessage `json:"rule"`
+		MergeSystemRule bool            `json:"merge_system_rule,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// Clear stale values for contract consistency: encoding/json does
+		// not zero the receiver before calling UnmarshalJSON. A
+		// shadow-struct decode error (e.g. a "path" field type mismatch)
+		// fails here before any field is read from raw, so it must not
+		// leave stale values behind. Clear every field the success path
+		// sets below (Path, MergeSystemRule, Rule, ruleInputs), not just
+		// Rule/ruleInputs — leaving a stale Path/MergeSystemRule on a
+		// re-decode into an already-populated entry would be the same
+		// contract violation the other non-productive branches guard
+		// against. (Syntactically malformed JSON never reaches
+		// UnmarshalJSON: the stdlib validates syntax before dispatching,
+		// so a field type mismatch is the realistic way this initial
+		// decode fails.)
+		e.Path = ""
+		e.MergeSystemRule = false
+		e.Rule = ""
+		e.ruleInputs = nil
+		return err
+	}
+	e.Path = raw.Path
+	e.MergeSystemRule = raw.MergeSystemRule
+
+	if len(raw.Rule) == 0 || string(raw.Rule) == "null" {
+		// "rule" absent or null: reset to zero values. encoding/json does not
+		// clear the receiver before calling UnmarshalJSON, so re-decoding into
+		// a previously populated entry must not leave stale Rule/ruleInputs.
+		e.Rule = ""
+		e.ruleInputs = nil
+		return nil
+	}
+
+	// Track the decode errors so a malformed "rule" value reports its cause
+	// instead of only a generic "must be a string or array of strings".
+	var arrayErr, stringErr error
+
+	// String form: legacy single value. Back-fill ruleInputs for traceability.
+	var s string
+	if stringErr = json.Unmarshal(raw.Rule, &s); stringErr == nil {
+		if s == "" {
+			// Empty string is equivalent to absent: clear Rule and ruleInputs so
+			// the entry is skipped downstream (same as the omitted case).
+			// encoding/json does not zero the receiver before calling
+			// UnmarshalJSON, so re-decoding must not leave stale values.
+			e.Rule = ""
+			e.ruleInputs = nil
+			return nil
+		}
+		e.Rule = s
+		e.ruleInputs = []string{s}
+		return nil
+	}
+
+	// Array form: multi-file merge. A single-element array degrades to the
+	// single-value path (Rule set, byte-identical to the string form).
+	var arr []string
+	if err := json.Unmarshal(raw.Rule, &arr); err == nil {
+		if len(arr) == 1 {
+			// Single-element array degrades to the single-value path (Rule
+			// set, byte-identical to the string form). An empty element is
+			// equivalent to the empty-string form: clear Rule and ruleInputs
+			// so the entry is skipped downstream, matching the string path.
+			if arr[0] == "" {
+				e.Rule = ""
+				e.ruleInputs = nil
+			} else {
+				e.Rule = arr[0]
+				e.ruleInputs = arr
+			}
+		} else {
+			// Empty or multi-element array: Rule is resolved later by
+			// resolveRuleEntries, so clear any stale value left from a prior
+			// decode (encoding/json does not zero the receiver first). An
+			// empty array behaves like absent (skip the entry), so nil out
+			// ruleInputs rather than keeping an empty non-nil slice.
+			e.Rule = ""
+			if len(arr) == 0 {
+				e.ruleInputs = nil
+			} else {
+				e.ruleInputs = arr
+			}
+		}
+		return nil
+	} else {
+		arrayErr = err
+	}
+
+	// Neither a string nor a valid string array: both decodes failed, so
+	// arrayErr and stringErr are non-nil. Pick the cause that best describes
+	// the actual input. For an array-shaped value, arrayErr pinpoints the
+	// offending element (e.g. a non-string element in a mixed-type array);
+	// for any other shape (number, bool, object), the string decode error
+	// names the actual offending type ("cannot unmarshal number into string")
+	// rather than the []string target the user never wrote.
+	cause := arrayErr
+	if !strings.HasPrefix(strings.TrimSpace(string(raw.Rule)), "[") {
+		cause = stringErr
+	}
+	// Clear stale values for contract consistency: encoding/json does not zero
+	// the receiver first, and the other non-productive branches above reset
+	// Rule/ruleInputs — the error path should too, so a re-decode of an
+	// already-populated entry with an invalid rule type leaves nothing behind.
+	// Clear Path/MergeSystemRule as well, matching the shadow-decode-error
+	// branch above: although those were validly decoded from the new JSON, an
+	// invalid rule means the whole entry is unusable (the caller drops it on
+	// error), so leaving them set would be an inconsistent half-cleared state
+	// that a future caller ignoring the error could mistake for a usable entry.
+	e.Path = ""
+	e.MergeSystemRule = false
+	e.Rule = ""
+	e.ruleInputs = nil
+	return fmt.Errorf("rule: must be a string or array of strings: %w", cause)
 }
 
 // ProjectRule holds rules loaded from <repoDir>/.opencodereview/rule.json.
@@ -529,7 +682,80 @@ func (c *composedResolver) matchProjectRuleDetail(pr *ProjectRule, path, source 
 	if entry.MergeSystemRule {
 		rule = c.mergeWithSystemRule(path, rule)
 	}
-	return &RuleDetail{Rule: rule, Source: source, Pattern: entry.Path}
+	return &RuleDetail{
+		Rule:      rule,
+		Source:    source,
+		Pattern:   entry.Path,
+		RuleFiles: classifyRuleFiles(entry.ruleInputs, entry.Rule),
+	}
+}
+
+// classifyRuleFiles maps an entry's raw rule inputs to display labels for the
+// "Rule Files:" line printed by ocr-rules-check. inputs is the user's original
+// ruleInputs, kept verbatim by resolveRuleEntries except when the maxRuleInputs
+// count cap trims it to the first maxRuleInputs survivors, so the display
+// reports exactly what the user wrote — including files that failed to read or
+// were rejected by #1100, which appear here even though they contributed nothing
+// to Rule. File-path inputs are kept verbatim (the full field as written, e.g.
+// "rules/kotlin.md"), so same-named files in different directories stay
+// distinguishable. This is local debug output only: RuleFiles has json:"-"
+// and never reaches the LLM prompt or delegate JSON, so the display label
+// preserves the input as-is. Path-traversal safety is already enforced by
+// #1100's confineRoot on the untrusted project layer, so no extra
+// sanitization is applied here. Inline inputs (anything looksLikeFilePath
+// rejects) become "<inline>". In a multi-element array, an empty or
+// whitespace-only element (e.g. a trailing comma) is skipped from the Rule
+// body by resolveMultiRuleParts with a warning, so it contributed nothing —
+// it is omitted from the "Rule Files:" display entirely rather than shown as
+// a misleading label. A single-value whitespace rule is different: it is the
+// whole rule and wins its layer (legacy leaves it byte-identical), so it is
+// genuine inline text and stays "<inline>". When inputs is empty/nil
+// (Go-literal-constructed entry with no UnmarshalJSON, so ruleInputs was
+// never populated), it falls back to inferring a single label from the
+// resolved Rule: a file path stays verbatim; inline text with non-whitespace
+// content becomes "<inline>"; empty or whitespace-only yields nil — there is
+// no file and no real text to attribute. When every input in a multi-element
+// array is an empty/whitespace element (all omitted), the inputs branch also
+// returns nil, so "no rule files" is a single nil representation across both
+// paths — a caller comparing != nil sees the same result either way.
+func classifyRuleFiles(inputs []string, fallbackRule string) []string {
+	if len(inputs) > 0 {
+		// A single input is the whole rule: if it is whitespace-only inline
+		// text it still wins its layer (legacy), so label it "<inline>".
+		// Empty/whitespace elements inside a multi-element array contributed
+		// nothing (resolveMultiRuleParts skips them), so omit them from the
+		// display rather than show a label for an input that is not a file and
+		// carries no inline text.
+		multi := len(inputs) > 1
+		out := make([]string, 0, len(inputs))
+		for _, in := range inputs {
+			if looksLikeFilePath(in) {
+				out = append(out, in)
+			} else if multi && strings.TrimSpace(in) == "" {
+				// Omitted: an empty element in a multi-element array is not a
+				// file and carries no inline text, so it has no label.
+				continue
+			} else {
+				out = append(out, "<inline>")
+			}
+		}
+		if len(out) == 0 {
+			// All inputs were empty/whitespace elements in a multi-element
+			// array: nothing is a file or inline text, so there is nothing to
+			// display. Return nil to match the fallback path's "no rule files"
+			// convention, so the two paths use a single representation (a
+			// caller comparing != nil sees the same result either way).
+			return nil
+		}
+		return out
+	}
+	if looksLikeFilePath(fallbackRule) {
+		return []string{fallbackRule}
+	}
+	if strings.TrimSpace(fallbackRule) != "" {
+		return []string{"<inline>"}
+	}
+	return nil
 }
 
 func matchProjectRuleEntry(pr *ProjectRule, path string) *ProjectRuleEntry {
@@ -555,6 +781,49 @@ func matchProjectRuleEntry(pr *ProjectRule, path string) *ProjectRuleEntry {
 // allowedRuleExts is the set of file extensions permitted for rule file references.
 var allowedRuleExts = map[string]bool{".md": true, ".txt": true, ".markdown": true}
 
+// maxRuleBodySize is the maximum byte budget of a resolved rule body. It bounds
+// both a single rule file (readRuleFileSafe rejects larger files) and the merged
+// body of a multi-input array entry (resolveMultiRuleParts skips an input whole
+// once adding it — segment content plus the "\n\n---\n\n" separator — would make
+// the running total exceed the budget; the running total is unchanged by the
+// skip, so a later smaller input can still fit and contribute). The two paths
+// share the same budget so a multi-file merge never expands the surface beyond
+// a single md file, regardless of how many files an untrusted project rule.json
+// references.
+const maxRuleBodySize = 512 * 1024
+
+// rulePartSep is the separator joinRuleParts inserts between merged rule parts.
+// It is shared with resolveMultiRuleParts, which counts len(rulePartSep) in the
+// running size total, so the size cap and the actual join can never drift apart
+// (the two stay in sync structurally rather than by convention).
+const rulePartSep = "\n\n---\n\n"
+
+// maxRuleInputs bounds the number of inputs a single multi-input array entry
+// (rule: ["...", ...]) resolves. The first maxRuleInputs inputs are processed;
+// any beyond that are dropped from both the resolved Rule body and ruleInputs
+// (with a warning), so they cost no file I/O and do not appear in "Rule Files:".
+// This caps both the file-read I/O (at most maxRuleInputs file reads per entry,
+// each ~3 syscalls) and the retained ruleInputs memory — two surfaces the byte
+// cap maxRuleBodySize alone cannot bound, because empty/missing/empty-file
+// inputs are skipped without growing the running total. Every input — valid file,
+// inline text, or an empty "" element — counts toward the limit, so a user who
+// pads the array with junk inputs (e.g. trailing commas) only starves their own
+// budget. 32 is far beyond any legitimate config (a real entry references a
+// handful of files); the byte cap still bounds the merged body, so 32 is a
+// count guard, not a content guard — 32 large files are still bounded to 512 KB.
+const maxRuleInputs = 32
+
+// entryPathCtx returns the entry-path suffix appended to resolve warnings,
+// or "" when path is empty/whitespace so no confusing "(path: )" leaks. The
+// warnings in resolveRuleEntries, resolveMultiRuleParts, and tryReadRuleFile
+// all share this form, so changing the suffix format here updates every site.
+func entryPathCtx(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (path: %s)", path)
+}
+
 // looksLikeFilePath returns true when s is likely a file path (not inline content).
 // Heuristic: multi-line text is always inline; single-line text without spaces
 // ending in .md/.txt/.markdown is treated as a file path. Values containing spaces
@@ -572,27 +841,251 @@ func looksLikeFilePath(s string) bool {
 // resolveRuleEntries reads file references in each rule entry and replaces them with
 // the file content. confineRoot is the canonical repo root for the untrusted project
 // layer (empty for trusted layers, meaning no confinement).
+//
+// Multi-input entries (rule came in as a >=2-element array) take a merge
+// path: each input is read/kept and the results joined with separators. Single
+// inputs and Go-literal-constructed entries (ruleInputs nil) take the legacy
+// single-value path, which is byte-identical to the previous behavior.
+//
+// For multi-input entries, ruleInputs is first capped to maxRuleInputs: only
+// the first maxRuleInputs inputs are resolved and retained (the rest are dropped
+// with a warning, before any file I/O). This bounds both the per-entry file-read
+// I/O and the retained ruleInputs memory that the byte cap alone cannot reach.
+// The surviving inputs are then resolved. When the cap triggers, ruleInputs is
+// trimmed to those survivors (not the full original array) so "Rule Files:"
+// reports only what was actually processed; when it does not trigger, ruleInputs
+// is the original array unchanged. The multi-input path is naturally idempotent
+// — a repeat call re-reads the same surviving inputs and rebuilds the same
+// Rule — so no resolved flag is needed. The single-value path uses e.Rule like
+// the legacy code; all current callers (loadGlobalRule/loadRuleFile/loadProjectRule)
+// call it exactly once per load.
 func resolveRuleEntries(entries []ProjectRuleEntry, repoDir string, confineRoot string) {
 	for i := range entries {
 		e := &entries[i]
+		if len(e.ruleInputs) >= 2 {
+			inputs := e.ruleInputs
+			if len(inputs) > maxRuleInputs {
+				// Cap before any file I/O: only the first maxRuleInputs inputs
+				// are resolved and retained. Dropping here (not inside
+				// resolveMultiRuleParts) bounds both the read I/O and the
+				// retained ruleInputs memory that the byte cap cannot reach,
+				// since empty/missing/empty-file inputs are skipped without
+				// growing the running total. Trailing inputs are dropped with
+				// a warning naming the first dropped index; the entry path is
+				// included so the user can locate the offending entry.
+				ctx := entryPathCtx(e.Path)
+				fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule array has %d inputs; only the first %d are resolved, the rest (from index %d) are dropped%s\n", len(inputs), maxRuleInputs, maxRuleInputs, ctx)
+				// Copy survivors into a fresh slice so the dropped inputs' string
+				// data can be GC'd. A plain subslice (inputs[:maxRuleInputs])
+				// aliases the original backing array populated by UnmarshalJSON,
+				// so the dropped entries' strings would stay alive for the
+				// entry's lifetime — undermining the "bounds retained
+				// ruleInputs memory" goal above for an untrusted rule.json with
+				// many large inline inputs.
+				survivors := make([]string, maxRuleInputs)
+				copy(survivors, inputs)
+				inputs = survivors
+				e.ruleInputs = survivors
+			}
+			parts := resolveMultiRuleParts(inputs, repoDir, confineRoot, e.Path)
+			e.Rule = joinRuleParts(parts)
+			// ruleInputs now holds only the surviving (capped) inputs. Empty
+			// or unreadable inputs among them are skipped from Rule by
+			// resolveMultiRuleParts but remain in ruleInputs so "Rule Files:"
+			// can report them — though empty "" elements are omitted from
+			// that display by classifyRuleFiles. The cap above already
+			// dropped everything past maxRuleInputs.
+			continue
+		}
+		// Single-value / Go-literal path (byte-identical to legacy behavior):
+		// the rule is a single file reference, read like the legacy path.
 		if strings.TrimSpace(e.Rule) == "" || !looksLikeFilePath(e.Rule) {
 			continue
 		}
-		if content := tryReadRuleFile(e.Rule, repoDir, confineRoot); content != nil {
+		if e.ruleInputs == nil {
+			// Go-literal-constructed entry: back-fill the source for RuleFiles
+			// tracing. This does not affect resolution, which uses e.Rule.
+			e.ruleInputs = []string{e.Rule}
+		}
+		if content := tryReadRuleFile(e.Rule, repoDir, confineRoot, ""); content != nil {
 			e.Rule = *content
+			// An empty/whitespace file resolves to its (possibly empty) content,
+			// byte-identical to legacy: an empty file resolves to "" (skipped
+			// unless MergeSystemRule) and a whitespace-only file still wins its
+			// layer. ruleInputs is left as the original input so "Rule Files:"
+			// reports the file the user wrote, even though it contributed no
+			// text — consistent with the multi-input path.
 		} else {
+			// The file is missing/unreadable: Rule is cleared (legacy behavior
+			// — the entry is skipped and falls through). ruleInputs is left as
+			// the original input so "Rule Files:" still reports what the user
+			// wrote, consistent with the multi-input path (which keeps missing
+			// files in ruleInputs but skips them from Rule).
 			e.Rule = ""
 		}
 	}
 }
 
+// resolveMultiRuleParts reads each input (file path or inline text) and returns
+// the segments that successfully contributed. confineRoot is forwarded to
+// every file read so #1100's path confinement applies to each array element,
+// never relaxed by merging. A missing/unreadable file is warned and skipped;
+// if all inputs drop out, the result is empty so the entry is skipped
+// downstream (same semantics as a single missing file). entryPath is the
+// owning entry's path pattern, included in the empty-element warning so the
+// user can locate which rule entry the skipped element belongs to.
+//
+// inputs is already capped to maxRuleInputs by the caller (resolveRuleEntries),
+// so the loop iterates at most maxRuleInputs times — that bounds the file-read
+// I/O. Within the loop, maxRuleBodySize — the same 512 KB budget as a single
+// rule file — bounds the merged body so merging many files never expands the
+// memory/LLM-prompt surface beyond a single md file; once adding an input
+// (segment content plus the "\n\n---\n\n" separator) would make the running
+// total exceed it, that input is skipped whole with a warning (the running
+// total is unchanged by the skip, so a later smaller input may still fit and
+// contribute), each part kept whole (never mid-file truncated). The caller's
+// count cap and the byte cap are complementary: the count cap bounds the
+// number of file reads (I/O), the byte cap bounds the merged content (LLM
+// prompt size).
+func resolveMultiRuleParts(inputs []string, repoDir string, confineRoot string, entryPath string) []string {
+	// ctx is the owning entry's path pattern, appended to warnings so the
+	// user can locate the offending entry. entryPathCtx keeps a
+	// whitespace-only path from producing a confusing "(path: )" suffix.
+	ctx := entryPathCtx(entryPath)
+	const sepLen = len(rulePartSep) // joinRuleParts separator, shared with the join
+	var parts []string
+	total := 0
+	for i, raw := range inputs {
+		if strings.TrimSpace(raw) == "" {
+			// An empty/whitespace array element (e.g. a trailing comma) is
+			// invalid config; warn with the element index and the owning entry's
+			// path so the user can locate it, consistent with missing-file
+			// warnings that carry the rule reference. The element still counts
+			// toward the caller's maxRuleInputs cap (it was not dropped there
+			// — only inputs past the cap were), so junk inputs only starve the
+			// user's own budget.
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: empty rule input skipped in array at index %d%s\n", i, ctx)
+			continue
+		}
+		var content string
+		if looksLikeFilePath(raw) {
+			c := tryReadRuleFile(raw, repoDir, confineRoot, entryPath)
+			if c == nil {
+				// Read failure: warned by tryReadRuleFile (which appends the
+				// entry path, consistent with the empty-element/empty-file
+				// warnings below), skip this input.
+				continue
+			}
+			if strings.TrimSpace(*c) == "" {
+				// The file exists but is empty or whitespace-only: it
+				// contributes no rule text, so skip it like a missing
+				// file rather than add a content-less segment that would
+				// produce a dangling separator with no body in the
+				// merged output.
+				// readRuleFileSafe only trims trailing newlines, so
+				// strings.TrimSpace is what catches all whitespace here
+				// (leading/internal newlines, spaces, tabs). Warn so the
+				// user knows the listed file added nothing, parallel to
+				// the not-found warning above. The empty-array-element
+				// check above uses TrimSpace and includes the owning
+				// entry's path for the same reason; this stays consistent
+				// with it, so the user can tell
+				// which rule entry an empty file belongs to when several
+				// entries reference same-named files.
+				fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file is empty: %s%s\n", raw, ctx)
+				continue
+			}
+			content = *c
+		} else {
+			content = raw
+		}
+		// Total-size cap: the merged body shares a single md file's budget.
+		// Count the separator joinRuleParts inserts before this part (none
+		// before the first). Drop the WHOLE part on overflow — never mid-file
+		// truncate — so each contributing file stays intact. A `break` would
+		// stop reading all later inputs, but `continue` is used instead: the
+		// overflowing part is skipped (total is unchanged, since the add below
+		// is not reached), so a later smaller input can still fit the budget
+		// and contribute. The overall file-read I/O is bounded separately by
+		// the maxRuleInputs count cap applied in resolveRuleEntries before this
+		// loop runs (at most maxRuleInputs reads per entry), so `continue`
+		// cannot re-open the I/O-amplification surface that the count cap
+		// closed. Each skipped part is warned individually; ruleInputs still
+		// lists it so "Rule Files:" reports what the user wrote.
+		//
+		// The file is read (via tryReadRuleFile above) before this cap
+		// decides to skip it, so an overflowing file is read then discarded
+		// rather than skipped unread. This is a deliberate trade-off, not
+		// an oversight. readRuleFileSafe already calls os.Stat internally
+		// and checks the size before os.ReadFile, so the size that would
+		// overflow is known before the read — but tryReadRuleFile returns
+		// only content or nil, so propagating that size to this caller to
+		// enable an early skip would require restructuring its API. The
+		// trade-off is that restructuring cost versus the bounded waste
+		// here (at most maxRuleInputs reads of ≤512 KB each, transient, on
+		// the config-load path, not a hot path). A separate pre-read os.Stat
+		// outside tryReadRuleFile is a worse alternative: it adds a
+		// redundant Stat to every file input — readRuleFileSafe already
+		// Stats each file once — and runs before readRuleFileSafe's
+		// EvalSymlinks+confineRoot (#1100) ordering, following a symlink
+		// to stat a target the read path would reject. Keeping the
+		// read-then-skip form preserves that ordering and avoids the
+		// redundant syscall.
+		delta := len(content)
+		if len(parts) > 0 {
+			delta += sepLen
+		}
+		if total+delta > maxRuleBodySize {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: merged rule body exceeds %d bytes at input index %d; this input skipped%s\n", maxRuleBodySize, i, ctx)
+			continue
+		}
+		total += delta
+		parts = append(parts, content)
+	}
+	return parts
+}
+
+// joinRuleParts concatenates rule parts with a blank line, "---", and a blank
+// line between segments. The merged Rule body is pure rule content only — no
+// per-file headings. File-source traceability is carried by the "Rule Files:"
+// line in `ocr rules check` (populated from ruleInputs via classifyRuleFiles),
+// which never enters the LLM prompt. Keeping the body heading-free makes the
+// single-value, single-element-array, and multi-element-array cases uniform
+// and keeps the `ocr rules check` body byte-identical to the `ocr review` LLM
+// input. Each part is just the segment text (file content or inline text); no
+// per-part metadata is carried here — source labels are derived at display
+// time by classifyRuleFiles from the original ruleInputs.
+func joinRuleParts(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, p := range parts {
+		if i > 0 {
+			b.WriteString(rulePartSep)
+		}
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
 // tryReadRuleFile reads a rule file reference. Absolute paths are used directly;
 // relative paths resolve against repoDir. When confineRoot is non-empty, the resolved
 // path must stay inside it. Returns nil when the file cannot be read safely.
-func tryReadRuleFile(rule string, repoDir string, confineRoot string) *string {
+//
+// entryPath is the owning entry's path pattern; when non-empty it is appended to
+// each warning so a missing/unreadable file in a multi-element array carries the
+// same context as the empty-element and empty-file warnings in resolveMultiRuleParts.
+// The single-value legacy caller passes "" so its warnings stay byte-identical
+// to the legacy behavior.
+func tryReadRuleFile(rule string, repoDir string, confineRoot string, entryPath string) *string {
+	// ctx is appended to warnings; empty for the legacy single-value caller so
+	// its warnings are byte-identical, non-empty for the multi-input caller.
+	// entryPathCtx guards a whitespace-only path against "(path: )".
+	ctx := entryPathCtx(entryPath)
 	if repoDir == "" {
 		if !filepath.IsAbs(rule) {
-			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot resolve relative rule path %q without a repo dir\n", rule)
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot resolve relative rule path %q without a repo dir%s\n", rule, ctx)
 			return nil
 		}
 	}
@@ -602,9 +1095,9 @@ func tryReadRuleFile(rule string, repoDir string, confineRoot string) *string {
 			return &content
 		}
 		if os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file not found: %s\n", rule)
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file not found: %s%s\n", rule, ctx)
 		} else {
-			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read rule file %s: %v\n", rule, err)
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read rule file %s: %v%s\n", rule, err, ctx)
 		}
 		return nil
 	}
@@ -613,7 +1106,7 @@ func tryReadRuleFile(rule string, repoDir string, confineRoot string) *string {
 	resolved := filepath.Clean(filepath.Join(repoDir, rule))
 	cleanRepo := filepath.Clean(repoDir)
 	if !strings.HasPrefix(resolved, cleanRepo+string(os.PathSeparator)) {
-		fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file path escapes repo dir: %s\n", rule)
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file path escapes repo dir: %s%s\n", rule, ctx)
 		return nil
 	}
 
@@ -622,16 +1115,17 @@ func tryReadRuleFile(rule string, repoDir string, confineRoot string) *string {
 		return &content
 	}
 	if os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file not found: %s\n", rule)
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: rule file not found: %s%s\n", rule, ctx)
 	} else {
-		fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read rule file %s: %v\n", resolved, err)
+		fmt.Fprintf(os.Stderr, "[ocr] WARNING: cannot read rule file %s: %v%s\n", resolved, err, ctx)
 	}
 	return nil
 }
 
-// readRuleFileSafe reads and validates a rule file: extension whitelist, 512 KB cap,
-// and symlink resolution. When confineRoot is non-empty, the resolved path must stay
-// inside it. Returns the trimmed content on success.
+// readRuleFileSafe reads and validates a rule file: extension whitelist,
+// maxRuleBodySize cap (512 KB, the same budget a multi-input merge shares), and
+// symlink resolution. When confineRoot is non-empty, the resolved path must
+// stay inside it. Returns the trimmed content on success.
 func readRuleFileSafe(path string, confineRoot string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
@@ -646,13 +1140,12 @@ func readRuleFileSafe(path string, confineRoot string) (string, error) {
 		return "", fmt.Errorf("unsupported extension %q, only .md/.txt/.markdown allowed", filepath.Ext(resolved))
 	}
 
-	const maxSize = 512 * 1024
 	info, err := os.Stat(resolved)
 	if err != nil {
 		return "", err
 	}
-	if info.Size() > maxSize {
-		return "", fmt.Errorf("file too large (%d bytes, max %d)", info.Size(), maxSize)
+	if info.Size() > maxRuleBodySize {
+		return "", fmt.Errorf("file too large (%d bytes, max %d)", info.Size(), maxRuleBodySize)
 	}
 
 	content, err := os.ReadFile(resolved)

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -59,6 +59,68 @@ Three independent fields:
   order**. The first `path` whose glob matches the file determines the
   prompt OCR sends to the model for that file.
 
+### Merging multiple rule files
+
+The `rule` field accepts either a string (inline text or a single `.md` file
+path) or an **array of strings** that merges several rule docs into one text —
+e.g. general + language + domain rules stacked. First-match-wins is unchanged:
+the single winning entry still applies; it just gets to carry multiple files.
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "rules/security.md", "rules/convention.md"]
+    }
+  ]
+}
+```
+
+Array elements may mix file paths and inline text:
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "extra: check exception handling"]
+    }
+  ]
+}
+```
+
+Merge format:
+
+- **Single value** (a string, or a one-element array) — emitted as-is, no
+  separator, byte-identical to the legacy behavior.
+- **Multiple files** — segments are joined with a blank line + `---` + blank
+  line. The merged rule text is pure content only — no per-file headings — so
+  the single-value, one-element-array, and multi-element-array cases are
+  uniform. File-source traceability is carried by the `Rule Files:` line that
+  `ocr rules check` prints (which never enters the LLM prompt), not by the
+  rule text.
+- A missing or empty element is dropped from the merged **rule text** (with a
+  warning); if all elements drop out the entry is skipped (same semantics as a
+  single missing file). A dropped **file path** is still listed in the
+  `Rule Files:` line as you wrote it, so a typo'd path that contributed nothing
+  stays visible. An empty/whitespace array element (e.g. a trailing comma) is
+  also dropped, but omitted from the `Rule Files:` line entirely since it is
+  neither a file nor inline text.
+
+> File paths inside an array are still bound by #1100's path-traversal
+> confinement: project-layer references cannot escape the repo root.
+
+Two caps bound an untrusted array so it cannot balloon I/O or memory:
+
+- **Count**: an array longer than 32 elements is truncated to its first 32
+  before any file is read; the rest are dropped with a warning. Empty elements
+  count toward the 32, so padding only starves the budget.
+- **Size**: the merged rule text is capped at 512 KB (524288 bytes). When an
+  input would push the total past the cap, that input is skipped (later,
+  smaller inputs still fit) with a warning; a single file larger than 512 KB
+  is rejected outright and the entry falls back to the system rule.
+
 ### Glob features
 
 OCR uses [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4)
@@ -224,14 +286,17 @@ $ ocr rules check --rule custom.json src/main/resources/mapper/UserMapper.xml
 File: src/main/resources/mapper/UserMapper.xml
 Source: Custom (--rule)
 Pattern: **/*mapper*.xml
+Rule Files: rules/java.md, rules/security.md, rules/convention.md
 Rule:
 ────────────────────────────────────────
-…contents of your custom rule…
+…contents of your merged rule…
 ────────────────────────────────────────
 ```
 
-Use this whenever a rule isn't behaving the way you expected — it tells
-you the **layer** and the **pattern** that won.
+The `Rule Files:` line lists which files the matched rule came from (inline
+text is shown as `<inline>`), making merged content traceable. Use this
+whenever a rule isn't behaving the way you expected — it tells you the
+**layer** and the **pattern** that won.
 
 ## Recipes
 
@@ -276,6 +341,37 @@ ocr review --rule ./.review-rules-only-for-this-pr.json
 
 Bypasses both the project and global layers — handy when a single PR
 needs a totally different review checklist (e.g., security-only review).
+
+### Project-level: stack language + concern rules
+
+Layer several rule docs onto the same path instead of cramming everything
+into one file. Pair a language base rule with any combination of concern
+rules — security, performance, convention — per `path`:
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "rules/security.md", "rules/convention.md"]
+    },
+    {
+      "path": "**/*.c",
+      "rule": ["rules/cpp.md", "rules/security.md", "rules/performance.md"]
+    },
+    {
+      "path": "**/*.kt",
+      "rule": ["rules/kotlin.md", "rules/security.md"]
+    }
+  ]
+}
+```
+
+`rules/java.md`, `rules/cpp.md`, `rules/kotlin.md` carry the language-specific
+base rule, kept per `path`; `rules/security.md`, `rules/performance.md`,
+`rules/convention.md` are reusable concern rules you combine as needed.
+`ocr rules check` prints the `Rule Files:` line so you can confirm which
+combination actually applied.
 
 ### Global personal preferences
 

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -52,6 +52,61 @@ OCR 用一条**四层优先级链**解析规则。对每个文件路径，按序
 - `rules`——`{path, rule}` 条目数组，按**声明顺序**求值。第一个 `path` glob
   匹配该文件的条目，决定 OCR 发给模型的 prompt。
 
+### 合并多个规则文件
+
+`rule` 字段除了写字符串（内联文本或单个 `.md` 文件路径），还可以写成一个
+**字符串数组**，把多个规则 md 合并成一段文本——例如通用规范 + 语言规范 + 领域规范
+三层叠加。first-match-wins 不变：仍是命中的**那一条** entry 生效，只是这条 entry
+可以携带多个文件。
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "rules/security.md", "rules/convention.md"]
+    }
+  ]
+}
+```
+
+数组里也可以混用文件路径与内联文本：
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "extra: check exception handling"]
+    }
+  ]
+}
+```
+
+合并格式：
+
+- **单值**（字符串、或只有一个元素的数组）——原样输出，无分隔线，与旧行为
+  字节一致。
+- **多个文件**——每段之间用空行 + `---` + 空行衔接。合并正文只含纯规则内容，
+  **不带任何文件标题**，使单值、单元素数组、多元素数组三种形态完全统一。文件
+  来源追溯由 `ocr rules check` 打印的 `Rule Files:` 行承担（该行不进 LLM
+  prompt），而非正文。
+- 文件不存在或缺省时该段从合并**正文**中跳过（并打印警告）；全部缺失则该条
+  entry 被跳过（与单文件缺失语义一致）。被跳过的**文件路径**仍按你写的原样列在
+  `Rule Files:` 行，便于发现拼错路径、实际未贡献内容的文件；但空/纯空白元素
+  （如尾随逗号）虽同样跳过，却完全不出现在 `Rule Files:` 行（它既非文件也非内联文本）。
+
+> 数组中的文件路径同样受 #1100 的路径穿越防护约束：项目层的引用不可逃出仓库
+> 根目录。
+>
+> 两条上限约束不可信数组，避免 I/O 与内存被放大：
+>
+> - **数量**：数组超过 32 个元素时，在任何文件读取之前截断为前 32 个，其余丢弃并
+>   告警。空元素计入这 32 个名额，所以用空元素填充只会浪费预算。
+> - **体积**：合并正文上限 512 KB（524288 字节）。某输入会令总量超过上限时，该
+>   输入被跳过（后续更小的输入仍可放入）并告警；单个文件大于 512 KB 直接拒读，
+>   该 entry 回退到系统规则。
+
 ### glob 能力
 
 OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4)
@@ -203,13 +258,16 @@ $ ocr rules check --rule custom.json src/main/resources/mapper/UserMapper.xml
 File: src/main/resources/mapper/UserMapper.xml
 Source: Custom (--rule)
 Pattern: **/*mapper*.xml
+Rule Files: rules/java.md, rules/security.md, rules/convention.md
 Rule:
 ────────────────────────────────────────
-…contents of your custom rule…
+…contents of your merged rule…
 ────────────────────────────────────────
 ```
 
-当某条规则未按预期生效时用它——它会显示生效的**层**与**模式**。
+`Rule Files:` 行列出命中规则来自哪些文件（内联文本记为 `<inline>`），便于追溯
+合并后的内容来源。当某条规则未按预期生效时用它——它会显示生效的**层**与
+**模式**。
 
 ## 配方
 
@@ -253,6 +311,36 @@ ocr review --rule ./.review-rules-only-for-this-pr.json
 
 同时绕过项目层与全局层——当单个 PR 需要完全不同的评审清单（如仅安全评审）时
 很方便。
+
+### 项目级：语言 base + 关注维度规则组合
+
+把多个规则 md 叠加到同一条路径，无需在单个 md 里堆砌所有内容。语言 base 规则
+随 `path` 对应的语言常驻，关注维度规则（security、performance、convention）按需
+任意组合：
+
+```json
+{
+  "rules": [
+    {
+      "path": "**/*.java",
+      "rule": ["rules/java.md", "rules/security.md", "rules/convention.md"]
+    },
+    {
+      "path": "**/*.c",
+      "rule": ["rules/cpp.md", "rules/security.md", "rules/performance.md"]
+    },
+    {
+      "path": "**/*.kt",
+      "rule": ["rules/kotlin.md", "rules/security.md"]
+    }
+  ]
+}
+```
+
+`rules/java.md`、`rules/cpp.md`、`rules/kotlin.md` 承载各语言 base 规则，
+随对应 `path` 常驻；`rules/security.md`、`rules/performance.md`、
+`rules/convention.md` 是可复用的关注维度规则，按需组合。`ocr rules check` 会打印
+`Rule Files:` 行，便于确认实际生效的组合。
 
 ### 全局个人偏好
 


### PR DESCRIPTION
Accept the `rule` field in rule.json as either a string (legacy) or an array of strings. The winning entry in the first-match-wins chain can now carry multiple rule docs merged into one text; matching and layering are unchanged.

- ProjectRuleEntry: add unexported ruleInputs holding the raw inputs. UnmarshalJSON accepts string|array and clears stale Rule/ruleInputs on every non-productive branch, so re-decoding never leaks stale values; a single-element array degrades to the single-value path for byte-identical legacy behavior.
- resolveRuleEntries: arrays (len>=2) merge via new resolveMultiRuleParts/joinRuleParts; single values and Go literals take the legacy path, unchanged. ruleInputs keeps the user's original inputs verbatim, so "Rule Files:" reports what the user wrote while Rule holds only the inputs that contributed (a cap exception aside — see below). The multi-input path is naturally idempotent, so no resolved flag is needed. #1100 confineRoot is forwarded to every array element, and resolve warnings share one TrimSpace-guarded entry-path ctx, so an absent or whitespace path leaks no "(path: )" suffix.
- Merge format: segments join with a blank line, "---", and a blank line (body is pure content, no per-file headings). Empty elements, empty/whitespace files, and missing/unreadable files are warned and skipped (no dangling separators). Empty elements are omitted from "Rule Files:"; files that failed to contribute are still reported.
- Two complementary caps bound surfaces an untrusted project rule.json could otherwise expand. maxRuleInputs (32) truncates a multi-input array to its first 32 entries before any file I/O, with a warning; empty "" elements count toward it, so padding only starves the budget. Survivors are copied into a fresh slice (not a subslice) so the dropped inputs' string data can be GC'd, and "Rule Files:" then reports only those survivors. maxRuleBodySize (512 KB — the same budget as a single rule file) bounds the merged body: once adding an input (content plus separator) would make the running total exceed it, that input is skipped whole with a warning; the running total is unchanged, so a later smaller input may still fit and contribute. ruleInputs is preserved, so skipped or count-dropped inputs are still listed in "Rule Files:".
- RuleDetail: add RuleFiles (json:"-") via classifyRuleFiles for ocr-rules-check traceability; never enters the LLM prompt or delegate.
- ocr rules check: print a "Rule Files:" line (single value and array).
- Docs: update review-rules.md (en/zh) with the array form, a merge recipe, and the "Rule Files:" output line.
- Tests: add multi_rule_test.go and rules_check_test.go covering UnmarshalJSON, both resolve paths, merge output, RuleFiles labels, #1100 array confinement, both caps, idempotency, the empty-path warning guard, ocr-rules-check output, and inter-layer array priority.

Closes #1177

## Description

### Summary

- Extend the `rule` field in `rule.json` from a single string to `string | []string`, so one `path` can merge multiple rule docs (e.g. general + language + domain rules) in order. This unblocks the layered-rule use case from discussion #633 / issue #1177, where a file like `UserRepository.kt` needs several rule layers at once — previously first-match-wins forced everything into one large md.
- Stay within the existing embedded-rule mechanism: no resolver precedence, layer selection, relative-path base, or `merge_system_rule` semantics change. The feature only merges multiple md within the winning entry.
- Bound an untrusted `rule.json` with two caps — `maxRuleInputs` (32) before any file I/O, and `maxRuleBodySize` (512 KB) skipping an overflowing input via `continue` so later smaller inputs still fit — and forward `#1100` path-traversal confinement to every array element.
- Add a `Rule Files:` line to `ocr rules check` for traceability (never enters the LLM prompt), and document the array form, a merge recipe, the caps, and the `Rule Files:` output in `review-rules.md` (en/zh).

### Backward Compatibility

Fully backward compatible. A single-string `rule` behaves byte-identically to before — a single-element array degrades to the legacy single-value path (sha256-identical). Layer selection (custom > project > global > system, first-match-wins), relative-path bases, and `merge_system_rule` concatenation semantics are all unchanged. The observable change is limited to paths configured with an array `rule`: previously only the first entry applied, now they merge in order. Paths without arrays see zero change. No CLI flag, public API, or config-schema migration.

### Non-goals

- No new supported file extensions.
- No changes to scan, preview, exclude, resolver selection logic, or rule precedence.
- No changes to public APIs / CLI flags / other config-schema fields.
- No parser, compiler, linter, or build-tool integration.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

### Validation Environment

- Host: Linux (WSL2), amd64
- Go: `go1.26.5 linux/amd64`
- Base: `2190f11` (`origin/main`)
- Commit: `5acdf4a`

### Automated Tests

Added `internal/config/rules/multi_rule_test.go` (48 test functions) and `cmd/opencodereview/rules_check_test.go` (2), covering: string-or-array `UnmarshalJSON`, single-value byte-identity (single-element array degrades to the legacy path, sha256-identical), both resolve paths, merge output format, `Rule Files:` labels, `#1100` array confinement, both caps (count 32 before I/O; size 512 KB with `continue` so later smaller inputs still fit), the `>` boundary (524288 in / 524289 out), idempotency, the empty-path warning guard, `ocr rules check` output, and inter-layer array priority. Full `go test ./...` across all 23 packages passes (exit 0). `internal/config/rules` statement coverage: **93.9%**.

### `ocr rules check` Three-Layer E2E

Against a self-built feature binary (v1.11.5), **27 sub-cases all pass / 0 fail**:

- **Single-layer symmetry** (Project / Custom / Global × array/legacy × `merge_system_rule` true/false = 12): each layer behaves identically and correctly (merge=true yields System+User two segments with system first; merge=false yields pure user body, no section headers).
- **Multi-layer precedence** (6): custom > project > global first-match-wins is preserved; losing layers do not participate at all (their md neither enters the body nor `Rule Files`).
- **Boundary** (9): count cap 32 under merge=true (system segment still precedes; user segments capped to 32); size cap `continue` (overflowing input skipped, later small input still merges in); single-element-array vs single-value sha256 identical; `>` boundary exact (524288 in / 524289 out); missing files retained in `Rule Files`; file + inline gets an `<inline>` tag; empty elements omitted; all warnings carry a `(path: PATTERN)` suffix.

Relative-path bases per layer (existing semantics, unchanged): Custom base is the custom json's directory; Project base is the repo root; Global base is `~/.opencodereview/`.

### `ocr review` Official Binary — 100 Rounds (Code-Review Side)

Using the **official release `/bin/ocr`** (v1.11.x, without this feature) to LLM-review the feature diff on the branch HEAD — an independent-reviewer perspective validating the feature code itself:

```bash
/bin/ocr review --format json --audience agent \
  --concurrency 16 --max-git-procs 32 --max-tools 500 --timeout 240 --commit HEAD
```

100 consecutive 0-comment rounds (streak 100/100) after 20 rounds of valid comment fixes (size-cap `break`→`continue` semantics, subslice-aliasing memory release, comment consistency, etc.), all amended into the same commit. Rebased onto the latest `origin/main`; the feature code replayed byte-equivalently, and post-rebase full tests + E2E show no regression.

### `ocr review` Real-Machine Validation (Functional Side)

A self-built feature binary was run for ~200 rounds of `ocr review` on another machine, confirming multiple md files take effect correctly (rule bodies merged and applied during review). This round exercised the multi-md form; the single-value legacy form is covered by the automated tests and E2E above.

### Pre-Submit Compliance (per CONTRIBUTING)

- `make check` (gofmt + `go vet` + SPDX license-header verification): `check passed`. The new file carries the required `SPDX-License-Identifier: Apache-2.0` header.
- `make test` (with `-race`): all 23 packages pass, exit 0.
- `make build`: exit 0, binary produced.
- Branch follows the `feat/` prefix; commit title follows Conventional Commits; `Closes #1177` and `Signed-off-by` trailers present.

### Known Limitations

- The ~200-round real-machine `ocr review` only exercised the multi-md form; the single-value legacy form is covered by automated tests and E2E, not by that run.
- CI has not yet run at the time of writing (PR not yet pushed); the GitHub Actions results (including CodeQL, cross-compile, Pages, translation-sync, and the repository's own OCR self-review) will be confirmed on the PR once pushed.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1177
Discussion: #633