### PR TITLE
fix(action): honor an explicit llm_protocol instead of forcing openai or anthropic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,18 @@ inputs:
       Selects the LLM protocol (mapped to env OCR_USE_ANTHROPIC). An explicitly supplied empty
       string, true, 1, or yes selects Anthropic
       case-insensitively; every other value selects the OpenAI-compatible
-      protocol, preserving the CLI environment contract.
+      protocol, preserving the CLI environment contract. Ignored when
+      llm_protocol names the protocol explicitly.
     required: true
+  llm_protocol:
+    description: >-
+      Explicit LLM protocol written to `llm.protocol`: anthropic, openai or
+      openai-responses (case-insensitive). When set it wins over
+      llm_use_anthropic, which is mirrored from it the way `ocr config set
+      llm.protocol` mirrors the boolean. Leave empty to keep deriving the
+      protocol from llm_use_anthropic; an OCR_LLM_PROTOCOL variable in the
+      job or step environment is honoured the same way when this is empty.
+    required: false
   llm_auth_header:
     description: Custom auth header name (mapped to env OCR_LLM_AUTH_HEADER).
     required: false
@@ -504,11 +514,16 @@ runs:
         OCR_LLM_URL: ${{ inputs.llm_url }}
         OCR_LLM_MODEL: ${{ inputs.llm_model }}
         OCR_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
+        OCR_LLM_PROTOCOL_INPUT: ${{ inputs.llm_protocol }}
         OCR_LLM_AUTH_HEADER: ${{ inputs.llm_auth_header }}
         OCR_EXTRA_BODY: ${{ inputs.llm_extra_body }}
         OCR_LANGUAGE: ${{ inputs.language }}
       shell: bash
       run: |
+        # An explicit protocol wins over llm_use_anthropic: the input first,
+        # then OCR_LLM_PROTOCOL inherited from the job or step environment.
+        # Read it before the derivation below reuses that variable name.
+        EXPLICIT_PROTOCOL="$(printf '%s' "${OCR_LLM_PROTOCOL_INPUT:-${OCR_LLM_PROTOCOL:-}}" | tr '[:upper:]' '[:lower:]')"
         NORMALIZED_USE_ANTHROPIC="$(printf '%s' "$OCR_USE_ANTHROPIC" | tr '[:upper:]' '[:lower:]')"
         case "$NORMALIZED_USE_ANTHROPIC" in
           ""|true|1|yes)
@@ -520,6 +535,28 @@ runs:
             OCR_LLM_PROTOCOL="openai"
             ;;
         esac
+        # use_anthropic is mirrored from the explicit protocol the same way
+        # `ocr config set llm.protocol` mirrors it, so the two never disagree.
+        case "$EXPLICIT_PROTOCOL" in
+          "")
+            ;;
+          anthropic)
+            OCR_USE_ANTHROPIC="true"
+            OCR_LLM_PROTOCOL="anthropic"
+            ;;
+          openai|openai-responses)
+            OCR_USE_ANTHROPIC="false"
+            OCR_LLM_PROTOCOL="$EXPLICIT_PROTOCOL"
+            ;;
+          *)
+            echo "::error::llm_protocol must be anthropic, openai or openai-responses (got '${EXPLICIT_PROTOCOL}')"
+            exit 1
+            ;;
+        esac
+        # Exported for the checkpoint fingerprint: the normalized explicit
+        # protocol, empty when neither the input nor the inherited variable
+        # was set, so checkpoints taken before the input existed stay valid.
+        echo "OCR_LLM_PROTOCOL_EXPLICIT=${EXPLICIT_PROTOCOL}" >> "$GITHUB_ENV"
         # reasoning_effort is OpenAI-compatible vocabulary; the Anthropic API
         # rejects unknown body fields, so fail fast instead of breaking every
         # request. Anthropic thinking control goes through an explicit
@@ -605,6 +642,7 @@ runs:
         OCR_FP_LLM_URL: ${{ inputs.llm_url }}
         OCR_FP_LLM_MODEL: ${{ inputs.llm_model }}
         OCR_FP_LLM_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
+        OCR_FP_LLM_PROTOCOL: ${{ env.OCR_LLM_PROTOCOL_EXPLICIT }}
         OCR_FP_LANGUAGE: ${{ inputs.language }}
         OCR_FP_LLM_EXTRA_BODY: ${{ inputs.llm_extra_body }}
         # Normalized by Validate inputs, so spellings that mean the same thing
@@ -747,6 +785,12 @@ runs:
                 process.env.OCR_FP_LLM_URL,
                 process.env.OCR_FP_LLM_MODEL,
                 process.env.OCR_FP_LLM_USE_ANTHROPIC,
+                // The explicit protocol as Configure OCR resolved it — the input
+                // first, then OCR_LLM_PROTOCOL inherited from the job — so a
+                // protocol switched through the environment alone still fails
+                // closed to a full review. Appended only when set, so
+                // checkpoints taken before the input existed stay valid.
+                ...(process.env.OCR_FP_LLM_PROTOCOL ? [process.env.OCR_FP_LLM_PROTOCOL] : []),
                 process.env.OCR_FP_LANGUAGE,
                 process.env.OCR_FP_LLM_EXTRA_BODY,
                 process.env.OCR_FP_LLM_REASONING_EFFORT,

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -266,7 +266,7 @@ The action posts a summary issue comment plus inline review comments. Two inputs
 | `corrupt_checkpoint` | the summary carries no readable checkpoint marker (absent, malformed, or two of them) |
 | `schema_invalid` | the marker is for another PR, another marker version, or records a run that did not complete |
 | `base_changed` | the base ref or the merge-base moved, so the diff basis is no longer the one the checkpoint was taken against |
-| `config_changed` | the model, language, `llm_extra_body`, `llm_reasoning_effort`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `effort`, `max_tokens_budget`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
+| `config_changed` | the model, language, `llm_protocol` (or an inherited `OCR_LLM_PROTOCOL`), `llm_extra_body`, `llm_reasoning_effort`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `effort`, `max_tokens_budget`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
 | `not_ancestor` | the checkpoint commit is in this clone but is not on the new head's history (the branch was reset to an earlier commit) |
 | `unknown_object` | the checkpoint commit is not in this clone, so ancestry could not be checked — where a force-push usually lands, since the replaced commit is no longer fetched |
 | `rule_unreadable` | a rule file was given but could not be read, so no stored fingerprint can be trusted to mean "same rules" |
@@ -487,6 +487,20 @@ OCR supports both OpenAI and Anthropic API formats:
   - Self-hosted models (vLLM, Ollama, etc.)
 - **Anthropic APIs** (set variable `OCR_LLM_USE_ANTHROPIC=true`, i.e. `llm_use_anthropic: true`):
   - Anthropic Claude models
+- **OpenAI Responses API** (`llm_protocol: openai-responses`):
+  - Reasoning models used with function tools, or endpoints that only serve `/v1/responses`
+
+`llm_protocol` (`anthropic`, `openai` or `openai-responses`) takes precedence over `llm_use_anthropic` when set, and `llm.use_anthropic` is mirrored from it. An `OCR_LLM_PROTOCOL` variable in the job environment is honoured the same way when the input is empty.
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    llm_url: ${{ vars.OCR_LLM_URL }}
+    llm_auth_token: ${{ secrets.OCR_LLM_TOKEN }}
+    llm_model: ${{ vars.OCR_LLM_MODEL }}
+    llm_use_anthropic: 'false'
+    llm_protocol: openai-responses
+```
 
 ## Troubleshooting
 

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -1124,6 +1124,112 @@ function testConfigureProtocolTracksUseAnthropic() {
   }
 }
 
+function testConfigureHonoursExplicitProtocol() {
+  const configure = stepNamed("Configure OCR");
+  assert.ok(configure, "action.yml must retain the Configure OCR step");
+  const base = {
+    llm_url: "https://llm.example.invalid/v1",
+    llm_model: "contract-model",
+    llm_auth_token: "protocol-token-sentinel",
+  };
+  // The explicit protocol wins, and use_anthropic follows it — the boolean
+  // alone is what forced every Responses API user onto chat/completions.
+  const cases = [
+    { input: "openai-responses", useAnthropic: "false", expectAnthropic: "false", expectProtocol: "openai-responses" },
+    { input: "openai-responses", useAnthropic: "true", expectAnthropic: "false", expectProtocol: "openai-responses" },
+    { input: "Anthropic", useAnthropic: "false", expectAnthropic: "true", expectProtocol: "anthropic" },
+    { input: "openai", useAnthropic: "true", expectAnthropic: "false", expectProtocol: "openai" },
+  ];
+  for (const testCase of cases) {
+    const fixture = makeFixture();
+    try {
+      const values = inputValues(Object.assign({}, base, {
+        llm_use_anthropic: testCase.useAnthropic,
+        llm_protocol: testCase.input,
+      }));
+      const result = runStep(configure, values, fixture);
+      assert.strictEqual(
+        result.status,
+        0,
+        `Configure OCR failed for llm_protocol=${testCase.input}; ${resultDescription(result)}`
+      );
+      const configured = configValues(configOperations(fixture));
+      assert.strictEqual(configured["llm.protocol"], testCase.expectProtocol);
+      assert.strictEqual(configured["llm.use_anthropic"], testCase.expectAnthropic);
+      assert.strictEqual(
+        readEnvAssignments(path.join(fixture.dir, "github-env")).OCR_LLM_PROTOCOL_EXPLICIT,
+        testCase.expectProtocol,
+        "the normalized explicit protocol must be exported for the checkpoint fingerprint"
+      );
+    } finally {
+      removeFixture(fixture);
+    }
+  }
+
+  // OCR_LLM_PROTOCOL from the job environment is honoured when the input is
+  // empty: it is the variable the CLI itself reads, and the one the report
+  // set without effect.
+  const inherited = makeFixture();
+  try {
+    const values = inputValues(Object.assign({}, base, { llm_use_anthropic: "false" }));
+    const result = runStep(configure, values, inherited, { OCR_LLM_PROTOCOL: "openai-responses" });
+    assert.strictEqual(result.status, 0, `Configure OCR failed with inherited OCR_LLM_PROTOCOL; ${resultDescription(result)}`);
+    const configured = configValues(configOperations(inherited));
+    assert.strictEqual(configured["llm.protocol"], "openai-responses");
+    assert.strictEqual(configured["llm.use_anthropic"], "false");
+    assert.strictEqual(
+      readEnvAssignments(path.join(inherited.dir, "github-env")).OCR_LLM_PROTOCOL_EXPLICIT,
+      "openai-responses",
+      "a protocol switched through the environment alone must reach the checkpoint fingerprint"
+    );
+  } finally {
+    removeFixture(inherited);
+  }
+
+  // With neither source set the export is empty, so the fingerprint stays
+  // exactly what it was before the input existed.
+  const neither = makeFixture();
+  try {
+    const values = inputValues(Object.assign({}, base, { llm_use_anthropic: "false" }));
+    const result = runStep(configure, values, neither);
+    assert.strictEqual(result.status, 0, `Configure OCR failed without a protocol source; ${resultDescription(result)}`);
+    assert.strictEqual(readEnvAssignments(path.join(neither.dir, "github-env")).OCR_LLM_PROTOCOL_EXPLICIT, "");
+  } finally {
+    removeFixture(neither);
+  }
+
+  // The resolve step fingerprints that export, not the raw input.
+  const resolve = STEPS.find((step) => step.name === "Resolve review range");
+  assert.ok(resolve, "action.yml must retain the Resolve review range step");
+  assert.strictEqual(
+    resolve.env.OCR_FP_LLM_PROTOCOL,
+    "${{ env.OCR_LLM_PROTOCOL_EXPLICIT }}",
+    "the checkpoint fingerprint must read the protocol Configure OCR resolved"
+  );
+
+  // The input outranks the inherited variable.
+  const both = makeFixture();
+  try {
+    const values = inputValues(Object.assign({}, base, { llm_use_anthropic: "false", llm_protocol: "anthropic" }));
+    const result = runStep(configure, values, both, { OCR_LLM_PROTOCOL: "openai-responses" });
+    assert.strictEqual(result.status, 0, `Configure OCR failed with both protocol sources; ${resultDescription(result)}`);
+    assert.strictEqual(configValues(configOperations(both))["llm.protocol"], "anthropic");
+  } finally {
+    removeFixture(both);
+  }
+
+  // An unknown protocol fails the step rather than silently configuring one.
+  const unknown = makeFixture();
+  try {
+    const values = inputValues(Object.assign({}, base, { llm_use_anthropic: "false", llm_protocol: "grpc" }));
+    const result = runStep(configure, values, unknown);
+    assert.notStrictEqual(result.status, 0, "an unknown llm_protocol must fail the Configure OCR step");
+    assert.match(`${result.stdout}${result.stderr}`, /llm_protocol must be/, "the failure must name the accepted protocols");
+  } finally {
+    removeFixture(unknown);
+  }
+}
+
 function testConfigurePreservesLegacyUseAnthropicResolution() {
   const configure = stepNamed("Configure OCR");
   assert.ok(configure, "action.yml must retain the Configure OCR step");
@@ -1615,6 +1721,7 @@ const TESTS = [
   ["Configure OCR never persists the token", testConfigureNeverPersistsToken],
   ["Configure OCR neutralizes stale provider and static token", testConfigureNeutralizesStaleProviderAndStaticToken],
   ["Configure OCR sets a protocol consistent with use_anthropic", testConfigureProtocolTracksUseAnthropic],
+  ["Configure OCR honours an explicit llm_protocol", testConfigureHonoursExplicitProtocol],
   ["Configure OCR preserves legacy use_anthropic resolution", testConfigurePreservesLegacyUseAnthropicResolution],
   ["Configure OCR clears stale persisted extra headers", testConfigureClearsStaleExtraHeadersBeforeTokenCommand],
   ["Configure OCR clears stale persisted retry codes", testConfigureClearsStaleRetryCodesBeforeEndpointConfig],


### PR DESCRIPTION
Fixes #1134.

The Configure OCR step derived `llm.protocol` from `llm_use_anthropic` alone, so it always wrote `openai` or `anthropic`, and users on the Responses API were sent to `/v1/chat/completions` no matter what they put in `OCR_LLM_PROTOCOL`.

This adds an optional `llm_protocol` input (`anthropic`, `openai`, `openai-responses`). When it is set, or when `OCR_LLM_PROTOCOL` is inherited from the job environment, that value is written and `llm.use_anthropic` is mirrored from it, the same way `ocr config set llm.protocol` mirrors the boolean. An unknown value fails the step with the accepted list. With neither set, nothing changes. The explicit protocol is added to the checkpoint fingerprint, appended only when set so existing checkpoints stay valid for everyone who never uses the input.

Contract tests cover the input, the inherited variable, precedence between the two, case folding, and the rejection of an unknown value. The GitHub Actions README documents the input.
