### PR TITLE
fix(action): keep OCR runtime stable during review

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -448,6 +448,12 @@ runs:
       shell: bash
       env:
         OCR_VERSION: ${{ inputs.ocr_version }}
+        # The action installs the OCR runtime itself, so the launcher's
+        # detached self-updater must not npm-replace that install mid-run:
+        # the concurrent global reinstall can briefly remove the ocr shim
+        # and the JS package tree, failing later ocr calls in this action,
+        # and silently changes the runtime during one action execution.
+        OCR_NO_UPDATE: "1"
       run: |
         npm install -g "@alibaba-group/open-code-review@${OCR_VERSION}"
         echo "OpenCodeReview installed:"
@@ -501,6 +507,9 @@ runs:
 
     - name: Configure OCR
       env:
+        # Keep every ocr invocation on the install performed above; see the
+        # Install OpenCodeReview step for why self-update is disabled.
+        OCR_NO_UPDATE: "1"
         OCR_LLM_URL: ${{ inputs.llm_url }}
         OCR_LLM_MODEL: ${{ inputs.llm_model }}
         OCR_USE_ANTHROPIC: ${{ inputs.llm_use_anthropic }}
@@ -819,6 +828,9 @@ runs:
 
     - name: Run OpenCodeReview
       env:
+        # Keep the review on the install performed above; see the Install
+        # OpenCodeReview step for why self-update is disabled.
+        OCR_NO_UPDATE: "1"
         OCR_LLM_URL: ${{ inputs.llm_url }}
         OCR_LLM_TOKEN: ${{ inputs.llm_auth_token }}
         OCR_LLM_MODEL: ${{ inputs.llm_model }}

--- a/scripts/github-actions/action-contract.test.js
+++ b/scripts/github-actions/action-contract.test.js
@@ -222,7 +222,7 @@ function makeFixture() {
 const fs = require("fs");
 const args = process.argv.slice(2);
 const env = {};
-for (const name of ["OCR_LLM_TIMEOUT", "OCR_LLM_EXTRA_HEADERS", "REVIEW_TASK_TIMEOUT", "OCR_TIMEOUT"]) {
+for (const name of ["OCR_LLM_TIMEOUT", "OCR_LLM_EXTRA_HEADERS", "REVIEW_TASK_TIMEOUT", "OCR_TIMEOUT", "OCR_NO_UPDATE"]) {
   if (process.env[name] !== undefined) env[name] = process.env[name];
 }
 const record = { args, env };
@@ -1537,6 +1537,104 @@ function testRequiredStepTopologyAndEnvironmentContracts() {
   }
 }
 
+// Returns the composite steps whose shell block invokes the `ocr` CLI.
+// Full-line shell comments are dropped first: they mention `ocr` in prose
+// (the Validate inputs step documents an `ocr review` flag), and a comment
+// is not an invocation. `ocr` must also sit in a command position — start of
+// line or after a shell separator — so quoted strings such as the
+// "ocr review exited with code ..." echo never count. The sweep stays
+// fail-closed: a future step that invokes `ocr` without disabling the
+// self-updater breaks this contract without any step-name list to maintain.
+function ocrInvokingSteps() {
+  return STEPS.filter((step) => {
+    if (typeof step.run !== "string") return false;
+    const code = step.run
+      .split(/\r?\n/)
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+    return /(?:^|[\s;&|(`])ocr\s+\S/.test(code);
+  });
+}
+
+function testActionOcrInvocationsDisableSelfUpdate() {
+  const invokers = ocrInvokingSteps();
+  const names = invokers.map((step) => step.name);
+  for (const expected of ["Install OpenCodeReview", "Configure OCR", "Run OpenCodeReview"]) {
+    assert.ok(
+      names.includes(expected),
+      `${expected} must be detected as an ocr-invoking step; detection must keep up with action.yml`
+    );
+  }
+  const values = inputValues({
+    llm_url: "https://llm.example.invalid/v1",
+    llm_auth_token: "unused-token",
+    llm_model: "contract-model",
+    llm_use_anthropic: "false",
+  });
+  for (const step of invokers) {
+    assert.strictEqual(
+      renderedEnv(step, values).OCR_NO_UPDATE,
+      "1",
+      `step ${step.name} invokes ocr and must disable CLI self-update (env OCR_NO_UPDATE: "1")`
+    );
+  }
+
+  // The same contract observed through the executed shell blocks: the first
+  // `ocr version` in the Install step is what spawns the detached updater,
+  // so every recorded invocation — version, config, review — must observe
+  // OCR_NO_UPDATE=1, not just the later steps.
+  const fixture = makeFixture();
+  try {
+    const install = runStep(
+      installStep(),
+      inputValues({ ocr_version: "1.9.10" }),
+      fixture,
+      { OCR_FAKE_VERSION_OUTPUT: "open-code-review 1.9.10 linux/amd64" }
+    );
+    assert.strictEqual(
+      install.status,
+      0,
+      `Install OpenCodeReview shell block failed; ${resultDescription(install)}`
+    );
+    const configure = runStep(stepNamed("Configure OCR"), values, fixture, {
+      OCR_LLM_TOKEN: values.llm_auth_token,
+    });
+    assert.strictEqual(
+      configure.status,
+      0,
+      `Configure OCR shell block failed; ${resultDescription(configure)}`
+    );
+    const run = runStep(
+      stepNamed("Run OpenCodeReview"),
+      values,
+      fixture,
+      { MERGE_BASE: "base-sha", HEAD_SHA: "head-sha", REVIEW_TASK_TIMEOUT: "15" },
+      { replaceResultPaths: true }
+    );
+    assert.strictEqual(
+      run.status,
+      0,
+      `Run OpenCodeReview shell block failed; ${resultDescription(run)}`
+    );
+    const calls = readJsonLines(fixture.callsPath);
+    for (const subcommand of ["version", "config", "review"]) {
+      assert.ok(
+        calls.some((call) => call.args[0] === subcommand),
+        `the executed steps must exercise \`ocr ${subcommand}\``
+      );
+    }
+    for (const call of calls) {
+      assert.strictEqual(
+        call.env.OCR_NO_UPDATE,
+        "1",
+        `every action-owned ocr invocation must observe OCR_NO_UPDATE=1; \`ocr ${call.args.join(" ")}\` saw ${JSON.stringify(call.env.OCR_NO_UPDATE)}`
+      );
+    }
+  } finally {
+    removeFixture(fixture);
+  }
+}
+
 function testContractsRunInDedicatedWorkflow() {
   assert.match(
     CONTRACT_WORKFLOW_TEXT,
@@ -1626,6 +1724,7 @@ const TESTS = [
   ["Install OpenCodeReview rejects stream_progress below v1.9.8", testInstallRejectsStreamProgressBelowV198],
   ["contract harness fails closed on unsupported YAML shapes", testContractHarnessFailsClosedOnUnsupportedYamlShapes],
   ["required action steps and env contracts are present", testRequiredStepTopologyAndEnvironmentContracts],
+  ["every action-owned ocr invocation disables CLI self-update", testActionOcrInvocationsDisableSelfUpdate],
   ["GitHub Actions contracts run in a dedicated workflow", testContractsRunInDedicatedWorkflow],
   ["GitHub Actions README documents timeout and version contracts", testExampleReadmeDocumentsTimeoutAndVersionContracts],
 ];


### PR DESCRIPTION
## Description

The composite GitHub Action installs an OCR runtime before configuration and review, but each `ocr` invocation can start the CLI's detached background updater.

When the npm registry contains a newer release, that updater can run `npm i -g` concurrently with later action steps. Besides changing the OCR version during one action execution, npm may temporarily remove the global `ocr` launcher and JavaScript package tree, causing subsequent `ocr config` or `ocr review` commands to fail.

This change disables CLI self-update only for OCR invocations owned by the composite Action (`OCR_NO_UPDATE: "1"` step-level env on the Install / Configure / Run steps — the step-level scope keeps it out of the caller's job environment). Standalone CLI behavior is unchanged: the launcher's updater still runs exactly as before for direct `ocr` users.

The contract holds regardless of the `ocr_version` input (exact pin, range, or `latest`): the Action has already performed its own installation, so the runtime should not change again during that execution.

### Relation to #704

#704 addresses resilience of the generic npm auto-upgrade path with a staged native-binary fallback. This PR is intentionally narrower: the GitHub Action already owns OCR installation for one review execution, so it avoids entering that background upgrade path during the action.

The action-level fix also covers launcher / JavaScript-package removal cases where a native-binary fallback cannot run because the launcher itself is temporarily unavailable (exit 127 `ocr: command not found`, or `Cannot find module '/usr/local/bin/ocr'` while npm replaces the global package tree).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI / Build / Tooling

## How Has This Been Tested?

Regression test: a new action-contract test (static YAML contract + executed shell-block contract via the existing fake-`ocr` harness) **fails on upstream/main before the fix** and passes after it.

Negative control (upstream/main worktree + test patch only):
```
not ok - every action-owned ocr invocation disables CLI self-update:
  step Install OpenCodeReview invokes ocr and must disable CLI self-update
  (env OCR_NO_UPDATE: "1")   — process exit 1
```

After the fix, all gates pass locally:
- [x] `node scripts/github-actions/action-contract.test.js` — 41/41 PASS
- [x] `npm run test:github-actions` — PASS
- [x] `npm run test:launcher` — PASS (standalone launcher auto-update behavior unchanged)
- [x] `npm run test:update` — PASS
- [x] `make check` — PASS
- [x] `make test` — PASS
- [x] `make build` — PASS

External hosted GitHub Actions reproduction (not part of this repo):

```
OCR installed: 1.11.6
registry latest: 1.11.7

auto-update enabled:  7/7 runs failed
OCR_NO_UPDATE=1:      10/10 runs passed
```

Observed during failing runs: detached `scripts/update.js` -> `npm i -g 1.11.7` -> global launcher/package-tree replacement with a 0.66-0.89 s unavailable window -> subsequent `ocr config` failing with exit 127 or `MODULE_NOT_FOUND`.

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if applicable) — no documentation change needed: this only makes the Action's existing installed runtime stable during its execution; standalone CLI behavior is unchanged
- [x] I have signed the CLA

## Related Issues

Related to #703.
Complementary to #704.
