### PR TITLE
feat(action): add llm_protocol input to unlock openai-responses preset

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,12 +19,14 @@ inputs:
     required: true
   llm_use_anthropic:
     description: >-
-      Selects the LLM protocol (mapped to env OCR_USE_ANTHROPIC). An explicitly supplied empty
-      string, true, 1, or yes selects Anthropic
+      Legacy protocol selector (mapped to env OCR_USE_ANTHROPIC). An
+      explicitly supplied empty string, true, 1, or yes selects Anthropic
       case-insensitively; every other value selects the OpenAI-compatible
       protocol, preserving the CLI environment contract. Ignored when
-      llm_protocol is set to a non-empty value.
-    required: true
+      llm_protocol is set to a non-empty value — callers using llm_protocol
+      can omit this entirely.
+    required: false
+    default: ''
   llm_protocol:
     description: >-
       Explicit LLM protocol override (case-insensitive): one of `openai`,
@@ -649,9 +651,12 @@ runs:
         OCR_FP_LLM_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
         # A protocol change routes requests to a different endpoint (and,
         # for openai-responses, a different request shape), so what a review
-        # would say shifts too. Empty when the caller didn't set llm_protocol,
-        # which is still distinct from an explicit "openai".
-        OCR_FP_LLM_PROTOCOL: ${{ inputs.llm_protocol }}
+        # would say shifts too. Read the normalized value from Validate
+        # inputs (same pattern as LLM_REASONING_EFFORT) so `OPENAI` vs
+        # `openai` don't hash differently and unnecessarily invalidate the
+        # checkpoint. Empty when the caller didn't set llm_protocol, which is
+        # still distinct from an explicit "openai".
+        OCR_FP_LLM_PROTOCOL: ${{ env.LLM_PROTOCOL }}
         OCR_FP_LANGUAGE: ${{ inputs.language }}
         OCR_FP_LLM_EXTRA_BODY: ${{ inputs.llm_extra_body }}
         # Normalized by Validate inputs, so spellings that mean the same thing

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,21 @@ inputs:
       Selects the LLM protocol (mapped to env OCR_USE_ANTHROPIC). An explicitly supplied empty
       string, true, 1, or yes selects Anthropic
       case-insensitively; every other value selects the OpenAI-compatible
-      protocol, preserving the CLI environment contract.
+      protocol, preserving the CLI environment contract. Ignored when
+      llm_protocol is set to a non-empty value.
     required: true
+  llm_protocol:
+    description: >-
+      Explicit LLM protocol override (case-insensitive): one of `openai`,
+      `openai-responses`, `anthropic`. When set, wins over llm_use_anthropic —
+      this is the only way to reach the CLI's built-in openai-responses
+      preset from this action, needed for models that require the OpenAI
+      Responses API (e.g. GPT-5.6 Sol/Terra/Luna, whose function-tool +
+      reasoning_effort combination is not accepted on /v1/chat/completions).
+      Empty (default) preserves the legacy behavior of deriving the
+      protocol from llm_use_anthropic.
+    required: false
+    default: ''
   llm_auth_header:
     description: Custom auth header name (mapped to env OCR_LLM_AUTH_HEADER).
     required: false
@@ -364,6 +377,7 @@ runs:
         MAX_TOKENS_BUDGET_INPUT: ${{ inputs.max_tokens_budget }}
         LLM_REASONING_EFFORT_INPUT: ${{ inputs.llm_reasoning_effort }}
         STREAM_PROGRESS_INPUT: ${{ inputs.stream_progress }}
+        LLM_PROTOCOL_INPUT: ${{ inputs.llm_protocol }}
       shell: bash
       run: |
         if [[ ! "$REVIEW_TASK_TIMEOUT" =~ ^[0-9]+$ ]]; then
@@ -428,6 +442,20 @@ runs:
             ;;
         esac
         echo "LLM_REASONING_EFFORT=$NORMALIZED_LLM_REASONING_EFFORT" >> "$GITHUB_ENV"
+
+        # Explicit protocol override. Empty leaves protocol selection to
+        # llm_use_anthropic in the Configure OCR step; non-empty pins the CLI
+        # to one of the built-in provider presets. Case-insensitive so a
+        # caller's HIGH-vs-high style doesn't matter here either.
+        NORMALIZED_LLM_PROTOCOL="$(printf '%s' "$LLM_PROTOCOL_INPUT" | tr '[:upper:]' '[:lower:]')"
+        case "$NORMALIZED_LLM_PROTOCOL" in
+          ""|openai|openai-responses|anthropic) ;;
+          *)
+            echo "::error::llm_protocol must be one of: openai, openai-responses, anthropic (got '$LLM_PROTOCOL_INPUT')"
+            exit 1
+            ;;
+        esac
+        echo "LLM_PROTOCOL=$NORMALIZED_LLM_PROTOCOL" >> "$GITHUB_ENV"
 
         # Display-only toggle: 'true' streams human-audience progress lines to
         # the workflow log, 'false' keeps the silent agent-audience run. It
@@ -509,17 +537,31 @@ runs:
         OCR_LANGUAGE: ${{ inputs.language }}
       shell: bash
       run: |
-        NORMALIZED_USE_ANTHROPIC="$(printf '%s' "$OCR_USE_ANTHROPIC" | tr '[:upper:]' '[:lower:]')"
-        case "$NORMALIZED_USE_ANTHROPIC" in
-          ""|true|1|yes)
+        # Two resolution paths. When llm_protocol was supplied, use it verbatim
+        # (already lowercase-normalized + validated in the Validate inputs
+        # step); derive OCR_USE_ANTHROPIC from it so the CLI env var stays
+        # consistent with the resolved protocol. Otherwise fall back to the
+        # legacy llm_use_anthropic derivation, unchanged.
+        if [ -n "${LLM_PROTOCOL:-}" ]; then
+          OCR_LLM_PROTOCOL="$LLM_PROTOCOL"
+          if [ "$OCR_LLM_PROTOCOL" = "anthropic" ]; then
             OCR_USE_ANTHROPIC="true"
-            OCR_LLM_PROTOCOL="anthropic"
-            ;;
-          *)
+          else
             OCR_USE_ANTHROPIC="false"
-            OCR_LLM_PROTOCOL="openai"
-            ;;
-        esac
+          fi
+        else
+          NORMALIZED_USE_ANTHROPIC="$(printf '%s' "$OCR_USE_ANTHROPIC" | tr '[:upper:]' '[:lower:]')"
+          case "$NORMALIZED_USE_ANTHROPIC" in
+            ""|true|1|yes)
+              OCR_USE_ANTHROPIC="true"
+              OCR_LLM_PROTOCOL="anthropic"
+              ;;
+            *)
+              OCR_USE_ANTHROPIC="false"
+              OCR_LLM_PROTOCOL="openai"
+              ;;
+          esac
+        fi
         # reasoning_effort is OpenAI-compatible vocabulary; the Anthropic API
         # rejects unknown body fields, so fail fast instead of breaking every
         # request. Anthropic thinking control goes through an explicit
@@ -605,6 +647,11 @@ runs:
         OCR_FP_LLM_URL: ${{ inputs.llm_url }}
         OCR_FP_LLM_MODEL: ${{ inputs.llm_model }}
         OCR_FP_LLM_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
+        # A protocol change routes requests to a different endpoint (and,
+        # for openai-responses, a different request shape), so what a review
+        # would say shifts too. Empty when the caller didn't set llm_protocol,
+        # which is still distinct from an explicit "openai".
+        OCR_FP_LLM_PROTOCOL: ${{ inputs.llm_protocol }}
         OCR_FP_LANGUAGE: ${{ inputs.language }}
         OCR_FP_LLM_EXTRA_BODY: ${{ inputs.llm_extra_body }}
         # Normalized by Validate inputs, so spellings that mean the same thing
@@ -747,6 +794,7 @@ runs:
                 process.env.OCR_FP_LLM_URL,
                 process.env.OCR_FP_LLM_MODEL,
                 process.env.OCR_FP_LLM_USE_ANTHROPIC,
+                process.env.OCR_FP_LLM_PROTOCOL,
                 process.env.OCR_FP_LANGUAGE,
                 process.env.OCR_FP_LLM_EXTRA_BODY,
                 process.env.OCR_FP_LLM_REASONING_EFFORT,


### PR DESCRIPTION
## Problem

The CLI has supported the `openai-responses` protocol preset since v1.10.1 (`fix(llm): serve GPT-5.6 models via the OpenAI Responses API`, #938), but the composite action still derives `llm.protocol` from `llm_use_anthropic` only — a two-value selector that can produce `openai` or `anthropic` but never `openai-responses`.

As a result, callers running GPT-5.6 Sol/Terra/Luna through the composite action get an instant HTTP 400 from `/v1/chat/completions`:

> Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions.

Same class of failure documented in #559. Fix in the CLI exists; wrapper has no way to reach it.

## Change

Additive — no existing caller changes behavior.

- **New optional input `llm_protocol`** — accepts `openai`, `openai-responses`, or `anthropic` (case-insensitive). Empty (default) keeps today's derivation from `llm_use_anthropic`.
- **Validation** in the \`Validate inputs\` step, matching the fail-fast conventions already used for \`effort\` and \`llm_reasoning_effort\`.
- **Configure OCR** — when \`llm_protocol\` is non-empty it wins over \`llm_use_anthropic\`; \`OCR_USE_ANTHROPIC\` is derived from the resolved protocol so the CLI env var stays consistent. The existing \`reasoning_effort × anthropic-protocol\` guard still fires correctly because it reads the resolved \`OCR_LLM_PROTOCOL\`.
- **Checkpoint fingerprint** — \`llm_protocol\` added to the fingerprint so switching protocols invalidates prior checkpoints (a protocol change routes requests to a different endpoint and, for \`openai-responses\`, a different request shape).

## Usage after this lands

\`\`\`yaml
- uses: alibaba/open-code-review@main
  with:
    llm_url: https://api.openai.com/v1/responses
    llm_auth_token: \${{ secrets.OPENAI_API_KEY }}
    llm_model: gpt-5.6-terra
    llm_use_anthropic: 'false'
    llm_protocol: openai-responses
\`\`\`

## Test

Ran end-to-end against \`gpt-5.6-terra\` on a live PR from a workflow that wraps this action — direct \`curl\` probe to \`/v1/chat/completions\` returned 200 (model is available), \`ocr review\` still 400d before this patch (function-tool + reasoning_effort combination), and succeeded with inline + sticky summary posted after the patch with \`llm_protocol: openai-responses\` + the \`/v1/responses\` URL.

Legacy callers (no \`llm_protocol\` set) exercise the unchanged \`llm_use_anthropic\` branch.