### PR TITLE
feat(action): expose --effort and --max-tokens-budget as inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,19 @@ inputs:
   rule:
     description: Path to a custom rules JSON file passed to `ocr review --rule`.
     required: false
+  effort:
+    description: >-
+      Review effort preset passed to `ocr review --effort`: low, medium or
+      high (one, two or three review rounds per file). Empty keeps the CLI's
+      configured or default preset. Changing it invalidates checkpoints.
+    required: false
+  max_tokens_budget:
+    description: >-
+      Cap on total token usage (input + output) for the whole review, passed
+      to `ocr review --max-tokens-budget`. Dispatch stops once it is
+      exceeded; partial results still publish and the run exits 0. A
+      non-negative integer; empty or 0 means unlimited.
+    required: false
   upload_artifacts:
     description: >-
       Upload raw JSON result and stderr as workflow artifacts. Must be the
@@ -461,6 +474,7 @@ runs:
         OCR_FP_ROUTE_SEVERITY_BELOW: ${{ inputs.route_severity_below }}
         OCR_FP_ROUTE_CATEGORIES: ${{ inputs.route_categories }}
         OCR_FP_BACKGROUND: ${{ inputs.background }}
+        OCR_FP_EFFORT: ${{ inputs.effort }}
         OCR_RULE_PATH: ${{ inputs.rule }}
         # `github.token` is always the "github-actions" app, so when the caller
         # did not override the token we know exactly which app wrote our summary
@@ -584,6 +598,9 @@ runs:
                 process.env.OCR_FP_ROUTE_SEVERITY_BELOW,
                 process.env.OCR_FP_ROUTE_CATEGORIES,
                 process.env.OCR_FP_BACKGROUND,
+                // Appended only when set, so checkpoints taken before the
+                // input existed stay valid for everyone who never uses it.
+                ...(process.env.OCR_FP_EFFORT ? [process.env.OCR_FP_EFFORT] : []),
                 versionActual,
                 ruleDigest,
                 localRuleDigest,
@@ -654,6 +671,8 @@ runs:
         OCR_REVIEW_CONCURRENCY: ${{ inputs.review_concurrency }}
         OCR_BACKGROUND: ${{ inputs.background }}
         OCR_RULE: ${{ inputs.rule }}
+        OCR_EFFORT: ${{ inputs.effort }}
+        OCR_MAX_TOKENS_BUDGET: ${{ inputs.max_tokens_budget }}
         # Step output, not job env: empty when the resolve step was skipped or
         # chose the full range, and never inherited from an earlier use of this
         # action in the same job.
@@ -665,10 +684,25 @@ runs:
           echo "::error::Validated review_task_timeout is missing; the timeout validation step must complete first"
           exit 1
         fi
+        # Both are checked here so a typo fails the step with its own
+        # message instead of surfacing as an `ocr review` usage error.
+        case "$OCR_EFFORT" in
+          ""|low|medium|high) ;;
+          *)
+            echo "::error::effort must be low, medium or high (got '${OCR_EFFORT}')"
+            exit 1
+            ;;
+        esac
+        if [ -n "$OCR_MAX_TOKENS_BUDGET" ] && ! [[ "$OCR_MAX_TOKENS_BUDGET" =~ ^[0-9]+$ ]]; then
+          echo "::error::max_tokens_budget must be a non-negative integer (got '${OCR_MAX_TOKENS_BUDGET}')"
+          exit 1
+        fi
         ARGS=(--from "${RANGE_FROM:-$MERGE_BASE}" --to "${HEAD_SHA}" --audience agent --format json --timeout "$REVIEW_TASK_TIMEOUT")
         [ -n "$OCR_REVIEW_CONCURRENCY" ] && ARGS+=(--concurrency "$OCR_REVIEW_CONCURRENCY")
         [ -n "$OCR_BACKGROUND" ] && ARGS+=(--background "$OCR_BACKGROUND")
         [ -n "$OCR_RULE" ] && ARGS+=(--rule "$OCR_RULE")
+        [ -n "$OCR_EFFORT" ] && ARGS+=(--effort "$OCR_EFFORT")
+        [ -n "$OCR_MAX_TOKENS_BUDGET" ] && ARGS+=(--max-tokens-budget "$OCR_MAX_TOKENS_BUDGET")
         set +e
         ocr review "${ARGS[@]}" > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log
         OCR_EXIT_CODE=$?

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -224,7 +224,7 @@ The action posts a summary issue comment plus inline review comments. Two inputs
 | `corrupt_checkpoint` | the summary carries no readable checkpoint marker (absent, malformed, or two of them) |
 | `schema_invalid` | the marker is for another PR, another marker version, or records a run that did not complete |
 | `base_changed` | the base ref or the merge-base moved, so the diff basis is no longer the one the checkpoint was taken against |
-| `config_changed` | the model, language, `llm_extra_body`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `background`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
+| `config_changed` | the model, language, `llm_extra_body`, `llm_extra_headers`, `llm_auth_header`, `llm_timeout`, `background`, `effort`, routing inputs, the resolved OCR version, or the contents of `rule` / `.opencodereview/rule.json` changed — or `ocr version` printed nothing, so the version could not be established at all |
 | `not_ancestor` | the checkpoint commit is in this clone but is not on the new head's history (the branch was reset to an earlier commit) |
 | `unknown_object` | the checkpoint commit is not in this clone, so ancestry could not be checked — where a force-push usually lands, since the replaced commit is no longer fetched |
 | `rule_unreadable` | a rule file was given but could not be read, so no stored fingerprint can be trusted to mean "same rules" |
@@ -313,6 +313,20 @@ If the read API itself is unavailable (rate-limited or `5xx`), the check returns
 - uses: alibaba/open-code-review@main
   with:
     review_concurrency: 5
+```
+
+### Set the review effort and a token budget
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `effort` | CLI default (`medium`) | Review-round preset passed to `ocr review --effort`: `low`, `medium` or `high` (one, two or three rounds per file). The round count is the biggest single lever on token use and wall-clock time. Changing it invalidates checkpoints. |
+| `max_tokens_budget` | unlimited | Cap on total tokens (input + output) for the whole review, passed to `ocr review --max-tokens-budget`. Dispatch stops once it is exceeded; partial results still publish and the run exits 0. |
+
+```yaml
+- uses: alibaba/open-code-review@main
+  with:
+    effort: low
+    max_tokens_budget: '150000'
 ```
 
 ### Provide background context

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -839,6 +839,59 @@ function testRunRetainsExtraHeadersEnvironmentOverride() {
   }
 }
 
+function testRunForwardsEffortAndTokenBudget() {
+  const run = stepNamed("Run OpenCodeReview");
+  assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
+  const base = {
+    llm_url: "https://llm.example.invalid/v1",
+    llm_auth_token: "unused-token",
+    llm_model: "contract-model",
+    llm_use_anthropic: "false",
+  };
+  const runEnv = { MERGE_BASE: "base-sha", HEAD_SHA: "head-sha", REVIEW_TASK_TIMEOUT: "15" };
+  // Set: both flags reach the review command with their values.
+  const set = makeFixture();
+  try {
+    const values = inputValues(Object.assign({}, base, { effort: "high", max_tokens_budget: "150000" }));
+    const result = runStep(run, values, set, runEnv, { replaceResultPaths: true });
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview failed with effort and budget set; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(set.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    const effortIndex = reviewCall.args.indexOf("--effort");
+    assert.ok(effortIndex >= 0, "effort must be forwarded as --effort");
+    assert.strictEqual(reviewCall.args[effortIndex + 1], "high");
+    const budgetIndex = reviewCall.args.indexOf("--max-tokens-budget");
+    assert.ok(budgetIndex >= 0, "max_tokens_budget must be forwarded as --max-tokens-budget");
+    assert.strictEqual(reviewCall.args[budgetIndex + 1], "150000");
+  } finally {
+    removeFixture(set);
+  }
+  // Empty: neither flag is passed, so the CLI keeps its own defaults.
+  const empty = makeFixture();
+  try {
+    const result = runStep(run, inputValues(base), empty, runEnv, { replaceResultPaths: true });
+    assert.strictEqual(result.status, 0, `Run OpenCodeReview failed with empty effort and budget; ${resultDescription(result)}`);
+    const reviewCall = readJsonLines(empty.callsPath).find((call) => call.args[0] === "review");
+    assert.ok(reviewCall, "Run OpenCodeReview must invoke `ocr review`");
+    assert.strictEqual(reviewCall.args.indexOf("--effort"), -1, "an empty effort must not reach the command line");
+    assert.strictEqual(reviewCall.args.indexOf("--max-tokens-budget"), -1, "an empty budget must not reach the command line");
+  } finally {
+    removeFixture(empty);
+  }
+  // Malformed values fail the step before `ocr review` runs.
+  for (const overrides of [{ effort: "max" }, { max_tokens_budget: "150k" }]) {
+    const bad = makeFixture();
+    try {
+      const result = runStep(run, inputValues(Object.assign({}, base, overrides)), bad, runEnv, { replaceResultPaths: true });
+      assert.notStrictEqual(result.status, 0, `${JSON.stringify(overrides)} must fail the Run OpenCodeReview step`);
+      const reviewCall = readJsonLines(bad.callsPath).find((call) => call.args[0] === "review");
+      assert.ok(!reviewCall, `${JSON.stringify(overrides)} must be rejected before ocr review is invoked`);
+    } finally {
+      removeFixture(bad);
+    }
+  }
+}
+
 function testRunFailsClosedWhenValidatedTaskTimeoutIsMissing() {
   const run = stepNamed("Run OpenCodeReview");
   assert.ok(run, "action.yml must retain the Run OpenCodeReview step");
@@ -1106,6 +1159,7 @@ const TESTS = [
   ["Configure OCR clears stale persisted retry codes", testConfigureClearsStaleRetryCodesBeforeEndpointConfig],
   ["Run OpenCodeReview retains the extra-headers env override", testRunRetainsExtraHeadersEnvironmentOverride],
   ["Run OpenCodeReview fails closed without validated task timeout", testRunFailsClosedWhenValidatedTaskTimeoutIsMissing],
+  ["Run OpenCodeReview forwards effort and max_tokens_budget", testRunForwardsEffortAndTokenBudget],
   ["the official OpenCodeReview NPM install is preserved", testOfficialNpmPackageInstallIsPreserved],
   ["Install OpenCodeReview enforces the auth_token_cmd version floor", testInstallEnforcesAuthTokenCommandVersionFloor],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],


### PR DESCRIPTION
Fixes #1147.

The composite action builds the `ocr review` command itself and only exposes `--concurrency`, `--timeout`, `--background` and `--rule`. The two flags that shape token spend the most were unreachable from a workflow: `--effort` selects the review-round preset, and `--max-tokens-budget` is the only circuit breaker against a runaway review.

This adds `effort` (`low`, `medium`, `high`) and `max_tokens_budget` (non-negative integer) inputs. Each is forwarded only when set, so the CLI's own defaults still apply, and a malformed value fails the step with its own message before the review starts. `effort` is added to the checkpoint fingerprint, appended only when set so existing checkpoints stay valid for everyone who never uses it.

Contract tests cover forwarding, the empty case, and the two rejections. The GitHub Actions README gets a section for the inputs and lists `effort` under `config_changed`.
