### PR TITLE
fix(tool): swap inverted file_read line range instead of erroring

### DIFF
--- a/internal/tool/file_read.go
+++ b/internal/tool/file_read.go
@@ -37,11 +37,14 @@ func (p *FileReadProvider) Execute(ctx context.Context, args map[string]any) (st
 
 	maxLines := fileReadMaxLines
 	if endLine > 0 {
-		requested := int(endLine) - int(startLine) + 1
-		if requested <= 0 {
-			return "", fmt.Errorf("invalid line range: start_line %d is greater than end_line %d", int(startLine), int(endLine))
+		if int(endLine) < int(startLine) {
+			// Models sometimes derive start_line from the old side of a diff
+			// hunk while end_line comes from the new file, or simply swap the
+			// two. Serve the swapped range instead of failing the call; the
+			// total-line count in the response lets the caller recover.
+			startLine, endLine = endLine, startLine
 		}
-		if requested < maxLines {
+		if requested := int(endLine) - int(startLine) + 1; requested < maxLines {
 			maxLines = requested
 		}
 	}

--- a/internal/tool/file_read_test.go
+++ b/internal/tool/file_read_test.go
@@ -353,20 +353,25 @@ func TestExecute_EmptyFilePath(t *testing.T) {
 	}
 }
 
-func TestExecute_InvalidLineRange(t *testing.T) {
+func TestExecute_SwappedLineRange(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, dir, "test.txt", "a\nb\nc\n")
 
 	fr := &FileReader{RepoDir: dir, Mode: ModeWorkspace}
 	p := NewFileRead(fr)
 
-	_, err := p.Execute(context.Background(), map[string]any{
+	// An inverted range is a common model slip (start from the old hunk side,
+	// end from the new file). The tool swaps it instead of erroring.
+	got, err := p.Execute(context.Background(), map[string]any{
 		"file_path":  "test.txt",
-		"start_line": float64(5),
+		"start_line": float64(3),
 		"end_line":   float64(2),
 	})
-	if err == nil {
-		t.Error("expected error for invalid line range")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "2|b\n3|c\n") {
+		t.Errorf("Execute() = %q, want swapped range 2-3", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`file_read` hard-errors when the model passes `end_line < start_line`:

```
file_read failed: invalid line range: start_line 430 is greater than end_line 120
```

This is a common model slip — the model derives `start_line` from the old side of a diff hunk while `end_line` comes from the new file's length. One bad call fails the whole file's review item (observed: 6/6 items in a review failed this way).

Fix: swap the inverted range and serve it. The response still reports `Total lines`, so the model can recover if the swap was not its intent. Updated `TestExecute_InvalidLineRange` to `TestExecute_SwappedLineRange` asserting the swapped range returns content.

## Validation

- `go test ./internal/tool/` — pass
- `make check` — pass
- Patched binary built and run locally: `ocr llm test` and `ocr review --commit <sha> -p` work.

## Disclosure

This change was developed with AI assistance (Devin / SWE-2) per the project's agent guidelines; the change was reviewed and tested before submission.