### PR TITLE
fix(mcp): bound the MCP shutdown phase

### DIFF
--- a/cmd/opencodereview/review_cmd.go
+++ b/cmd/opencodereview/review_cmd.go
@@ -196,10 +196,10 @@ func executeReviewContext(ctx context.Context, opts reviewOptions) (retErr error
 
 	mcpClients := initMCPClients(ctx, rt.AppCfg, tools, cc.RepoDir, Version)
 	defer func() {
-		for _, mc := range mcpClients {
-			if err := mc.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "[ocr] WARNING: failed to close MCP server %q: %v\n", mc.Name(), err)
-			}
+		closeCtx, cancel := context.WithTimeout(context.Background(), mcp.CloseAllTimeout)
+		defer cancel()
+		if err := mcp.CloseAll(closeCtx, mcpClients); err != nil {
+			fmt.Fprintf(os.Stderr, "[ocr] WARNING: %v\n", err)
 		}
 	}()
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -5,14 +5,21 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	SubprocessTerminateDuration = 800 * time.Millisecond
+	CloseAllTimeout             = 2800 * time.Millisecond
 )
 
 // Client wraps a single MCP server connection.
@@ -21,6 +28,12 @@ type Client struct {
 	session *mcp.ClientSession
 	tools   []*mcp.Tool
 }
+
+// subprocessTerminateDuration is the per-stage shutdown budget handed to every
+// CommandTransport. It defaults to SubprocessTerminateDuration and is widened
+// only by tests running under the race detector, whose re-exec'd children pay
+// ~1s of runtime overhead before noticing stdin EOF.
+var subprocessTerminateDuration = SubprocessTerminateDuration
 
 // NewClient starts an MCP server subprocess (stdio transport), initializes the
 // connection, and caches the list of available tools. The context governs the
@@ -39,7 +52,7 @@ func NewClient(ctx context.Context, name, command string, args, env []string, di
 		nil,
 	)
 
-	transport := &mcp.CommandTransport{Command: cmd}
+	transport := &mcp.CommandTransport{Command: cmd, TerminateDuration: subprocessTerminateDuration}
 	session, err := client.Connect(ctx, transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("connect to MCP server %q: %w", name, err)
@@ -175,6 +188,62 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]any)
 
 func (c *Client) Close() error {
 	return c.session.Close()
+}
+
+// CloseAll closes every client concurrently and returns all failures in
+// configuration order, or stops waiting when ctx expires. CommandTransport
+// bounds each client to at most three SubprocessTerminateDuration waits, so
+// concurrency keeps the phase bounded by the slowest server.
+//
+// The result channel is buffered to len(clients), so close goroutines that
+// are still running when ctx expires write their result and exit without
+// blocking — the CLI returns promptly while the SDK escalates to SIGKILL
+// in the background, and the OS reaps whatever outlives the process. On the
+// timeout path, errors already collected from servers that finished in time
+// are preserved alongside the deadline error.
+func CloseAll(ctx context.Context, clients []*Client) error {
+	if len(clients) == 0 {
+		return nil
+	}
+
+	type result struct {
+		idx int
+		err error
+	}
+	results := make(chan result, len(clients))
+	for i, c := range clients {
+		go func(idx int, cl *Client) {
+			var err error
+			if cerr := cl.Close(); cerr != nil {
+				err = fmt.Errorf("close MCP server %q: %w", cl.name, cerr)
+			}
+			results <- result{idx, err}
+		}(i, c)
+	}
+
+	errs := make([]error, len(clients))
+	for range clients {
+		select {
+		case r := <-results:
+			errs[r.idx] = r.err
+		case <-ctx.Done():
+			// Drain any results that arrived concurrently with the deadline,
+			// so errors from servers that finished in time are not lost.
+			for {
+				select {
+				case r := <-results:
+					errs[r.idx] = r.err
+				default:
+					timeoutErr := fmt.Errorf("timed out closing MCP server(s): %w", ctx.Err())
+					if joined := errors.Join(errs...); joined != nil {
+						return errors.Join(timeoutErr, joined)
+					}
+					return timeoutErr
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func contentToText(contents []mcp.Content) string {

--- a/internal/mcp/closeall_stress_test.go
+++ b/internal/mcp/closeall_stress_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Stress coverage for issue #1141: the acceptance criterion says MCP shutdown
+// must stay bounded "regardless of how many stdio servers are configured".
+// These tests scale past the realistic fleet size (typical configs mount 1-5
+// servers) and exercise mixed-failure profiles, so the concurrency model's
+// "total cost = the slowest server" property is demonstrated rather than
+// assumed from the 2-server case.
+
+// TestCloseAll_StressManyUnresponsiveServers drives 24 hanging servers —
+// an order of magnitude past any realistic configuration — and asserts the
+// whole phase still finishes inside the 3s budget: with concurrent closing
+// the wall time is the single slowest server (~1.6s), not the sum.
+func TestCloseAll_StressManyUnresponsiveServers(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	var clients []*Client
+	for i := 0; i < 24; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("hang-%02d", i), runAsHangingServerEnv))
+	}
+
+	start := time.Now()
+	err := CloseAll(context.Background(), clients)
+	elapsed := time.Since(start)
+
+	if elapsed >= 3*time.Second {
+		t.Errorf("24 unresponsive servers took %s to close, want well inside 3s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors for the SIGKILLed servers, got nil")
+	}
+	// Every server is named in the joined error, including the last one.
+	for _, name := range []string{"hang-00", "hang-12", "hang-23"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("CloseAll error %q does not mention server %q", err, name)
+		}
+	}
+}
+
+// TestCloseAll_MixedFleetRealisticProfile models a realistic fleet: healthy
+// servers, hung servers, and servers that exit non-zero, all closing at once.
+// The total stays inside the budget, every failing server is named, and the
+// healthy ones are not reported as failures.
+func TestCloseAll_MixedFleetRealisticProfile(t *testing.T) {
+	if raceDetectorEnabled {
+		// Raced children notice stdin EOF ~1s late and, under the load of
+		// ten concurrent children, can miss even the widened 2500ms stage —
+		// healthy servers then get SIGTERM'd and pollute the error names.
+		// The production timing semantics this test asserts are only
+		// deterministic in non-race builds; CloseAll logic remains covered
+		// under -race by the pinned-budget tests.
+		t.Skip("child EOF-notice latency under -race breaks production timing; covered by non-race runs")
+	}
+	pinProductionTerminateDuration(t)
+
+	var clients []*Client
+	for i := 0; i < 4; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("normal-%d", i), runAsServerEnv))
+	}
+	for i := 0; i < 4; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("hang-%d", i), runAsHangingServerEnv))
+	}
+	for i := 0; i < 2; i++ {
+		clients = append(clients, startEnvServer(t, fmt.Sprintf("exit3-%d", i), runAsExit3ServerEnv))
+	}
+
+	start := time.Now()
+	err := CloseAll(context.Background(), clients)
+	elapsed := time.Since(start)
+
+	if elapsed >= 3*time.Second {
+		t.Errorf("mixed fleet took %s to close, want well inside 3s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors from hung and exit-3 servers, got nil")
+	}
+	msgText := err.Error()
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(msgText, fmt.Sprintf("hang-%d", i)) {
+			t.Errorf("error %q does not mention hung server hang-%d", msgText, i)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if !strings.Contains(msgText, fmt.Sprintf("exit3-%d", i)) {
+			t.Errorf("error %q does not mention exit-3 server exit3-%d", msgText, i)
+		}
+	}
+	if strings.Contains(msgText, "normal-") {
+		t.Errorf("error %q mentions healthy servers", msgText)
+	}
+}
+
+// TestCloseAll_SlowCooperativeServerIsWaitedFor covers the distinction the
+// escalation exists to make: a server that needs ~1.2s to wind down after
+// stdin closes is waited for and exits cleanly (no error, no SIGKILL), while
+// still finishing inside the budget. Only genuinely unresponsive servers
+// should be killed.
+func TestCloseAll_SlowCooperativeServerIsWaitedFor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Process.Signal(SIGTERM) is unsupported on Windows, so the SDK
+		// skips its SIGTERM wait and Kills right after the stdin-close
+		// stage: the "waited for, clean wind-down" premise is POSIX-only.
+		t.Skip("SIGTERM wind-down wait does not apply on Windows")
+	}
+	if raceDetectorEnabled {
+		// The raced child notices stdin EOF ~1s late, so its 1.2s wind-down
+		// self-exit lands after the SIGKILL escalation (1.6s) — production
+		// semantics (waited for, clean exit) are only deterministic in
+		// non-race builds.
+		t.Skip("raced child wind-down misses its self-exit window; covered by non-race runs")
+	}
+	pinProductionTerminateDuration(t)
+
+	client := startEnvServer(t, "slow-exit", runAsSlowExitServerEnv)
+
+	start := time.Now()
+	err := CloseAll(context.Background(), []*Client{client})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("CloseAll of a cooperative slow server: %v (want clean exit)", err)
+	}
+	if elapsed < time.Second {
+		t.Errorf("CloseAll returned after %s; the slow wind-down should have been awaited", elapsed)
+	}
+	if elapsed >= 3*time.Second {
+		t.Errorf("CloseAll took %s, want well inside 3s", elapsed)
+	}
+}

--- a/internal/mcp/closeall_test.go
+++ b/internal/mcp/closeall_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startEnvServer starts this test binary as the given child MCP server mode.
+func startEnvServer(t *testing.T, name, env string) *Client {
+	t.Helper()
+	requireExec(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewClient(context.Background(), name, exe, nil, []string{env + "=1"}, "", "v0.0.1")
+	if err != nil {
+		t.Fatalf("NewClient(%s): %v", name, err)
+	}
+	return c
+}
+
+// pinProductionTerminateDuration restores the production shutdown budget for
+// tests whose timing must not shift with the race detector's widened budget.
+func pinProductionTerminateDuration(t *testing.T) {
+	t.Helper()
+	old := subprocessTerminateDuration
+	subprocessTerminateDuration = SubprocessTerminateDuration
+	t.Cleanup(func() { subprocessTerminateDuration = old })
+}
+
+// TestCloseAll_UnresponsiveServersStayWithinBudget covers the issue #1141
+// acceptance criterion: total MCP shutdown stays well inside 3s no matter how
+// unresponsive the configured servers are. The hanging children ignore
+// SIGTERM, so each one exercises the full stdin-close -> SIGTERM -> SIGKILL
+// escalation of the SDK before Close returns.
+//
+// The test pins the production TerminateDuration: a SIGKILLed child dies
+// immediately even under the race detector, so the measured wall time is
+// deterministic in both build modes.
+func TestCloseAll_UnresponsiveServersStayWithinBudget(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	clients := []*Client{
+		startEnvServer(t, "hang-a", runAsHangingServerEnv),
+		startEnvServer(t, "hang-b", runAsHangingServerEnv),
+	}
+
+	start := time.Now()
+	err := CloseAll(context.Background(), clients)
+	elapsed := time.Since(start)
+
+	// POSIX: two escalation waits of 800ms each, then the SIGKILL lands.
+	// Windows: Process.Signal(SIGTERM) is unsupported (EWINDOWS), so the SDK
+	// skips its wait entirely and Kills right after the first stage — total
+	// ~800ms, below the POSIX lower bound.
+	if elapsed >= 3*time.Second {
+		t.Errorf("CloseAll took %s, want well inside 3s", elapsed)
+	}
+	if runtime.GOOS != "windows" && elapsed < 1500*time.Millisecond {
+		t.Errorf("CloseAll took %s; the SIGTERM stage should elapse before the SIGKILL", elapsed)
+	}
+	if err == nil {
+		t.Fatal("CloseAll: expected errors for the SIGKILLed servers, got nil")
+	}
+	if runtime.GOOS != "windows" && !strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("CloseAll error = %v, want it to mention the killed subprocess", err)
+	}
+}
+
+// TestCloseAll_ResponsiveServersCloseCleanly pins the unchanged behavior for
+// well-behaved servers: close is quick and error-free.
+func TestCloseAll_ResponsiveServersCloseCleanly(t *testing.T) {
+	clients := []*Client{
+		startEnvServer(t, "normal-a", runAsServerEnv),
+		startEnvServer(t, "normal-b", runAsServerEnv),
+	}
+
+	start := time.Now()
+	if err := CloseAll(context.Background(), clients); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	// Under the race detector the children need ~1s to notice stdin EOF, so
+	// the speed claim is only enforced in production builds; the error-free
+	// close is asserted everywhere.
+	if elapsed := time.Since(start); !raceDetectorEnabled && elapsed > time.Second {
+		t.Errorf("responsive servers took %s to close, want well under 1s", elapsed)
+	}
+}
+
+// TestCloseAll_JoinsPerServerErrorMessages checks the error aggregation: every
+// failing server is named, in a single joined message, and quiet servers do
+// not pollute it.
+func TestCloseAll_JoinsPerServerErrorMessages(t *testing.T) {
+	clients := []*Client{
+		startEnvServer(t, "exit3-a", runAsExit3ServerEnv),
+		startEnvServer(t, "normal", runAsServerEnv),
+		startEnvServer(t, "exit3-b", runAsExit3ServerEnv),
+	}
+
+	err := CloseAll(context.Background(), clients)
+	if err == nil {
+		t.Fatal("CloseAll: expected joined errors from the exit-3 servers, got nil")
+	}
+	msg := err.Error()
+	for _, name := range []string{"exit3-a", "exit3-b"} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("CloseAll error %q does not mention server %q", msg, name)
+		}
+	}
+	if !strings.Contains(msg, "exit status 3") {
+		t.Errorf("CloseAll error %q does not mention the child exit status", msg)
+	}
+	if strings.Contains(msg, `"normal"`) {
+		t.Errorf("CloseAll error %q mentions the responsive server", msg)
+	}
+}
+
+// TestCloseAll_TimeoutPreservesCollectedErrors checks that when the ctx
+// deadline fires, errors from servers that already finished closing are not
+// dropped: one exit-3 server completes quickly, one hanging server is still
+// closing when the deadline hits, and the returned error must carry both the
+// timeout and the exit-3 failure.
+func TestCloseAll_TimeoutPreservesCollectedErrors(t *testing.T) {
+	pinProductionTerminateDuration(t)
+
+	clients := []*Client{
+		startEnvServer(t, "fast-error", runAsExit3ServerEnv),
+		startEnvServer(t, "slow-hang", runAsHangingServerEnv),
+	}
+
+	// The exit-3 server finishes within the first TerminateDuration stage
+	// (~800ms); the hanging server needs the full escalation (~1.6s). A
+	// 500ms deadline fires between the two, so the exit-3 result is already
+	// in the buffered channel when the timeout branch drains it.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	err := CloseAll(ctx, clients)
+	if err == nil {
+		t.Fatal("CloseAll: expected a timeout error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "timed out closing MCP server(s)") {
+		t.Errorf("CloseAll error %q does not mention the timeout", msg)
+	}
+	if !strings.Contains(msg, `"fast-error"`) {
+		t.Errorf("CloseAll error %q does not preserve the exit-3 server error", msg)
+	}
+	if !strings.Contains(msg, "exit status 3") {
+		t.Errorf("CloseAll error %q does not mention the exit status", msg)
+	}
+
+	// CloseAll returned at the deadline, but the hanging server's close
+	// goroutine is still running in the background and needs up to
+	// SubprocessTerminateDuration to Kill the child. Wait for it to finish
+	// so the test binary cleanup on Windows does not race with a live
+	// child process ("Access is denied" unlinking mcp.test.exe).
+	time.Sleep(SubprocessTerminateDuration * 2)
+}

--- a/internal/mcp/norace_test.go
+++ b/internal/mcp/norace_test.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build !race
+
+package mcp
+
+// raceDetectorEnabled reports whether this test binary was built with -race.
+const raceDetectorEnabled = false

--- a/internal/mcp/race_test.go
+++ b/internal/mcp/race_test.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 alibaba/open-code-review Contributors
+
+//go:build race
+
+package mcp
+
+// raceDetectorEnabled reports whether this test binary was built with -race.
+const raceDetectorEnabled = true

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -8,23 +8,47 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"os/signal"
 	"runtime"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const runAsServerEnv = "_OCR_MCP_TEST_SERVER"
+const (
+	runAsServerEnv         = "_OCR_MCP_TEST_SERVER"
+	runAsHangingServerEnv  = "_OCR_MCP_TEST_HANG_SERVER"
+	runAsExit3ServerEnv    = "_OCR_MCP_TEST_EXIT3_SERVER"
+	runAsSlowExitServerEnv = "_OCR_MCP_TEST_SLOW_EXIT_SERVER"
+)
 
 func TestMain(m *testing.M) {
-	if os.Getenv(runAsServerEnv) != "" {
-		runTestMCPServer()
-		return
+	if raceDetectorEnabled {
+		// A race-instrumented child pays ~1s of runtime overhead between
+		// seeing stdin EOF and exiting (measured: 12ms plain vs ~1s raced).
+		// Tests that need a responsive child to beat its own shutdown budget
+		// widen that budget accordingly; tests that only rely on signal death
+		// keep the production value and pin it themselves.
+		subprocessTerminateDuration = 2500 * time.Millisecond
 	}
-	os.Exit(m.Run())
+	switch {
+	case os.Getenv(runAsServerEnv) != "":
+		runTestMCPServer()
+	case os.Getenv(runAsHangingServerEnv) != "":
+		runHangingMCPServer()
+	case os.Getenv(runAsExit3ServerEnv) != "":
+		runExit3MCPServer()
+	case os.Getenv(runAsSlowExitServerEnv) != "":
+		runSlowExitMCPServer()
+	default:
+		os.Exit(m.Run())
+	}
 }
 
-func runTestMCPServer() {
+// newTestMCPServer returns a working MCP server with a single echo tool.
+func newTestMCPServer() *mcp.Server {
 	server := mcp.NewServer(
 		&mcp.Implementation{Name: "test-server", Version: "v0.0.1"},
 		nil,
@@ -52,10 +76,55 @@ func runTestMCPServer() {
 			}, nil
 		},
 	)
+	return server
+}
 
-	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+func runTestMCPServer() {
+	if err := newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		log.Fatal(err)
 	}
+	// Exit explicitly with code 0 as soon as stdin EOF ends the server loop,
+	// rather than unwinding through the test runtime, whose teardown adds a
+	// slow and variable tail under the race detector.
+	os.Exit(0)
+}
+
+// runHangingMCPServer serves MCP normally but never exits: it ignores SIGTERM
+// and blocks forever once stdin closes, so only the SDK's SIGKILL escalation
+// can reclaim it. This is the unresponsive-server case from issue #1141.
+func runHangingMCPServer() {
+	signal.Ignore(syscall.SIGTERM)
+	go func() {
+		_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	}()
+	for {
+		// Sleeping keeps a timer pending, which keeps the runtime's deadlock
+		// detector quiet after the server goroutine returns on stdin EOF.
+		time.Sleep(time.Hour)
+	}
+}
+
+// runExit3MCPServer behaves like the normal server but exits with status 3
+// once stdin closes, so Close deterministically reports a child error.
+func runExit3MCPServer() {
+	_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	os.Exit(3)
+}
+
+// runSlowExitMCPServer models a cooperative but slow server: it serves MCP
+// until stdin closes (the parent's Close), then takes a while to wind down
+// its own state before exiting cleanly. It ignores SIGTERM so its wind-down
+// completes, exiting on its own before the SDK's SIGKILL escalation.
+func runSlowExitMCPServer() {
+	signal.Ignore(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = newTestMCPServer().Run(context.Background(), &mcp.StdioTransport{})
+	}()
+	<-done                              // stdin EOF: the parent's Close started
+	time.Sleep(1200 * time.Millisecond) // cooperative wind-down
+	os.Exit(0)
 }
 
 func TestNewClient_Stdio(t *testing.T) {


### PR DESCRIPTION
## Description

MCP clients were closed sequentially during review shutdown. The MCP SDK waits up to 5 seconds at each shutdown stage, so one unresponsive stdio server could delay shutdown by about 15 seconds, and multiple servers multiplied that delay — overrunning docker stop's 10-second grace period and the VS Code extension's 3-second SIGKILL escalation.

This change:

- sets `CommandTransport.TerminateDuration` to 800 ms, bounding each server to at most three 800 ms waits (~2.4 s worst case);
- closes MCP clients concurrently through `mcp.CloseAll`, so the phase costs the slowest server instead of the sum;
- waits for every `Close` to finish within the deadline, so child processes are normally reaped before the caller exits; on timeout, remaining closes complete in the background as the SDK escalates to SIGKILL;
- preserves per-server errors and names in the returned error, joined in configuration order.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- `internal/mcp/closeall_test.go` covers responsive servers, unresponsive servers, and error aggregation. The unresponsive-server case completes in about 1.6 seconds and asserts a total below 3 seconds.
- `internal/mcp/closeall_stress_test.go` covers 24 unresponsive servers, a mixed fleet of healthy and failing servers, and a slow cooperative server.
- `internal/mcp/stdio_test.go` provides the normal, hanging, non-zero-exit, and slow-exit subprocess fixtures used by those tests.
- `internal/mcp/race_test.go` and `norace_test.go` keep subprocess timing deterministic under the race detector without changing production values.
- POSIX-only timing assertions are gated on Windows, where `Process.Signal(SIGTERM)` is unsupported and the SDK proceeds directly to `Kill`.

- [x] `make test` passes locally
- [x] Manual testing: verified the unresponsive and stress cases stay below the 3-second shutdown budget

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA

## Related Issues

Related to #1141 (item 2).
