### PR TITLE
fix(rules): route Gradle scripts to Gradle rules

### DIFF
--- a/internal/config/rules/system_rules.json
+++ b/internal/config/rules/system_rules.json
@@ -4,7 +4,7 @@
     "**/*.properties": "properties.md",
     "**/*{mapper,dao}*.xml": "mapper_dao_xml.md",
     "**/pom.xml": "pom_xml.md",
-    "**/build.gradle": "build_gradle.md",
+    "**/*.gradle": "build_gradle.md",
     "**/package.json": "package_json.md",
     "**/Cargo.toml": "cargo_toml.md",
     "**/composer.json": "composer_json.md",

--- a/internal/config/rules/system_rules_test.go
+++ b/internal/config/rules/system_rules_test.go
@@ -82,6 +82,10 @@ func TestResolve_DefaultRules(t *testing.T) {
 		{"src/main/resources/dao/userdao.xml", "SQL Logic Error Detection"},
 		{"pom.xml", "snapshot"},
 		{"submodule/pom.xml", "snapshot"},
+		{"build.gradle", "snapshot version dependencies"},
+		{"settings.gradle", "snapshot version dependencies"},
+		{"scripts/dependencies.gradle", "snapshot version dependencies"},
+		{"SETTINGS.GRADLE", "snapshot version dependencies"},
 		{"src/main/resources/application.properties", "Configuration Error Detection"},
 		{"frontend/package.json", "latest"},
 		{"composer.json", "Composer Manifest Review Principles"},
@@ -182,6 +186,7 @@ func TestResolve_FallbackToDefault(t *testing.T) {
 		"readme.md",
 		"docs/architecture.txt",
 		"Makefile",
+		"gradlew",
 	}
 
 	for _, path := range paths {

--- a/pages/src/content/docs/en/review-rules.md
+++ b/pages/src/content/docs/en/review-rules.md
@@ -149,7 +149,7 @@ matching order:
 | `**/*.properties` | `properties.md` — i18n / configuration files. |
 | `**/*{mapper,dao}*.xml` | `mapper_dao_xml.md` — MyBatis-style mapper SQL. |
 | `**/pom.xml` | `pom_xml.md` — Maven dependencies. |
-| `**/build.gradle` | `build_gradle.md` — Gradle dependencies. |
+| `**/*.gradle` | `build_gradle.md` — Gradle dependencies. |
 | `**/package.json` | `package_json.md` — NPM dependencies / scripts. |
 | `**/Cargo.toml` | `cargo_toml.md` — Rust manifest. |
 | `**/composer.json` | `composer_json.md` — Composer dependencies, autoloading, scripts, plugins, and package configuration. |

--- a/pages/src/content/docs/ja/review-rules.md
+++ b/pages/src/content/docs/ja/review-rules.md
@@ -111,7 +111,7 @@ OCR は [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.properties` | `properties.md`: i18n / 設定ファイル。 |
 | `**/*{mapper,dao}*.xml` | `mapper_dao_xml.md`: MyBatis 形式の mapper SQL。 |
 | `**/pom.xml` | `pom_xml.md`: Maven 依存関係。 |
-| `**/build.gradle` | `build_gradle.md`: Gradle 依存関係。 |
+| `**/*.gradle` | `build_gradle.md`: Gradle 依存関係。 |
 | `**/package.json` | `package_json.md`: NPM 依存関係 / スクリプト。 |
 | `**/Cargo.toml` | `cargo_toml.md`: Rust manifest。 |
 | `**/composer.json` | `composer_json.md`: Composer の依存関係、自動読み込み、スクリプト、プラグイン、パッケージ設定。 |

--- a/pages/src/content/docs/ko/review-rules.md
+++ b/pages/src/content/docs/ko/review-rules.md
@@ -140,7 +140,7 @@ diff 단계에서 일어납니다.
 | `**/*.properties` | `properties.md` — i18n / 설정 파일. |
 | `**/*{mapper,dao}*.xml` | `mapper_dao_xml.md` — MyBatis 형식의 매퍼 SQL. |
 | `**/pom.xml` | `pom_xml.md` — Maven 의존성. |
-| `**/build.gradle` | `build_gradle.md` — Gradle 의존성. |
+| `**/*.gradle` | `build_gradle.md` — Gradle 의존성. |
 | `**/package.json` | `package_json.md` — NPM 의존성 / 스크립트. |
 | `**/Cargo.toml` | `cargo_toml.md` — Rust 매니페스트. |
 | `**/composer.json` | `composer_json.md` — Composer 의존성, 오토로딩, 스크립트, 플러그인, 패키지 설정. |

--- a/pages/src/content/docs/ru/review-rules.md
+++ b/pages/src/content/docs/ru/review-rules.md
@@ -151,7 +151,7 @@ OCR использует [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com
 | `**/*.properties` | `properties.md` — i18n / файлы конфигурации. |
 | `**/*{mapper,dao}*.xml` | `mapper_dao_xml.md` — MyBatis-стиль mapper SQL. |
 | `**/pom.xml` | `pom_xml.md` — зависимости Maven. |
-| `**/build.gradle` | `build_gradle.md` — зависимости Gradle. |
+| `**/*.gradle` | `build_gradle.md` — зависимости Gradle. |
 | `**/package.json` | `package_json.md` — зависимости / скрипты NPM. |
 | `**/Cargo.toml` | `cargo_toml.md` — манифест Rust. |
 | `**/composer.json` | `composer_json.md` — зависимости Composer, автозагрузка, скрипты, плагины и конфигурация пакета. |

--- a/pages/src/content/docs/zh/review-rules.md
+++ b/pages/src/content/docs/zh/review-rules.md
@@ -132,7 +132,7 @@ OCR 用 [`bmatcuk/doublestar/v4`](https://pkg.go.dev/github.com/bmatcuk/doublest
 | `**/*.properties` | `properties.md`——i18n / 配置文件。 |
 | `**/*{mapper,dao}*.xml` | `mapper_dao_xml.md`——MyBatis 风格 mapper SQL。 |
 | `**/pom.xml` | `pom_xml.md`——Maven 依赖。 |
-| `**/build.gradle` | `build_gradle.md`——Gradle 依赖。 |
+| `**/*.gradle` | `build_gradle.md`——Gradle 依赖。 |
 | `**/package.json` | `package_json.md`——NPM 依赖 / 脚本。 |
 | `**/Cargo.toml` | `cargo_toml.md`——Rust manifest。 |
 | `**/composer.json` | `composer_json.md`——Composer 依赖、自动加载、脚本、插件和包配置。 |


### PR DESCRIPTION
## Description

Only files named `build.gradle` currently receive the built-in Gradle rule. Other supported Gradle scripts, including `settings.gradle` and nested `.gradle` files, fall back to the default rules.

This PR changes the system mapping from `**/build.gradle` to `**/*.gradle`. It also adds coverage for root, nested, and uppercase Gradle paths and updates the rule tables in all five documentation languages.

`build.gradle.kts` remains mapped to the Kotlin rules.

The existing `build_gradle.md` content is unchanged. It currently focuses on snapshot dependencies, so I would appreciate confirmation that it should apply to all `.gradle` scripts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing

Additional checks:

- `make check`
- `make coverage`
- `make build`
- `go test ./internal/config/rules/... -count=1`
- `ocr rules check build.gradle`
- `ocr rules check settings.gradle`
- `ocr rules check scripts/dependencies.gradle`
- `ocr rules check SETTINGS.GRADLE`

All tested `.gradle` paths resolve to `build_gradle.md`. Kotlin DSL files continue to use the Kotlin rules.

## Related Issues

Closes #1184 