### PR TITLE
fix(llm): add deepseek-flash to DeepSeek provider

### DIFF
--- a/extensions/vscode/src/shared/providers.ts
+++ b/extensions/vscode/src/shared/providers.ts
@@ -64,7 +64,7 @@ export const PROVIDER_PRESETS: OcrProviderPreset[] = [
     protocol: 'openai',
     baseUrl: 'https://api.deepseek.com',
     envVar: 'DEEPSEEK_API_KEY',
-    models: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+    models: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-flash'],
   },
   {
     name: 'tencent-tokenhub',

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -204,6 +204,7 @@ var registry = []Provider{
 		Models: []string{
 			"deepseek-v4-pro",
 			"deepseek-v4-flash",
+			"deepseek-flash",
 		},
 	},
 	{

--- a/internal/llm/providers_test.go
+++ b/internal/llm/providers_test.go
@@ -185,6 +185,16 @@ func TestLookupProvider_OpenAIDetails(t *testing.T) {
 	}
 }
 
+func TestLookupProvider_DeepSeekFlash(t *testing.T) {
+	p, ok := LookupProvider("deepseek")
+	if !ok {
+		t.Fatal("deepseek not found")
+	}
+	if !ModelListContains(p.Models, "deepseek-flash") {
+		t.Error(`deepseek models do not contain "deepseek-flash"`)
+	}
+}
+
 func TestLookupProvider_OpenAIResponsesDetails(t *testing.T) {
 	const expectedEnvVar = "OPENAI_RESPONSES_API_KEY"
 


### PR DESCRIPTION
## Description

Add the official `deepseek-flash` model to the built-in DeepSeek provider.

The DeepSeek API accepts `deepseek-flash`, but the current provider validation only allows legacy model names, causing valid requests to be rejected locally.

This change:

- Adds `deepseek-flash` to the Go provider registry.
- Synchronizes the VS Code provider preset.
- Preserves the existing model order and default selection.
- Adds a regression test for provider model lookup.
- Retains legacy model names for backward compatibility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

- [x] `make test` passes locally
- [x] Manual testing (describe below)

Additional verification:

- `make check`
- `make build`
- DeepSeek provider regression test
- Successful live review using `ocr review --provider deepseek --model deepseek-flash`

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (not applicable: provider model lists are not documented)
- [x] I have signed the CLA



## Related Issues

Closes #1207