### PR TITLE
feat(viewer): number the lines inside the Existing Code block (#1172)

### DIFF
--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -241,6 +241,49 @@ func severityCounts(comments []*ReviewComment) SeverityCount {
 	return counts
 }
 
+// codeLine is one rendered line of an Existing Code block. Num is the file
+// line number, or 0 when the number cannot be trusted.
+type codeLine struct {
+	Num  int
+	Text string
+}
+
+// numberedCodeLines pairs each line of existing_code with its file line number.
+//
+// Num is left at 0 on every line whenever the reported range and the snippet
+// cannot both be true. internal/diff/resolver.go matches existing_code against
+// the file with blank lines dropped on both sides (splitAndNormalize and
+// resolveFromFileContent), so endLine-startLine+1 is not guaranteed to equal
+// the number of lines in the snippet, and numbering it anyway would put line
+// numbers next to the wrong code. In a review tool no gutter beats a wrong one.
+func numberedCodeLines(code string, startLine, endLine int) []codeLine {
+	if code == "" {
+		return nil
+	}
+	raw := strings.Split(code, "\n")
+	// A trailing newline terminates the last line, it does not start a new one.
+	if len(raw) > 1 && raw[len(raw)-1] == "" {
+		raw = raw[:len(raw)-1]
+	}
+	lines := make([]codeLine, len(raw))
+	for i, text := range raw {
+		lines[i] = codeLine{Text: strings.TrimSuffix(text, "\r")}
+	}
+	if endLine == 0 {
+		// A record with only start_line set is a single-line finding. A
+		// non-zero inverted range is left alone so the guard below rejects
+		// it, matching the hasRegion test in cmd/opencodereview/sarif.go.
+		endLine = startLine
+	}
+	if startLine <= 0 || endLine-startLine+1 != len(lines) {
+		return lines
+	}
+	for i := range lines {
+		lines[i].Num = startLine + i
+	}
+	return lines
+}
+
 func parseTemplate(name string) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"formatDuration": formatDuration,
@@ -360,6 +403,7 @@ func parseTemplate(name string) (*template.Template, error) {
 				return "cat-default"
 			}
 		},
+		"numberedCodeLines": numberedCodeLines,
 	}
 	content, err := assets.ReadFile("templates/" + name)
 	if err != nil {

--- a/internal/viewer/server_startserver_test.go
+++ b/internal/viewer/server_startserver_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -225,5 +226,119 @@ func TestCategoryCounts_NormalizesUnknownCategories(t *testing.T) {
 	})
 	if counts.Bug != 1 || counts.Maintainability != 1 || counts.Other != 2 {
 		t.Fatalf("unexpected category counts: %+v", counts)
+	}
+}
+
+// TestNumberedCodeLines pins the numbering contract for the Existing Code
+// gutter. The interesting half of the table is the cases where the reported
+// range and the snippet disagree: internal/diff/resolver.go drops blank lines
+// while matching, so the span can be wider or narrower than the snippet, and
+// numbering it anyway would print wrong file line numbers.
+func TestNumberedCodeLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		code  string
+		start int
+		end   int
+		want  []codeLine
+	}{
+		{"single line", "foo()", 10, 10, []codeLine{{10, "foo()"}}},
+		{"multi line contiguous", "a\nb\nc", 10, 12, []codeLine{{10, "a"}, {11, "b"}, {12, "c"}}},
+		{"trailing newline is not a line", "a\nb\n", 10, 11, []codeLine{{10, "a"}, {11, "b"}}},
+		{"end line zero means single line", "foo()", 7, 0, []codeLine{{7, "foo()"}}},
+		{"inverted range yields no numbers", "foo()", 12, 10, []codeLine{{0, "foo()"}}},
+		{"unresolved range yields no numbers", "a\nb", 0, 0, []codeLine{{0, "a"}, {0, "b"}}},
+		{"negative start yields no numbers", "a", -3, -1, []codeLine{{0, "a"}}},
+		{"span wider than snippet yields no numbers", "a\nb", 10, 14, []codeLine{{0, "a"}, {0, "b"}}},
+		{"span narrower than snippet yields no numbers", "a\nb\nc\nd", 10, 11, []codeLine{{0, "a"}, {0, "b"}, {0, "c"}, {0, "d"}}},
+		{"internal blank line counted", "a\n\nb", 10, 12, []codeLine{{10, "a"}, {11, ""}, {12, "b"}}},
+		{"leading blank line breaks consistency", "\na\nb", 10, 11, []codeLine{{0, ""}, {0, "a"}, {0, "b"}}},
+		{"empty code has no lines", "", 10, 10, nil},
+		{"crlf line endings", "a\r\nb", 10, 11, []codeLine{{10, "a"}, {11, "b"}}},
+		{"html metacharacters are returned verbatim", "if a < b && c > d {", 5, 5, []codeLine{{5, "if a < b && c > d {"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := numberedCodeLines(tt.code, tt.start, tt.end)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("numberedCodeLines(%q, %d, %d) = %#v, want %#v", tt.code, tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseTemplate_ExistingCodeLineNumbers asserts the rendered session page,
+// not which helper ran: a trustworthy range gets a per-line gutter, anything
+// else keeps the plain block it has today.
+func TestParseTemplate_ExistingCodeLineNumbers(t *testing.T) {
+	tmpl, err := parseTemplate("session.html")
+	if err != nil {
+		t.Fatalf("parseTemplate: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		comment    *ReviewComment
+		wantHas    []string
+		wantHasNot []string
+	}{
+		{
+			name:    "resolved range is numbered",
+			comment: &ReviewComment{FilePath: "a.go", Content: "c", ExistingCode: "a\nb\nc", StartLine: 10, EndLine: 12},
+			wantHas: []string{
+				`<span class="line-no" aria-hidden="true">10</span><span class="line-text">a</span>`,
+				`<span class="line-no" aria-hidden="true">11</span><span class="line-text">b</span>`,
+				`<span class="line-no" aria-hidden="true">12</span><span class="line-text">c</span>`,
+				`<span class="comment-lines sr-only">L10-L12</span>`,
+			},
+		},
+		{
+			name:       "unresolved range is not numbered",
+			comment:    &ReviewComment{FilePath: "a.go", Content: "c", ExistingCode: "a\nb"},
+			wantHas:    []string{"<pre><code>a\nb</code></pre>"},
+			wantHasNot: []string{`class="line-no"`},
+		},
+		{
+			name:       "inconsistent span is not numbered",
+			comment:    &ReviewComment{FilePath: "a.go", Content: "c", ExistingCode: "a\nb", StartLine: 10, EndLine: 14},
+			wantHas:    []string{"<pre><code>a\nb</code></pre>", `<span class="comment-lines">L10-L14</span>`},
+			wantHasNot: []string{`class="line-no"`},
+		},
+		{
+			name:       "suggestion block is never numbered",
+			comment:    &ReviewComment{FilePath: "a.go", Content: "c", SuggestionCode: "x\ny", StartLine: 10, EndLine: 11},
+			wantHas:    []string{`<div class="code-panel-label">Suggested Change</div>`, "<pre><code>x\ny</code></pre>"},
+			wantHasNot: []string{`class="line-no"`},
+		},
+		{
+			name:       "html in numbered code is escaped",
+			comment:    &ReviewComment{FilePath: "a.go", Content: "c", ExistingCode: "<script>alert(1)</script>", StartLine: 3, EndLine: 3},
+			wantHas:    []string{`<span class="line-text">&lt;script&gt;alert(1)&lt;/script&gt;</span>`},
+			wantHasNot: []string{"<script>alert(1)</script>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := &ViewSession{
+				Summary:  SessionSummary{SessionID: "s", CWD: "/p"},
+				Comments: []*ReviewComment{tt.comment},
+			}
+			rr := httptest.NewRecorder()
+			if err := tmpl.Execute(rr, sessionPageData{EncodedRepo: "r", RepoName: "R", Session: vs}); err != nil {
+				t.Fatalf("execute session.html: %v", err)
+			}
+			body := rr.Body.String()
+			for _, want := range tt.wantHas {
+				if !strings.Contains(body, want) {
+					t.Errorf("rendered page missing %q", want)
+				}
+			}
+			for _, unwanted := range tt.wantHasNot {
+				if strings.Contains(body, unwanted) {
+					t.Errorf("rendered page unexpectedly contains %q", unwanted)
+				}
+			}
+		})
 	}
 }

--- a/internal/viewer/static/style.css
+++ b/internal/viewer/static/style.css
@@ -1080,6 +1080,20 @@ p {
     font-size: 0.85rem;
 }
 
+/* Visually hidden but still in the accessibility tree. Used for the line
+   range when the code gutter carries the numbers visually. */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .comment-lines {
     font-family: var(--mono);
     font-size: 0.72rem;
@@ -1131,6 +1145,33 @@ p {
     background: none;
 }
 
+/* Line-number gutter for the Existing Code block — issue #1172.
+   The newlines between rows exist so the raw markup stays readable; the rows
+   are block-level, so white-space is reset on the <pre> to keep those newlines
+   from rendering as blank lines, and pre-wrap moves onto the code text alone. */
+.code-panel pre.code-numbered {
+    white-space: normal;
+}
+.code-numbered .code-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.7rem;
+}
+.code-numbered .line-no {
+    flex: 0 0 auto;
+    min-width: 2.5em;
+    text-align: right;
+    user-select: none;
+    -webkit-user-select: none;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+.code-numbered .line-text {
+    flex: 1 1 auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .code-existing .code-panel-label {
     background: #fef2f2;
     color: #dc2626;
@@ -1151,6 +1192,7 @@ p {
     .code-existing pre { background: rgba(220, 38, 38, 0.05); }
     .code-suggestion .code-panel-label { background: rgba(52, 211, 153, 0.12); color: #6ee7b7; }
     .code-suggestion pre { background: rgba(52, 211, 153, 0.05); }
+    .code-numbered .line-no { color: #8b93b5; }
 }
 
 /* ── Responsive ── */

--- a/internal/viewer/templates/session.html
+++ b/internal/viewer/templates/session.html
@@ -148,11 +148,13 @@
         </summary>
         <div class="comment-file-body">
         {{range .Comments}}
+            {{$lines := numberedCodeLines .ExistingCode .StartLine .EndLine}}
+            {{$numbered := and $lines (index $lines 0).Num}}
             <div class="comment-card" data-comment-card data-category="{{commentCategory .Category}}" data-severity="{{commentSeverity .Severity}}" data-mark-id="{{.MarkID}}">
                 <div class="comment-meta">
                     {{if .Category}}<span class="comment-badge {{categoryClass .Category}}">{{.Category}}</span>{{end}}
                     {{if .Severity}}<span class="comment-badge {{severityClass .Severity}}">{{.Severity}}</span>{{end}}
-                    {{if .StartLine}}<span class="comment-lines">L{{.StartLine}}{{if and .EndLine (ne .EndLine .StartLine)}}-L{{.EndLine}}{{end}}</span>{{end}}
+                    {{if .StartLine}}<span class="comment-lines{{if $numbered}} sr-only{{end}}">L{{.StartLine}}{{if and .EndLine (ne .EndLine .StartLine)}}-L{{.EndLine}}{{end}}</span>{{end}}
                     <span class="comment-badge mark-chip" data-mark-chip hidden></span>
                 </div>
                 <div class="comment-content">{{.Content}}</div>
@@ -161,7 +163,8 @@
                     {{if .ExistingCode}}
                     <div class="code-panel code-existing">
                         <div class="code-panel-label">Existing Code</div>
-                        <pre><code>{{.ExistingCode}}</code></pre>
+                        {{if $numbered}}<pre class="code-numbered"><code>{{range $i, $l := $lines}}{{if $i}}
+{{end}}<span class="code-line"><span class="line-no" aria-hidden="true">{{$l.Num}}</span><span class="line-text">{{$l.Text}}</span></span>{{end}}</code></pre>{{else}}<pre><code>{{.ExistingCode}}</code></pre>{{end}}
                     </div>
                     {{end}}
                     {{if .SuggestionCode}}


### PR DESCRIPTION
## Description

The session page prints the Existing Code block with no line numbers and puts the
range in a separate `L120-L124` chip above the comment text. Mapping "the third line
of this snippet" back to a file means counting rows by hand, and the chip is the only
place the absolute numbers appear.

This numbers each line of the block in its own gutter. The gutter is
`user-select: none`, so copying the snippet still yields just the code, and it is
`aria-hidden` so a screen reader does not read a number before every line. The
chip is redundant once the gutter is there, so it is hidden visually with an
`.sr-only` class rather than dropped — otherwise a numbered block would have no
line location left in the accessibility tree at all.

Numbers are emitted only when `EndLine-StartLine+1` matches the line count of
`ExistingCode`. That guard is load-bearing rather than defensive: `internal/diff/resolver.go`
skips blank lines on both sides while matching (`splitAndNormalize`, and again in
`resolveFromFileContent`), so the stored span and the stored snippet can legitimately
disagree.

A zero `EndLine` is treated as a single-line finding. An inverted non-zero range is
left alone so the length check rejects it, matching the `hasRegion` test in
`cmd/opencodereview/sarif.go`.
When they do, the block renders exactly as it does today instead of printing numbers
that point at the wrong lines.

Nothing outside the viewer changes — the resolver, the store and the suggested-change
block are untouched.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

`TestNumberedCodeLines` covers the helper across 13 cases: empty input, a span/snippet
length mismatch, `endLine < startLine`, `startLine <= 0`, CRLF, and a single trailing
newline.

`TestParseTemplate_ExistingCodeLineNumbers` asserts the rendered DOM. Its
`resolved range is numbered` subtest fails on the parent commit — no `<span class="line-no"`
is present and the `comment-lines` chip still is — and passes with the change.
`TestParseTemplate_SessionWithComments` is unmodified and still passes.

Also run: `make check` (license-check, english-check, `go mod tidy`, `gofmt`, `go vet`)
and `go test -race ./internal/viewer/...`.

Manually: opened a session with both a resolver-matched comment and one where the model
supplied its own range, and confirmed the second still renders unnumbered with its chip
intact.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Closes #1172