### PR TITLE
chore: remove stale alias pointing to `deepseek-flash`

### DIFF
--- a/extensions/vscode/src/shared/providers.ts
+++ b/extensions/vscode/src/shared/providers.ts
@@ -64,7 +64,7 @@ export const PROVIDER_PRESETS: OcrProviderPreset[] = [
     protocol: 'openai',
     baseUrl: 'https://api.deepseek.com',
     envVar: 'DEEPSEEK_API_KEY',
-    models: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-flash'],
+    models: ['deepseek-v4-pro', 'deepseek-flash'],
   },
   {
     name: 'tencent-tokenhub',

--- a/internal/llm/providers.go
+++ b/internal/llm/providers.go
@@ -203,7 +203,6 @@ var registry = []Provider{
 		EnvVar:      "DEEPSEEK_API_KEY",
 		Models: []string{
 			"deepseek-v4-pro",
-			"deepseek-v4-flash",
 			"deepseek-flash",
 		},
 	},


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
There is a stale pointer named `deepseek-v4-flash` pointing to the new `deepseek-flash`.
Per the docs:
<img width="2032" height="1079" alt="Screenshot 2026-09-11 at 10 04 34 PM" src="https://github.com/user-attachments/assets/7cfc107d-6a65-4bb8-a94b-5b48394699b9" />


Therefore the `deepseek-v4-flash` should be removed, because it will always points towards to the new model.
The last PR updating the models list is incomplete.


`deepseek-v4-pro` is not effected because per the docs deepseek said it still supports v4 pro model

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI / Build / Tooling

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details about your test configuration. -->

- [x] `make test` passes locally
- [ ] Manual testing (describe below)

## Checklist

- [x] My code follows the project's coding style (`go fmt`, `go vet`)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have signed the CLA
- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.
**No AI used in any way**

<!-- Please disclose the model used here if AI was used. -->

## Related Issues

<!-- Link related issues below. Use "closes #123" to auto-close on merge. -->
N/A